### PR TITLE
fix(chart): update chart type toggle on UI

### DIFF
--- a/frontend/src/Editor/Components/Chart.jsx
+++ b/frontend/src/Editor/Components/Chart.jsx
@@ -80,8 +80,8 @@ export const Chart = function Chart({ width, height, darkMode, properties, style
       newData = [
         {
           type: chartType,
-          values: rawData.map((item) => item['value']),
-          labels: rawData.map((item) => item['label']),
+          values: rawData.map((item) => item['y']),
+          labels: rawData.map((item) => item['x']),
         },
       ];
     } else {
@@ -99,7 +99,7 @@ export const Chart = function Chart({ width, height, darkMode, properties, style
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const memoizedChartData = useMemo(() => computeChartData(data, dataString), [data, dataString]);
+  const memoizedChartData = useMemo(() => computeChartData(data, dataString), [data, dataString, chartType]);
 
   return (
     <div data-disabled={disabledState} style={computedStyles}>


### PR DESCRIPTION
## Description

The PR fixes toggling the chart type on the UI. Updates react memo deps to consider the chart type as well

## Issue

Solves #1670 

## How to test?

1. Run Tooljet
2. Drag the chart widget
3. Change the `Chart Type` under `Properties`. The chart should change its type as per the selected option from the dropdown