### PR TITLE
Recompute table columns whenever action button position is changed

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -487,7 +487,8 @@ export function Table({
   const columns = useMemo(
     () => [...leftActionsCellData, ...columnData, ...rightActionsCellData],
     [JSON.stringify(columnData), 
-      leftActionsCellData.length + rightActionsCellData.length,
+      leftActionsCellData.length,
+      rightActionsCellData.length,
       componentState.changeSet,
       JSON.stringify(component.definition.properties.columns)
     ] // Hack: need to fix


### PR DESCRIPTION
This PR fixes the bug that required us to save and reload for the editor to display changes made to table action button position

https://www.loom.com/share/968fa27e22f54c1f81101b21827b7faa