### PR TITLE
[Hotfix]: Adds current user's groups the inspector in the editor

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -54,6 +54,7 @@ class Editor extends React.Component {
         email: currentUser.email,
         firstName: currentUser.first_name,
         lastName: currentUser.last_name,
+        groups: currentUser.group_permissions.map((group) => group.group),
       };
     }
 

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -54,7 +54,7 @@ class Editor extends React.Component {
         email: currentUser.email,
         firstName: currentUser.first_name,
         lastName: currentUser.last_name,
-        groups: currentUser.group_permissions.map((group) => group.group),
+        groups: currentUser?.group_permissions.map((group) => group.group),
       };
     }
 

--- a/frontend/src/Editor/LeftSidebar/SidebarInspector.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarInspector.jsx
@@ -63,7 +63,7 @@ export const LeftSidebarInspector = ({ darkMode, globals, components, queries })
             collapsed={true}
             displayObjectSize={false}
             quotesOnKeys={false}
-            sortKeys={true}
+            sortKeys={false}
             // indentWidth={1}
           />
         </div>


### PR DESCRIPTION
Resolves #1874 

In the Inspector, the globals have a key name `groups` which list all the groups the current user belongs to.

### Screenshots
<img width="544" alt="Screenshot 2022-01-20 at 2 29 15 AM" src="https://user-images.githubusercontent.com/67645175/150214040-17b12a1b-dd54-4c19-baf1-c393113a954f.png">
<img width="544" alt="Screenshot 2022-01-20 at 2 29 11 AM" src="https://user-images.githubusercontent.com/67645175/150214059-ea11dfa5-b739-4ff1-baaa-c8cfe4f54192.png">

