### PR TITLE
Fixes app editor view authorization

### DIFF
--- a/app/commands/authorize_api_request.rb
+++ b/app/commands/authorize_api_request.rb
@@ -19,8 +19,8 @@ class AuthorizeApiRequest
     @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
     @user || errors.add(:token, "Invalid token") && nil
 
-    org_user = OrganizationUser.where(user: @user, organization: @user.organization)&.first
-    @user = nil unless org_user.active?
+    org_user = OrganizationUser.where(user: @user, organization: @user&.organization)&.first
+    @user = nil unless org_user&.active?
 
     @user || errors.add(:token, "Archived user") && nil
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,12 +11,15 @@ class ApplicationController < ActionController::API
     @current_user ||= AuthorizeApiRequest.call(request.headers).result
   end
 
-
-  def authenticate_request
-    render json: { error: 'Not Authorized' }, status: :unauthorized if current_user.blank?
+  def render_not_authenticated
+    render json: { error: 'Not Authorized' }, status: :unauthorized
   end
 
   private
+
+  def authenticate_request
+    render_not_authenticated if current_user.blank?
+  end
 
   def render_user_not_authorized
     render json: { error: 'Access denied' }, status: :forbidden

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AppsController < ApplicationController
-  skip_before_action :authenticate_request, only: %i[show slug]
+  skip_before_action :authenticate_request, only: %i[slugs]
 
   def index
     authorize App
@@ -42,7 +42,6 @@ class AppsController < ApplicationController
   def show
     @app = App.find(params[:id])
 
-    authenticate_request
     authorize @app
   end
 
@@ -55,11 +54,9 @@ class AppsController < ApplicationController
   def slugs
     @app = App.find_by(slug: params[:slug])
 
-    unless @app.is_public
-      authenticate_request
-      authorize @app, :show_public?
-    end
+    return render_not_authenticated if !@app.is_public && current_user.blank?
 
+    authorize @app, :show_public?
     render :show
   end
 

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -57,7 +57,7 @@ class AppsController < ApplicationController
 
     unless @app.is_public
       authenticate_request
-      authorize @app, :show?
+      authorize @app, :show_public?
     end
 
     render :show

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -42,11 +42,8 @@ class AppsController < ApplicationController
   def show
     @app = App.find(params[:id])
 
-    # Logic to bypass auth for public apps
-    unless @app.is_public
-      authenticate_request
-      authorize @app
-    end
+    authenticate_request
+    authorize @app
   end
 
   def destroy

--- a/app/controllers/data_queries_controller.rb
+++ b/app/controllers/data_queries_controller.rb
@@ -4,7 +4,10 @@ class DataQueriesController < ApplicationController
   skip_before_action :authenticate_request, only: [:run]
 
   def index
-    @data_queries = DataQuery.where(app_id: params[:app_id])
+    app = App.find(params[:app_id])
+    authorize app, :show_public?
+
+    @data_queries = app.data_queries
   end
 
   def create

--- a/app/policies/app_policy.rb
+++ b/app/policies/app_policy.rb
@@ -23,4 +23,10 @@ class AppPolicy < ApplicationPolicy
   def show?
     (user.organization_id === app.organization_id) && (user.org_admin? || user.org_developer? || user.org_viewer?)
   end
+
+  def show_public?
+    return true if app.is_public?
+
+    show?
+  end
 end


### PR DESCRIPTION
This change includes fixes for:
- App editor viewable by non-org users if the app is made public by directly hitting the editor view URL
- Public apps not viewable unless a signed-in user is present.
