### PR TITLE
fix alert when email already exists from

### DIFF
--- a/frontend/src/SignupPage/SignupPage.jsx
+++ b/frontend/src/SignupPage/SignupPage.jsx
@@ -42,7 +42,7 @@ class SignupPage extends React.Component {
         this.setState({ isLoading: false, signupSuccess: true });
       },
       () => {
-        toast.error('Invalid email', {
+        toast.error('Email already exists', {
           position: 'top-center',
         });
         this.setState({ isLoading: false });


### PR DESCRIPTION
Fixes #2375 
When the email already exists I should say "Email already exists" instead of "Invalid email"

