### PR TITLE
fixes icon and text alignment for query-pane datasource selection

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -228,12 +228,17 @@ let QueryManager = class QueryManager extends React.Component {
     return (
       <div>
         {props.kind === 'runjs' ? (
-          <RunjsIcon style={{ height: 25, width: 25 }} />
+          <RunjsIcon style={{ height: 25, width: 25, marginTop: '-3px' }} />
         ) : (
           Icon && <Icon style={{ height: 25, width: 25 }} />
         )}
 
-        <span className={`mx-2 ${this.props.darkMode ? 'text-white' : 'text-muted'}`}>{props.label}</span>
+        <span
+          style={{ height: '25px', display: 'inline-block', marginTop: '3.5px' }}
+          className={`mx-2 ${this.props.darkMode ? 'text-white' : 'text-muted'}`}
+        >
+          {props.label}
+        </span>
       </div>
     );
   };

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -11,6 +11,7 @@ import { allSvgs } from '@tooljet/plugins/client';
 import { EventManager } from '../Inspector/EventManager';
 import { CodeHinter } from '../CodeBuilder/CodeHinter';
 import { DataSourceTypes } from '../DataSourceManager/SourceComponents';
+import RunjsIcon from '../Icons/runjs.svg';
 
 const queryNameRegex = new RegExp('^[A-Za-z0-9_-]*$');
 
@@ -223,11 +224,15 @@ let QueryManager = class QueryManager extends React.Component {
   };
 
   renderDataSourceOption = (props) => {
-    //Todo: add icon for the "runjs" query
     const Icon = allSvgs[props.kind];
     return (
       <div>
-        {Icon && <Icon style={{ height: 25, width: 25 }} />}
+        {props.kind === 'runjs' ? (
+          <RunjsIcon style={{ height: 25, width: 25 }} />
+        ) : (
+          Icon && <Icon style={{ height: 25, width: 25 }} />
+        )}
+
         <span className={`mx-2 ${this.props.darkMode ? 'text-white' : 'text-muted'}`}>{props.label}</span>
       </div>
     );


### PR DESCRIPTION
Resolves #2250 

Adding `runjs` icon fixes the icons and texts alignment.

### Screenshots
Before:
![Screenshot 2022-02-18 at 11 47 21 AM](https://user-images.githubusercontent.com/67645175/154629103-40988eb6-4b04-45ac-b18e-0d5a737bf62c.png)


After:
![Screenshot 2022-02-18 at 11 50 44 AM](https://user-images.githubusercontent.com/67645175/154629080-5ca29bbb-5b40-4a46-a7a5-901098c8ca52.png)
