### PR TITLE
fix: use state instead of props in util file

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/utils.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/utils.js
@@ -3,7 +3,7 @@ export function changeOption(_ref, option, value) {
   _ref.setState(
     {
       options: {
-        ..._ref.props.options,
+        ..._ref.state.options,
         [option]: value
       }
     },


### PR DESCRIPTION
Earlier, due to spread of old props, new changes in the state variable were not getting captured, this PR fixes that 

Testing notes: 

Used in query editors, checked for 9/14 datasources