### PR TITLE
fix: border-bottom of active classname in user group manager

### DIFF
--- a/frontend/src/ManageGroupPermissionResources/ManageGroupPermissionResources.jsx
+++ b/frontend/src/ManageGroupPermissionResources/ManageGroupPermissionResources.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 import SelectSearch, { fuzzySearch } from 'react-select-search';
 import { groupPermissionService } from '../_services/groupPermission.service';
 import 'react-toastify/dist/ReactToastify.css';
@@ -327,32 +328,26 @@ class ManageGroupPermissionResources extends React.Component {
           <div className="page-body">
             <div className="container-xl">
               <div className="card">
-                <ul className="nav nav-tabs">
-                  <li className="nav-item">
-                    <a
-                      className={`nav-link ${currentTab === 'apps' ? 'active' : ''}`}
-                      onClick={() => this.setState({ currentTab: 'apps' })}
-                    >
-                      Apps
-                    </a>
-                  </li>
-                  <li className="nav-item">
-                    <a
-                      className={`nav-link ${currentTab === 'users' ? 'active' : ''}`}
-                      onClick={() => this.setState({ currentTab: 'users' })}
-                    >
-                      Users
-                    </a>
-                  </li>
-                  <li className="nav-item">
-                    <a
-                      className={`nav-link ${currentTab === 'permissions' ? 'active' : ''}`}
-                      onClick={() => this.setState({ currentTab: 'permissions' })}
-                    >
-                      Permissions
-                    </a>
-                  </li>
-                </ul>
+                <nav className="nav nav-tabs">
+                  <a
+                    onClick={() => this.setState({ currentTab: 'apps' })}
+                    className={cx('nav-item nav-link', { active: currentTab === 'apps' })}
+                  >
+                    Apps
+                  </a>
+                  <a
+                    onClick={() => this.setState({ currentTab: 'users' })}
+                    className={cx('nav-item nav-link', { active: currentTab === 'users' })}
+                  >
+                    Users
+                  </a>
+                  <a
+                    onClick={() => this.setState({ currentTab: 'permissions' })}
+                    className={cx('nav-item nav-link', { active: currentTab === 'permissions' })}
+                  >
+                    Permissions
+                  </a>
+                </nav>
                 <div className="card-body">
                   <div className="tab-content">
                     {/* Apps Tab */}


### PR DESCRIPTION
In user group manager page, the border bottom of the active tab was 1px above the border of the parent div

This PR fixes the above

![image](https://user-images.githubusercontent.com/12490590/141776708-3451fb11-3b2e-4c98-a133-cbd5434b7e96.png)
