### PR TITLE
Use 'npm start' to launch front-end server(#461)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     environment:
       - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
       - NODE_ENV=development
-    command: ['npm', 'run', '--prefix', 'server', 'start:prod']
+    command: ['npm', 'start']
 
   server:
     # env_file: .env


### PR DESCRIPTION
This commit changes the command used to launch front-end server

from: npm run --prefix server start:prod

to: npm start

Fixes #461 