### PR TITLE
Fix invalid links from docs

### DIFF
--- a/docs/docs/contributing-guide/setup/Mac OS.md
+++ b/docs/docs/contributing-guide/setup/Mac OS.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 ---
 
 # Mac OS
-Follow these steps to setup and run ToolJet on Mac OS for development purposes. Open terminal and run the commands below. We recommend reading our guide on [architecture](http://localhost:3001/docs/deployment/architecture) of ToolJet before proceeding.
+Follow these steps to setup and run ToolJet on Mac OS for development purposes. Open terminal and run the commands below. We recommend reading our guide on [architecture](/docs/deployment/architecture) of ToolJet before proceeding.
 
 1. ## Setting up the environment
     ### Install Homebrew

--- a/docs/docs/deployment/heroku.md
+++ b/docs/docs/deployment/heroku.md
@@ -22,5 +22,5 @@ The one click deployment will create a free dyno and a free postgresql database.
 :::
 
 :::tip
-ToolJet server and client can be deployed as standalone applications. If you do not want to deploy the client on Heroku, modify `package.json` accordingly. We have a [guide](http://localhost:3001/docs/deployment/client) on deploying ToolJet client using services such as Firebase.
+ToolJet server and client can be deployed as standalone applications. If you do not want to deploy the client on Heroku, modify `package.json` accordingly. We have a [guide](/docs/deployment/client) on deploying ToolJet client using services such as Firebase.
 :::


### PR DESCRIPTION
- Fix link from `Mac OS` setup guide
- Fix link from `Heroku` deployment