### PR TITLE
Docs for deploying tooljet on GKE

### DIFF
--- a/deploy/kubernetes/GKE/certificate.yaml
+++ b/deploy/kubernetes/GKE/certificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: tj
+spec:
+  domains:
+    - tooljet.your-domain.com

--- a/deploy/kubernetes/GKE/deployment.yaml
+++ b/deploy/kubernetes/GKE/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tooljet-deployment
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      component: tooljet
+  template:
+    metadata:
+      labels:
+        component: tooljet
+    spec:
+      imagePullSecrets:
+        - name: docker-secret
+      containers:
+        - name: container
+          image: tooljet/tooljet-ce:latest
+          imagePullPolicy: Always
+          args: ["npm", "run", "start:prod"]
+          resources:
+            limits:
+              memory: "1000Mi"
+              cpu: "500m"
+            requests:
+              memory: "1000Mi"
+              cpu: "500m"
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              port: 3000
+              path: /api/health
+            successThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 6
+          env:
+            - name: PG_HOST
+              value: ""
+            - name: PG_USER
+              value: "postgres"
+            - name: PG_PASS
+              value: ""
+            - name: PG_DB
+              value: ""
+            - name: LOCKBOX_MASTER_KEY
+              value: ""
+            - name: SECRET_KEY_BASE
+              value: ""
+            - name: TOOLJET_HOST
+              value: "https://tooljet.your-domain.com"

--- a/deploy/kubernetes/GKE/ingress.yaml
+++ b/deploy/kubernetes/GKE/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: backend-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "tj-static-ip"
+    networking.gke.io/managed-certificates: "tj"
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+
+spec:
+  rules:
+  - host: tooljet.your-domain.com
+    http:
+      paths:
+        - path: /*
+          backend:
+            serviceName: tj-service
+            servicePort: 8080
+            

--- a/deploy/kubernetes/GKE/service.yaml
+++ b/deploy/kubernetes/GKE/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tj-service
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    component: tooljet
+  type: NodePort

--- a/docs/docs/deployment/kubernetes-gke.md
+++ b/docs/docs/deployment/kubernetes-gke.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 4
+sidebar_label: Kubernetes (GKE)
+---
+
+# Deploying ToolJet on Kubernetes (GKE)
+
+:::info
+You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using Cloud SQL since this guide is for deploying using GKE.
+:::
+
+Follow the steps below to deploy ToolJet on a GKE Kubernetes cluster.
+
+1. Create an SSL certificate. 
+```bash
+curl -LO https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/GKE/certificate.yaml
+```
+
+Change the domain name to the domain/subdomain that you wish to use for ToolJet installation.
+
+2. Reserve a static IP address using `gcloud` cli 
+```bash
+gcloud compute addresses create tj-static-ip --global
+```
+
+3. Create k8s deployment
+```bash
+curl -LO https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/GKE/deployment.yaml
+```
+
+Make sure to edit the environment variables in the `deployment.yaml`. You can check out the available options [here](https://docs.tooljet.io/docs/deployment/env-vars).
+
+4. Create k8s service 
+```bash
+curl -LO https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/GKE/service.yaml
+```
+
+5. Create k8s ingress
+```bash
+curl -LO https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/GKE/ingress.yaml
+```
+
+Change the domain name to the domain/subdomain that you wish to use for ToolJet installation.
+
+6. Apply YAML configs
+
+```bash
+kubectl apply -f certificate.yaml, deployment.yaml, service.yaml, ingress.yaml
+```
+
+:::info
+It might take a few minutes to provision the managed certificates. [Managed certificates documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs).
+:::
+
+You will be able to access your ToolJet installation once the pods, service and the ingress is running. 
+
+If you want to seed the database with a sample user, please SSH into a pod and run:   
+`npm run db:seed --prefix server`.   
+This seeds the database with a default user with the following credentials:   
+   
+email: `dev@tooljet.io`   
+password: `password`


### PR DESCRIPTION
YAML configurations and documentation for deploying ToolJet on a GKE Kubernetes cluster. 
Fixes #313 