### PR TITLE
Fix response of google sheets append queries

### DIFF
--- a/app/services/googlesheets_query_service.rb
+++ b/app/services/googlesheets_query_service.rb
@@ -41,6 +41,7 @@ class GooglesheetsQueryService
       end
 
       error = result.code != 200
+      data = result
     end
 
     if operation === 'read'


### PR DESCRIPTION
Bug: Appending rows to Google sheets doesn't return the response as data.