### PR TITLE
Add missing sourceOptions to Snowflake to fix the warehouse/database/schema/role when connecting

### DIFF
--- a/plugins/packages/snowflake/lib/index.ts
+++ b/plugins/packages/snowflake/lib/index.ts
@@ -71,6 +71,10 @@ export default class Snowflake implements QueryService {
       account: sourceOptions.account,
       username: sourceOptions.username,
       password: sourceOptions.password,
+      warehouse: sourceOptions.warehouse,
+      database: sourceOptions.database,
+      schema: sourceOptions.schema,
+      role: sourceOptions.role
     });
 
     return await this.connAsync(connection);

--- a/plugins/packages/snowflake/package.json
+++ b/plugins/packages/snowflake/package.json
@@ -20,6 +20,6 @@
     "@tooljet-plugins/common": "file:../common",
     "@types/snowflake-sdk": "^1.6.2",
     "react": "^17.0.2",
-    "snowflake-sdk": "github:ToolJet/snowflake-connector-nodejs#chore/update-https-agent"
+    "snowflake-sdk": "^1.6.8"
   }
 }

--- a/plugins/packages/snowflake/package.json
+++ b/plugins/packages/snowflake/package.json
@@ -20,6 +20,6 @@
     "@tooljet-plugins/common": "file:../common",
     "@types/snowflake-sdk": "^1.6.2",
     "react": "^17.0.2",
-    "snowflake-sdk": "^1.6.8"
+    "snowflake-sdk": "github:ToolJet/snowflake-connector-nodejs#chore/update-https-agent"
   }
 }


### PR DESCRIPTION
Snowflake is missing various sourceOptions, which means that role is passing in as public, so the role defined in the UI isn't working. Also added the other missing sourceOptions.