### PR TITLE
Use focus pseudoclass instead of focus-within to highlight table-row

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -775,7 +775,7 @@ body {
   }
 
   .table-row:hover,
-  .table-row:focus-within {
+  .table-row:focus {
     background: rgba(lightBlue, 0.25);
   }
 


### PR DESCRIPTION
This PR resolves the issue where the focus on a table row persists when its corresponding selector is clicked.


https://user-images.githubusercontent.com/20333972/136341022-9f8c17ce-4f6f-45a2-8ef0-b69e6e504379.mp4

