### PR TITLE
Added feature: close the creation folder modal when click outside.

### DIFF
--- a/frontend/src/HomePage/Modal.jsx
+++ b/frontend/src/HomePage/Modal.jsx
@@ -4,6 +4,7 @@ import { default as BootstrapModal } from 'react-bootstrap/Modal';
 export default function Modal({ title, show, setShow, customClassName, children }) {
   return (
     <BootstrapModal
+      onHide={() => setShow(false)}
       contentClassName={`home-modal-component${customClassName ? ` ${customClassName}` : ''}`}
       show={show}
       size="md"


### PR DESCRIPTION
Resolves #955

Added feature to the folder creation modal. When you click outside of the modal, it's closing now.

![folder](https://user-images.githubusercontent.com/72993041/149041301-6618e3dc-f5a5-4975-9e90-7f86337f0c3c.gif)
