### PR TITLE
fix: add correct display value in oauth type selection

### DIFF
--- a/frontend/src/_ui/OAuth/index.js
+++ b/frontend/src/_ui/OAuth/index.js
@@ -23,7 +23,7 @@ const OAuth = ({
           { name: 'None', value: 'none' },
           { name: 'OAuth 2.0', value: 'oauth2' },
         ]}
-        value={grant_type}
+        value={auth_type}
         onChange={(value) => optionchanged('auth_type', value)}
       />
       <Authentication


### PR DESCRIPTION
This `value` to display data was incorrect, setting it to the oauth component