### PR TITLE
[Chore] `BlankPage.jsx` - Fixes typo 

### DIFF
--- a/frontend/src/HomePage/BlankPage.jsx
+++ b/frontend/src/HomePage/BlankPage.jsx
@@ -22,7 +22,7 @@ export const BlankPage = function BlankPage({
                 />
               </div>
               <h3 className="empty-welcome-header" style={{ color: darkMode && '#ffffff' }}>
-                Welcome to Tooljet!
+                Welcome to ToolJet!
               </h3>
               <p className="empty-title" style={{ color: darkMode && '#ffffff' }}>
                 You can get started by creating a new application or by creating an application using a template in


### PR DESCRIPTION
Before:
<img width="882" alt="Screenshot 2022-02-05 at 12 12 59 AM" src="https://user-images.githubusercontent.com/67645175/152585125-9b5cab48-b1c5-4a84-9496-142f178ded57.png">




After:
<img width="1440" alt="Screenshot 2022-02-05 at 12 09 56 AM" src="https://user-images.githubusercontent.com/67645175/152585145-27822f5a-f916-4e87-91e6-6c371bba3bb9.png">

