### PR TITLE
Add query params option to Go-to-app action

### DIFF
--- a/frontend/src/Editor/ActionTypes.js
+++ b/frontend/src/Editor/ActionTypes.js
@@ -24,7 +24,8 @@ export const ActionTypes = [
     name: 'Go to app',
     id: 'go-to-app',
     options: [
-      { name: 'app', type: 'url', default: 'https://app.tooljet.io/applications/app-id' }
+      { name: 'app', type: 'url', default: 'https://app.tooljet.io/applications/app-id' },
+      { name: 'queryParams', type: 'code', default: '{}' }
     ]
   },
   {

--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -230,6 +230,7 @@ class Table extends React.Component {
             eventOptionUpdated={this.actionButtonEventOptionUpdated}
             currentState={this.state.currentState}
             extraData={{ actionButton: action, index: index }} // This data is returned in the callbacks
+            apps={this.props.apps}
           />
           <button className="btn btn-sm btn-outline-danger col" onClick={() => this.removeAction(index)}>
             Remove

--- a/frontend/src/Editor/Inspector/EventSelector.jsx
+++ b/frontend/src/Editor/Inspector/EventSelector.jsx
@@ -45,12 +45,13 @@ export const EventSelector = ({
         })
       }
     })
-    
+
     return modalOptions;
   }
 
   function getAllApps() {
     let appsOptionsList = [];
+
     apps.map((item) => {
       appsOptionsList.push({
         name: item.name,
@@ -136,6 +137,15 @@ export const EventSelector = ({
                     }}
                     filterOptions={fuzzySearch}
                     placeholder="Select.."
+                  />
+                  <label className="form-label mt-1">Query params</label>
+
+                  <CodeHinter
+                    currentState={currentState}
+                    initialValue={definition.options.queryParams}
+                    onChange={(value) => eventOptionUpdated(param, 'queryParams', value, extraData)}
+                    mode='javascript'
+                    singleLine={false}
                   />
                 </div>
               )}

--- a/frontend/src/Editor/Inspector/Inspector.jsx
+++ b/frontend/src/Editor/Inspector/Inspector.jsx
@@ -21,7 +21,7 @@ export const Inspector = ({
   darkMode,
   switchSidebarTab
 }) => {
-  
+
   const selectedComponent = { id: selectedComponentId, component: allComponents[selectedComponentId].component, layouts: allComponents[selectedComponentId].layouts}
   const [component, setComponent] = useState(selectedComponent);
 
@@ -191,6 +191,7 @@ export const Inspector = ({
           components={components}
           currentState={currentState}
           darkMode={darkMode}
+          apps={apps}
         />
       }
 

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import Tooltip from 'react-bootstrap/Tooltip';
 import { history } from '@/_helpers';
+import { serializeNestedObjectToQueryParams } from './utils';
 
 export function setStateAsync(_ref, state) {
   return new Promise((resolve) => {
@@ -100,8 +101,16 @@ function executeAction(_ref, event, mode) {
 
     if (event.actionId === 'go-to-app') {
       const slug = resolveReferences(event.options.slug, _ref.state.currentState);
+      const queryParams = resolveReferences(event.options.queryParams, _ref.state.currentState);
 
-      const url = `/applications/${slug}`;
+      let url =`/applications/${slug}`;
+
+      if (queryParams) {
+        const queryPart = serializeNestedObjectToQueryParams(queryParams)
+
+        if (queryPart.length > 0)
+          url = url + `?${queryPart}`
+      }
 
       if(mode === 'view') {
         _ref.props.history.push(url);

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -132,3 +132,18 @@ export function validateQueryName(name){
 
 
 export const convertToKebabCase = string => string.replace(/([a-z])([A-Z])/g, '$1-$2').replace(/\s+/g, '-').toLowerCase()
+
+export const serializeNestedObjectToQueryParams = function(obj, prefix) {
+  var str = [],
+    p;
+  for (p in obj) {
+    if (obj.hasOwnProperty(p)) {
+      var k = prefix ? prefix + "[" + p + "]" : p,
+        v = obj[p];
+      str.push((v !== null && typeof v === "object") ?
+        serialize(v, k) :
+        encodeURIComponent(k) + "=" + encodeURIComponent(v));
+    }
+  }
+  return str.join("&");
+}

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1328,6 +1328,7 @@ body {
     font-family: 'Roboto', sans-serif;
     font-size: 0.9rem;
     padding: 0px;
+    z-index: 10000;
 
     li.CodeMirror-hint-active {
         background: #3c92dc;


### PR DESCRIPTION
Adds support for setting query params for the
go-to-app action. When the new app is launched, the passed in
object will be sent as search query params.

https://www.loom.com/share/e0dcac7bcad044a68fa34d8e77717db6