### PR TITLE
Set default to "true" for AddMarkers in React-google-map component

### DIFF
--- a/frontend/src/Editor/Components/components.js
+++ b/frontend/src/Editor/Components/components.js
@@ -1003,8 +1003,8 @@ export const componentTypes = [
         canSearch: {
           value: `{{true}}` ,
         },
+		addNewMarkers: { value: '{{true}}' },
       },
-      addNewMarkers: { value: '{{false}}' },
       events: [],
       styles: {
         visibility: { value: '{{true}}' },


### PR DESCRIPTION
Fix for the issue - #1230 