### PR TITLE
Bugfix: The search box should be displayed on the map if `canSearch` is set to true by default 

### DIFF
--- a/frontend/src/Editor/Components/components.js
+++ b/frontend/src/Editor/Components/components.js
@@ -1001,7 +1001,7 @@ export const componentTypes = [
           value: `{{ [{"lat": 40.7128, "lng": -73.935242}] }}`,
         },
         canSearch: {
-          value: true ,
+          value: `{{true}}` ,
         },
       },
       addNewMarkers: { value: '{{false}}' },


### PR DESCRIPTION
Fixes #1231 
heroku-deploy : https://tooljet-test001.herokuapp.com/apps/a9623b25-0864-48d6-84d4-6333f57de2c9