### PR TITLE
feat: add escape shortcut to close widget inspector

### DIFF
--- a/frontend/src/Editor/Inspector/Inspector.jsx
+++ b/frontend/src/Editor/Inspector/Inspector.jsx
@@ -37,6 +37,7 @@ export const Inspector = ({
   const tabsRef = useRef(null);
 
   useHotkeys('backspace', () => setWidgetDeleteConfirmation(true));
+  useHotkeys('escape', () => switchSidebarTab(2));
 
   const componentMeta = componentTypes.find((comp) => component.component.component === comp.component);
 


### PR DESCRIPTION
feat: add escape shortcut to close widget inspector