### PR TITLE
Fix plugin documentation link

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,3 +1,3 @@
 # Tooljet plugins
 
-Documentation on:  https://docs.tooljet.com/docs/contributing-guide/creating-a-plugin
+Documentation on:  https://docs.tooljet.com/docs/contributing-guide/tutorials/creating-a-plugin


### PR DESCRIPTION
Hey, just stumbled upon a dead link in the plugin README.

Be aware: visiting the link will lead to an infinite redirect - this probably should be fixed as well in your documentation website.