### PR TITLE
[ADD] enable pgcrypto extension

### DIFF
--- a/server/migrations/1625814801415-MaybeCreateExtension.ts
+++ b/server/migrations/1625814801415-MaybeCreateExtension.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class  MaybeCreateExtension1625814801415 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pgcrypto;')
+   
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+  }
+
+}

--- a/server/migrations/1625814801415-MaybeCreateExtension.ts
+++ b/server/migrations/1625814801415-MaybeCreateExtension.ts
@@ -3,9 +3,7 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 export class  MaybeCreateExtension1625814801415 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    
-    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pgcrypto;')
-   
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pgcrypto;')   
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/server/migrations/1625814801416-CreateOrganizations.ts
+++ b/server/migrations/1625814801416-CreateOrganizations.ts
@@ -3,6 +3,9 @@ import { MigrationInterface, QueryRunner, Table, TableIndex } from "typeorm";
 export class CreateOrganizations1625814801416 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pgcrypto;')
+
     await queryRunner.createTable(new Table({
       name: "organizations",
       columns: [

--- a/server/migrations/1625814801416-CreateOrganizations.ts
+++ b/server/migrations/1625814801416-CreateOrganizations.ts
@@ -3,8 +3,6 @@ import { MigrationInterface, QueryRunner, Table, TableIndex } from "typeorm";
 export class CreateOrganizations1625814801416 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    
-
     await queryRunner.createTable(new Table({
       name: "organizations",
       columns: [

--- a/server/migrations/1625814801416-CreateOrganizations.ts
+++ b/server/migrations/1625814801416-CreateOrganizations.ts
@@ -4,7 +4,6 @@ export class CreateOrganizations1625814801416 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     
-    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pgcrypto;')
 
     await queryRunner.createTable(new Table({
       name: "organizations",


### PR DESCRIPTION
This fix handles the gen_random_uuid() when developers run the migration first time. otherwise, Postgres might throw an error saying that `QueryFailedError: function gen_random_uuid() does not exist`

![Screenshot 2021-08-13 at 4 58 52 PM](https://user-images.githubusercontent.com/10022243/129350857-c1219d66-e394-44da-829d-fc06651eabda.png)
