### PR TITLE
fix: docs typo: transformations heading

### DIFF
--- a/docs/docs/tutorial/transformations.md
+++ b/docs/docs/tutorial/transformations.md
@@ -2,27 +2,27 @@
 sidebar_position: 4
 ---
 
-# Tranformations
+# Transformations
 
-Transformations can be enabled on queries to transform the query results. Let's write a simple transformation to compute `first_name` and `last_name` for all the customers that we fetch in the previous step. 
+Transformations can be enabled on queries to transform the query results. Let's write a simple transformation to compute `first_name` and `last_name` for all the customers that we fetch in the previous step.
 
 ```javascript
 // write your code here
 // return value will be set as data and the original data will be available as rawData
-return data.map(row => { 
-  return { 
+return data.map((row) => {
+  return {
     ...row,
     first_name: row.name.split(' ')[0],
-    last_name: row.name.split(' ')[1]
-	}
+    last_name: row.name.split(' ')[1],
+  };
 });
 ```
 
-The query will now look like this: 
+The query will now look like this:
 
 <img class="screenshot-full" src="/img/tutorial/transformations/transform.gif" alt="ToolJet - Query result transformations" height="420"/>
 
-Click the `create` button to create the query. Saved queries can be run using the `run` icon near the query name. Queries run using the run button wil behave just as if it was triggered by an app event like button click and thus will alter the state of the app. You can view the query results using the state inspector on the left side-bar of the app builder. 
+Click the `create` button to create the query. Saved queries can be run using the `run` icon near the query name. Queries run using the run button wil behave just as if it was triggered by an app event like button click and thus will alter the state of the app. You can view the query results using the state inspector on the left side-bar of the app builder.
 
 <img class="screenshot-full" src="/img/tutorial/transformations/result.gif" alt="ToolJet - Query result transformations" height="420"/>
 


### PR DESCRIPTION
Small typo in the "transformations" heading in the docs. Also ran prettier in the entire file.

Hope you don't mind pull requests :) 