### PR TITLE
Removed class text-muted from Library card text

### DIFF
--- a/frontend/src/HomePage/LibraryApps.jsx
+++ b/frontend/src/HomePage/LibraryApps.jsx
@@ -55,7 +55,7 @@ export const LibraryApps = function LibraryApps() {
                   {/* <div className="empty-img">
                 </div> */}
                   <h3>{app.name}</h3>
-                  <p className="text-muted">{app.description}</p>
+                  <p>{app.description}</p>
                   <div className="flex">
                     {app.widgets.map((widget) => (
                       <span className="badge bg-azure-lt mx-2" key={app.widget}>


### PR DESCRIPTION
Resolves #1134

I remove class `text-muted` from Library card text, because text is not legible in dark mode. When class `text-muted` is removed everything looks right

With class `text-muted` :

![2022-01-08_13-34](https://user-images.githubusercontent.com/72993041/148645412-5a462044-1c7a-4702-a5d1-64e1917b630c.png)

Without class `text-muted` : 

![2022-01-08_13-34_1](https://user-images.githubusercontent.com/72993041/148645430-769e8495-86c4-4047-82e0-c85790d456c3.png)

