### PR TITLE
Move documentation link in transformation popover to a new line

### DIFF
--- a/frontend/src/Editor/QueryManager/Transformation.jsx
+++ b/frontend/src/Editor/QueryManager/Transformation.jsx
@@ -33,7 +33,7 @@ return data.filter(row => row.amount > 1000);`;
     <Popover id="transformation-popover-container">
       <p className="transformation-popover">
         Transformations can be used to transform the results of queries. All the app variables are accessible from
-        transformers and supports JS libraries such as Lodash & Moment
+        transformers and supports JS libraries such as Lodash & Moment.
         <br />
         <a href="https://docs.tooljet.io/docs/tutorial/transformations" target="_blank" rel="noreferrer">
           Read documentation

--- a/frontend/src/Editor/QueryManager/Transformation.jsx
+++ b/frontend/src/Editor/QueryManager/Transformation.jsx
@@ -33,7 +33,8 @@ return data.filter(row => row.amount > 1000);`;
     <Popover id="transformation-popover-container">
       <p className="transformation-popover">
         Transformations can be used to transform the results of queries. All the app variables are accessible from
-        transformers and supports JS libraries such as Lodash & Moment.{' '}
+        transformers and supports JS libraries such as Lodash & Moment
+        <br />
         <a href="https://docs.tooljet.io/docs/tutorial/transformations" target="_blank" rel="noreferrer">
           Read documentation
         </a>


### PR DESCRIPTION
- Move documentation link in transformation popover to a new line. Fixes the issue 2735