### PR TITLE
Table widget: data on inspector is readable in dark mode

### DIFF
--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -513,7 +513,7 @@ class Table extends React.Component {
   };
 
   render() {
-    const { dataQueries, component, paramUpdated, componentMeta, components, currentState } = this.props;
+    const { dataQueries, component, paramUpdated, componentMeta, components, currentState, darkMode } = this.props;
 
     const columns = component.component.definition.properties.columns;
     const actions = component.component.definition.properties.actions || { value: [] };
@@ -533,7 +533,8 @@ class Table extends React.Component {
           'data',
           'properties',
           currentState,
-          components
+          components,
+          darkMode
         )}
 
         <div className="field mb-2 mt-3">


### PR DESCRIPTION
Fixes #823 


**Loom**: https://www.loom.com/share/7e7f5c6e600a4231aff1a299beb5e172
