### PR TITLE
GitHub should be spelled GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,17 +12,17 @@ We love your input! We want to make contributing to this project as easy and tra
 [Docker](https://docs.tooljet.io/docs/contributing-guide/setup/docker)
 [Ubuntu](https://docs.tooljet.io/docs/contributing-guide/setup/ubuntu)
 
-## We Develop with Github
-We use github to host code, to track issues and feature requests, as well as accept pull requests.
+## We Develop with GitHub
+We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
 
 ## First-time contributors
-We've tagged some issues to make it easy to get started :)
+We've tagged some issues to make it easy to get started :smile:
 [Good first issues](https://github.com/ToolJet/ToolJet/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 Looking for ReactJS issues? Check out our [Frontend issues](https://github.com/ToolJet/ToolJet/issues?q=is%3Aissue+is%3Aopen+label%3Afrontend)
 
 Add a comment on the issue and wait for the issue to be assigned before you start working on it. This helps to avoid multiple people working on similar issues.
 
-## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
+## We Use [GitHub Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
 Pull requests are the best way to propose changes to the codebase (we use [Git-Flow](https://nvie.com/posts/a-successful-git-branching-model/)). We actively welcome your pull requests:
 
 1. Fork the repo and create your branch from `develop`. Please create the branch in the format feature/<issue-id>-<issue-name> (eg: feature/176-chart-widget)
@@ -35,7 +35,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Git-F
 ## Any contributions you make will be under the AGPL v3 License
 In short, when you submit code changes, your submissions are understood to be under the same [AGPL v3 License](https://www.gnu.org/licenses/agpl-3.0.en.html) that covers the project.
 
-## Report bugs using Github's [issues](https://github.com/ToolJet/ToolJet/issues)
+## Report bugs using GitHub's [issues](https://github.com/ToolJet/ToolJet/issues)
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/ToolJet/ToolJet/issues/new/choose). It's that easy!
 
 **Great Bug Reports** tend to have:


### PR DESCRIPTION
It's GitHub, not github, or Github :wink: sorry couldn't help myself as per the GitHub guidelines: https://github.com/logos
Also added the smile emoji instead of just :)
Happy Hacking everyone!