### PR TITLE
Icon to close inspector is not visible in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1947,7 +1947,7 @@ input:focus-visible {
   .btn-light,
   .btn-outline-light {
     background-color: #42546a !important;
-
+    --tblr-btn-color-text: #ffffff;
     img {
       filter: brightness(0) invert(1);
     }


### PR DESCRIPTION
closes issue no: #988

before:

![image](https://user-images.githubusercontent.com/67395591/138322747-efdf643a-9e1f-45cb-a1e8-78e0c099950f.png)

After:

![image](https://user-images.githubusercontent.com/67395591/138322784-11a4d328-71de-4b6d-9f18-fc8afc279420.png)
