### PR TITLE
Chore: Run ci only when label is added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'run-ci' }}
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -56,6 +57,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'run-ci' }}
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
-    types: [ labeled ]
     branches: [develop, main]
   pull_request:
+    types: [ labeled ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
+    types: [ labeled ]
     branches: [develop, main]
   pull_request:
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
Ci will only be run if `run-ci` label is added onto a pull request. This will help save unnecessary ci runs when PRs are be revised or is in draft.