### PR TITLE
Fix toggle query editor icon showing up on navbar when query editor is closed

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -654,7 +654,6 @@ class Editor extends React.Component {
       showQueryEditor: !prev.showQueryEditor,
       queryPaneHeight: this.state.queryPaneHeight === 100 ? 30 : 100,
     }));
-    this.toolTipRefShow.current.style.display = this.state.showQueryEditor ? 'flex' : 'none';
   };
 
   toggleComments = () => {
@@ -698,7 +697,6 @@ class Editor extends React.Component {
     });
   };
 
-  toolTipRefShow = createRef();
   queryPaneRef = createRef();
 
   getCanvasWidth = () => {
@@ -811,23 +809,6 @@ class Editor extends React.Component {
                 {this.state.editingVersion && (
                   <small className="app-version-name">{`App version: ${this.state.editingVersion.name}`}</small>
                 )}
-                <div className="editor-buttons">
-                  <span
-                    className={`btn btn-light mx-2`}
-                    onClick={this.toggleQueryEditor}
-                    data-tip="Show query editor"
-                    data-class="py-1 px-2"
-                    ref={this.toolTipRefShow}
-                    style={{ display: 'none', opacity: 0.5 }}
-                  >
-                    <img
-                      style={{ transform: 'rotate(-90deg)' }}
-                      src="/assets/images/icons/editor/sidebar-toggle.svg"
-                      width="12"
-                      height="12"
-                    />
-                  </span>
-                </div>
                 <div className="layout-buttons cursor-pointer">
                   {this.renderLayoutIcon(currentLayout === 'desktop')}
                 </div>


### PR DESCRIPTION
Toggle query editor icon showing up on navbar when query editor is closed