### PR TITLE
Include ToolJet version in exported JSON

### DIFF
--- a/server/src/controllers/apps.controller.ts
+++ b/server/src/controllers/apps.controller.ts
@@ -141,7 +141,10 @@ export class AppsController {
     }
 
     const app = await this.appImportExportService.export(req.user, params.id);
-    return app;
+    return {
+      ...app,
+      tooljetVersion: globalThis.TOOLJET_VERSION,
+    };
   }
 
   @UseGuards(JwtAuthGuard)


### PR DESCRIPTION
Closes #1275

I've also tested to ensure that this doesn't break compatibility with the import API