### PR TITLE
Add class navbar-brand-autodark

### DIFF
--- a/frontend/src/LoginPage/LoginPage.jsx
+++ b/frontend/src/LoginPage/LoginPage.jsx
@@ -48,7 +48,7 @@ class LoginPage extends React.Component {
       <div className="page page-center">
         <div className="container-tight py-2">
           <div className="text-center mb-4">
-            <a href=".">
+            <a href="." className="navbar-brand-autodark">
               <img src="/assets/images/logo-text.svg" height="30" alt="" />
             </a>
           </div>


### PR DESCRIPTION
ToolJet logo was not visible on dark mode, Below is the screenshot after fixing it.

<img width="697" alt="Screenshot 2021-07-19 at 8 33 42 AM" src="https://user-images.githubusercontent.com/9956022/126096861-42042a3d-d84c-40e9-a85e-c7e0a0abd126.png">
