### PR TITLE
Add link to documentation on empty canvas

### DIFF
--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -312,6 +312,7 @@ export const Container = ({
         <div className="mx-auto w-50 p-5 bg-light no-components-box" style={{ marginTop: '10%' }}>
           <center className="text-muted">
             You haven&apos;t added any components yet. Drag components from the right sidebar and drop here.
+            Check out our <a href="https://docs.tooljet.io/docs/tutorial/adding-widget" target="_blank">guide</a> on adding widgets.
           </center>
         </div>
       )}

--- a/frontend/src/Editor/SubContainer.jsx
+++ b/frontend/src/Editor/SubContainer.jsx
@@ -305,7 +305,10 @@ export const SubContainer = ({
 
       {Object.keys(boxes).length === 0 && !appLoading && !isDragging && (
         <div className="mx-auto mt-5 w-50 p-5 bg-light no-components-box">
-          <center className="text-muted">Drag components from the right sidebar and drop here.</center>
+          <center className="text-muted">
+            Drag components from the right sidebar and drop here. 
+            Check out our <a href="https://docs.tooljet.io/docs/tutorial/adding-widget" target="_blank">guide</a> on adding widgets.
+          </center>
         </div>
       )}
       {appLoading && (


### PR DESCRIPTION
closes #942 

Added link to the documentation below the text "You haven't added any components yet. Drag components from the right sidebar and drop here."

New text:
"You haven't added any components yet. Drag components from the right sidebar and drop them here. Check out our [guide](https://docs.tooljet.io/docs/tutorial/adding-widget) on adding widgets."

Set `target` attribute for `<a>` element to `_blank` to open the documentation in a new tab.