### PR TITLE
884 - make table headers more legible in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2114,6 +2114,7 @@ input:focus-visible {
 .theme-dark .markdown > table thead th,
 .theme-dark .table thead th {
   background: #1c252f;
+  color: #fff;
 }
 
 .sketch-picker {


### PR DESCRIPTION
Fixes #884
Set the header color to white:
![image](https://user-images.githubusercontent.com/1907152/135919859-2187f284-ba04-44b5-89a2-d1a37370e33b.png)
