### PR TITLE
Disable drag while table columns are being resized 

### DIFF
--- a/frontend/src/Editor/DraggableBox.jsx
+++ b/frontend/src/Editor/DraggableBox.jsx
@@ -207,7 +207,7 @@ export const DraggableBox = function DraggableBox({
               setDragging(false)
               onDragStop(e, id, direction, currentLayout, currentLayoutOptions)
             }}
-            cancel={`div.table-responsive.jet-data-table`}
+            cancel={`div.table-responsive.jet-data-table, div.calendar-widget`}
             onDragStart={(e) => e.stopPropagation()}
             enableResizing={mode === 'edit'}
             onResizeStop={(e, direction, ref, d, position) => {

--- a/frontend/src/Editor/DraggableBox.jsx
+++ b/frontend/src/Editor/DraggableBox.jsx
@@ -207,6 +207,7 @@ export const DraggableBox = function DraggableBox({
               setDragging(false)
               onDragStop(e, id, direction, currentLayout, currentLayoutOptions)
             }}
+            cancel={`div.table-responsive.jet-data-table > table > thead`}
             onDragStart={(e) => e.stopPropagation()}
             enableResizing={mode === 'edit'}
             onResizeStop={(e, direction, ref, d, position) => {

--- a/frontend/src/Editor/DraggableBox.jsx
+++ b/frontend/src/Editor/DraggableBox.jsx
@@ -207,7 +207,7 @@ export const DraggableBox = function DraggableBox({
               setDragging(false)
               onDragStop(e, id, direction, currentLayout, currentLayoutOptions)
             }}
-            cancel={`div.table-responsive.jet-data-table > table > thead`}
+            cancel={`div.table-responsive.jet-data-table`}
             onDragStart={(e) => e.stopPropagation()}
             enableResizing={mode === 'edit'}
             onResizeStop={(e, direction, ref, d, position) => {


### PR DESCRIPTION
The drag event should not start when the table columns ar being resized or when calendar events are being selected.