### PR TITLE
[Bugfix]: data resets or current table data is updated the selectedRow and selectedRowId is still populated with the previous data.

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -830,6 +830,8 @@ export function Table({
     onComponentOptionsChanged(component, [
       ['currentPageData', pageData],
       ['currentData', currentData],
+      ['selectedRow', []],
+      ['selectedRowId', null],
     ]);
   }, [tableData.length, componentState.changeSet]);
 


### PR DESCRIPTION
Resolves #2652 


**Loom**
https://www.loom.com/share/717619bb1990485fbf24de85acb10fb2