### PR TITLE
fix(docs): update the sidebar positions for doc items

### DIFF
--- a/docs/docs/widgets/Image.md
+++ b/docs/docs/widgets/Image.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Image

--- a/docs/docs/widgets/divider.md
+++ b/docs/docs/widgets/divider.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 6
 ---
 
 # Divider

--- a/docs/docs/widgets/dropdown.md
+++ b/docs/docs/widgets/dropdown.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Dropdown

--- a/docs/docs/widgets/map.md
+++ b/docs/docs/widgets/map.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Map

--- a/docs/docs/widgets/modal.md
+++ b/docs/docs/widgets/modal.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Modal

--- a/docs/docs/widgets/multiselect.md
+++ b/docs/docs/widgets/multiselect.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # Multiselect

--- a/docs/docs/widgets/number-input.md
+++ b/docs/docs/widgets/number-input.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 12
 ---
 
 # Number Input

--- a/docs/docs/widgets/qr-scanner.md
+++ b/docs/docs/widgets/qr-scanner.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 13
 ---
 
 # QR Scanner

--- a/docs/docs/widgets/radio-button.md
+++ b/docs/docs/widgets/radio-button.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 14
 ---
 
 # Radio Button

--- a/docs/docs/widgets/rich-text-editor.md
+++ b/docs/docs/widgets/rich-text-editor.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 ---
 
 # Rich Text Editor

--- a/docs/docs/widgets/star.md
+++ b/docs/docs/widgets/star.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 16
 ---
 
 # Star rating

--- a/docs/docs/widgets/table.md
+++ b/docs/docs/widgets/table.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 17
 ---
 
 # Table

--- a/docs/docs/widgets/text-input.md
+++ b/docs/docs/widgets/text-input.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 18
 ---
 
 # Text Input

--- a/docs/docs/widgets/text.md
+++ b/docs/docs/widgets/text.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 19
 ---
 
 # Text

--- a/docs/docs/widgets/textarea.md
+++ b/docs/docs/widgets/textarea.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 20
 ---
 
 # Textarea

--- a/docs/docs/widgets/toggle-switch.md
+++ b/docs/docs/widgets/toggle-switch.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 21
 ---
 
 # Toggle Switch


### PR DESCRIPTION
### Description

The PR fixes the sidebar order positioning of `Divider` Widget

### Fixes

Fixes https://github.com/ToolJet/ToolJet/issues/1242

### How to test?
1. Run docs on local
2. Open `Widget Reference` from the side nav
3. All the widgets should be ordered alphabetically.