### PR TITLE
don't overwrite the background color of the jet-container

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2846,7 +2846,7 @@ input:focus-visible {
   }
 
   .jet-container {
-    background-color: #1f2936 !important;
+    background-color: #1f2936;
   }
 
   .nav-tabs .nav-item.show .nav-link,


### PR DESCRIPTION
The Container has a backgroundColor property, which is currently overwritten when the dark mode is set to true. This should not happen, because the Container has a default backgroundColor, which the user should be able to change to any color. 

Fixes #2457 

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1907152/157212008-ed5cc72b-18f3-4145-a504-12245da0fc3b.png">
