### PR TITLE
[docs] added Slack Code of Conduct(etiquettes)

### DIFF
--- a/docs/docs/contributing-guide/code-of-conduct.md
+++ b/docs/docs/contributing-guide/code-of-conduct.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: Code of Conduct
 ---
 
@@ -60,7 +60,7 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at hello@tooljet.com . All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/docs/docs/contributing-guide/slackcoc.md
+++ b/docs/docs/contributing-guide/slackcoc.md
@@ -5,7 +5,7 @@ sidebar_label: Slack Code of Conduct
 
 # Slack Code of Conduct
 
-This code of conduct governs ToolJet's Community events and discussions.
+This code of conduct governs ToolJet's Slack Community events and discussions.
 
 ---
 

--- a/docs/docs/contributing-guide/slackcoc.md
+++ b/docs/docs/contributing-guide/slackcoc.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 4
+sidebar_label: Slack Code of Conduct
+---
+
+# Slack Code of Conduct
+
+This code of conduct governs ToolJet's Community events and discussions.
+
+---
+
+## Introduction
+
+- Diversity and inclusion make our community strong. We encourage participation from the most varied and diverse backgrounds possible and want to be very clear about where we stand.
+
+- Our goal is to maintain a safe, helpful and friendly community for everyone, regardless of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other defining characteristic.
+
+- This code and related procedures apply to unacceptable behavior occurring in all community venues, including behavior outside the scope of community activities — online and in-person— as well as in all one-on-one communications, and anywhere such behavior has the potential to adversely affect the safety and well-being of community members.
+
+## Expected behavior
+
+- Be welcoming.
+- Be kind.
+- Look out for each other.
+
+## Unacceptable Behavior
+
+- Conduct or speech which might be considered sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory or offensive in nature.
+  - Do not use unwelcome, suggestive, derogatory or inappropriate nicknames or terms.
+  - Do not show disrespect towards others. (Jokes, innuendo, dismissive attitudes.)
+- Intimidation or harassment (online or in-person).
+- Disrespect towards differences of opinion.
+- Inappropriate attention or contact. Be aware of how your actions affect others. If it makes someone uncomfortable, stop.
+- Not understanding the differences between constructive criticism and disparagement.
+- Sustained disruptions.
+- Violence, threats of violence or violent language.
+
+## Enforcement
+
+- Understand that speech and actions have consequences, and unacceptable behavior will not be tolerated.
+- If you are the subject of, or witness to any violations of this Code of Conduct, please contact us via email at hello@tooljet.com or dm @navaneeth on slack.
+- If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
+
+:::info
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/) under a Creative Commons Attribution-ShareAlike license.
+:::
+
+---
+
+## Etiquettes to follow
+
+#### 1. Be nice to everyone
+
+#### 2. Check off your resolved questions
+
+If you have received a useful reply to your question, please drop a ✅ reaction or a reply for confirmation.
+
+#### 3. Try not to repost question
+
+If you have asked a question and have not got a response in 24hrs, please review your question for clarity and revise it. If you still feel you haven't received adequate response, feel free to ping @navaneeth.
+
+#### 4. Post in public
+
+Please don't direct message any individual member of ToolJet community without their explicit permission, independent of reason. Your question might be helpful for other community members.
+
+#### 5. Don't spam tags
+
+ToolJet's community of volunteer is very active and helpful, generally avoid tagging members unless it is urgent.
+
+#### 6. Use threads for discussion
+
+To keep the main channel area clear, we request to use threads to keep an ongoing conversation organized.

--- a/docs/docs/contributing-guide/slackcoc.md
+++ b/docs/docs/contributing-guide/slackcoc.md
@@ -53,7 +53,7 @@ Portions derived from the [Django Code of Conduct](https://www.djangoproject.com
 
 #### 2. Check off your resolved questions
 
-If you have received a useful reply to your question, please drop a ✅ reaction or a reply for confirmation.
+If you have received a useful reply to your question, please drop a ✅ reaction or a reply for affirmation.
 
 #### 3. Try not to repost question
 

--- a/docs/docs/contributing-guide/tutorials/creating-a-plugin.md
+++ b/docs/docs/contributing-guide/tutorials/creating-a-plugin.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 sidebar_label: Creating a plugin
 ---
 


### PR DESCRIPTION
#### Changes
- Moved `creating a plugin` in the Tutorials section under Contributing guide
- Added `Slack code of conduct`