### PR TITLE
Show tooltip containing widget description when hovering over a widget

### DIFF
--- a/frontend/src/Editor/Box.jsx
+++ b/frontend/src/Editor/Box.jsx
@@ -15,8 +15,8 @@ import { Multiselect } from './Components/Multiselect';
 import { Modal } from './Components/Modal';
 import { Chart } from './Components/Chart';
 import { Map } from './Components/Map';
-import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
 import { renderTooltip } from '../_helpers/appUtils';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 
 const AllComponents = {
   Button,

--- a/frontend/src/Editor/Box.jsx
+++ b/frontend/src/Editor/Box.jsx
@@ -15,6 +15,8 @@ import { Multiselect } from './Components/Multiselect';
 import { Modal } from './Components/Modal';
 import { Chart } from './Components/Chart';
 import { Map } from './Components/Map';
+import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
+import { renderTooltip } from '../_helpers/appUtils';
 
 const AllComponents = {
   Button,
@@ -68,6 +70,10 @@ export const Box = function Box({
   const ComponentToRender = AllComponents[component.component];
 
   return (
+    <OverlayTrigger
+      placement="top"
+      overlay={(props) => renderTooltip({props, text: `${component.description}`})}
+    >
     <div style={{ ...styles, backgroundColor }} role={preview ? 'BoxPreview' : 'Box'}>
       {inCanvas ? (
         <ComponentToRender
@@ -106,5 +112,6 @@ export const Box = function Box({
         </div>
       )}
     </div>
+    </OverlayTrigger>
   );
 };


### PR DESCRIPTION
### Changes

- Wrapped JSX for the widget component inside `<OverlayTrigger />` component to show tooltip when user hovers over a widget.

### Screenshot

<img width="1792" alt="Screenshot 2021-06-25 at 6 31 43 PM" src="https://user-images.githubusercontent.com/4965435/123429775-f71c0300-d5e4-11eb-9de0-7e3db0282bdf.png">
