### PR TITLE
added logos to querymanager

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -208,11 +208,22 @@ let QueryManager = class QueryManager extends React.Component {
   };
 
   renderDataSourceOption = (props, option, snapshot, className) => {
+    const icon = option.kind ? `/assets/images/icons/editor/datasources/${option.kind.toLowerCase() + '.svg'}` : null;
     return (
       <button {...props} className={className} type="button">
         <div className="row">
           <div className="col-md-9">
-            <span className="text-muted mx-2">{option.name}</span>
+            
+            <span className="text-muted mx-2">
+              {icon && <img
+                    src={icon}
+                    style={{ objectFit: 'contain' }}
+                    height="25"
+                    width="25"
+                    className="mt-1 col-md-2">
+              </img>}
+              {option.name}
+            </span>
           </div>
         </div>
       </button>
@@ -365,7 +376,7 @@ let QueryManager = class QueryManager extends React.Component {
                     <SelectSearch
                       options={[
                         ...dataSources.map((source) => {
-                          return { name: source.name, value: source.id };
+                          return { name: source.name, value: source.id, kind: source.kind };
                         }),
                         ...staticDataSources.map((source) => {
                           return { name: source.name, value: source.id };

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -213,15 +213,10 @@ let QueryManager = class QueryManager extends React.Component {
       <button {...props} className={className} type="button">
         <div className="row">
           <div className="col-md-9">
-            
             <span className="text-muted mx-2">
-              {icon && <img
-                    src={icon}
-                    style={{ objectFit: 'contain' }}
-                    height="25"
-                    width="25"
-                    className="mt-1 col-md-2">
-              </img>}
+              {icon && (
+                <img src={icon} style={{ objectFit: 'contain' }} height="25" width="25" className="mt-1·col-md-2"></img>
+              )}
               {option.name}
             </span>
           </div>


### PR DESCRIPTION
Resolves #1655 

Added datasource logos to each item in the QueryManager dropdown:
![image](https://user-images.githubusercontent.com/47090434/148331435-80933242-c8f5-45bc-843a-4e7cb29d5e0b.png)

Last two default options are without a logo, did we want to add something for them?
![image](https://user-images.githubusercontent.com/47090434/148331600-271e617e-81f6-4763-a11b-2928eba672a4.png)
