### PR TITLE
[Bugfix] Homepage 'no results' not legible for app search

### DIFF
--- a/frontend/src/HomePage/AppList.jsx
+++ b/frontend/src/HomePage/AppList.jsx
@@ -51,7 +51,9 @@ const AppList = (props) => {
       )}
       {!props.isLoading && props.meta.total_count === 0 && !(props.currentFolder && props.currentFolder.id) && (
         <div>
-          <span className="d-block text-center text-body pt-5">No Applications found</span>
+          <span className={`d-block text-center text-body pt-5 ${props.darkMode && 'text-white-50'}`}>
+            No Applications found
+          </span>
         </div>
       )}
       {!props.isLoading && props.currentFolder.count === 0 && (


### PR DESCRIPTION
Fixes #1982 

<img width="1037" alt="Screenshot 2022-01-28 at 5 45 00 AM" src="https://user-images.githubusercontent.com/67645175/151464583-83b99c19-bf20-4bb5-83b1-563dcce781f1.png">

