### PR TITLE
Add source map for debugging

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx']
   },
+  devtool: 'inline-source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
When webpack bundles your source code, it can become difficult to track down errors and warnings to their original location. For example, if you bundle three source files (a.js, b.js, and c.js) into one bundle (bundle.js) and one of the source files contains an error, the stack trace will point to bundle.js. This isn't always helpful as you probably want to know exactly which source file the error came from.

In order to make it easier to track down errors and warnings, JavaScript offers source maps, which map your compiled code back to your original source code. If an error originates from b.js, the source map will tell you exactly that.

more info: https://webpack.js.org/guides/development/#using-source-maps