### PR TITLE
fix: broken links in docs

### DIFF
--- a/docs/docs/data-sources/elasticsearch.md
+++ b/docs/docs/data-sources/elasticsearch.md
@@ -27,5 +27,5 @@ Click on `+` button of the query manager at the bottom panel of the editor and s
 Select the operation that you want to perform on Firestore and click 'Save' to save the query. 
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
 :::

--- a/docs/docs/data-sources/firestore.md
+++ b/docs/docs/data-sources/firestore.md
@@ -23,5 +23,5 @@ Click on `+` button of the query manager at the bottom panel of the editor and s
 Select the operation that you want to perform on Firestore and click 'Save' to save the query. 
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
 :::

--- a/docs/docs/data-sources/graphql.md
+++ b/docs/docs/data-sources/graphql.md
@@ -36,5 +36,5 @@ Click on `+` button of the query manager at the bottom panel of the editor and s
 Click on the 'run' button to run the query. NOTE: Query should be saved before running.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
 :::

--- a/docs/docs/data-sources/mssql.md
+++ b/docs/docs/data-sources/mssql.md
@@ -37,5 +37,5 @@ Click on the 'run' button to run the query. NOTE: Query should be saved before r
 
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
 :::

--- a/docs/docs/data-sources/mysql.md
+++ b/docs/docs/data-sources/mysql.md
@@ -33,5 +33,5 @@ Click on `+` button of the query manager at the bottom panel of the editor.
 Click on the 'run' button to run the query. NOTE: Query should be saved before running.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
 :::

--- a/docs/docs/data-sources/postgresql.md
+++ b/docs/docs/data-sources/postgresql.md
@@ -34,5 +34,5 @@ Click on '+' button of the query manager at the bottom panel of the editor and s
 Click on the 'run' button to run the query. NOTE: Query should be saved before running.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
 :::

--- a/docs/docs/data-sources/rest-api.md
+++ b/docs/docs/data-sources/rest-api.md
@@ -41,5 +41,5 @@ NOTE: Query should be saved before running.
 :::
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
 :::

--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -40,5 +40,5 @@ Application load balancing on Amazon EKS: https://docs.aws.amazon.com/eks/latest
 GKE Ingress for HTTP(S) Load Balancing: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
 
 :::tip
-If you want to serve ToolJet client from services such as Firebase or Netlify, please read the client deployment documentation [here](/docs/setup/client).
+If you want to serve ToolJet client from services such as Firebase or Netlify, please read the client deployment documentation [here](/docs/deployment/client).
 :::


### PR DESCRIPTION
Resolves all the broken links warnings while running `npm run build`