### PR TITLE
fix vertical alignment of empty folder in homepage

### DIFF
--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -314,11 +314,7 @@ class HomePage extends React.Component {
                     </div>
 
                     <div
-                      className={
-                        currentFolder.count === 0
-                          ? 'table-responsive w-100 apps-table mt-3 d-flex align-items-center'
-                          : 'table-responsive w-100 apps-table mt-3'
-                      }
+                      className='table-responsive w-100 apps-table'
                       style={{ minHeight: '600px' }}
                     >
                       <table


### PR DESCRIPTION
The empty folder div should now be properly vertically aligned with the sidebar


Now looks like:
![image](https://user-images.githubusercontent.com/57676066/138371606-3dc55891-26fc-4cc6-b199-283608511c02.png)

Fixes issue [#1154](https://github.com/ToolJet/ToolJet/issues/1154)