### PR TITLE
[Hotfix] Dropdown widget : exposed value for initial render

### DIFF
--- a/frontend/src/Editor/AppVersionsManager.jsx
+++ b/frontend/src/Editor/AppVersionsManager.jsx
@@ -36,6 +36,17 @@ export const AppVersionsManager = function AppVersionsManager({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    setEditingAppVersion(editingVersion);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingVersion]);
+
+  useEffect(() => {
+    appVersions[appVersions.findIndex((appVersion) => appVersion.id === editingVersion.id)] = editingAppVersion;
+    setCreateAppVersionFrom(editingAppVersion);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingAppVersion]);
+
   const wrapperRef = useRef(null);
   useEffect(() => {
     const handleClickOutside = (event) => {

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -827,7 +827,14 @@ class Editor extends React.Component {
     } else if (!isEmpty(this.state.editingVersion)) {
       this.setState({ isSavingEditingVersion: true, showSaveDetail: true });
       appVersionService.save(this.state.appId, this.state.editingVersion.id, this.state.appDefinition).then(() => {
-        this.setState({ isSavingEditingVersion: false });
+        this.setState({
+          isSavingEditingVersion: false,
+          editingVersion: {
+            ...this.state.editingVersion,
+            ...{ definition: this.state.appDefinition },
+          },
+        });
+
         setTimeout(() => this.setState({ showSaveDetail: false }), 3000);
       });
     }

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -122,6 +122,15 @@ let QueryManager = class QueryManager extends React.Component {
     this.setStateFromProps(this.props);
   }
 
+  // // Preventing unnecessary renders by only updating state when necessary
+  shouldComponentUpdate(nextProps, nextState) {
+    console.log('shouldComponentUpdate', JSON.stringify(nextProps));
+    // if (nextProps !== this.props) {
+    //   return true;
+    // }
+    return true;
+  }
+
   isJson = (maybeJson) => {
     if (typeof maybeJson === 'object') return true;
     return false;
@@ -302,7 +311,7 @@ let QueryManager = class QueryManager extends React.Component {
       queryPreviewData,
       dataSourceMeta,
     } = this.state;
-
+    console.log('QueryPane Render');
     let ElementToRender = '';
 
     if (selectedDataSource) {


### PR DESCRIPTION
`setCurrentStateAsync` from utils.js gets called with a promise and it gets executed in the next render cycle and not in the initial cycle

cc: @gondar00 have to look into setCurrentStateAsync