### PR TITLE
[Hotfix] resolves crash for table cell types expecting input type array

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -321,6 +321,8 @@ export function Table({
         columnOptions.selectOptions = labels.map((label, index) => {
           return { name: label, value: values[index] };
         });
+      } else {
+        columnOptions.selectOptions = [];
       }
     }
     if (columnType === 'datepicker') {

--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -130,6 +130,14 @@ class Table extends React.Component {
     }
     return false;
   }
+  onColumnItemChanged = (index, key, value, validateInputType, expectedInputType) => {
+    if (validateInputType) {
+      const isResolved = this.validateInputType(value, expectedInputType);
+      if (isResolved) {
+        this.onColumnItemChange(index, key, value);
+      }
+    }
+  };
 
   columnPopover = (column, index) => {
     if (
@@ -325,7 +333,7 @@ class Table extends React.Component {
                   mode="javascript"
                   lineNumbers={false}
                   placeholder={'{{[1, 2, 3]}}'}
-                  onChange={(value) => this.onColumnItemChange(index, 'values', value, true, 'array')}
+                  onChange={(value) => this.onColumnItemChanged(index, 'values', value, true, 'array')}
                   componentName={this.getPopoverFieldSource(column.columnType, 'values')}
                 />
               </div>
@@ -338,7 +346,7 @@ class Table extends React.Component {
                   mode="javascript"
                   lineNumbers={false}
                   placeholder={'{{["one", "two", "three"]}}'}
-                  onChange={(value) => this.onColumnItemChange(index, 'labels', value, true, 'array')}
+                  onChange={(value) => this.onColumnItemChanged(index, 'labels', value, true, 'array')}
                   componentName={this.getPopoverFieldSource(column.columnType, 'labels')}
                 />
               </div>
@@ -566,20 +574,7 @@ class Table extends React.Component {
     this.props.paramUpdated({ name: 'actions' }, 'value', newValue, 'properties');
   };
 
-  onColumnItemChange = (index, item, value, validateInputType = false, expectedInputType = undefined) => {
-    if (validateInputType) {
-      const isResolved = this.validateInputType(value, expectedInputType);
-      if (!isResolved) {
-        switch (expectedInputType) {
-          case 'array':
-            value = [];
-            break;
-
-          default:
-            break;
-        }
-      }
-    }
+  onColumnItemChange = (index, item, value) => {
     const columns = this.props.component.component.definition.properties.columns;
     const column = columns.value[index];
 

--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -325,7 +325,7 @@ class Table extends React.Component {
                   mode="javascript"
                   lineNumbers={false}
                   placeholder={'{{[1, 2, 3]}}'}
-                  onChange={(value) => this.onColumnItemChange(index, 'values', value)}
+                  onChange={(value) => this.onColumnItemChange(index, 'values', value, true, 'array')}
                   componentName={this.getPopoverFieldSource(column.columnType, 'values')}
                 />
               </div>

--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -124,11 +124,10 @@ class Table extends React.Component {
 
   validateInputType(value, type) {
     const [resolvedValue] = resolveReferences(value, this.state.currentState, null, {}, true);
-    console.log('validateInputType', resolvedValue);
+
     if (type === 'array') {
       return Array.isArray(resolvedValue);
     }
-
     return false;
   }
 

--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -615,7 +615,6 @@ class Table extends React.Component {
 
   render() {
     const { dataQueries, component, paramUpdated, componentMeta, components, currentState, darkMode } = this.props;
-    console.log('JSON ==>', JSON.stringify(component));
     const columns = component.component.definition.properties.columns;
     const actions = component.component.definition.properties.actions || { value: [] };
 


### PR DESCRIPTION
Fixes app crash for cell type multi-select, dropdown, badge, radio and badges of table widget which expects input type of array.
Also resolves app crash for existing field values for the same.