### PR TITLE
Dark mode for preview rjv

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -375,6 +375,7 @@ class QueryManager extends React.Component {
                             style={{ fontSize: '0.7rem' }}
                             enableClipboard={false}
                             src={queryPreviewData}
+                            theme={this.props.darkMode ? 'shapeshifter' : 'rjv-default'}
                             displayDataTypes={true}
                             collapsed={false}
                             displayObjectSize={true}


### PR DESCRIPTION
Bug: Query previews are not readable in dark mode.
Solution: Use the `shapeshifter` theme of rjv in dark mode