### PR TITLE
Fix: Center alignment icon of text widget's alignment property is different color in dark mode 

### DIFF
--- a/frontend/src/Editor/Inspector/Elements/AlignButtons.jsx
+++ b/frontend/src/Editor/Inspector/Elements/AlignButtons.jsx
@@ -51,7 +51,7 @@ export const AlignButtons = ({ param, definition, onChange, paramType, component
               viewBox="0 0 16 16"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
-              className="svg-icon"
+              // className="svg-icon"
             >
               <path
                 d="M2 4H14M4.66667 8H11.3333M3.33333 12H12.6667"

--- a/frontend/src/Editor/Inspector/Elements/AlignButtons.jsx
+++ b/frontend/src/Editor/Inspector/Elements/AlignButtons.jsx
@@ -45,14 +45,7 @@ export const AlignButtons = ({ param, definition, onChange, paramType, component
             checked={initialValue === 'center'}
           />
           <div className="action-icon">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              // className="svg-icon"
-            >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path
                 d="M2 4H14M4.66667 8H11.3333M3.33333 12H12.6667"
                 stroke={initialValue == 'center' ? '#fff' : '#8092AC'}


### PR DESCRIPTION
Fixes #1876