### PR TITLE
Reset selected component state to `null` when component is deleted

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -207,7 +207,8 @@ class Editor extends React.Component {
 
   switchSidebarTab = (tabIndex) => {
     this.setState({
-      currentSidebarTab: tabIndex
+      currentSidebarTab: tabIndex,
+      selectedComponent: null
     });
   };
 

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -207,8 +207,7 @@ class Editor extends React.Component {
 
   switchSidebarTab = (tabIndex) => {
     this.setState({
-      currentSidebarTab: tabIndex,
-      selectedComponent: null
+      currentSidebarTab: tabIndex
     });
   };
 
@@ -231,6 +230,16 @@ class Editor extends React.Component {
     this.computeComponentState(newDefinition.components);
   };
 
+  handleInspectorView = (component) => {
+    if (this.state.selectedComponent.hasOwnProperty('component')) {
+      const { id: selectedComponentId } = this.state.selectedComponent;
+      if (selectedComponentId === component.id) {
+        this.setState({selectedComponent: null})
+        this.switchSidebarTab(2);
+      }
+    }
+  }
+
   removeComponent = (component) => {
     let newDefinition = this.state.appDefinition;
 
@@ -242,7 +251,7 @@ class Editor extends React.Component {
 
     delete newDefinition.components[component.id];
     this.appDefinitionChanged(newDefinition);
-    this.switchSidebarTab(2);
+    this.handleInspectorView(component);
   };
 
   componentDefinitionChanged = (newDefinition) => {


### PR DESCRIPTION
### Changes 

Had to reset the `selectedComponent` state to `null` after the `selectedComponent` was deleted.

Loom - https://www.loom.com/share/58cbbc60b3b34be5914a737117fd2af7