### PR TITLE
[Hotfix] resolves crash for table cell types expecting input type array

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -330,6 +330,8 @@ export function Table({
         columnOptions.selectOptions = labels.map((label, index) => {
           return { name: label, value: values[index] };
         });
+      } else {
+        columnOptions.selectOptions = [];
       }
     }
     if (columnType === 'datepicker') {


### PR DESCRIPTION
Fixes app crash for cell type multi-select, dropdown, badge, radio and badges of table widget which expects input type of array.