### PR TITLE
fix app being able to be named empty or whitespace string in editor

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -309,6 +309,23 @@ class Editor extends React.Component {
     });
   };
 
+  saveAppName = (id, name, notify = false) => {
+
+    if (!name.trim()) {
+      toast.warn("App name can't be empty or whitespace", {
+        hideProgressBar: true,
+        position: 'top-center',
+      });
+
+      this.setState({
+        app: { ...this.state.app, name: this.state.oldName },
+      })
+
+      return;
+    }
+    this.saveApp(id, {name}, notify);
+  }
+
   renderDataSource = (dataSource) => {
     const sourceMeta = DataSourceTypes.find((source) => source.kind === dataSource.kind);
     return (
@@ -569,8 +586,9 @@ class Editor extends React.Component {
                   <input
                     type="text"
                     style={{ width: '200px', left: '80px', position: 'absolute' }}
+                    onFocus={(e) => this.setState({ oldName: e.target.value })}
                     onChange={(e) => this.onNameChanged(e.target.value)}
-                    onBlur={(e) => this.saveApp(this.state.app.id, { name: e.target.value })}
+                    onBlur={(e) => this.saveAppName(this.state.app.id, e.target.value)}
                     className="form-control-plaintext form-control-plaintext-sm"
                     value={this.state.app.name}
                   />


### PR DESCRIPTION
The app now can no longer be renamed to an empty or whitespace string in Editor
Fixes issue [#1155](https://github.com/ToolJet/ToolJet/issues/1155)
Loom: https://www.loom.com/share/813f84b3fa7e42c2ba2e7d824e0266f2