### PR TITLE
Fix issue where the client crashes when goto app action is selected

### DIFF
--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -230,6 +230,7 @@ class Table extends React.Component {
             eventOptionUpdated={this.actionButtonEventOptionUpdated}
             currentState={this.state.currentState}
             extraData={{ actionButton: action, index: index }} // This data is returned in the callbacks
+            apps={this.props.apps}
           />
           <button className="btn btn-sm btn-outline-danger col" onClick={() => this.removeAction(index)}>
             Remove

--- a/frontend/src/Editor/Inspector/EventSelector.jsx
+++ b/frontend/src/Editor/Inspector/EventSelector.jsx
@@ -51,7 +51,7 @@ export const EventSelector = ({
 
   function getAllApps() {
     let appsOptionsList = [];
-    apps.map((item) => {
+    apps.filter(item => item.slug != undefined).map((item) => {
       appsOptionsList.push({
         name: item.name,
         value: item.slug

--- a/frontend/src/Editor/Inspector/Inspector.jsx
+++ b/frontend/src/Editor/Inspector/Inspector.jsx
@@ -191,6 +191,7 @@ export const Inspector = ({
           components={components}
           currentState={currentState}
           darkMode={darkMode}
+          apps={apps}
         />
       }
 

--- a/frontend/src/_services/app.service.js
+++ b/frontend/src/_services/app.service.js
@@ -16,7 +16,10 @@ export const appService = {
 
 function getAll(page, folder) {
   const requestOptions = { method: 'GET', headers: authHeader() };
-  return fetch(`${config.apiUrl}/apps?page=${page}&folder=${folder || ''}`, requestOptions).then(handleResponse);
+  if (page === 0)
+    return fetch(`${config.apiUrl}/apps`, requestOptions).then(handleResponse);
+  else
+    return fetch(`${config.apiUrl}/apps?page=${page}&folder=${folder || ''}`, requestOptions).then(handleResponse);
 }
 
 function createApp() {


### PR DESCRIPTION
This commit supplies the missing prop 'apps' to Table component
and EventSelector component so that they can properly display the
apps.

This commit also modifies the get-all-apps query logic such that
if the queried page is 0, it fetches all the apps.

It adds a filtering logic such that presently only the apps with
slugs are listed as targets for goto app action.