### PR TITLE
move babel-plugin-import to dependancies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "babel-plugin-import": "^1.13.3",
     "@babel/core": "^7.4.3",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/preset-env": "^7.4.3",
@@ -69,7 +70,6 @@
     "@cypress/webpack-dev-server": "^1.3.1",
     "@cypress/webpack-preprocessor": "^5.9.0",
     "@svgr/webpack": "^5.5.0",
-    "babel-plugin-import": "^1.13.3",
     "cypress": "^7.4.0",
     "path": "^0.12.7",
     "webpack": "^4.29.6",


### PR DESCRIPTION
move babel-plugin-import to dependancies from devDeps as heroku build is failing