### PR TITLE
(#1942) fix sort direction indicator blending in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1554,7 +1554,7 @@ button {
   .sort-desc:after {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-top: 5px solid #333;
+    border-top: 5px solid #767676;
     border-bottom: 5px solid transparent;
     left: 6px;
     top: 8px;
@@ -1564,7 +1564,7 @@ button {
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
     border-top: 0px solid transparent;
-    border-bottom: 5px solid #333;
+    border-bottom: 5px solid #767676;
     left: 6px;
     bottom: 8px;
   }


### PR DESCRIPTION
## Dark Mode:
### Before and After

![image](https://user-images.githubusercontent.com/67158080/151885823-d6549cd0-26bd-4df3-b904-5864dac2ff3d.png)

## Light Mode:
### Before and After

![image](https://user-images.githubusercontent.com/67158080/151885906-f351904f-636a-4095-bfa9-87eaa6969d1b.png)

Changed Indicator colour from `#333333` to `#767676` which works well for both light mode and dark mode