### PR TITLE
fix: update theme toggle position to bottom

### DIFF
--- a/frontend/src/Editor/LeftSidebar/index.js
+++ b/frontend/src/Editor/LeftSidebar/index.js
@@ -42,7 +42,7 @@ export const LeftSidebar = ({
       <div className="left-sidebar-stack-bottom">
         <LeftSidebarZoom onZoomChanged={onZoomChanged} />
         <div className="left-sidebar-item no-border">
-          <DarkModeToggle switchDarkMode={switchDarkMode} darkMode={darkMode} />
+          <DarkModeToggle switchDarkMode={switchDarkMode} darkMode={darkMode} tooltipPlacement="right" />
         </div>
         {/* <LeftSidebarItem icon='support' className='left-sidebar-item' /> */}
       </div>

--- a/frontend/src/_components/DarkModeToggle.jsx
+++ b/frontend/src/_components/DarkModeToggle.jsx
@@ -3,7 +3,11 @@ import { useSpring, animated } from 'react-spring';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 
-export const DarkModeToggle = function DarkModeToggle({ darkMode = false, switchDarkMode }) {
+export const DarkModeToggle = function DarkModeToggle({
+  darkMode = false,
+  switchDarkMode,
+  tooltipPlacement = 'bottom',
+}) {
   const toggleDarkMode = () => {
     switchDarkMode(!darkMode);
   };
@@ -43,7 +47,7 @@ export const DarkModeToggle = function DarkModeToggle({ darkMode = false, switch
 
   return (
     <OverlayTrigger
-      placement="bottom"
+      placement={tooltipPlacement}
       delay={{ show: 250, hide: 400 }}
       overlay={<Tooltip id="button-tooltip">{darkMode ? 'Activate light mode' : 'Activate dark mode'}</Tooltip>}
     >

--- a/frontend/src/_styles/left-sidebar.scss
+++ b/frontend/src/_styles/left-sidebar.scss
@@ -26,7 +26,7 @@
   .left-sidebar-stack-bottom {
     width: 3%;
     position: fixed;
-    bottom: 12vw;
+    bottom: 4vw;
     height: 50px;
     text-align: center;
   }


### PR DESCRIPTION
### Description

The PR updates the position of the theme toggler on edit page

### Issue

Fixes https://github.com/ToolJet/ToolJet/issues/548

### How to test?

1. Edit any existing app or create a new app
2. Look at the bottom left. The Theme Toggle should be at the very bottom.
3. Hover over the toggle, the tooltip should come to the right similar to the zoom tooltip
4. Navigate to the main page
5. Hover over the header theme toggle, the tooltip should come at bottom as before.