### PR TITLE
Fixed the SEO issues

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   title: 'ToolJet - Documentation',
   tagline: 'Build and deploy internal tools.',
-  url: 'https://tooljet.io',
+  url: 'https://docs.tooljet.io',
   baseUrl: '/',
   onBrokenLinks: 'ignore',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
So the conical urls and alternate urls, Open graph url showing for the docs page are broken due to an error in docusaurus config file.

## Before

![sdfgdf](https://user-images.githubusercontent.com/37118134/138647138-0a5e0e6d-0b76-4587-a342-5015997aedd5.jpg)
![UUGIIF](https://user-images.githubusercontent.com/37118134/138647141-36d09a6a-7a0d-4818-9ee7-047e4f34d799.jpg)


## After 

![fdgfdgdf](https://user-images.githubusercontent.com/37118134/138647110-31337c31-b503-434a-ab99-c31c24bd5b0b.jpg)
![gdsffg](https://user-images.githubusercontent.com/37118134/138647134-650c17d0-ff6c-4a58-9635-489a3db82738.jpg)