### PR TITLE
[Bugfix] On dispatching Undo ⌘Z or Redo ⌘+shift+Z actions to a component on the editor should also update the internal state or props for the children.

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -506,6 +506,7 @@ class Editor extends React.Component {
       this.handleAddPatch
     );
     setStateAsync(_self, newDefinition).then(() => {
+      computeComponentState(_self, _self.state.appDefinition.components);
       this.autoSave();
     });
   };
@@ -882,9 +883,6 @@ class Editor extends React.Component {
     } = this.state;
 
     const appVersionPreviewLink = editingVersion ? `/applications/${app.id}/versions/${editingVersion.id}` : '';
-
-    console.log('Render App:: EDITOR ==> currentState', JSON.stringify(this.state.currentState));
-    console.log('Render App:: EDITOR ==> Full State', JSON.stringify(this.state));
 
     return (
       <div className="editor wrapper">

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -144,6 +144,12 @@ class Editor extends React.Component {
     });
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.appDefinition !== this.state.appDefinition) {
+      computeComponentState(this, this.state.appDefinition.components);
+    }
+  }
+
   isVersionReleased = (version = this.state.editingVersion) => {
     if (isEmpty(version)) {
       return false;
@@ -876,6 +882,9 @@ class Editor extends React.Component {
     } = this.state;
 
     const appVersionPreviewLink = editingVersion ? `/applications/${app.id}/versions/${editingVersion.id}` : '';
+
+    console.log('Render App:: EDITOR ==> currentState', JSON.stringify(this.state.currentState));
+    console.log('Render App:: EDITOR ==> Full State', JSON.stringify(this.state));
 
     return (
       <div className="editor wrapper">


### PR DESCRIPTION
Resolves #2825 