### PR TITLE
fix: add placeholder for records while bulk update in postgresSQL

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/Postgresql.schema.json
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Postgresql.schema.json
@@ -54,7 +54,8 @@
           "$label": "Records to update",
           "$key": "records",
           "type": "codehinter",
-          "description": "Enter records"
+          "description": "Enter records",
+          "placeholder": "{{ [ ] }}"
         }
       }
     }


### PR DESCRIPTION
This PR adds the missing placeholder while bulk updation in postgresSQL