### PR TITLE
Add a minimal delay to promise

### DIFF
--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -197,7 +197,7 @@ class HomePage extends React.Component {
                             }
                             </>)
                           }
-                          {currentFolder.count == 0  && (
+                          {(!isLoading && currentFolder.count === 0)  && (
                             <div>
                               <img className = "mx-auto d-block" src ="assets/images/icons/empty-folder-svgrepo-com.svg" height="120px"/>
                               <span className= "d-block text-center text-body">This folder is empty</span>

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -7,6 +7,7 @@ import { AppMenu } from './AppMenu';
 import { BlankPage } from './BlankPage';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import { renderTooltip } from '@/_helpers/appUtils';
+import { waitAtLeast } from '../_helpers/appUtils';
 
 class HomePage extends React.Component {
   constructor(props) {
@@ -37,11 +38,13 @@ class HomePage extends React.Component {
       isLoading: true
     })
 
-    appService.getAll(page, folder).then((data) => this.setState({
-      apps: data.apps,
-      meta: data.meta,
-      isLoading: false
-    }));
+    const promise = appService.getAll(page, folder)
+    waitAtLeast(400, promise)
+      .then(data => this.setState({
+        apps: data.apps,
+        meta: data.meta,
+        isLoading: false
+      }));
   }
 
   fetchFolders = () => {

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -369,3 +369,11 @@ export function renderTooltip({props, text}) {
     {text}
   </Tooltip>
 };
+
+export function waitAtLeast(time, promise) {
+  const promiseTimeout = new Promise((resolve) => {
+    setTimeout(resolve, time);
+  });
+  const promiseCombined = Promise.all([promise, promiseTimeout]);
+  return promiseCombined.then((values) => values[0]);
+};


### PR DESCRIPTION
### Fixes - [Screen flickers when we switch to another folder](https://github.com/ToolJet/ToolJet/issues/199)

### Cause 

Loading happens too fast and the skeleton gets replaced immediately with content.

### Changes

Added a function that 
1. Creates a new `Promise` that resolves after 400ms
2. Waits for both the timer Promise and network request `Promise` to resolve
3. Returns the value

This handles following scenarios -
1. The network returns the data in less than a 400ms. The combined promise will resolve when the timer fires after 400ms. As both promises need to be complete, the function will return after 400ms.
2. The network request takes exactly or more than 400ms. The combined promise will resolve when the network request returns. As the timer has already expired while waiting, the response is available immediately.

### Loom 

https://www.loom.com/share/b325a9242a144f83b404a18638adfb2b


