### PR TITLE
Dont port forward host's 5432 to the pg containers 5432 port

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,8 +52,6 @@ services:
   postgres:
     image: postgres:12
     restart: always
-    ports:
-      - '5432:5432'
     volumes:
       - postgres:/data/postgres
     environment:


### PR DESCRIPTION
Currently, we are port forwarding the host's 5432 to the pg container's 5432. This seems unnecessary and would break for people running pg locally or running some other service on the 5432 port.

This PR fixes this issue #240 