### PR TITLE
Fix charts default values

### DIFF
--- a/frontend/src/Editor/Components/components.js
+++ b/frontend/src/Editor/Components/components.js
@@ -183,9 +183,9 @@ export const componentTypes = [
         type: { value: `line` },
         data: {
           value: `[
-  { "x": 100, "y": "Jan"},
-  { "x": 80, "y": "Feb"},
-  { "x": 40, "y": "Mar"}
+  { "x": "Jan", "y": 100},
+  { "x": "Feb", "y": 80},
+  { "x": "Mar", "y": 40}
 ]`,
         },
       },


### PR DESCRIPTION
Interchanged X and Y values.

Before:
<img width="1136" alt="Screenshot 2021-09-21 at 3 54 53 PM" src="https://user-images.githubusercontent.com/5313625/134155037-148ec777-4e77-4711-b15f-fe2698a386f7.png">


After:
<img width="1106" alt="Screenshot 2021-09-21 at 3 52 17 PM" src="https://user-images.githubusercontent.com/5313625/134154697-46a386f4-901c-4085-981e-fd1988b2bd3a.png">

