### PR TITLE
add aws ec2 deployment documentation

### DIFF
--- a/docs/docs/deployment/ec2.md
+++ b/docs/docs/deployment/ec2.md
@@ -16,36 +16,49 @@ Follow the steps below to deploy ToolJet on AWS EC2 machines
 
 3. Under the Images section, click on the `AMIs` button.
 
-4. Now, from the AMI search page, select the search type as "Public Images" and input `AMI Name : tooljet_latest_ubuntu_bionic` in the search bar.
+4. Now, from the AMI search page, select the search type as "Public Images" and input `AMI Name : tooljet_latest_ubuntu_bionic` in the    search bar.
 
-5. Select the ToolJet app's AMI and bootup an EC2 machine. (Make sure that you have ssh access to this machine while allowing traffic on port 443 and 80 from the internet)
+5. Select the ToolJet app's AMI and bootup an EC2 machine.
 
-6. Once the machine boots up, ssh into the machine by running `ssh -i <path_to_pem_file> ubuntu@<your_machines_public_ip>`
+  Create or use security groups which at the very least, allow the following inbound rules:
 
-7. cd into the `app` by running `cd ~/app` from the shell. Now, modify the `.env` file in the directory by running `vim .env`.
+   protocol| port     | allowed_cidr|
+   ----| -----------  | ----------- |
+   tcp | 22           | yourIP/32  |
+   tcp | 80           | 0.0.0.0/0   |
+   tcp | 443          | 0.0.0.0/0   |
 
-```
-TOOLJET_HOST=http://<example>
-LOCKBOX_MASTER_KEY=<example>
-SECRET_KEY_BASE=<example>
-PG_DB=tooljet_prod
-PG_USER=<pg user name>
-PG_HOST=<pg host>
-PG_PASS=<pg user password>
-```
-( Read [environment variables reference](/docs/deployment/env-vars)  )
 
-8. The value in `TOOLJET_HOST` can either be the public ipv4 address of your machine or a custom domain that you own.
+6. Once the machine boots up, ssh into the machine by running `ssh -i <path_to_pem_file> ubuntu@<public_ip_of_the_machine>`
 
-Example:
-`TOOLJET_HOST=http://12.34.56.78` or
-`TOOLJET_HOST=https://yourdomain.com`
+7. cd into the `app` directory by running `cd ~/app`. Now, modify the `.env` file in the directory by running `vim .env`.
 
-We use a lets encrypt plugin on top of nginx to create TLS certificates on the fly.
-:::info
-Please make sure that `TOOLJET_HOST` starts with either `http://` or `https://`
-:::
+   The provided `.env` file looks like this:
+   ```
+   TOOLJET_HOST=http://<example>
+   LOCKBOX_MASTER_KEY=<example>
+   SECRET_KEY_BASE=<example>
+   PG_DB=tooljet_prod
+   PG_USER=<pg user name>
+   PG_HOST=<pg host>
+   PG_PASS=<pg user password>
+   ```
+   ( Read [environment variables reference](/docs/deployment/env-vars)  )
 
-9. Finally, run `./setup_app.rb` to setup the app and start all the required services.
+8. The value in `TOOLJET_HOST` determines where you can access the ToolJet client. It can either be the public ipv4 address of your machine or a custom domain that you want to use.
 
-10. You're all done, ToolJet would now be served at `TOOLJET_HOST`.
+   Example:
+
+   `TOOLJET_HOST=http://12.34.56.78` or
+   `TOOLJET_HOST=https://yourdomain.com`
+
+   We use a lets encrypt plugin on top of nginx to create TLS certificates on the fly.
+   :::info
+   Please make sure that `TOOLJET_HOST` starts with either `http://` or `https://`
+   :::
+
+9. Once you've configured all the variables in `.env`, run `./setup_app.rb` to setup the app and start all the required services.
+
+10. If you've set a custom domain for `TOOLJET_HOST`, please make a new A record entry in your dns settings to point to the public ip address of the ec2 machine.
+
+12. You're all done, ToolJet client would now be served at the value you've set in `TOOLJET_HOST`.

--- a/docs/docs/deployment/ec2.md
+++ b/docs/docs/deployment/ec2.md
@@ -10,15 +10,15 @@ You should setup a PostgreSQL database manually to be used by the ToolJet server
 
 Follow the steps below to deploy ToolJet on AWS EC2 instances.
 
-1. Setup a PostgreSQL database.(Please make sure that the EC2 instance which runs the ToolJet application is able to connect to the database.)
+1. Setup a PostgreSQL database and make sure that the database is accessible from the EC2 instance.
 
 2. Login to your AWS management console and go to the EC2 management page.
 
-3. Under the Images section, click on the `AMIs` button.
+3. Under the `Images` section, click on the `AMIs` button.
 
 4. Now, from the AMI search page, select the search type as "Public Images" and input `AMI Name : tooljet_latest_ubuntu_bionic` in the    search bar.
 
