### PR TITLE
Fix for broken pin icon of popovers in dark mode

### DIFF
--- a/frontend/src/Editor/LeftSidebar/SidebarPinnedButton.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPinnedButton.jsx
@@ -7,8 +7,8 @@ export const SidebarPinnedButton = ({ state, component, updateState }) => {
     const tooltipMsg = state ? `Unpin ${component}` : `Pin ${component}`
     return (
         <SidebarPinnedButton.OverlayContainer tip={tooltipMsg}>
-            <div className={`btn btn-sm m-1 ${state ? 'btn-light' : 'btn-default'} ${(component === 'Inspector') && "position-absolute end-0" }`} onClick={updateState} >
-                <img src={`/assets/images/icons/editor/left-sidebar/pinned.svg`} width="16" height="16" />
+            <div className={`btn btn-sm m-1 ${state ? 'btn-light' : 'btn-outline-secondary'} ${(component === 'Inspector') && "position-absolute end-0" }`} onClick={updateState} >
+                <img className="svg-icon" src={`/assets/images/icons/editor/left-sidebar/pinned.svg`} width="16" height="16" />
             </div>            
         </SidebarPinnedButton.OverlayContainer>
     )

--- a/frontend/src/Editor/LeftSidebar/SidebarPinnedButton.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPinnedButton.jsx
@@ -8,7 +8,7 @@ export const SidebarPinnedButton = ({ state, component, updateState }) => {
     return (
         <SidebarPinnedButton.OverlayContainer tip={tooltipMsg}>
             <div className={`btn btn-sm m-1 ${state ? 'btn-light' : 'btn-default'} ${(component === 'Inspector') && "position-absolute end-0" }`} onClick={updateState} >
-                <img className="svg-icon" src={`/assets/images/icons/editor/left-sidebar/pinned.svg`} width="16" height="16" />
+                <img src={`/assets/images/icons/editor/left-sidebar/pinned.svg`} width="16" height="16" />
             </div>            
         </SidebarPinnedButton.OverlayContainer>
     )


### PR DESCRIPTION
Fixes #791 
Issue: 
<img width="175" alt="Screenshot 2021-09-21 at 1 20 44 PM" src="https://user-images.githubusercontent.com/22231095/134154492-ec86168c-bfb7-44a1-bb99-da4f44d4a765.png">

In this update, if the pin is in inactive state it will show like,
<img width="169" alt="Screenshot 2021-09-21 at 3 20 05 PM" src="https://user-images.githubusercontent.com/22231095/134154618-93dfd57d-cbc6-4c7f-961b-a6c954b4d351.png">

If the pin button is in active state: 
<img width="168" alt="Screenshot 2021-09-21 at 1 16 18 PM" src="https://user-images.githubusercontent.com/22231095/134154696-4e2da45f-8618-4c9d-9c7a-fe185817fcbc.png">



