### PR TITLE
Add websocket url fallback as window.location.host

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -107,9 +107,16 @@ class Editor extends React.Component {
     }
   }
 
+  getWebsocketUrl = () => {
+    const re = /https?:\/\//g;
+    if (re.test(config.apiUrl)) return config.apiUrl.replace(/(^\w+:|^)\/\//, '').replace('/api', '');
+
+    return window.location.host;
+  };
+
   initWebSocket = () => {
     // TODO: add retry policy
-    const socket = new WebSocket(`ws://${config.apiUrl.replace(/(^\w+:|^)\/\//, '').replace('/api', '')}`);
+    const socket = new WebSocket(`ws://${this.getWebsocketUrl()}`);
 
     // Connection opened
     socket.addEventListener('open', function (event) {


### PR DESCRIPTION
This PR adds a fallback of `window.location.host` as fallback when we are trying to connect to websocket as on stagin the config.apiUrl returns `/api` because frontend and backend are hosted on the same url