### PR TITLE
chore: update package lock

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -104,6 +104,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@tooljet-plugins/airtable": "file:packages/airtable",
+        "@tooljet-plugins/bigquery": "file:packages/bigquery",
         "@tooljet-plugins/common": "file:packages/common",
         "@tooljet-plugins/dynamodb": "file:packages/dynamodb",
         "@tooljet-plugins/elasticsearch": "file:packages/elasticsearch",
@@ -16190,6 +16191,7 @@
       "version": "file:../plugins",
       "requires": {
         "@tooljet-plugins/airtable": "file:packages/airtable",
+        "@tooljet-plugins/bigquery": "file:packages/bigquery",
         "@tooljet-plugins/common": "file:packages/common",
         "@tooljet-plugins/dynamodb": "file:packages/dynamodb",
         "@tooljet-plugins/elasticsearch": "file:packages/elasticsearch",

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -14841,6 +14841,7 @@
       "dependencies": {
         "@google-cloud/bigquery": "^5.10.0",
         "@tooljet-plugins/common": "file:../common",
+        "json5": "^2.2.0",
         "react": "^17.0.2"
       }
     },
@@ -18374,6 +18375,7 @@
       "requires": {
         "@google-cloud/bigquery": "^5.10.0",
         "@tooljet-plugins/common": "file:../common",
+        "json5": "^2.2.0",
         "react": "^17.0.2"
       }
     },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -91,6 +91,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@tooljet-plugins/airtable": "file:packages/airtable",
+        "@tooljet-plugins/bigquery": "file:packages/bigquery",
         "@tooljet-plugins/common": "file:packages/common",
         "@tooljet-plugins/dynamodb": "file:packages/dynamodb",
         "@tooljet-plugins/elasticsearch": "file:packages/elasticsearch",
@@ -14272,6 +14273,7 @@
       "version": "file:../plugins",
       "requires": {
         "@tooljet-plugins/airtable": "file:packages/airtable",
+        "@tooljet-plugins/bigquery": "file:packages/bigquery",
         "@tooljet-plugins/common": "file:packages/common",
         "@tooljet-plugins/dynamodb": "file:packages/dynamodb",
         "@tooljet-plugins/elasticsearch": "file:packages/elasticsearch",


### PR DESCRIPTION
- pins missed dependency on package-lock