### PR TITLE
added dark theme to querymanager dropdown lists

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -211,10 +211,25 @@ let QueryManager = class QueryManager extends React.Component {
   renderDataSourceOption = (props, option, snapshot, className) => {
     const icon = option.kind ? `/assets/images/icons/editor/datasources/${option.kind.toLowerCase() + '.svg'}` : null;
     return (
-      <button {...props} className={className} type="button">
+      <button
+        {...props}
+        className={`${className} ${this.props.darkMode ? 'select-search__option__dark' : ''}`}
+        type="button"
+      >
         <div>
-          <span className="text-muted">
-            {icon && <img src={icon} style={{ margin: 'auto', marginRight: '3px' }} height="25" width="25"></img>}
+          <span>
+            {icon && (
+              <img
+                src={icon}
+                style={{
+                  margin: 'auto',
+                  marginRight: '3px',
+                  filter: this.props.darkMode ? 'brightness(0) invert(1)' : '',
+                }}
+                height="25"
+                width="25"
+              ></img>
+            )}
             {option.name}
           </span>
         </div>
@@ -380,6 +395,7 @@ let QueryManager = class QueryManager extends React.Component {
                       filterOptions={fuzzySearch}
                       renderOption={this.renderDataSourceOption}
                       placeholder="Select a data source"
+                      className={`${this.props.darkMode ? 'select-search-dark' : 'select-search'}`}
                     />
                   </div>
                 )}

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -224,7 +224,6 @@ let QueryManager = class QueryManager extends React.Component {
                 style={{
                   margin: 'auto',
                   marginRight: '3px',
-                  filter: this.props.darkMode ? 'brightness(0) invert(1)' : '',
                 }}
                 height="25"
                 width="25"

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1086,6 +1086,219 @@ button {
   color: #888;
 }
 
+/**
+* Select Search Dark Mode 
+*/
+.select-search-dark {
+  width: 300px;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.select-search-dark *,
+.select-search-dark *::after,
+.select-search-dark *::before {
+  box-sizing: inherit;
+}
+
+/**
+ * Value wrapper
+ */
+.select-search-dark__value {
+  position: relative;
+  z-index: 1;
+}
+
+.select-search-dark__value::after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: calc(50% - 4px);
+  right: 13px;
+  width: 6px;
+  height: 6px;
+  filter: brightness(0) invert(1);
+}
+
+/**
+ * Input
+ */
+.select-search-dark__input {
+  display: block;
+  width: 100%;
+  padding: 0.4375rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.4285714;
+  color: #fff;
+  background-color: #2b3547;
+  background-clip: padding-box;
+  border: 1px solid #232e3c;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.select-search-dark__input::-webkit-search-decoration,
+.select-search-dark__input::-webkit-search-cancel-button,
+.select-search-dark__input::-webkit-search-results-button,
+.select-search-dark__input::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+}
+
+.select-search-dark__input:not([readonly]):focus {
+  cursor: initial;
+}
+
+/**
+ * Options wrapper
+ *
+.select-search-dark__select {
+  background: #fff;
+  box-shadow: 0 0.0625rem 0.125rem rgba(0, 0, 0, 0.15);
+}
+*/
+
+/**
+ * Options
+ */
+.select-search-dark__options {
+  list-style: none;
+  padding: 0;
+}
+
+/**
+ * Option row
+ */
+.select-search-dark__row:not(:first-child) {
+  border-top: none;
+}
+
+/**
+ * Option
+ */
+.select-search-dark__option,
+.select-search-dark__not-found {
+  display: block;
+  height: 36px;
+  width: 100%;
+  padding: 0 16px;
+  background-color: #2b3547;
+  color: #fff;
+  border: none;
+  outline: none;
+  font-family: "Roboto", sans-serif;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 0;
+}
+
+.select-search-dark--multiple .select-search-dark__option {
+  height: 48px;
+}
+
+/**
+*
+.select-search-dark__option.is-highlighted,
+.select-search-dark__option:not(.is-selected):hover {
+  background: rgba(47, 204, 139, 0.1);
+}
+*/
+
+/**
+*
+.select-search-dark__option.is-highlighted.is-selected,
+.select-search-dark__option.is-selected:hover {
+  background: #2eb378;
+  color: #fff;
+}
+*/
+
+/**
+ * Group
+ */
+.select-search-dark__group-header {
+  font-size: 10px;
+  text-transform: uppercase;
+  background: #eee;
+  padding: 8px 16px;
+}
+
+/**
+ * States
+ */
+.select-search-dark.is-disabled {
+  opacity: 0.5;
+}
+
+.select-search-dark.is-loading .select-search-dark__value::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='50' height='50' viewBox='0 0 50 50'%3E%3Cpath fill='%232F2D37' d='M25,5A20.14,20.14,0,0,1,45,22.88a2.51,2.51,0,0,0,2.49,2.26h0A2.52,2.52,0,0,0,50,22.33a25.14,25.14,0,0,0-50,0,2.52,2.52,0,0,0,2.5,2.81h0A2.51,2.51,0,0,0,5,22.88,20.14,20.14,0,0,1,25,5Z'%3E%3CanimateTransform attributeName='transform' type='rotate' from='0 25 25' to='360 25 25' dur='0.6s' repeatCount='indefinite'/%3E%3C/path%3E%3C/svg%3E");
+  background-size: 11px;
+}
+
+.select-search-dark:not(.is-disabled) .select-search-dark__input {
+  cursor: pointer;
+}
+
+/**
+ * Modifiers
+ */
+.select-search-dark--multiple {
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.select-search-dark:not(.is-loading):not(.select-search-dark--multiple) .select-search-dark__value::after {
+  transform: rotate(45deg);
+  border-right: 1px solid #000;
+  border-bottom: 1px solid #000;
+  pointer-events: none;
+}
+
+.select-search-dark--multiple .select-search-dark__input {
+  cursor: initial;
+}
+
+.select-search-dark--multiple .select-search-dark__input {
+  border-radius: 3px 3px 0 0;
+}
+
+.select-search-dark--multiple:not(.select-search-dark--search) .select-search-dark__input {
+  cursor: default;
+}
+
+.select-search-dark:not(.select-search-dark--multiple) .select-search-dark__input:hover {
+  border-color: #fff;
+}
+
+.select-search-dark:not(.select-search-dark--multiple) .select-search-dark__select {
+  position: absolute;
+  z-index: 2;
+  right: 0;
+  left: 0;
+  border-radius: 3px;
+  overflow: auto;
+  max-height: 360px;
+}
+
+.select-search-dark--multiple .select-search-dark__select {
+  position: relative;
+  overflow: auto;
+  max-height: 260px;
+  border-top: 1px solid #eee;
+  border-radius: 0 0 3px 3px;
+}
+
+.select-search-dark__not-found {
+  height: auto;
+  padding: 16px;
+  text-align: center;
+  color: #888;
+}
+
 .jet-table-footer {
   .table-footer {
     width: 100%;

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -885,6 +885,9 @@ button {
   .select-search {
     width: 300px;
   }
+  .select-search-dark {
+    width: 300px;
+  }
 }
 
 .select-search {
@@ -1090,7 +1093,7 @@ button {
 * Select Search Dark Mode 
 */
 .select-search-dark {
-  width: 300px;
+  width: 100%;
   position: relative;
   box-sizing: border-box;
 }

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1156,15 +1156,6 @@ button {
 }
 
 /**
- * Options wrapper
- *
-.select-search-dark__select {
-  background: #fff;
-  box-shadow: 0 0.0625rem 0.125rem rgba(0, 0, 0, 0.15);
-}
-*/
-
-/**
  * Options
  */
 .select-search-dark__options {
@@ -1202,23 +1193,6 @@ button {
 .select-search-dark--multiple .select-search-dark__option {
   height: 48px;
 }
-
-/**
-*
-.select-search-dark__option.is-highlighted,
-.select-search-dark__option:not(.is-selected):hover {
-  background: rgba(47, 204, 139, 0.1);
-}
-*/
-
-/**
-*
-.select-search-dark__option.is-highlighted.is-selected,
-.select-search-dark__option.is-selected:hover {
-  background: #2eb378;
-  color: #fff;
-}
-*/
 
 /**
  * Group

--- a/frontend/src/_ui/Select/index.js
+++ b/frontend/src/_ui/Select/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import SelectSearch, { fuzzySearch } from 'react-select-search';
 
 const Select = ({ options = [], value, hasSearch = false, onChange }) => {
+  const darkMode = localStorage.getItem('darkMode') === 'true';
   return (
     <SelectSearch
       options={options}
@@ -10,6 +11,7 @@ const Select = ({ options = [], value, hasSearch = false, onChange }) => {
       onChange={onChange}
       filterOptions={fuzzySearch}
       placeholder="Select.."
+      className={`${darkMode ? 'select-search-dark' : 'select-search'}`}
     />
   );
 };


### PR DESCRIPTION
Resolves #1745 

No changes to functionality, just added dark theme.

Datasource dropdown:
![image](https://user-images.githubusercontent.com/47090434/149643706-47d5a48c-7dc1-46bd-988d-cccd537900ba.png)
![image](https://user-images.githubusercontent.com/47090434/149643709-50f8d7af-a18e-4303-8ce5-6a32e343e8ec.png)


Operation dropdown:
![image](https://user-images.githubusercontent.com/47090434/149643758-57e0818e-362b-4eb5-816f-6a69857b12e4.png)
![image](https://user-images.githubusercontent.com/47090434/149643777-450e0308-f6c7-4704-b7be-99e0d1a6e997.png)
