### PR TITLE
Note that npm 7.20.0 is required, otherwise an error will show for linux

### DIFF
--- a/docs/docs/contributing-guide/setup/ubuntu.md
+++ b/docs/docs/contributing-guide/setup/ubuntu.md
@@ -13,6 +13,9 @@ Follow these steps to setup and run ToolJet on Ubuntu. Open terminal and run the
     ```bash
     curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
     sudo apt-get install -y nodejs
+
+    # Ensure you have the correct version of npm, or it will cause an error about fsevents.
+    npm i -g npm@7.20.0
     ```
 
     1.2 Install Postgres


### PR DESCRIPTION
This uses the same version as https://github.com/ToolJet/ToolJet/blob/develop/docker/client.Dockerfile.dev#L6

By default when using nodejs 14.17.3 it comes with a version of npm that throws errors about fsevents for Linux. This note should hopefully help other first time contributors.