### PR TITLE
fix: add encrypted icon to firestore api

### DIFF
--- a/frontend/src/Editor/DataSourceManager/SourceComponents/Database/Firestore.schema.json
+++ b/frontend/src/Editor/DataSourceManager/SourceComponents/Database/Firestore.schema.json
@@ -13,7 +13,10 @@
       "rawData": []
     },
     "options": {
-      "gcp_key": { "type": "string", "encrypted": true }
+      "gcp_key": {
+        "type": "string",
+        "encrypted": true
+      }
     }
   },
   "properties": {
@@ -21,9 +24,12 @@
       "$label": "Private key",
       "$key": "gcp_key",
       "$rows": 15,
+      "$encrypted": true,
       "type": "textarea",
       "description": "Enter private key"
     }
   },
-  "required": ["gcp_key"]
+  "required": [
+    "gcp_key"
+  ]
 }

--- a/frontend/src/_components/DynamicForm.jsx
+++ b/frontend/src/_components/DynamicForm.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Input from '@/_ui/Input';
+import Textarea from '@/_ui/Textarea';
 import Select from '@/_ui/Select';
 import Headers from '@/_ui/HttpHeaders';
 import OAuth from '@/_ui/OAuth';
@@ -17,8 +18,9 @@ const DynamicForm = ({ schema, optionchanged, createDataSource, options, isSavin
     switch (type) {
       case 'password':
       case 'text':
-      case 'textarea':
         return Input;
+      case 'textarea':
+        return Textarea;
       case 'dropdown':
         return Select;
       case 'toggle':
@@ -96,7 +98,7 @@ const DynamicForm = ({ schema, optionchanged, createDataSource, options, isSavin
     return (
       <div className="row">
         {Object.keys(obj).map((key) => {
-          const { $label, type } = obj[key];
+          const { $label, type, $encrypted } = obj[key];
 
           const Element = getElement(type);
 
@@ -105,7 +107,7 @@ const DynamicForm = ({ schema, optionchanged, createDataSource, options, isSavin
               {$label && (
                 <label className="form-label">
                   {$label}
-                  {type === 'password' && (
+                  {(type === 'password' || $encrypted) && (
                     <small className="text-green mx-2">
                       <img
                         className="mx-2 encrypted-icon"

--- a/frontend/src/_ui/Textarea/index.js
+++ b/frontend/src/_ui/Textarea/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Input = ({ helpText, ...props }) => (
+  <>
+    <textarea {...props} />
+    {helpText && <small className="text-muted" dangerouslySetInnerHTML={{ __html: helpText }} />}
+  </>
+);
+
+export default Input;


### PR DESCRIPTION
This PR fixes the following - 

- Adding an encryped icon beside the private key label by added `$encrypted: true` to the json schema
- Adds textarea component 

![image](https://user-images.githubusercontent.com/12490590/138668615-f8404de6-48b7-4cd4-bcf5-c70576aaa712.png)
