### PR TITLE
fix: remove unused package resizable

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,6 @@
         "papaparse": "^5.3.0",
         "plotly.js-basic-dist-min": "^1.58.4",
         "query-string": "^6.13.6",
-        "re-resizable": "^6.9.0",
         "react": "^16.14.0",
         "react-bootstrap": "^1.5.2",
         "react-color": "^2.19.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
         "@babel/core": "^7.4.3",
@@ -52,7 +53,6 @@
         "react-loading-skeleton": "^2.2.0",
         "react-plotly.js": "^2.5.1",
         "react-qr-reader": "^2.2.1",
-        "react-resizable": "^1.11.1",
         "react-rnd": "^10.3.0",
         "react-router-dom": "^5.0.0",
         "react-scripts": "3.4.3",
@@ -17844,19 +17844,6 @@
       "peerDependencies": {
         "react": "~16",
         "react-dom": "~16"
-      }
-    },
-    "node_modules/react-resizable": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.11.1.tgz",
-      "integrity": "sha512-S70gbLaAYqjuAd49utRHibtHLrHXInh7GuOR+6OO6RO6uleQfuBnWmZjRABfqNEx3C3Z6VPLg0/0uOYFrkfu9Q==",
-      "dependencies": {
-        "prop-types": "15.x",
-        "react-draggable": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": "0.14.x || 15.x || 16.x || 17.x",
-        "react-dom": "0.14.x || 15.x || 16.x || 17.x"
       }
     },
     "node_modules/react-rnd": {
@@ -37523,15 +37510,6 @@
         "jsqr": "^1.2.0",
         "prop-types": "^15.7.2",
         "webrtc-adapter": "^7.2.1"
-      }
-    },
-    "react-resizable": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.11.1.tgz",
-      "integrity": "sha512-S70gbLaAYqjuAd49utRHibtHLrHXInh7GuOR+6OO6RO6uleQfuBnWmZjRABfqNEx3C3Z6VPLg0/0uOYFrkfu9Q==",
-      "requires": {
-        "prop-types": "15.x",
-        "react-draggable": "^4.0.3"
       }
     },
     "react-rnd": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,6 @@
     "react-loading-skeleton": "^2.2.0",
     "react-plotly.js": "^2.5.1",
     "react-qr-reader": "^2.2.1",
-    "react-resizable": "^1.11.1",
     "react-rnd": "^10.3.0",
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,6 @@
     "papaparse": "^5.3.0",
     "plotly.js-basic-dist-min": "^1.58.4",
     "query-string": "^6.13.6",
-    "re-resizable": "^6.9.0",
     "react": "^16.14.0",
     "react-bootstrap": "^1.5.2",
     "react-color": "^2.19.3",


### PR DESCRIPTION
This PR removes unused package from deps saving around 10kb + 5kb

https://bundlephobia.com/package/react-resizable@3.0.4
https://bundlephobia.com/package/re-resizable@6.9.1