### PR TITLE
Adding annotate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'annotate'
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     aws-eventstream (1.1.1)
     aws-partitions (1.455.0)
@@ -1368,6 +1371,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   aws-sdk (~> 3)
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: apps
+#
+#  id                 :uuid             not null, primary key
+#  definition         :json
+#  is_public          :boolean          default(FALSE)
+#  name               :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  current_version_id :uuid
+#  organization_id    :uuid             not null
+#  user_id            :uuid
+#
+# Indexes
+#
+#  index_apps_on_current_version_id  (current_version_id)
+#  index_apps_on_organization_id     (organization_id)
+#  index_apps_on_user_id             (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (current_version_id => app_versions.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class App < ApplicationRecord
   belongs_to :organization
   has_many :data_queries

--- a/app/models/app_user.rb
+++ b/app/models/app_user.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: app_users
+#
+#  id         :uuid             not null, primary key
+#  role       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  app_id     :uuid             not null
+#  user_id    :uuid             not null
+#
+# Indexes
+#
+#  index_app_users_on_app_id   (app_id)
+#  index_app_users_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class AppUser < ApplicationRecord
   belongs_to :app
   belongs_to :user

--- a/app/models/app_version.rb
+++ b/app/models/app_version.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: app_versions
+#
+#  id         :uuid             not null, primary key
+#  definition :json
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  app_id     :uuid             not null
+#
+# Indexes
+#
+#  index_app_versions_on_app_id  (app_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#
 class AppVersion < ApplicationRecord
   belongs_to :app
 end

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: credentials
+#
+#  id               :uuid             not null, primary key
+#  encrypted_value  :text
+#  value_ciphertext :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 class Credential < ApplicationRecord
   encrypts :value
 end

--- a/app/models/data_query.rb
+++ b/app/models/data_query.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: data_queries
+#
+#  id             :uuid             not null, primary key
+#  kind           :string
+#  name           :string
+#  options        :json
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  app_id         :uuid             not null
+#  data_source_id :uuid
+#
+# Indexes
+#
+#  index_data_queries_on_app_id          (app_id)
+#  index_data_queries_on_data_source_id  (data_source_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#  fk_rails_...  (data_source_id => data_sources.id)
+#
 class DataQuery < ApplicationRecord
   belongs_to :app
   belongs_to :data_source, optional: true

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: data_sources
+#
+#  id         :uuid             not null, primary key
+#  kind       :string
+#  name       :string
+#  options    :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  app_id     :uuid             not null
+#
+# Indexes
+#
+#  index_data_sources_on_app_id  (app_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#
 class DataSource < ApplicationRecord
   belongs_to :app
   has_many :data_queries

--- a/app/models/data_source_user_oauth2.rb
+++ b/app/models/data_source_user_oauth2.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: data_source_user_oauth2s
+#
+#  id                 :uuid             not null, primary key
+#  encrypted_options  :text
+#  options_ciphertext :text
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  data_source_id     :uuid             not null
+#  user_id            :uuid             not null
+#
+# Indexes
+#
+#  index_data_source_user_oauth2s_on_data_source_id  (data_source_id)
+#  index_data_source_user_oauth2s_on_user_id         (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (data_source_id => data_sources.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class DataSourceUserOauth2 < ApplicationRecord
   belongs_to :user
   belongs_to :data_source

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: folders
+#
+#  id              :uuid             not null, primary key
+#  name            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_folders_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
 class Folder < ApplicationRecord
   belongs_to :organization
   has_many :folder_apps

--- a/app/models/folder_app.rb
+++ b/app/models/folder_app.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: folder_apps
+#
+#  id         :uuid             not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  app_id     :uuid             not null
+#  folder_id  :uuid             not null
+#
+# Indexes
+#
+#  index_folder_apps_on_app_id     (app_id)
+#  index_folder_apps_on_folder_id  (folder_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#  fk_rails_...  (folder_id => folders.id)
+#
 class FolderApp < ApplicationRecord
   belongs_to :folder
   belongs_to :app

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -1,2 +1,11 @@
+# == Schema Information
+#
+# Table name: metadata
+#
+#  id         :uuid             not null, primary key
+#  data       :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Metadatum < ApplicationRecord
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organizations
+#
+#  id         :uuid             not null, primary key
+#  domain     :string
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Organization < ApplicationRecord
   has_many :users
   has_many :apps

