### PR TITLE
chore: Display Kubernetes GKE deployment page

### DIFF
--- a/docs/docs/deployment/client.md
+++ b/docs/docs/deployment/client.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Deploying ToolJet client
@@ -15,14 +15,14 @@ For example: `TOOLJET_SERVER_URL=https://server.tooljet.io npm run build && fire
 :::
 
 1. Initialize firebase project
-    ```bash
-     firebase init 
-    ```
-    Select Firebase Hosting and set build as the static file directory
+   ```bash
+    firebase init
+   ```
+   Select Firebase Hosting and set build as the static file directory
 2. Deploy client to Firebase
-    ```bash
-     firebase deploy
-    ```
+   ```bash
+    firebase deploy
+   ```
 
 :::tip
 If you want to run ToolJet on your local machine, please checkout the setup section of the contributing guide: [link](/docs/contributing-guide/setup/docker)

--- a/docs/docs/deployment/env-vars.md
+++ b/docs/docs/deployment/env-vars.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Environment variables
@@ -10,30 +10,28 @@ Both the ToolJet server and client requires some environment variables to start 
 
 #### ToolJet host ( required )
 
-| variable      | description |
-| ----------- | ----------- |
+| variable     | description                                                     |
+| ------------ | --------------------------------------------------------------- |
 | TOOLJET_HOST | the public URL of ToolJet client ( eg: https://app.tooljet.io ) |
-
-
 
 #### Database configuration ( required )
 
 ToolJet server uses PostgreSQL as the database.
 
-| variable      | description |
-| ----------- | ----------- |
-| PG_HOST      | postgres database host |
-| PG_DB      | name of the database       |
-| PG_USER      | username |
-| PG_PASS      | password       |
+| variable | description            |
+| -------- | ---------------------- |
+| PG_HOST  | postgres database host |
+| PG_DB    | name of the database   |
+| PG_USER  | username               |
+| PG_PASS  | password               |
 
 #### Lockbox configuration ( required )
+
 ToolJet server uses lockbox to encrypt datasource credentials. You should set the environment variable `LOCKBOX_MASTER_KEY` with a 32 byte hexadecimal string.
 
-
 #### Application Secret ( required )
-ToolJet server uses a secure 64 byte hexadecimal string to encrypt session cookies. You should set the environment variable `SECRET_KEY_BASE`.
 
+ToolJet server uses a secure 64 byte hexadecimal string to encrypt session cookies. You should set the environment variable `SECRET_KEY_BASE`.
 
 :::tip
 If you have `openssl` installed, you can run the following commands to generate the the value for `LOCKBOX_MASTER_KEY` and `SECRET_KEY_BASE`.
@@ -41,7 +39,6 @@ If you have `openssl` installed, you can run the following commands to generate 
 For `LOCKBOX_MASTER_KEY` use `openssl rand -hex 32`
 For `SECRET_KEY_BASE` use `openssl rand -hex 64`
 :::
-
 
 #### Disabling signups ( optional )
 
@@ -53,7 +50,7 @@ You will still be able to see the signup page but won't be able to successfully 
 
 #### Serve client as a server end-point ( optional )
 
-By default, the `SERVE_CLIENT` variable will be set to `false` and the server won't serve the client at its `/`  end-point.
+By default, the `SERVE_CLIENT` variable will be set to `false` and the server won't serve the client at its `/` end-point.
 You can set `SERVE_CLIENT` to `true` and the server will attempt to serve the client at its root end-point (`/`).
 
 #### SMTP configuration ( optional )
@@ -61,7 +58,7 @@ You can set `SERVE_CLIENT` to `true` and the server will attempt to serve the cl
 ToolJet uses SMTP services to send emails ( Eg: invitation email when you add new users to your organization ).
 
 | variable           | description                               |
-|--------------------|-------------------------------------------|
+| ------------------ | ----------------------------------------- |
 | DEFAULT_FROM_EMAIL | from email for the email fired by ToolJet |
 | SMTP_USERNAME      | username                                  |
 | SMTP_PASSWORD      | password                                  |
@@ -72,34 +69,34 @@ ToolJet uses SMTP services to send emails ( Eg: invitation email when you add ne
 
 If your ToolJet installation requires Slack as a datasource, you need to create a Slack app and set the following environment variables:
 
-| variable      | description |
-| ----------- | ----------- |
-| SLACK_CLIENT_ID      | client id of the slack app |
-| SLACK_CLIENT_SECRET      | client secret of the slack app |
+| variable            | description                    |
+| ------------------- | ------------------------------ |
+| SLACK_CLIENT_ID     | client id of the slack app     |
+| SLACK_CLIENT_SECRET | client secret of the slack app |
 
 #### Google OAuth ( optional )
 
 If your ToolJet installation needs access to datasources such as Google sheets, you need to create OAuth credentials from Google Cloud Console.
 
-| variable      | description |
-| ----------- | ----------- |
-| GOOGLE_CLIENT_ID      | client id |
-| GOOGLE_CLIENT_SECRET      | client secret |
+| variable             | description   |
+| -------------------- | ------------- |
+| GOOGLE_CLIENT_ID     | client id     |
+| GOOGLE_CLIENT_SECRET | client secret |
 
 #### Google maps configuration ( optional )
 
 If your ToolJet installation requires `Maps` widget, you need to create an API key for Google Maps API.
 
-| variable      | description |
-| ----------- | ----------- |
+| variable            | description         |
+| ------------------- | ------------------- |
 | GOOGLE_MAPS_API_KEY | Google maps API key |
 
 #### APM VENDOR ( optional )
 
 Specify application monitoring vendor. Currently supported values - `sentry`.
 
-| variable      | description |
-| ----------- | ----------- |
+| variable   | description                               |
+| ---------- | ----------------------------------------- |
 | APM VENDOR | Application performance monitoring vendor |
 
 #### SENTRY DNS ( optional )
@@ -112,21 +109,23 @@ Prints logs for sentry. Supported values: `true` | `false`
 Default value is `false`
 
 #### Server URL ( optional)
+
 This is used to set up for CSP headers and put trace info to be used with APM vendors.
 
-| variable | description |
-| ----------- | ----------- |
+| variable           | description                                                 |
+| ------------------ | ----------------------------------------------------------- |
 | TOOLJET_SERVER_URL | the URL of ToolJet server ( eg: https://server.tooljet.io ) |
 
-
 #### RELEASE VERSION ( optional)
+
 Once set any APM provider that supports segregation with releases will track it.
 
 ## ToolJet client
 
 #### Server URL ( optionally required )
+
 This is required when client is built separately.
 
-| variable | description |
-| ----------- | ----------- |
+| variable           | description                                                 |
+| ------------------ | ----------------------------------------------------------- |
 | TOOLJET_SERVER_URL | the URL of ToolJet server ( eg: https://server.tooljet.io ) |

--- a/docs/docs/deployment/heroku.md
+++ b/docs/docs/deployment/heroku.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: Heroku
 ---
 
@@ -8,12 +8,13 @@ sidebar_label: Heroku
 Follow the steps below to deploy ToolJet on Heroku:
 
 1. Click the button below to start one click deployment.  
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/tooljet/tooljet/tree/main)
+   [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/tooljet/tooljet/tree/main)
 
 2. Navigate to Heroku dashboard and go to resources tab to verify that the dyno is turned on.
-3. Go to settings tab on Heroku dashboard and select `reveal config vars` to configure additional environment variables that your installation might need.   
+3. Go to settings tab on Heroku dashboard and select `reveal config vars` to configure additional environment variables that your installation might need.
 
-    Read [environment variables reference](/docs/deployment/env-vars)
+   Read [environment variables reference](/docs/deployment/env-vars)
+
 4. Open the app.
 5. The default username of the admin is dev@tooljet.io and password is `password`.
 

--- a/docs/docs/deployment/kubernetes-gke.md
+++ b/docs/docs/deployment/kubernetes-gke.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 sidebar_label: Kubernetes (GKE)
 ---
 
@@ -11,31 +11,36 @@ You should setup a PostgreSQL database manually to be used by ToolJet. We recomm
 
 Follow the steps below to deploy ToolJet on a GKE Kubernetes cluster.
 
-1. Create an SSL certificate. 
+1. Create an SSL certificate.
+
 ```bash
 curl -LO https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/GKE/certificate.yaml
 ```
 
 Change the domain name to the domain/subdomain that you wish to use for ToolJet installation.
 
-2. Reserve a static IP address using `gcloud` cli 
+2. Reserve a static IP address using `gcloud` cli
+
 ```bash
 gcloud compute addresses create tj-static-ip --global
 ```
 
 3. Create k8s deployment
+
 ```bash
 curl -LO https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/GKE/deployment.yaml
 ```
 
 Make sure to edit the environment variables in the `deployment.yaml`. You can check out the available options [here](https://docs.tooljet.io/docs/deployment/env-vars).
 
-4. Create k8s service 
+4. Create k8s service
+
 ```bash
 curl -LO https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/GKE/service.yaml
 ```
 
 5. Create k8s ingress
+
 ```bash
 curl -LO https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/GKE/ingress.yaml
 ```
@@ -52,11 +57,11 @@ kubectl apply -f certificate.yaml, deployment.yaml, service.yaml, ingress.yaml
 It might take a few minutes to provision the managed certificates. [Managed certificates documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs).
 :::
 
-You will be able to access your ToolJet installation once the pods, service and the ingress is running. 
+You will be able to access your ToolJet installation once the pods, service and the ingress is running.
 
-If you want to seed the database with a sample user, please SSH into a pod and run:   
-`npm run db:seed --prefix server`.   
-This seeds the database with a default user with the following credentials:   
-   
-email: `dev@tooljet.io`   
+If you want to seed the database with a sample user, please SSH into a pod and run:  
+`npm run db:seed --prefix server`.  
+This seeds the database with a default user with the following credentials:
+
+email: `dev@tooljet.io`  
 password: `password`

--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Kubernetes
 ---
 
@@ -12,11 +12,11 @@ You should setup a PostgreSQL database manually to be used by ToolJet.
 Follow the steps below to deploy ToolJet on a Kubernetes cluster.
 
 1. Setup a PostgreSQL database
-    ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not have plans to support other databases such as MySQL.
+   ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not have plans to support other databases such as MySQL.
 
 2. Create a Kubernetes secret with name `server`. For the minimal setup, ToolJet requires `pg_host`, `pg_db`, `pg_user`, `pg_password`, `secret_key_base` & `lockbox_key` keys in the secret.
 
-    Read [environment variables reference](/docs/deployment/env-vars)
+   Read [environment variables reference](/docs/deployment/env-vars)
 
 3. Create a Kubernetes deployment
 
@@ -35,9 +35,9 @@ The file given above is just a template and might not suit production environmen
 ```
 
 5. Create a Kubernetes services to publish the Kubernetes deployment that you've created. This step varies with cloud providers. We have a [template](https://raw.githubusercontent.com/ToolJet/ToolJet/main/deploy/kubernetes/service.yaml) for exposing the ToolJet server as a service using an AWS loadbalancer.
-Examples:
-Application load balancing on Amazon EKS: https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
-GKE Ingress for HTTP(S) Load Balancing: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+   Examples:
+   Application load balancing on Amazon EKS: https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+   GKE Ingress for HTTP(S) Load Balancing: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
 
 :::tip
 If you want to serve ToolJet client from services such as Firebase or Netlify, please read the client deployment documentation [here](/docs/deployment/client).


### PR DESCRIPTION
Hey it seems like there is a couple of extra stuff in your docs that can improve the legibility of your markdown, also it seems like the sidebar_positions are kinda outdated and the Deploy Page for GKE is not displayed, not sure if this can fix that issue?