### PR TITLE
Refactor: removes directly used builtins for Object.prototype (#999)

### DIFF
--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -165,7 +165,7 @@ export const serializeNestedObjectToQueryParams = function (obj, prefix) {
   var str = [],
     p;
   for (p in obj) {
-    if (obj.hasOwnProperty(p)) {
+    if (Object.prototype.hasOwnProperty.call(obj, p)) {
       var k = prefix ? prefix + '[' + p + ']' : p,
         v = obj[p];
       str.push(


### PR DESCRIPTION
Replace `obj.hasOwnProperty` to `Object.prototype.hasOwnProperty.call` to fix JS-0021 issue
Closes #999