### PR TITLE
support heroku  standard  installation

### DIFF
--- a/app.json
+++ b/app.json
@@ -36,8 +36,7 @@
   },
   "formation": {
     "web": {
-      "quantity": 1,
-      "size": "FREE"
+      "quantity": 1
     }
   },
   "image": "heroku/ruby",


### PR DESCRIPTION
close https://github.com/ToolJet/ToolJet/issues/228 


To test, try deploying this to heroku with the following Link
https://dashboard.heroku.com/new?template=https%3A%2F%2Fgithub.com%2Fsoorajshankar%2Ftooljet%2Ftree%2Fheroku-remove-FREE-tier-enforcement-to-support-enterprise-installs