### PR TITLE
Feature/2372 - add text alignment option to dropdown

### DIFF
--- a/frontend/src/Editor/Components/DropDown.jsx
+++ b/frontend/src/Editor/Components/DropDown.jsx
@@ -14,7 +14,7 @@ export const DropDown = function DropDown({
   component,
 }) {
   let { label, value, display_values, values } = properties;
-  const { selectedTextColor, borderRadius, visibility, disabledState } = styles;
+  const { selectedTextColor, borderRadius, visibility, disabledState, justifyContent } = styles;
   const [currentValue, setCurrentValue] = useState(() => value);
 
   if (!_.isArray(values)) {
@@ -81,6 +81,7 @@ export const DropDown = function DropDown({
       ...provided,
       height: height,
       padding: '0 6px',
+      justifyContent,
     }),
 
     singleValue: (provided, _state) => ({
@@ -117,6 +118,7 @@ export const DropDown = function DropDown({
           };
       return {
         ...provided,
+        justifyContent,
         height: 'auto',
         display: 'flex',
         flexDirection: 'rows',

--- a/frontend/src/Editor/Components/components.js
+++ b/frontend/src/Editor/Components/components.js
@@ -900,6 +900,7 @@ export const componentTypes = [
       visibility: { type: 'toggle', displayName: 'Visibility' },
       selectedTextColor: { type: 'color', displayName: 'Selected Text Color' },
       disabledState: { type: 'toggle', displayName: 'Disable' },
+      justifyContent: { type: 'alignButtons', displayName: 'Align Text' },
     },
     exposedVariables: {
       value: null,


### PR DESCRIPTION
Add `justifyContent` option to `components.js` to justify the selected value and the list of the dropdown. Implements #2372 

<img width="699" alt="image" src="https://user-images.githubusercontent.com/1907152/156371718-1b520fe2-9579-4ba6-9eb8-8dc12f992e6d.png">
