### PR TITLE
Add Bundle installation in the environment setup

### DIFF
--- a/docs/docs/contributing-guide/setup/Mac OS.md
+++ b/docs/docs/contributing-guide/setup/Mac OS.md
@@ -27,6 +27,10 @@ Follow these steps to setup and run ToolJet on Mac OS. Open terminal and run the
     $ rvm install ruby-2.7.3
     $ rvm use 2.7.3
     ```
+    ### Install [Bundler](https://bundler.io/)
+    ```bash
+    gem install bundler:2.1.4
+    ```
 
     ### Install Node.js
     ```bash


### PR DESCRIPTION
Developers need to install Bundler to use `bundle` command