### PR TITLE
Make 'Manage Organization Users' link more prominent in dark mode

### DIFF
--- a/frontend/src/Editor/ManageAppUsers.jsx
+++ b/frontend/src/Editor/ManageAppUsers.jsx
@@ -297,7 +297,7 @@ class ManageAppUsers extends React.Component {
           </Modal.Body>
 
           <Modal.Footer>
-            <a href="/users" target="_blank">
+            <a href="/users" target="_blank" className="btn btn-outline-azure mt-3">
               Manage Organization Users
             </a>
           </Modal.Footer>


### PR DESCRIPTION
Fixes #924 

![tooljet-btn](https://user-images.githubusercontent.com/44368997/136368134-55a5ed17-a8c1-4987-952f-cf98b7796e80.gif)

