### PR TITLE
Fix input consistency in posgres GUI

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/Postgresql.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Postgresql.jsx
@@ -60,7 +60,7 @@ class Postgresql extends React.Component {
             )}
             {options.mode === 'gui' && (
               <div>
-                <div className="row">
+                <div className="row">  
                   <div className="col">
                     <label className="form-label">Table</label>
                     <CodeHinter
@@ -71,16 +71,18 @@ class Postgresql extends React.Component {
                   </div>
                   <div className="col">
                     <label className="form-label">Operation</label>
-                    <SelectSearch
-                      options={[{ name: 'Bulk update using primary key', value: 'bulk_update_pkey' }]}
-                      value={options.operation}
-                      search={true}
-                      onChange={(value) => {
-                        changeOption(this, 'operation', value);
-                      }}
-                      filterOptions={fuzzySearch}
-                      placeholder="Select.."
-                    />
+                    <div className="gui-select-wrappper">
+                      <SelectSearch
+                        options={[{ name: 'Bulk update using primary key', value: 'bulk_update_pkey' }]}
+                        value={options.operation}
+                        search={true}
+                        onChange={(value) => {
+                          changeOption(this, 'operation', value);
+                        }}
+                        filterOptions={fuzzySearch}
+                        placeholder="Select.."
+                      />
+                    </div>
                   </div>
                 </div>
 

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -568,7 +568,6 @@ body {
 .select-search__input {
   display: block;
   width: 100%;
-  height: 30px;
   padding: 0.4375rem 0.75rem;
   font-size: 0.875rem;
   font-weight: 400;
@@ -1968,3 +1967,8 @@ input:focus-visible {
 .modal-backdrop.show {
   opacity: 0.74;
 }
+
+.gui-select-wrappper .select-search__input {
+  height: 30px;
+}
+

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -568,6 +568,7 @@ body {
 .select-search__input {
   display: block;
   width: 100%;
+  height: 30px;
   padding: 0.4375rem 0.75rem;
   font-size: 0.875rem;
   font-weight: 400;


### PR DESCRIPTION
### Issue - [Style inconsistency in input fields of postgres GUI mode #332](https://github.com/ToolJet/ToolJet/issues/332)

### Changes - 

Set height to dropdown to make it equal to other fields.

### Screenshot - 

<img width="1071" alt="Screenshot 2021-07-07 at 9 37 41 AM" src="https://user-images.githubusercontent.com/9956022/124698981-90adb380-df07-11eb-9d9b-d7468c0e7a7b.png">
