### PR TITLE
[Hotfix] Dropdown widget : exposed value for initial render

### DIFF
--- a/frontend/src/Editor/AppVersionsManager.jsx
+++ b/frontend/src/Editor/AppVersionsManager.jsx
@@ -36,6 +36,17 @@ export const AppVersionsManager = function AppVersionsManager({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    setEditingAppVersion(editingVersion);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingVersion]);
+
+  useEffect(() => {
+    appVersions[appVersions.findIndex((appVersion) => appVersion.id === editingVersion.id)] = editingAppVersion;
+    setCreateAppVersionFrom(editingAppVersion);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingAppVersion]);
+
   const wrapperRef = useRef(null);
   useEffect(() => {
     const handleClickOutside = (event) => {

--- a/frontend/src/Editor/Components/DropDown.jsx
+++ b/frontend/src/Editor/Components/DropDown.jsx
@@ -36,6 +36,14 @@ export const DropDown = function DropDown({
   const validationData = validate(value);
   const { isValid, validationError } = validationData;
 
+  React.useEffect(() => {
+    //* setCurrentStateAsync from utils.js getting called with a promise and it gets executed in the next render cycle and not in the initial cycle,
+    setTimeout(() => {
+      setExposedVariable('value', value);
+    }, 300);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     setExposedVariable('isValid', isValid);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -827,7 +827,14 @@ class Editor extends React.Component {
     } else if (!isEmpty(this.state.editingVersion)) {
       this.setState({ isSavingEditingVersion: true, showSaveDetail: true });
       appVersionService.save(this.state.appId, this.state.editingVersion.id, this.state.appDefinition).then(() => {
-        this.setState({ isSavingEditingVersion: false });
+        this.setState({
+          isSavingEditingVersion: false,
+          editingVersion: {
+            ...this.state.editingVersion,
+            ...{ definition: this.state.appDefinition },
+          },
+        });
+
         setTimeout(() => this.setState({ showSaveDetail: false }), 3000);
       });
     }


### PR DESCRIPTION
`setCurrentStateAsync` from utils.js gets called with a promise and it gets executed in the next render cycle and not in the initial cycle

@gondar00 have to look into setCurrentStateAsync