### PR TITLE
 Horizontal scroll missing for table widget

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -893,7 +893,6 @@ body {
 
 .jet-data-table::-webkit-scrollbar {
   background: transparent;
-  height: 0;
 }
 
 .jet-data-table:hover {


### PR DESCRIPTION
fix for the issue no: https://github.com/ToolJet/ToolJet/issues/489

Before: 

![image](https://user-images.githubusercontent.com/67395591/137177451-400e8f4b-a563-49f9-97f2-8903621fae2b.png)


After: 

![image](https://user-images.githubusercontent.com/67395591/137177523-3f0e9269-5d97-413e-90fe-400422b4fdc2.png)


