### PR TITLE
Bugfix/stop propagation when table selector is clicked

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -630,8 +630,8 @@ export function Table({
             marginTop: 8,
             marginLeft: 10,
           }}
-          {...rest}
           onClick={(event) => event.stopPropagation()}
+          {...rest}
         />
       </>
     );


### PR DESCRIPTION
This PR resolves the issue where 'row clicked' events are fired when selector checkboxes are selected/deselected.