### PR TITLE
fix(table): add condition to check empty id row

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -148,7 +148,7 @@ export function Table({
     let newFilters = filters;
     newFilters.splice(index, 1);
     setFilters(newFilters);
-    setAllFilters(newFilters);
+    setAllFilters(newFilters.filter((filter) => filter.id !== ''));
   }
 
   function clearFilters() {


### PR DESCRIPTION
### Description

The PR fixes a bug where applying filters and clearing on an empty filter break the app

### Issue Fixed?

Fixes https://github.com/ToolJet/ToolJet/issues/1191

### How to test?

1. Create a new app
2. Drag table and click on Filter icon
3. Click on Add Filters to add 2-3 empty filters
4. Click on `X` button of any filter
5. Filter should get cleared with any error or blank screen