### PR TITLE
Feature: Create a default version on app create

### DIFF
--- a/server/migrations/1641546739091-BackfillDefaultAppVersionForApps.ts
+++ b/server/migrations/1641546739091-BackfillDefaultAppVersionForApps.ts
@@ -1,0 +1,26 @@
+import { App } from 'src/entities/app.entity';
+import { AppVersion } from 'src/entities/app_version.entity';
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BackfillDefaultAppVersionForApps1641546739091 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const manager = queryRunner.manager;
+    const appsWithoutVersions = await manager
+      .createQueryBuilder(App, 'apps')
+      .leftJoin('apps.appVersions', 'app_versions')
+      .where('app_versions.app_id is NULL')
+      .getMany();
+
+    for (const app of appsWithoutVersions) {
+      const version = manager.create(AppVersion, {
+        name: 'default',
+        appId: app.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      await manager.save(AppVersion, version);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/server/src/services/apps.service.ts
+++ b/server/src/services/apps.service.ts
@@ -91,6 +91,7 @@ export class AppsService {
     );
 
     await this.createAppGroupPermissionsForAdmin(app);
+    await this.createVersion(user, app, 'default');
 
     return app;
   }

--- a/server/test/controllers/apps.e2e-spec.ts
+++ b/server/test/controllers/apps.e2e-spec.ts
@@ -82,6 +82,9 @@ describe('apps controller', () => {
 
         expect(response.statusCode).toBe(201);
         expect(response.body.name).toBe('Untitled app');
+
+        const defaultVersion = await getManager().findOne(AppVersion, { name: 'default' });
+        expect(defaultVersion).toBeDefined();
       });
     });
 
@@ -103,6 +106,9 @@ describe('apps controller', () => {
 
       expect(application.name).toBe('Untitled app');
       expect(application.id).toBe(application.slug);
+
+      const defaultVersion = await getManager().findOne(AppVersion, { name: 'default' });
+      expect(defaultVersion).toBeDefined();
     });
   });
 


### PR DESCRIPTION
Prerequisite for #1758
- App versions `default` created on app creation
- Backfill for existing apps with no app versions