--- a/app/models/organization_user.rb
+++ b/app/models/organization_user.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: organization_users
+#
+#  id              :uuid             not null, primary key
+#  role            :string
+#  status          :string           default("invited")
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+# Indexes
+#
+#  index_organization_users_on_organization_id  (organization_id)
+#  index_organization_users_on_user_id          (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class OrganizationUser < ApplicationRecord
   belongs_to :organization
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id               :uuid             not null, primary key
+#  email            :string
+#  first_name       :string
+#  image            :text
+#  invitation_token :string
+#  last_name        :string
+#  password_digest  :string
+#  role             :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  organization_id  :uuid
+#
+# Indexes
+#
+#  index_users_on_organization_id  (organization_id)
+#
 class User < ApplicationRecord
   has_secure_password
   has_many :organization_users

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/test/models/app_user_test.rb
+++ b/test/models/app_user_test.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: app_users
+#
+#  id         :uuid             not null, primary key
+#  role       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  app_id     :uuid             not null
+#  user_id    :uuid             not null
+#
+# Indexes
+#
+#  index_app_users_on_app_id   (app_id)
+#  index_app_users_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require 'test_helper'
 
 class AppUserTest < ActiveSupport::TestCase

--- a/test/models/app_version_test.rb
+++ b/test/models/app_version_test.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: app_versions
+#
+#  id         :uuid             not null, primary key
+#  definition :json
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  app_id     :uuid             not null
+#
+# Indexes
+#
+#  index_app_versions_on_app_id  (app_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#
 require 'test_helper'
 
 class AppVersionTest < ActiveSupport::TestCase

--- a/test/models/credential_test.rb
+++ b/test/models/credential_test.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: credentials
+#
+#  id               :uuid             not null, primary key
+#  encrypted_value  :text
+#  value_ciphertext :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 require 'test_helper'
 
 class CredentialTest < ActiveSupport::TestCase

--- a/test/models/data_query_test.rb
+++ b/test/models/data_query_test.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: data_queries
+#
+#  id             :uuid             not null, primary key
+#  kind           :string
+#  name           :string
+#  options        :json
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  app_id         :uuid             not null
+#  data_source_id :uuid
+#
+# Indexes
+#
+#  index_data_queries_on_app_id          (app_id)
+#  index_data_queries_on_data_source_id  (data_source_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#  fk_rails_...  (data_source_id => data_sources.id)
+#
 require 'test_helper'
 
 class DataQueryTest < ActiveSupport::TestCase

--- a/test/models/data_source_test.rb
+++ b/test/models/data_source_test.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: data_sources
+#
+#  id         :uuid             not null, primary key
+#  kind       :string
+#  name       :string
+#  options    :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  app_id     :uuid             not null
+#
+# Indexes
+#
+#  index_data_sources_on_app_id  (app_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#
 require 'test_helper'
 
 class DataSourceTest < ActiveSupport::TestCase

--- a/test/models/data_source_user_oauth2_test.rb
+++ b/test/models/data_source_user_oauth2_test.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: data_source_user_oauth2s
+#
+#  id                 :uuid             not null, primary key
+#  encrypted_options  :text
+#  options_ciphertext :text
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  data_source_id     :uuid             not null
+#  user_id            :uuid             not null
+#
+# Indexes
+#
+#  index_data_source_user_oauth2s_on_data_source_id  (data_source_id)
+#  index_data_source_user_oauth2s_on_user_id         (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (data_source_id => data_sources.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require 'test_helper'
 
 class DataSourceUserOauth2Test < ActiveSupport::TestCase

--- a/test/models/folder_app_test.rb
+++ b/test/models/folder_app_test.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: folder_apps
+#
+#  id         :uuid             not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  app_id     :uuid             not null
+#  folder_id  :uuid             not null
+#
+# Indexes
+#
+#  index_folder_apps_on_app_id     (app_id)
+#  index_folder_apps_on_folder_id  (folder_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (app_id => apps.id)
+#  fk_rails_...  (folder_id => folders.id)
+#
 require "test_helper"
 
 class FolderAppTest < ActiveSupport::TestCase

--- a/test/models/folder_test.rb
+++ b/test/models/folder_test.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: folders
+#
+#  id              :uuid             not null, primary key
+#  name            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_folders_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
 require "test_helper"
 
 class FolderTest < ActiveSupport::TestCase

--- a/test/models/metadatum_test.rb
+++ b/test/models/metadatum_test.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: metadata
+#
+#  id         :uuid             not null, primary key
+#  data       :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require "test_helper"
 
 class MetadatumTest < ActiveSupport::TestCase

--- a/test/models/organization_user_test.rb
+++ b/test/models/organization_user_test.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: organization_users
+#
+#  id              :uuid             not null, primary key
+#  role            :string
+#  status          :string           default("invited")
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#  user_id         :uuid             not null
+#
+# Indexes
+#
+#  index_organization_users_on_organization_id  (organization_id)
+#  index_organization_users_on_user_id          (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require 'test_helper'
 
 class OrganizationUserTest < ActiveSupport::TestCase


### PR DESCRIPTION
I personally really enjoy having the `annotate` gem putting the details of the schema on the models.
I find it useful for grepping column names but also verifying if appropriate indexes exist.

That being said I don't feel too strongly about it so feel free close this PR if you don't want this. Annotate can be annoying when it starts trailing migrations.