### PR TITLE
fix(date-range): show date format from the properties

### DIFF
--- a/frontend/src/Editor/Components/DaterangePicker.jsx
+++ b/frontend/src/Editor/Components/DaterangePicker.jsx
@@ -26,11 +26,11 @@ export const DaterangePicker = function DaterangePicker({
     const end = dates.endDate;
 
     if (start) {
-      setExposedVariable('startDate', start.format(formatProp.value));
+      setExposedVariable('startDate', start.format(formatProp));
     }
 
     if (end) {
-      setExposedVariable('endDate', end.format(formatProp.value));
+      setExposedVariable('endDate', end.format(formatProp));
     }
 
     setStartDate(start);
@@ -54,6 +54,7 @@ export const DaterangePicker = function DaterangePicker({
         onFocusChange={(focus) => focusChanged(focus)}
         focusedInput={focusedInput}
         hideKeyboardShortcutsPanel={true}
+        displayFormat={formatProp}
       />
     </div>
   );


### PR DESCRIPTION
## Description

The PR fixes date range format when changed from the properties panel

## Issue

Solves #1623 

## How to test?

1. Drag a Date Range picker
2. Select start and end dates
3. From the properties, change to a valid format, the date displayed **should update** accordingly

![image](https://user-images.githubusercontent.com/15359575/148075991-325e9856-bf62-4c91-9caa-671ffea00eda.png)
