### PR TITLE
[Navbar]: Fixed incorrect color when hover logo image.

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2691,6 +2691,11 @@ input[type="text"] {
   height: 1.2rem;
 }
 
+.navbar .navbar-brand:hover,
+.theme-dark .navbar .navbar-brand:hover {
+  opacity: 1;
+}
+
 .nav-tabs .nav-link.active {
   font-weight: 400 !important;
   margin-bottom: -1px !important;


### PR DESCRIPTION
Resolves #1573

I saw that in `tabler.scss` file, when hovering navbar logo opacity is adjusted to `0.8` and I just override this in `theme.scss`.
This fixes the issue.
