### PR TITLE
fixed dark mode text in groups page

### DIFF
--- a/frontend/src/ManageGroupPermissions/ManageGroupPermissions.jsx
+++ b/frontend/src/ManageGroupPermissions/ManageGroupPermissions.jsx
@@ -107,11 +107,7 @@ class ManageGroupPermissions extends React.Component {
               <div className="row align-items-center">
                 <div className="col">
                   <div className="page-pretitle"></div>
-                  <ol className="breadcrumb" aria-label="breadcrumbs">
-                    <li className="breadcrumb-item">
-                      <Link>User groups</Link>
-                    </li>
-                  </ol>
+                  <h2 className="page-title">User Groups</h2>
                 </div>
                 <div className="col-auto ms-auto d-print-none">
                   {!showNewGroupForm && (

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1795,6 +1795,9 @@ input:focus-visible {
   .card {
     background-color: #324156 !important;
   }
+  .card .table tbody td a{
+    color: inherit;
+  }
 
   .DateInput {
     background: #1f2936;


### PR DESCRIPTION
Changed the page title to Plain text and made it bigger to match [Users](https://app.tooljet.io/users) page.
Changed the font-color of table text to have more visibility in dark mode.<br>
Here's what it looks now,
Light Mode:
![image](https://user-images.githubusercontent.com/68785723/137528648-817041d1-8bec-4b9b-8d0b-30bae8b349fd.png)
Dark Mode:
![image](https://user-images.githubusercontent.com/68785723/137528695-831cd992-4113-4ce6-9ef8-0b6c4f3b9e16.png)
closes #1027
