### PR TITLE
Add devTool only in development for webpack

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -14,12 +14,14 @@ const ASSET_PATH = {
   development: '/public/',
 };
 
+console.log('environment', environment);
+
 module.exports = {
   mode: 'development',
   resolve: {
     extensions: ['.js', '.jsx'],
   },
-  devtool: 'inline-source-map',
+  ...(environment === 'development' && { devtool: 'inline-source-map' }),
   module: {
     rules: [
       {
@@ -62,19 +64,15 @@ module.exports = {
           extensions: ['.js', '.jsx'],
         },
         use: {
-          loader: "babel-loader",
+          loader: 'babel-loader',
           options: {
             plugins: [
-              [
-                'import',
-                { libraryName: 'lodash', libraryDirectory: "", camel2DashComponentName: false},
-                'lodash',
-              ],
+              ['import', { libraryName: 'lodash', libraryDirectory: '', camel2DashComponentName: false }, 'lodash'],
             ],
           },
-        }
-      }
-    ]
+        },
+      },
+    ],
   },
   resolve: {
     extensions: ['.js', '.jsx', '.png'],
@@ -100,7 +98,7 @@ module.exports = {
     config: JSON.stringify({
       apiUrl: `${API_URL[environment] || ''}/api`,
       assetPath: ASSET_PATH[environment],
-      SERVER_IP: process.env.SERVER_IP
-    })
-  }
+      SERVER_IP: process.env.SERVER_IP,
+    }),
+  },
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -14,8 +14,6 @@ const ASSET_PATH = {
   development: '/public/',
 };
 
-console.log('environment', environment);
-
 module.exports = {
   mode: 'development',
   resolve: {


### PR DESCRIPTION
Adding devTool key in production was increasing the build size, adding it only for development mode currently