### PR TITLE
made the confirmation modal  consistent with the currently applied theme

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -980,6 +980,7 @@ class Editor extends React.Component {
           confirmButtonLoading={isDeletingDataQuery}
           onConfirm={() => this.executeDataQueryDeletion()}
           onCancel={() => this.cancelDeleteDataQuery()}
+          darkMode={this.props.darkMode}
         />
         <DndProvider backend={HTML5Backend}>
           <div className="header">

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -973,6 +973,7 @@ class Editor extends React.Component {
           onConfirm={(queryConfirmationData) => onQueryConfirm(this, queryConfirmationData)}
           onCancel={() => onQueryCancel(this)}
           queryConfirmationData={this.state.queryConfirmationData}
+          darkMode={this.props.darkMode}
         />
         <Confirm
           show={showDataQueryDeletionConfirmation}

--- a/frontend/src/Editor/Viewer/Confirm.jsx
+++ b/frontend/src/Editor/Viewer/Confirm.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 
-export function Confirm({ show, message, onConfirm, onCancel, queryConfirmationData }) {
+export function Confirm({ show, message, onConfirm, onCancel, queryConfirmationData, darkMode }) {
   const [showModal, setShow] = useState(show);
 
   useEffect(() => {
@@ -21,7 +21,13 @@ export function Confirm({ show, message, onConfirm, onCancel, queryConfirmationD
 
   return (
     <>
-      <Modal show={showModal} onHide={handleClose} size="sm" centered={true}>
+      <Modal
+        show={showModal}
+        onHide={handleClose}
+        size="sm"
+        centered={true}
+        contentClassName={darkMode ? 'theme-dark' : ''}
+      >
         <div className="modal-status bg-danger"></div>
         <Modal.Body>{message}</Modal.Body>
         <Modal.Footer>

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -501,6 +501,7 @@ class HomePage extends React.Component {
           confirmButtonLoading={isDeletingApp}
           onConfirm={() => this.executeAppDeletion()}
           onCancel={() => this.cancelDeleteAppDialog()}
+          darkMode={this.props.darkMode}
         />
 
         <ConfirmDialog

--- a/frontend/src/_components/ConfirmDialog.jsx
+++ b/frontend/src/_components/ConfirmDialog.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 
-export function ConfirmDialog({ show, message, onConfirm, onCancel, confirmButtonLoading }) {
+export function ConfirmDialog({ show, message, onConfirm, onCancel, confirmButtonLoading, darkMode }) {
   const [showModal, setShow] = useState(show);
 
   useEffect(() => {
@@ -20,7 +20,13 @@ export function ConfirmDialog({ show, message, onConfirm, onCancel, confirmButto
 
   return (
     <>
-      <Modal show={showModal} onHide={handleClose} size="sm" centered={true}>
+      <Modal
+        show={showModal}
+        onHide={handleClose}
+        size="sm"
+        centered={true}
+        contentClassName={darkMode ? 'theme-dark' : ''}
+      >
         <div className="modal-status bg-danger"></div>
         <Modal.Body>{message}</Modal.Body>
         <Modal.Footer>


### PR DESCRIPTION
Resolve #2655
I have made the confirmation modal  consistent with the currently applied theme.
Earlier, when we used to switch to dark mode, the confirmation modal in dashboard after clicking delete app, was not consistent with the dark theme.
