### PR TITLE
Hotfix: Make use of entityManager within migration backfill

### DIFF
--- a/server/migrations/1641446596775-SetImageBorderTypeToNone.ts
+++ b/server/migrations/1641446596775-SetImageBorderTypeToNone.ts
@@ -4,10 +4,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class SetImageBorderTypeToNone1641446596775 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     const entityManager = queryRunner.manager;
-    const queryBuilder = queryRunner.connection.createQueryBuilder();
-    const appVersionRepository = entityManager.getRepository(AppVersion);
-
-    const appVersions = await appVersionRepository.find();
+    const appVersions = await entityManager.find(AppVersion);
 
     for (const version of appVersions) {
       const definition = version['definition'];
@@ -35,7 +32,7 @@ export class SetImageBorderTypeToNone1641446596775 implements MigrationInterface
         definition['components'] = components;
         version.definition = definition;
 
-        await queryBuilder.update(AppVersion).set({ definition }).where('id = :id', { id: version.id }).execute();
+        await entityManager.update(AppVersion, { id: version.id }, { definition });
       }
     }
   }

--- a/server/migrations/1644229722021-SetFxActiveToTrueForFxFieldsConvertedToUI.ts
+++ b/server/migrations/1644229722021-SetFxActiveToTrueForFxFieldsConvertedToUI.ts
@@ -4,12 +4,10 @@ import { AppVersion } from '../src/entities/app_version.entity';
 export class SetFxActiveToTrueForFxFieldsConvertedToUI1644229722021 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     const entityManager = queryRunner.manager;
-    const queryBuilder = queryRunner.connection.createQueryBuilder();
-    const appVersionRepository = entityManager.getRepository(AppVersion);
     const propertiesBeingSetToFxActive = ['loadingState'];
     const stylesBeingSetToFxActive = ['visibility', 'disabledState'];
 
-    const appVersions = await appVersionRepository.find();
+    const appVersions = await entityManager.find(AppVersion);
 
     for (const version of appVersions) {
       const definition = version['definition'];
@@ -53,7 +51,7 @@ export class SetFxActiveToTrueForFxFieldsConvertedToUI1644229722021 implements M
         definition['components'] = components;
         version.definition = definition;
 
-        await queryBuilder.update(AppVersion).set({ definition }).where('id = :id', { id: version.id }).execute();
+        await entityManager.update(AppVersion, { id: version.id }, { definition });
       }
     }
   }


### PR DESCRIPTION
- Fixes migrations being stuck in a transaction when running migrations