### PR TITLE
Dropdown text height issue fixed

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2144,6 +2144,7 @@ input[type=text] {
 
     .select-search__option {
       height: auto;
+      min-height: 30px;
     }
   }
 }


### PR DESCRIPTION
Fixes #807 

Minimum text height added for dropdown options.
Before: 
<img width="629" alt="Screenshot 2021-09-21 at 6 52 48 PM" src="https://user-images.githubusercontent.com/22231095/134178470-db62c202-53af-4ff4-83b5-ef6948faffda.png">

After:

<img width="588" alt="Screenshot 2021-09-21 at 6 53 23 PM" src="https://user-images.githubusercontent.com/22231095/134178645-f49aa574-ff8a-44d5-84d7-d2858d4f0056.png">

Heroku Link: https://dropdown-text-line-height.herokuapp.com/