### PR TITLE
fix: re-render of container

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -887,10 +887,27 @@ class Editor extends React.Component {
     );
   };
 
+  handleOnComponentOptionChanged = (component, optionName, value) => {
+    onComponentOptionChanged(this, component, optionName, value);
+  };
+
+  handleOnComponentOptionsChanged = (component, options) => {
+    onComponentOptionsChanged(this, component, options);
+  };
+
+  handleComponentClick = (id, component) => {
+    this.setState({
+      selectedComponent: { id, component },
+    });
+    this.switchSidebarTab(1);
+  };
+
+  handleEvent = (eventName, options) => onEvent(this, eventName, options, 'edit');
+
   render() {
     const {
       currentSidebarTab,
-      selectedComponent,
+      selectedComponent = {},
       appDefinition,
       appId,
       slug,
@@ -1086,26 +1103,17 @@ class Editor extends React.Component {
                         zoomLevel={zoomLevel}
                         currentLayout={currentLayout}
                         deviceWindowWidth={deviceWindowWidth}
-                        selectedComponent={selectedComponent || {}}
+                        selectedComponent={selectedComponent}
                         appLoading={isLoading}
-                        onEvent={(eventName, options) => onEvent(this, eventName, options, 'edit')}
-                        onComponentOptionChanged={(component, optionName, value) =>
-                          onComponentOptionChanged(this, component, optionName, value)
-                        }
-                        onComponentOptionsChanged={(component, options) =>
-                          onComponentOptionsChanged(this, component, options)
-                        }
+                        onEvent={this.handleEvent}
+                        onComponentOptionChanged={this.handleOnComponentOptionChanged}
+                        onComponentOptionsChanged={this.handleOnComponentOptionsChanged}
                         currentState={this.state.currentState}
                         configHandleClicked={this.configHandleClicked}
                         handleUndo={this.handleUndo}
                         handleRedo={this.handleRedo}
                         removeComponent={this.removeComponent}
-                        onComponentClick={(id, component) => {
-                          this.setState({
-                            selectedComponent: { id, component },
-                          });
-                          this.switchSidebarTab(1);
-                        }}
+                        onComponentClick={this.handleComponentClick}
                       />
                       <CustomDragLayer
                         snapToGrid={true}


### PR DESCRIPTION
Removes arrow function from inside render as Arrow functions are reallocated on every render.

> Avoid arrow functions and binds in render. It breaks performance optimizations like shouldComponentUpdate and PureComponent.

Profiler - before: 

![image](https://user-images.githubusercontent.com/12490590/151770874-94dff886-22cc-4303-afb8-b796095b52b6.png)

Profiler - after: 

![image](https://user-images.githubusercontent.com/12490590/151770964-f50ab567-b6ae-4e09-ae4a-453a1c750c2a.png)


Unable to find which hooks have changed, related [here](https://github.com/facebook/react/issues/21856)