### PR TITLE
BugFix: Postgres queries return every field as string

### DIFF
--- a/app/services/postgresql_query_service.rb
+++ b/app/services/postgresql_query_service.rb
@@ -86,6 +86,8 @@ class PostgresqlQueryService
       host: source_options['host'],
       port: source_options['port']
     )
+
+    connection.type_map_for_results = PG::BasicTypeMapForResults.new connection
     
     cache_connection(data_source, connection)
 


### PR DESCRIPTION
Fixes #193 

Bug: Data type of every field in Postgres query result is string 

Solution: https://www.rubydoc.info/gems/pg/PG/BasicTypeMapForResults