### PR TITLE
Add `ap-east-1` (HongKong) to the list of AWS Regions for AMI release

### DIFF
--- a/deploy/ec2/variables.pkr.hcl
+++ b/deploy/ec2/variables.pkr.hcl
@@ -19,5 +19,5 @@ variable "ami_groups" {
 
 variable "ami_regions" {
   type    = list(string)
-  default = ["us-west-1", "us-east-1", "us-east-2", "eu-west-2", "eu-central-1", "ap-northeast-1", "ap-southeast-1", "ap-northeast-3", "ap-south-1", "ap-northeast-2", "ap-southeast-2", "ca-central-1", "eu-west-1", "eu-north-1", "sa-east-1"]
+  default = ["us-west-1", "us-east-1", "us-east-2", "eu-west-2", "eu-central-1", "ap-northeast-1", "ap-southeast-1",  "ap-northeast-3", "ap-south-1", "ap-northeast-2", "ap-southeast-2", "ca-central-1", "eu-west-1", "eu-north-1", "sa-east-1", "ap-east-1"]
 }


### PR DESCRIPTION
Closes #2654 