### PR TITLE
Fix: docker compose build plugins

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,9 @@ services:
     platform: linux/x86_64
     volumes:
       - ./frontend:/app/frontend:delegated
-      - ./plugins/:/app/plugins:cached
+      - ./plugins/:/app/plugins
+      - /app/plugins/dist/
+      - /app/plugins/node_modules/
       - /app/frontend/node_modules/
     ports:
       - 8082:8082
@@ -28,7 +30,9 @@ services:
       - postgres
     volumes:
       - ./server:/app/server:delegated
-      - ./plugins/:/app/plugins:cached
+      - ./plugins/:/app/plugins
+      - /app/plugins/dist/
+      - /app/plugins/node_modules/
       - /app/server/node_modules/
       - '.env:/app/.env'
       - '.env.test:/app/.env.test'

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "start:prod": "npm --prefix server run start:prod",
     "db:create": "npm --prefix server run db:create",
     "db:migrate": "npm --prefix server run db:migrate",
+    "db:seed": "npm --prefix server run db:seed",
     "db:reset": "npm --prefix server run db:reset",
     "db:drop": "npm --prefix server run db:drop",
     "deploy": "cp -a frontend/build/. public/",


### PR DESCRIPTION
fixes build failing when prebuilt plugins folders don't exist on local