### PR TITLE
[BUGFIX] 2740 - fix refreshing selected datasource component

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -450,7 +450,7 @@ let QueryManager = class QueryManager extends React.Component {
                 {selectedDataSource && (
                   <div>
                     <ElementToRender
-                      selectedDataSource={this.state.selectedSource}
+                      selectedDataSource={selectedDataSource}
                       options={this.state.options}
                       optionsChanged={this.optionsChanged}
                       optionchanged={this.optionchanged}


### PR DESCRIPTION
Resizing the querymanager panel refreshes the component with the incorrect selectedDatasource prop.
Fixes #2740