### PR TITLE
Bugfix - Add tooltip to query panel and use ellipsis when the name is too long

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -46,6 +46,8 @@ import { AppVersionsManager } from './AppVersionsManager';
 import { SearchBoxComponent } from '@/_ui/Search';
 import { initEditorWalkThrough } from '@/_helpers/createWalkThrough';
 import { createWebsocketConnection } from '@/_helpers/websocketConnection';
+import Tooltip from 'react-bootstrap/Tooltip';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 
 setAutoFreeze(false);
 enablePatches();
@@ -630,13 +632,22 @@ class Editor extends React.Component {
         onMouseEnter={() => this.setShowHiddenOptionsForDataQuery(dataQuery.id)}
         onMouseLeave={() => this.setShowHiddenOptionsForDataQuery(null)}
       >
-        <div className="col">
+        <div className="col-auto" style={{ width: '28px' }}>
           {sourceMeta.kind === 'runjs' ? (
             <RunjsIcon style={{ height: 25, width: 25 }} />
           ) : (
             getSvgIcon(sourceMeta.kind.toLowerCase(), 25, 25)
           )}
-          <span className="p-3">{dataQuery.name}</span>
+        </div>
+        <div className="col">
+          <OverlayTrigger
+            trigger={['hover', 'focus']}
+            placement="top"
+            delay={{ show: 800, hide: 100 }}
+            overlay={<Tooltip id="button-tooltip">{dataQuery.name}</Tooltip>}
+          >
+            <div className="px-3 query-name">{dataQuery.name}</div>
+          </OverlayTrigger>
         </div>
         <div className="col-auto mx-1">
           {isQueryBeingDeleted ? (

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -475,6 +475,12 @@ button {
         .query-copy-button {
           display: none;
         }
+        .query-name {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          width: 100%;
+        }
       }
 
       .query-row-selected {
@@ -1117,7 +1123,7 @@ button {
    svg {
     filter: invert(89%) sepia(2%) saturate(127%) hue-rotate(175deg) brightness(99%) contrast(96%);
    }
-    
+
   }
 }
 
@@ -3315,7 +3321,7 @@ input[type="text"] {
 }
 .empty-action {
   margin-top: 0 !important;
-  
+
   a + a.btn-loading::after {
     color: $primary;
   }
@@ -3977,7 +3983,7 @@ input[type="text"] {
 .modal-content.home-modal-component.dark {
   background-color: $bg-dark-light !important;
   color: $white !important;
-  
+
   .modal-header {
     background-color: $bg-dark-light !important;
   }
@@ -4414,7 +4420,7 @@ div#driver-highlighted-element-stage, div#driver-page-overlay {
 
 .popover.popover-dark-themed {
   background-color: $bg-dark-light;
-  border-color: rgba(101, 109, 119, 0.16); 
+  border-color: rgba(101, 109, 119, 0.16);
   .popover-body {
     color: #D9DCDE !important;
   }


### PR DESCRIPTION
Adds a tooltip to the name of a saved query and uses ellipsis overflow when the query name is longer than the width of the panel. The story mentioned that the tooltip should only be shown when the name exceeds the max allowed characters, but I couldn't find the limitation (backend, frontend or database), so I just use the tooltip by default:
<img width="351" alt="image" src="https://user-images.githubusercontent.com/1907152/155617278-9f5c8b00-e494-495e-8a1e-2279ccf063a2.png">

Fixes #1660