### PR TITLE
#150 Add copy to clipboard to actions

### DIFF
--- a/frontend/src/Editor/ActionTypes.js
+++ b/frontend/src/Editor/ActionTypes.js
@@ -26,5 +26,12 @@ export const ActionTypes = [
     options: [
       { name: 'modal', type: 'text', default: '' }
     ]
+  },
+  {
+    name: 'Copy to clipboard',
+    id: 'copy-to-clipboard',
+    options: [
+      { name: 'copy-to-clipboard', type: 'text', default: '' }
+    ]
   }
 ];

--- a/frontend/src/Editor/Inspector/EventSelector.jsx
+++ b/frontend/src/Editor/Inspector/EventSelector.jsx
@@ -48,23 +48,6 @@ export const EventSelector = ({
     return modalOptions;
   }
 
-  function getTextInputOptions() {
-    let textInputOptions = [];
-    Object.keys(components || {}).forEach((key) => {
-      if (
-      components[key].component.component === 'TextInput' || 
-      components[key].component.component === 'TextArea'
-      ) {
-        textInputOptions.push({
-          name: components[key].component.name,
-          value: key
-        })
-      }
-    })
-    
-    return textInputOptions;
-  }
-
   function eventChanged(param, value, extraData) { 
     if(value === 'none') { 
       eventUpdated(param, null, null);

--- a/frontend/src/Editor/Inspector/EventSelector.jsx
+++ b/frontend/src/Editor/Inspector/EventSelector.jsx
@@ -150,15 +150,9 @@ export const EventSelector = ({
               {definition.actionId === 'copy-to-clipboard' && (
                 <div className="p-1">
                   <label className="form-label mt-1">Text input</label>
-                  <SelectSearch
-                    options={getTextInputOptions()}
-                    value={definition.options.model}
-                    search={true}
-                    onChange={(value) => {
-                      eventOptionUpdated(param, 'textFieldId', value, extraData);
-                    }}
-                    filterOptions={fuzzySearch}
-                    placeholder="Select.."
+                  <CodeHinter
+                    currentState={currentState}
+                    onChange={(value) => eventOptionUpdated(param, 'contentToCopy', value, extraData)}
                   />
                 </div>
               )}

--- a/frontend/src/Editor/Inspector/EventSelector.jsx
+++ b/frontend/src/Editor/Inspector/EventSelector.jsx
@@ -48,6 +48,23 @@ export const EventSelector = ({
     return modalOptions;
   }
 
+  function getTextInputOptions() {
+    let textInputOptions = [];
+    Object.keys(components || {}).forEach((key) => {
+      if (
+      components[key].component.component === 'TextInput' || 
+      components[key].component.component === 'TextArea'
+      ) {
+        textInputOptions.push({
+          name: components[key].component.name,
+          value: key
+        })
+      }
+    })
+    
+    return textInputOptions;
+  }
+
   function eventChanged(param, value, extraData) { 
     if(value === 'none') { 
       eventUpdated(param, null, null);
@@ -123,6 +140,22 @@ export const EventSelector = ({
                     search={true}
                     onChange={(value) => {
                       eventOptionUpdated(param, 'modal', value, extraData);
+                    }}
+                    filterOptions={fuzzySearch}
+                    placeholder="Select.."
+                  />
+                </div>
+              )}
+
+              {definition.actionId === 'copy-to-clipboard' && (
+                <div className="p-1">
+                  <label className="form-label mt-1">Text input</label>
+                  <SelectSearch
+                    options={getTextInputOptions()}
+                    value={definition.options.model}
+                    search={true}
+                    onChange={(value) => {
+                      eventOptionUpdated(param, 'textFieldId', value, extraData);
                     }}
                     filterOptions={fuzzySearch}
                     placeholder="Select.."

--- a/frontend/src/Editor/Inspector/EventSelector.jsx
+++ b/frontend/src/Editor/Inspector/EventSelector.jsx
@@ -132,7 +132,7 @@ export const EventSelector = ({
 
               {definition.actionId === 'copy-to-clipboard' && (
                 <div className="p-1">
-                  <label className="form-label mt-1">Text input</label>
+                  <label className="form-label mt-1">Text</label>
                   <CodeHinter
                     currentState={currentState}
                     onChange={(value) => eventOptionUpdated(param, 'contentToCopy', value, extraData)}

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -122,10 +122,8 @@ function executeAction(_ref, event) {
     }
 
     if (event.actionId === 'copy-to-clipboard') {
-      const textFieldId = event.options.textFieldId;
-      const textFieldName = _ref.state.appDefinition.components[textFieldId].component.name;
-      const textFieldValue = _ref.state.currentState.components[textFieldName].value;
-      copyToClipboard(textFieldValue);
+      const contentToCopy = resolveReferences(event.options.contentToCopy, _ref.state.currentState);
+      copyToClipboard(contentToCopy);
     }
   }
 }

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -76,6 +76,14 @@ export function onQueryCancel(_ref) {
   });
 }
 
+async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    console.log('Failed to copy!', err);
+  }
+};
+
 function executeAction(_ref, event) {
   if (event) {
     if (event.actionId === 'show-alert') {
@@ -110,6 +118,14 @@ function executeAction(_ref, event) {
       }
 
       _ref.setState(newState)
+    }
+
+    if (event.actionId === 'copy-to-clipboard') {
+      const textFieldId = event.options.textFieldId;
+      const textFieldName = _ref.state.appDefinition.components[textFieldId].component.name;
+      const textFieldValue = _ref.state.currentState.components[textFieldName].value;
+      copyToClipboard(textFieldValue);
+      toast.success('Copied to clipboard!', { hideProgressBar: true, autoClose: 3000 });
     }
   }
 }

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -79,6 +79,7 @@ export function onQueryCancel(_ref) {
 async function copyToClipboard(text) {
   try {
     await navigator.clipboard.writeText(text);
+    toast.success('Copied to clipboard!', { hideProgressBar: true, autoClose: 3000 });
   } catch (err) {
     console.log('Failed to copy!', err);
   }
@@ -125,7 +126,6 @@ function executeAction(_ref, event) {
       const textFieldName = _ref.state.appDefinition.components[textFieldId].component.name;
       const textFieldValue = _ref.state.currentState.components[textFieldName].value;
       copyToClipboard(textFieldValue);
-      toast.success('Copied to clipboard!', { hideProgressBar: true, autoClose: 3000 });
     }
   }
 }


### PR DESCRIPTION
### Changes

- Add 'Copy to clipboard' to ActionTypes
- Populate TextInput and TextArea fields in dropdown when `onClick` 'Copy to clipboard' is selected
- Show success toast on successful copy