### PR TITLE
Cypress Tests for Empty dashboard state

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,11 @@
   "baseUrl": "http://localhost:8082",
   "env": {
     "apiUrl": "http://localhost:3000"
-  }
+  },
+  "testFiles": [
+    "auth.spec.js",
+    "empty-state-dashboard.spec.js",
+    "dashboard.spec.js"
+    ]
+    
 }

--- a/cypress/integration/dashboard.spec.js
+++ b/cypress/integration/dashboard.spec.js
@@ -5,15 +5,27 @@ describe('Dashboard', () => {
 
   beforeEach(() => {
     cy.login(email, password);
+    cy.wait(1000)
+    cy.get('body').then(($title=>
+        {
+          //check you are not running tests on empty dashboard state
+          if($title.text().includes('You haven\'t created any apps yet.'))
+          {
+            cy.get('a.btn').eq(0).should('have.text','Create your first app')
+            .click()
+            cy.go('back')
+          }
+        }))
+    
   })
 
-  it('site header is visible with nav items', () => {
+  it('should show site header with nav items', () => {
     cy.get('.navbar')
       .find('.navbar-nav')
       .should('be.visible');
   });
 
-  it('Users tab should navigate to Users page', () => {
+  it('should navigate to users page using users tab', () => {
     cy.get('.navbar')
       .find('.navbar-nav')
       .find('li').not('.active')
@@ -23,7 +35,7 @@ describe('Dashboard', () => {
     cy.get('[data-testid="usersTable"]').should('be.visible');
   })
 
-  it('Apps tab should navigate to Apps page', () => {
+  it('should navigate to apps page using apps tab', () => {
     cy.get('.navbar')
       .find('.navbar-nav')
       .find('li.active')
@@ -33,18 +45,18 @@ describe('Dashboard', () => {
     cy.get('[data-testid="appsTable"]').should('be.visible');
   })
 
-  it('should show User avatar and logout the user when user clicks logout', () => {
+  it('should show user avatar and logout the user when user clicks logout', () => {
     cy.get('[data-testid="userAvatarHeader"]').should('be.visible');
     // TODO - Add functionality to detect when user hovers over the avatar,
     // Issues with hover functionality and hide/show of dom elements
   })
   
-  it('Application folders list is visible', () => {
+  it('should show list of application folders', () => {
     cy.get('[data-testid="applicationFoldersList"]')
       .should('be.visible');
   });
 
-  it('Count bubble for "All applications should equal number of rows in table', () => {
+  it('should show correct number of applications in the count bubble of "All Applications" list', () => {
     cy.get('[data-testid="allApplicationsCount"]').then(($countBubble) => {
       cy.get('[data-testid="appsTable"]')
         .wait(500)

--- a/cypress/integration/empty-state-dashboard.spec.js
+++ b/cypress/integration/empty-state-dashboard.spec.js
@@ -1,0 +1,43 @@
+describe('Empty state of dashboard', () => {
+
+    const email = 'dev@tooljet.io';
+    const password = 'password';
+  
+      beforeEach(() => {
+        cy.login(email, password);
+      })
+      
+  
+      it('should show empty screen when there are no apps', () => {
+  
+          cy.wait(1000)
+          cy.get('body').then(($title=>
+          {
+            //if user has not created any app yet
+            if($title.text().includes('You haven\'t created any apps yet.'))
+            {
+              //image for empty state should be visible  
+              cy.get('.empty-img').should('be.visible')
+  
+              //empty title should be visible
+              cy.log('Testing empty state dashboard view.')
+              cy.get('.empty-title').should('be.visible')
+              .and('have.text','You haven\'t created any apps yet.')
+              
+              //Read Documentation button should be present and working
+              cy.get('a.btn').eq(1).should('have.attr','href','https://docs.tooljet.io')
+              .and('have.text','Read documentation')
+              
+              //test Create your first app button should be visible and working
+              cy.get('a.btn').eq(0).should('be.visible')
+              .and('have.text','Create your first app')
+              .click()
+              cy.get('title').should('have.text','ToolJet - Dashboard')
+            }
+            else
+            {
+              cy.log("User has already created few apps hence this test will be skipped.")
+            }
+          })) 
+        })
+  })


### PR DESCRIPTION
Issue - #398 
1. Modified all 'dashboard.spec.js' test descriptions.
2. Added condition in 'dashboard.spec.js' to run test only when there is an existing app. If not, then create an app first to proceed.
3. Updated 'cypress.json' with test tag to define a sequence.
4. Added test file 'empty-state-dashboard.spec.js' to test dashboard state when no app exists. 