### PR TITLE
Fix: Stack trace not being logged

### DIFF
--- a/server/src/all-exceptions-filter.ts
+++ b/server/src/all-exceptions-filter.ts
@@ -1,0 +1,25 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common';
+import { Logger } from 'nestjs-pino';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  constructor(private readonly logger: Logger) {}
+
+  catch(exception: Error, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+
+    const status = exception instanceof HttpException ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
+      this.logger.error(exception);
+    }
+
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}


### PR DESCRIPTION
Fixes #981 

This is currently an [open issue](https://github.com/iamolegga/nestjs-pino/issues/535) on nestjs-pino.
The current approach adds in a global filter that will explicitly log the trace given the exception thrown is of `Error` type.