### PR TITLE
[Stylefix] fixes codehinter field margin for text

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -4363,11 +4363,7 @@ input[type="text"] {
   .popup-btn {
     margin-top: 0.65rem !important;
   }
-  .CodeMirror pre.CodeMirror-line {
-    height: 32px !important;
-    margin-bottom: 6px !important;
-  }
-  .CodeMirror-placeholder {
+  .CodeMirror-placeholder, .CodeMirror pre.CodeMirror-line {
     height: 21px !important;
     position: absolute !important;
     margin-top: 3px !important;


### PR DESCRIPTION
Resolves #2556 


### Before 
<img width="673" alt="Screenshot 2022-03-17 at 3 06 07 PM" src="https://user-images.githubusercontent.com/67645175/158781245-2f36ac38-bf53-4b28-a344-93075f4ffc1e.png">

### After
<img width="673" alt="Screenshot 2022-03-17 at 3 08 50 PM" src="https://user-images.githubusercontent.com/67645175/158781265-1eece6e1-3e2c-4eaa-a99d-dc6d83c01d0d.png">

<img width="673" alt="Screenshot 2022-03-17 at 3 08 58 PM" src="https://user-images.githubusercontent.com/67645175/158781286-bfb4cc94-0817-4f4c-8c88-28326a79f3e8.png">

