### PR TITLE
Run migrations on heroku deployments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: npm run start:prod --prefix server
+release: npm run db:migrate --prefix server

--- a/server/ormconfig.ts
+++ b/server/ormconfig.ts
@@ -53,7 +53,8 @@ function determineFilePathForEnv(env: string | undefined): string {
 function throwErrorIfFileNotPresent(filePath: string, env: string): void {
   if (!fs.existsSync(filePath)) {
     console.log(
-      `Unable to fetch database config from env file for environment: ${env}\n `
+      `Unable to fetch database config from env file for environment: ${env}\n` +
+        'Picking up config from the environment',
     );
   }
 }

--- a/server/scripts/database-config-utils.ts
+++ b/server/scripts/database-config-utils.ts
@@ -1,0 +1,31 @@
+import * as Joi from 'joi';
+
+function buildDatabaseConfig(): any {
+  return {
+    PG_HOST: process.env.PG_HOST,
+    PG_PORT: process.env.PG_PORT,
+    PG_PASS: process.env.PG_PASS,
+    PG_USER: process.env.PG_USER,
+    PG_DB: process.env.PG_DB,
+  };
+}
+
+function validateDatabaseConfig(dbOptions: any): Joi.ValidationResult {
+  const envVarsSchema = Joi.object()
+    .keys({
+      PG_HOST: Joi.string().default('localhost'),
+      PG_PORT: Joi.number().positive().default(5432),
+      PG_PASS: Joi.string().default(''),
+      PG_USER: Joi.string().required(),
+      PG_DB: Joi.string().default('tooljet_db'),
+    })
+    .unknown();
+
+  return envVarsSchema.validate(dbOptions);
+}
+
+export function buildAndValidateDatabaseConfig(): Joi.ValidationResult {
+  const dbOptions: any = buildDatabaseConfig();
+
+  return validateDatabaseConfig(dbOptions);
+}

--- a/server/scripts/drop-database.ts
+++ b/server/scripts/drop-database.ts
@@ -2,21 +2,7 @@ import * as path from 'path';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import { exec } from 'child_process';
-import * as Joi from 'joi';
-
-function validateDatabaseConfig(): Joi.ValidationResult {
-  const envVarsSchema = Joi.object()
-    .keys({
-      PG_HOST: Joi.string().required(),
-      PG_PORT: Joi.number().positive().default(5432),
-      PG_PASS: Joi.string().default(''),
-      PG_USER: Joi.string().required(),
-      PG_DB: Joi.string().required(),
-    })
-    .unknown();
-
-  return envVarsSchema.validate(process.env);
-}
+import { buildAndValidateDatabaseConfig } from './database-config-utils';
 
 function dropDatabaseFromFile(envPath: string): void {
   const result = dotenv.config({ path: envPath });
@@ -29,7 +15,7 @@ function dropDatabaseFromFile(envPath: string): void {
 }
 
 function dropDatabase(): void {
-  const { value: envVars, error } = validateDatabaseConfig();
+  const { value: envVars, error } = buildAndValidateDatabaseConfig();
 
   if (error) {
     throw new Error(`Config validation error: ${error.message}`);
@@ -73,7 +59,7 @@ if (fs.existsSync(nodeEnvPath)) {
 } else {
   console.log(
     `${nodeEnvPath} file not found to drop database\n` +
-    'Inferring config from the environment',
+      'Picking up config from the environment',
   );
   dropDatabase();
 }


### PR DESCRIPTION
Heroku provisions database when using postgres addon. We can skip creating db and then just execute the migrations.