### PR TITLE
Update footer text

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -86,7 +86,7 @@ module.exports = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} ToolJet.`,
+      copyright: `Copyright © ${new Date().getFullYear()} ToolJet Solutions, Inc.`,
     },
   },
   presets: [


### PR DESCRIPTION
Fixes #945 
Updated footer text from "Tooljet" to "ToolJet Solutions, Inc."
<img width="1440" alt="Screenshot 2021-10-08 at 1 30 59 PM" src="https://user-images.githubusercontent.com/73102734/136520126-318fcbc9-7e71-4dcf-a5d9-5b6e4f7ef29a.png">


