### PR TITLE
Input for alert action now parses dynamic variables

### DIFF
--- a/frontend/src/Editor/Inspector/EventSelector.jsx
+++ b/frontend/src/Editor/Inspector/EventSelector.jsx
@@ -93,13 +93,11 @@ export const EventSelector = ({
               {definition.actionId === 'show-alert' && (
                 <div className="p-1">
                   <label className="form-label mt-1">Message</label>
-                  <input
-                    onBlur={(e) => eventOptionUpdated(param, 'message', e.target.value, extraData)}
-                    value={message}
-                    type="text"
-                    className="form-control form-control-sm"
-                    placeholder="Text goes here"
+                  <CodeHinter
+                    currentState={currentState}
+                    onChange={(value) => eventOptionUpdated(param, 'message', value, extraData)}
                   />
+                  
                 </div>
               )}
 

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -88,7 +88,8 @@ async function copyToClipboard(text) {
 function executeAction(_ref, event) {
   if (event) {
     if (event.actionId === 'show-alert') {
-      toast(event.options.message, { hideProgressBar: true });
+      const message = resolveReferences(event.options.message, _ref.state.currentState);
+      toast(message, { hideProgressBar: true });
     }
 
     if (event.actionId === 'open-webpage') {


### PR DESCRIPTION
Fixes  - #253 

Ability to use dynamic variables to set the text of alert action.

Loom - https://www.loom.com/share/49725c7b565c4f1f81cf2ba4eb4db967