### PR TITLE
Marker color and 'show grid lines' options are not required for pie chart 

### DIFF
--- a/frontend/src/Editor/Inspector/Components/Chart.jsx
+++ b/frontend/src/Editor/Inspector/Components/Chart.jsx
@@ -58,6 +58,8 @@ class Chart extends React.Component {
 
     const data = this.state.component.component.definition.properties.data;
 
+    const chartType = this.state.component.component.definition.properties.type.value;
+
     return (
       <div className="properties-container p-2">
         {renderElement(
@@ -99,17 +101,19 @@ class Chart extends React.Component {
 
         {renderElement(component, componentMeta, paramUpdated, dataQueries, 'loadingState', 'properties', currentState)}
 
-        {renderElement(component, componentMeta, paramUpdated, dataQueries, 'markerColor', 'properties', currentState)}
+        {chartType !== 'pie' &&
+          renderElement(component, componentMeta, paramUpdated, dataQueries, 'markerColor', 'properties', currentState)}
 
-        {renderElement(
-          component,
-          componentMeta,
-          paramUpdated,
-          dataQueries,
-          'showGridLines',
-          'properties',
-          currentState
-        )}
+        {chartType !== 'pie' &&
+          renderElement(
+            component,
+            componentMeta,
+            paramUpdated,
+            dataQueries,
+            'showGridLines',
+            'properties',
+            currentState
+          )}
       </div>
     );
   }


### PR DESCRIPTION
Fixed issue #1042 



Gif:

![chart](https://user-images.githubusercontent.com/11629780/138253580-7cd22441-1ad5-4c56-a14e-aada7676cced.gif)

