### PR TITLE
Fixes inconsistent styles for widgets in darkmode

### DIFF
--- a/frontend/src/Editor/Components/StarRating/index.js
+++ b/frontend/src/Editor/Components/StarRating/index.js
@@ -14,7 +14,7 @@ export const StarRating = function StarRating({ properties, styles, fireEvent, s
 
   const { visibility, disabledState, textColor, labelColor } = styles;
   const color = textColor ?? '#ffb400';
-  const labelColorStyle = labelColor === '#333' ? (darkMode ? '#fff' : '#000') : labelColor;
+  const labelColorStyle = labelColor === '#333' ? (darkMode ? '#fff' : '#333') : labelColor;
 
   const animatedStars = useTrail(maxRating, {
     config: {

--- a/frontend/src/Editor/Components/StarRating/index.js
+++ b/frontend/src/Editor/Components/StarRating/index.js
@@ -5,7 +5,7 @@ import { useTrail } from 'react-spring';
 
 import Star from './star';
 
-export const StarRating = function StarRating({ properties, styles, fireEvent, setExposedVariable }) {
+export const StarRating = function StarRating({ properties, styles, fireEvent, setExposedVariable, darkMode }) {
   const label = properties.label;
   const defaultSelected = properties.defaultSelected ?? 5;
   const maxRating = properties.maxRating ?? 5;
@@ -14,6 +14,7 @@ export const StarRating = function StarRating({ properties, styles, fireEvent, s
 
   const { visibility, disabledState, textColor, labelColor } = styles;
   const color = textColor ?? '#ffb400';
+  const labelColorStyle = labelColor === '#333' ? (darkMode ? '#fff' : '#000') : labelColor;
 
   const animatedStars = useTrail(maxRating, {
     config: {
@@ -68,7 +69,7 @@ export const StarRating = function StarRating({ properties, styles, fireEvent, s
 
   return (
     <div data-disabled={disabledState} className="star-rating" style={{ display: visibility ? '' : 'none' }}>
-      <span className="label form-check-label col-auto" style={{ color: labelColor }}>
+      <span className="label form-check-label col-auto" style={{ color: labelColorStyle }}>
         {label}
       </span>
       <div className="col px-1 py-0 mt-0">

--- a/frontend/src/Editor/Components/Text.jsx
+++ b/frontend/src/Editor/Components/Text.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import DOMPurify from 'dompurify';
 
-export const Text = function Text({ height, properties, styles }) {
+export const Text = function Text({ height, properties, styles, darkMode }) {
   const [loadingState, setLoadingState] = useState(false);
 
   const { textColor, textAlign, visibility, disabledState } = styles;
   const text = properties.text ?? '';
-  const color = textColor;
+  const color = textColor === '#000' ? (darkMode ? '#fff' : '#000') : textColor;
 
   useEffect(() => {
     const loadingStateProperty = properties.loadingState;

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -3237,7 +3237,6 @@ input[type="text"] {
     min-height: 26px;
     padding: 0;
     padding-left: 2px;
-    background-color: $white;
   }
 
   td.rdtActive,


### PR DESCRIPTION
Related #2140 



###Screenshots

**Before**
<img width="488" alt="Screenshot 2022-02-14 at 11 10 22 AM" src="https://user-images.githubusercontent.com/67645175/153806546-f4ac4d4b-6d21-4c40-9d40-1c2da9aae614.png">
<img width="488" alt="Screenshot 2022-02-14 at 11 10 09 AM" src="https://user-images.githubusercontent.com/67645175/153806555-26deb939-0738-4b2d-b12c-0d90363b12ce.png">
<img width="488" alt="Screenshot 2022-02-14 at 11 09 55 AM" src="https://user-images.githubusercontent.com/67645175/153806562-ade44c5b-87b0-44cf-8ffd-f7d5ce9bd8e1.png">
**After**
<img width="488" alt="Screenshot 2022-02-14 at 11 14 45 AM" src="https://user-images.githubusercontent.com/67645175/153806885-9827327c-9736-4dfb-b3ea-d5463978f636.png">
<img width="488" alt="Screenshot 2022-02-14 at 11 13 50 AM" src="https://user-images.githubusercontent.com/67645175/153806896-776f37fa-19c5-4daf-ae20-6305b1e50b39.png">

<img width="488" alt="Screenshot 2022-02-14 at 11 13 35 AM" src="https://user-images.githubusercontent.com/67645175/153806907-83207200-0176-43f8-a644-165c74e52172.png">

