### PR TITLE
Removed filter from badge class in dark theme to prevent status colour varies.

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2234,8 +2234,6 @@ input:focus-visible {
   }
 
   .badge {
-    filter: brightness(1) invert(1);
-
     .svg-icon {
       filter: brightness(1) invert(0);
     }


### PR DESCRIPTION
I remove `filter: brightness(1) invert(0);` from class `.badge` on dark theme because this make colours different on white and dark theme