### PR TITLE
[Bugfix] Widget inspector: properties & styles - the background color is same for body and non selected tab 

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2832,10 +2832,6 @@ input[type="text"] {
     border-bottom: 1px solid #e7eaef;
   }
 
-  .nav-link {
-    border-color: transparent !important;
-  }
-
   .nav-link.active {
     border: 1px solid transparent;
     border-bottom: 1px solid $primary;


### PR DESCRIPTION
Fixes #1729 

### Screenshots
<img width="558" alt="Screenshot 2022-01-04 at 3 09 24 PM" src="https://user-images.githubusercontent.com/67645175/148039607-8f466023-b151-4bef-ad1a-5788961f62fd.png">
<img width="558" alt="Screenshot 2022-01-04 at 3 09 30 PM" src="https://user-images.githubusercontent.com/67645175/148039620-a4a78285-e8c2-4cce-b957-0405c1be6b5c.png">

