### PR TITLE
402 - Widget should be marked as not selected when the inspector is c…

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -221,6 +221,10 @@ class Editor extends React.Component {
   };
 
   switchSidebarTab = (tabIndex) => {
+    if (tabIndex == 2)
+    {
+      this.setState({ selectedComponent: null });
+    }
     this.setState({
       currentSidebarTab: tabIndex
     });


### PR DESCRIPTION
Set selectedComponent to null. Have done it at the Editor level.

Given that Inspector is a functional component, I tried to use Hook https://reactjs.org/docs/hooks-state.html to no avail.

Fixes #402 