### PR TITLE
add the global "connections" variable back to the initializer

### DIFF
--- a/config/initializers/connections.rb
+++ b/config/initializers/connections.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
+# For backward compatibilty with existing query services.
+# Will be removed once all the query services start using the new
+# connection pooling library.
+$connections = {}
 # A thread safe map data structure.
 $connection_pools = Concurrent::Map.new


### PR DESCRIPTION
Add the global variable "connections" back to the initializer as all the existing query services use it.