### PR TITLE
remove the password from the apps request

### DIFF
--- a/server/src/controllers/apps.controller.ts
+++ b/server/src/controllers/apps.controller.ts
@@ -200,6 +200,8 @@ export class AppsController {
     } else {
       apps = await this.appsService.all(req.user, page, searchKey);
     }
+    //remove password from user info
+    apps.forEach((app) => (app.user.password = undefined));
 
     const totalCount = await this.appsService.count(req.user, searchKey);
 


### PR DESCRIPTION
fixes #2356

I couldn't find a way to remove the password using the SelectQueryBuilder from TypeORM, without having to select every single property separately. 