### PR TITLE
[Bugfix] Adding extra whitespace at the end or beginning of any field for object type resolves as a string

### DIFF
--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -96,7 +96,7 @@ export function CodeHinter({
 
   function valueChanged(editor, onChange, suggestions, ignoreBraces) {
     handleChange(editor, onChange, suggestions, ignoreBraces);
-    setCurrentValue(editor.getValue());
+    setCurrentValue(editor.getValue()?.trim());
   }
 
   const getPreviewContent = (content, type) => {


### PR DESCRIPTION
Fixes #2407 