-5. Select the ToolJet app's AMI and bootup an EC2 instance.
+5. Select ToolJet's AMI and bootup an EC2 instance.
 
   Creating a new security group is recommended. For example, if the installation should receive traffic from the internet, the inbound rules of the security group should look like this:
 

--- a/docs/docs/deployment/ec2.md
+++ b/docs/docs/deployment/ec2.md
@@ -8,9 +8,9 @@ sidebar_position: 4
 You should setup a PostgreSQL database manually to be used by the ToolJet server.
 :::
 
-Follow the steps below to deploy ToolJet on AWS EC2 machines
+Follow the steps below to deploy ToolJet on AWS EC2 instances.
 
-1. Setup a PostgreSQL database.(Please make sure that the EC2 machine which runs the ToolJet application is able to connect to the database.)
+1. Setup a PostgreSQL database.(Please make sure that the EC2 instance which runs the ToolJet application is able to connect to the database.)
 
 2. Login to your AWS management console and go to the EC2 management page.
 
@@ -18,7 +18,7 @@ Follow the steps below to deploy ToolJet on AWS EC2 machines
 
 4. Now, from the AMI search page, select the search type as "Public Images" and input `AMI Name : tooljet_latest_ubuntu_bionic` in the    search bar.
 
-5. Select the ToolJet app's AMI and bootup an EC2 machine.
+5. Select the ToolJet app's AMI and bootup an EC2 instance.
 
   Creating a new security group is recommended. For example, if the installation should receive traffic from the internet, the inbound rules of the security group should look like this:
 
@@ -29,7 +29,7 @@ Follow the steps below to deploy ToolJet on AWS EC2 machines
    tcp | 443          | 0.0.0.0/0   |
 
 
-6. Once the machine boots up, SSH into the machine by running `ssh -i <path_to_pem_file> ubuntu@<public_ip_of_the_machine>`
+6. Once the instance boots up, SSH into the instance by running `ssh -i <path_to_pem_file> ubuntu@<public_ip_of_the_instance>`
 
 7. Switch to the app directory by running `cd ~/app`. Modify the contents of the `.env` file. ( Eg: `vim .env` )
 
@@ -45,7 +45,7 @@ Follow the steps below to deploy ToolJet on AWS EC2 machines
    ```
    Read [environment variables reference](/docs/deployment/env-vars)
 
-8. `TOOLJET_HOST` environment variable determines where you can access the ToolJet client. It can either be the public ipv4 address of your machine or a custom domain that you want to use.
+8. `TOOLJET_HOST` environment variable determines where you can access the ToolJet client. It can either be the public ipv4 address of your instance or a custom domain that you want to use.
 
    Examples:   
    `TOOLJET_HOST=http://12.34.56.78` or   
@@ -62,6 +62,6 @@ Follow the steps below to deploy ToolJet on AWS EC2 machines
 
 9. Once you've configured the `.env` file, run `./setup_app.rb`. This script will install all the dependencies of ToolJet and then will start the required services.
 
-10. If you've set a custom domain for `TOOLJET_HOST`, please make a new A record entry in your dns settings to point to the IP address of the ec2 machine.
+10. If you've set a custom domain for `TOOLJET_HOST`, add a `A record` entry in your DNS settings to point to the IP address of the EC2 instance.
 
 12. You're all done, ToolJet client would now be served at the value you've set in `TOOLJET_HOST`.

--- a/docs/docs/deployment/ec2.md
+++ b/docs/docs/deployment/ec2.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 4
+---
+
+# AWS EC2
+
+:::info
+You should setup a PostgreSQL database manually to be used by the ToolJet server.
+:::
+
+Follow the steps below to deploy ToolJet on AWS EC2 machines
+
+1. Setup a PostgreSQL database.(Please make sure that the EC2 machine which runs the ToolJet application is able to connect to the database.)
+
+2. Login to your aws management console and go to the EC2 management page.
+
+3. Under the Images section, click on the `AMIs` button.
+
+4. Now, from the AMI search page, select the search type as "Public Images" and input `AMI Name : tooljet_latest_ubuntu_bionic` in the search bar.
+
+5. Select the ToolJet app's AMI and bootup an EC2 machine. (Make sure that you have ssh access to this machine while allowing traffic on port 443 and 80 from the internet)
+
+6. Once the machine boots up, ssh into the machine by running `ssh -i <path_to_pem_file> ubuntu@<your_machines_public_ip>`
+
+7. cd into the `app` by running `cd ~/app` from the shell. Now, modify the `.env` file in the directory by running `vim .env`.
+
+```
+TOOLJET_HOST=http://<example>
+LOCKBOX_MASTER_KEY=<example>
+SECRET_KEY_BASE=<example>
+PG_DB=tooljet_prod
+PG_USER=<pg user name>
+PG_HOST=<pg host>
+PG_PASS=<pg user password>
+```
+( Read [environment variables reference](/docs/deployment/env-vars)  )
+
+8. The value in `TOOLJET_HOST` can either be the public ipv4 address of your machine or a custom domain that you own.
+
+Example:
+`TOOLJET_HOST=http://12.34.56.78` or
+`TOOLJET_HOST=https://yourdomain.com`
+
+We use a lets encrypt plugin on top of nginx to create TLS certificates on the fly.
+:::info
+Please make sure that `TOOLJET_HOST` starts with either `http://` or `https://`
+:::
+
+9. Finally, run `./setup_app.rb` to setup the app and start all the required services.
+
+10. You're all done, ToolJet would now be served at `TOOLJET_HOST`.

