### PR TITLE
Fixed placement for delete button on text input, button and etc.

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1697,6 +1697,7 @@ hr {
     top: -20px;
     position: fixed;
     max-height: 10px;
+    min-width: 108px;
 
     .badge {
       font-size: 9px;


### PR DESCRIPTION
Resolves #1417

When class `.config-handle` doesn't have `min-width` delete button placement is incorrect when text input/button is smaller.

Without `min-width` :

![Capture](https://user-images.githubusercontent.com/72993041/148701679-03a17acc-ab2b-44cf-b9bc-783d62a1c540.PNG)

With `min-width` : 

![Capture2](https://user-images.githubusercontent.com/72993041/148701683-4089090e-d34e-4eb4-a9f5-600475315b15.PNG)

I added exactly 108px because I checked and see that this is the minimum width needed to work correctly.
