### PR TITLE
disable preview and create query button when no datasource selected

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -409,7 +409,7 @@ let QueryManager = class QueryManager extends React.Component {
                 }}
                 className={`btn button-family-secondary m-1 float-right1 ${previewLoading ? 'button-loading' : ''} ${
                   this.props.darkMode ? 'dark' : ''
-                } `}
+                } ${this.state.selectedDataSource ? '' : 'disabled'}`}
                 style={{ width: '72px', height: '28px' }}
               >
                 Preview
@@ -419,7 +419,9 @@ let QueryManager = class QueryManager extends React.Component {
               <button
                 onClick={this.createOrUpdateDataQuery}
                 disabled={buttonDisabled}
-                className={`btn btn-primary m-1 float-right ${isUpdating || isCreating ? 'btn-loading' : ''}`}
+                className={`btn btn-primary m-1 float-right ${isUpdating || isCreating ? 'btn-loading' : ''} ${
+                  this.state.selectedDataSource ? '' : 'disabled'
+                }`}
                 style={{ width: '72px', height: '28px' }}
               >
                 {buttonText}


### PR DESCRIPTION
Resolves #1654 

In the QueryManager, the "preview" and "create" buttons show before a datasource is selected. I've updated this so those buttons are disabled (not clickable, wont respond to mouse on hover, and shaded darker).

Before selecting datasource:

![image](https://user-images.githubusercontent.com/47090434/155054265-c6d2c1e0-b481-4451-ba21-c0518b4e79c6.png)
![image](https://user-images.githubusercontent.com/47090434/155054564-bfb18733-72ff-453e-af3c-4dce9e22c7d0.png)

After selecting a datasource:

![image](https://user-images.githubusercontent.com/47090434/155054398-9dcfff9f-1a58-463b-a90b-9114228dd5b5.png)
![image](https://user-images.githubusercontent.com/47090434/155055205-740d8b74-e2a2-47f7-ad92-250670571039.png)