--- a/docs/docs/deployment/ec2.md
+++ b/docs/docs/deployment/ec2.md
@@ -53,7 +53,7 @@ Follow the steps below to deploy ToolJet on AWS EC2 instances.
    `TOOLJET_HOST=https://tooljet.yourdomain.com`
 
    :::info
-   We use a lets encrypt plugin on top of nginx to create TLS certificates on the fly.
+   We use a [lets encrypt](https://letsencrypt.org/) plugin on top of nginx to create TLS certificates on the fly.
    :::
 
    :::info

--- a/docs/docs/deployment/ec2.md
+++ b/docs/docs/deployment/ec2.md
@@ -12,7 +12,7 @@ Follow the steps below to deploy ToolJet on AWS EC2 machines
 
 1. Setup a PostgreSQL database.(Please make sure that the EC2 machine which runs the ToolJet application is able to connect to the database.)
 
-2. Login to your aws management console and go to the EC2 management page.
+2. Login to your AWS management console and go to the EC2 management page.
 
 3. Under the Images section, click on the `AMIs` button.
 
@@ -20,20 +20,20 @@ Follow the steps below to deploy ToolJet on AWS EC2 machines
 
 5. Select the ToolJet app's AMI and bootup an EC2 machine.
 
-  Create or use security groups which at the very least, allow the following inbound rules:
+  Creating a new security group is recommended. For example, if the installation should receive traffic from the internet, the inbound rules of the security group should look like this:
 
    protocol| port     | allowed_cidr|
    ----| -----------  | ----------- |
-   tcp | 22           | yourIP/32  |
-   tcp | 80           | 0.0.0.0/0   |
+   tcp | 22           | your IP |
+   tcp | 80           | 0.0.0.0/0 |
    tcp | 443          | 0.0.0.0/0   |
 
 
-6. Once the machine boots up, ssh into the machine by running `ssh -i <path_to_pem_file> ubuntu@<public_ip_of_the_machine>`
+6. Once the machine boots up, SSH into the machine by running `ssh -i <path_to_pem_file> ubuntu@<public_ip_of_the_machine>`
 
-7. cd into the `app` directory by running `cd ~/app`. Now, modify the `.env` file in the directory by running `vim .env`.
+7. Switch to the app directory by running `cd ~/app`. Modify the contents of the `.env` file. ( Eg: `vim .env` )
 
-   The provided `.env` file looks like this:
+   The default `.env` file looks like this:
    ```
    TOOLJET_HOST=http://<example>
    LOCKBOX_MASTER_KEY=<example>
@@ -43,22 +43,25 @@ Follow the steps below to deploy ToolJet on AWS EC2 machines
    PG_HOST=<pg host>
    PG_PASS=<pg user password>
    ```
-   ( Read [environment variables reference](/docs/deployment/env-vars)  )
+   Read [environment variables reference](/docs/deployment/env-vars)
 
-8. The value in `TOOLJET_HOST` determines where you can access the ToolJet client. It can either be the public ipv4 address of your machine or a custom domain that you want to use.
+8. `TOOLJET_HOST` environment variable determines where you can access the ToolJet client. It can either be the public ipv4 address of your machine or a custom domain that you want to use.
 
-   Example:
+   Examples:   
+   `TOOLJET_HOST=http://12.34.56.78` or   
+   `TOOLJET_HOST=https://yourdomain.com` or   
+   `TOOLJET_HOST=https://tooljet.yourdomain.com`
 
-   `TOOLJET_HOST=http://12.34.56.78` or
-   `TOOLJET_HOST=https://yourdomain.com`
-
+   :::info
    We use a lets encrypt plugin on top of nginx to create TLS certificates on the fly.
+   :::
+
    :::info
    Please make sure that `TOOLJET_HOST` starts with either `http://` or `https://`
    :::
 
-9. Once you've configured all the variables in `.env`, run `./setup_app.rb` to setup the app and start all the required services.
+9. Once you've configured the `.env` file, run `./setup_app.rb`. This script will install all the dependencies of ToolJet and then will start the required services.
 
-10. If you've set a custom domain for `TOOLJET_HOST`, please make a new A record entry in your dns settings to point to the public ip address of the ec2 machine.
+10. If you've set a custom domain for `TOOLJET_HOST`, please make a new A record entry in your dns settings to point to the IP address of the ec2 machine.
 
 12. You're all done, ToolJet client would now be served at the value you've set in `TOOLJET_HOST`.


### PR DESCRIPTION
Adds documentation for deploying ToolJet on aws EC2 using ami's.