### PR TITLE
Fix widget documentation link to persist the applied theme

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2150,6 +2150,14 @@ input:focus-visible {
     border-right: 1px solid #fff;
     border-bottom: 1px solid #fff;
   }
+
+  .widget-documentation-link {
+    background-color: #1f2936;
+  }
+
+  .widget-documentation-link a {
+    color: rgb(66, 153, 225);
+  }
 }
 
 .main-wrapper {


### PR DESCRIPTION
Issue: #1233 

### Light theme:
![widget-docs-light](https://user-images.githubusercontent.com/48540198/138804091-bf7d5392-dc9e-44a9-bfe4-f3cf8a903540.png)

### Dark theme:
![widget-docs-dark](https://user-images.githubusercontent.com/48540198/138804125-90175788-2e02-491a-b3e0-c1d73ef7fe3f.png)


