### PR TITLE
This PR ensures sizes of table action columns are persisted

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -438,7 +438,7 @@ export function Table({
         id: 'leftActions',
         Header: 'Actions',
         accessor: 'edit',
-        width: columnSizes.actions || defaultColumn.width,
+        width: columnSizes.leftActions || defaultColumn.width,
         Cell: (cell) => {
           return leftActions().map((action) => (
                 <button
@@ -464,7 +464,7 @@ export function Table({
         id: 'rightActions',
         Header: 'Actions',
         accessor: 'edit',
-        width: columnSizes.actions || defaultColumn.width,
+        width: columnSizes.rightActions || defaultColumn.width,
         Cell: (cell) => {
           return rightActions().map((action) => (
                 <button


### PR DESCRIPTION
I couldn't get loom to work at this moment. This PR resolves the bug which caused the column of left action buttons of table to not be resizeable, they just keep resetting back to a massive size.