### PR TITLE
Fixed hide tooltip once left sidebar icon is clicked bug

### DIFF
--- a/frontend/src/Editor/LeftSidebar/sidebar-item.js
+++ b/frontend/src/Editor/LeftSidebar/sidebar-item.js
@@ -7,8 +7,8 @@ export const LeftSidebarItem = ({ tip = '', className, icon, text, onClick, ...r
   return (
     <OverlayTrigger
       trigger={['click','hover', 'focus']}
-      placement="bottom"
-      delay={{ show: 250, hide: 400 }}
+      placement="right"
+      delay={{ show: 800, hide: 100 }}
       overlay={<Tooltip id="button-tooltip">
         {tip}
       </Tooltip>}

--- a/frontend/src/Editor/LeftSidebar/sidebar-item.js
+++ b/frontend/src/Editor/LeftSidebar/sidebar-item.js
@@ -3,8 +3,10 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 
 export const LeftSidebarItem = ({ tip = '', className, icon, text, onClick, ...rest }) => {
+
   return (
     <OverlayTrigger
+      trigger={['click','hover', 'focus']}
       placement="bottom"
       delay={{ show: 250, hide: 400 }}
       overlay={<Tooltip id="button-tooltip">
@@ -13,7 +15,7 @@ export const LeftSidebarItem = ({ tip = '', className, icon, text, onClick, ...r
     >
       <div {...rest} className={className} onClick={onClick && onClick}>
       {icon && <img className="svg-icon" src={`/assets/images/icons/editor/left-sidebar/${icon}.svg`} width="20" height="20" />}
-      {text && text} 
+      {text && text}
     </div>
     </OverlayTrigger>
   )


### PR DESCRIPTION
Fixes #525 

- Fixed the bug, now the tooltip is hidden when a user clicks on the icon 
https://www.loom.com/share/0a8676276a1c4892945ebf69d40cf218