### PR TITLE
Run only queries belonging to current version

### DIFF
--- a/server/src/controllers/apps.controller.ts
+++ b/server/src/controllers/apps.controller.ts
@@ -57,9 +57,12 @@ export class AppsController {
     const response = decamelizeKeys(app);
 
     const seralizedQueries = [];
+    const dataQueriesBelongingToEditingVersion = app.dataQueries.filter(
+      (query) => query.appVersionId === app.editingVersion.id
+    );
 
     // serialize queries
-    for (const query of app.dataQueries) {
+    for (const query of dataQueriesBelongingToEditingVersion) {
       const decamelizedQuery = decamelizeKeys(query);
       decamelizedQuery['options'] = query.options;
       seralizedQueries.push(decamelizedQuery);
@@ -89,8 +92,8 @@ export class AppsController {
 
     // serialize
     return {
-      current_version_id: app['current_version_id'],
-      data_queries: app.dataQueries,
+      current_version_id: app['currentVersionId'],
+      data_queries: app.dataQueries.filter((query) => query.appVersionId === app['currentVersionId']),
       definition: app.editingVersion?.definition,
       is_public: app.isPublic,
       name: app.name,


### PR DESCRIPTION
Resolves #2015

This PR filters out the queries being sent from the backend, to only contain those that belong to the current editing version of the app being edited, or the current deployed version of the app being viewed.