### PR TITLE
Bugfix: toggle should be disabled when a toggle column of table widget is not editable

### DIFF
--- a/frontend/src/Editor/Components/Table/Toggle.jsx
+++ b/frontend/src/Editor/Components/Table/Toggle.jsx
@@ -19,6 +19,7 @@ export const Toggle = ({ readOnly, value, onChange, activeColor }) => {
           onClick={() => {
             if (!readOnly) toggle();
           }}
+          disabled={readOnly}
         />
       </label>
     </div>


### PR DESCRIPTION
closes #2316 