### PR TITLE
fix: tabs text jump in inspector

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2657,6 +2657,11 @@ input[type='text'] {
   .nav-item:not(.active) {
     border-bottom: 1px solid #e7eaef;
   }
+
+  .nav-link.active {
+    border: 1px solid transparent;
+    border-bottom: 1px solid $primary;
+  }
 }
 
 .tabs-inspector.nav-tabs {


### PR DESCRIPTION
This PR fixes the text jump issue in widget inspector

https://user-images.githubusercontent.com/12490590/144741937-08989bca-39d4-430c-b01a-a90e5f7091cb.mov


