### PR TITLE
Add rewrite rules to netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,10 @@
 
 [template.environment]
   NODE_ENV = "production"  
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+  force = false
+  query = {path = ":path"}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,5 @@
 
 [[redirects]]
   from = "/*"
-  to = "/index.html"
+  to = "/"
   status = 200
-  force = false
-  query = {path = ":path"}


### PR DESCRIPTION
Bug: ToolJet client deployed on Netlify will throw 404 on refresh.