### PR TITLE
fix: replace `let` statement with `const`

### DIFF
--- a/frontend/src/Editor/Components/Datepicker.jsx
+++ b/frontend/src/Editor/Components/Datepicker.jsx
@@ -48,7 +48,7 @@ export const Datepicker = function Datepicker({
   }
 
   function onDateChange(event) {
-    let _dateFormat = enableTime ? `${dateFormat.value} LT` : dateFormat.value;
+    const _dateFormat = enableTime ? `${dateFormat.value} LT` : dateFormat.value;
     const value = event._isAMomentObject ? event.format(_dateFormat) : event;
 
     setDateText(value);


### PR DESCRIPTION
Fix issue #1173.
Use `const` alternatively of `let` keyword statement.
