### PR TITLE
fix: dark mode toggle on app viewer

### DIFF
--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -138,7 +138,7 @@ class Viewer extends React.Component {
                   </a>
                 </h1>
                 {this.state.app && <span>{this.state.app.name}</span>}
-                <div className="navbar-nav flex-row order-md-last">
+                <div className="d-flex align-items-center m-1 p-1">
                   <DarkModeToggle
                     switchDarkMode={this.props.switchDarkMode}
                     darkMode={this.props.darkMode}


### PR DESCRIPTION
This PR fixes the alignment of dark mode on the app viewer screen

Before: 

![image](https://user-images.githubusercontent.com/12490590/130217204-34c4ec28-2726-4ce8-bcb6-e11e652bf631.png)

After: 

![image](https://user-images.githubusercontent.com/12490590/130217337-6a643ad2-b612-4004-99fc-715e111b85f5.png)

