### PR TITLE
fixed edit icon in inspector not visible in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2014,6 +2014,9 @@ input:focus-visible {
   .editor .editor-sidebar .inspector .header {
     border: solid rgba(255, 255, 255, 0.09) !important;
     border-width: 0px 0px 1px 0px !important;
+    .input-icon .input-icon-addon img {
+        filter: invert(1);
+    }
   }
   .editor .editor-sidebar .inspector .hr-text {
     color: #fff !important;


### PR DESCRIPTION
Light mode:
![image](https://user-images.githubusercontent.com/68785723/137726423-53794637-fd45-48ba-9ae6-8e697607cc26.png)
Dark Mode:
![image](https://user-images.githubusercontent.com/68785723/137589019-2aae39c4-27a2-4550-9f61-2acb932a0c64.png)
closes #1114