### PR TITLE
showModal handler won't crash when no modalId

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -98,7 +98,7 @@ async function copyToClipboard(text) {
 }
 
 function showModal(_ref, modalId, show) {
-  if (!modalId) {
+  if (_.isEmpty(modalId)) {
     console.log('No modal is associated with this event.');
     return Promise.resolve();
   }


### PR DESCRIPTION
Fixes #934 