### PR TITLE
Feature: previews for CodeHinter fields

### DIFF
--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -10,9 +10,20 @@ import 'codemirror/addon/hint/show-hint.css';
 import 'codemirror/theme/base16-light.css';
 import 'codemirror/theme/duotone-light.css';
 import { getSuggestionKeys, onBeforeChange, handleChange } from './utils';
+import { resolveReferences } from '@/_helpers/utils';
 
 export function CodeHinter({
-  initialValue, onChange, currentState, mode, theme, lineNumbers, className, placeholder, ignoreBraces
+  initialValue, 
+  onChange, 
+  currentState, 
+  mode, 
+  theme, 
+  lineNumbers, 
+  className, 
+  placeholder, 
+  ignoreBraces, 
+  enablePreview, 
+  height
 }) {
   const options = {
     lineNumbers: lineNumbers,
@@ -26,6 +37,7 @@ export function CodeHinter({
   };
 
   const [realState, setRealState] = useState(currentState);
+  const [currentValue, setCurrentValue] = useState(initialValue);
 
   useEffect(() => {
     setRealState(currentState);
@@ -35,20 +47,31 @@ export function CodeHinter({
     return getSuggestionKeys(realState);
   }, [realState.components, realState.queries]);
 
+  function valueChanged(editor, onChange, suggestions, ignoreBraces) {
+    handleChange(editor, onChange, suggestions, ignoreBraces);
+    setCurrentValue(editor.getValue());
+  }
+
   return (
     <div className={`code-hinter ${className || 'codehinter-default-input'}`} key={suggestions.length}>
       <CodeMirror
         value={initialValue}
         realState={realState}
         scrollbarStyle={null}
+        height={height || '100%'}
         onBlur={(editor) => { 
           const value = editor.getValue();
           onChange(value);
         }}
-        onChange={(editor) => handleChange(editor, onChange, suggestions, ignoreBraces)}
+        onChange={(editor) => valueChanged(editor, onChange, suggestions, ignoreBraces)}
         onBeforeChange={(editor, change) => onBeforeChange(editor, change, ignoreBraces)}
         options={options}
       />
+      {enablePreview && 
+        <div className="dynamic-variable-preview bg-azure-lt px-2 py-1">
+          {resolveReferences(currentValue, realState)}
+        </div>
+      }
     </div>
   );
 }

--- a/frontend/src/Editor/QueryManager/QueryEditors/Postgresql.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Postgresql.jsx
@@ -52,6 +52,8 @@ class Postgresql extends React.Component {
                   theme="duotone-light"
                   lineNumbers={true}
                   className="query-hinter"
+                  enablePreview
+                  height="120px"
                   onChange={(value) => changeOption(this, 'query', value)}
                 />
               </div>

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1637,6 +1637,7 @@ input:focus-visible {
 
 .dynamic-variable-preview { 
   height: 30px;
+  margin-top: -2px;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
 }

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1634,3 +1634,9 @@ input:focus-visible {
     z-index: 3;
   }
 }
+
+.dynamic-variable-preview { 
+  height: 30px;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+}


### PR DESCRIPTION
Fixes #333 

![image](https://user-images.githubusercontent.com/7828962/123515897-04092700-d6b7-11eb-9b4f-cdfb33045d5f.png)

The feature can be enabled using the `enablePreview` property of the CodeHinter component.

eg: 

```
<CodeHinter
    currentState={this.props.currentState}
    initialValue={options.query}
    mode="sql"
    theme="duotone-light"
    lineNumbers={true}
    className="query-hinter"
    enablePreview
    height="120px"
    onChange={(value) => changeOption(this, 'query', value)}
  />
```