### PR TITLE
[Bugfix] Tabs widget's Highlight text color doesn't change 

### DIFF
--- a/frontend/src/Editor/Components/Tabs.jsx
+++ b/frontend/src/Editor/Components/Tabs.jsx
@@ -77,6 +77,11 @@ export const Tabs = function Tabs({
                   ? { color: parsedHighlightColor, borderBottom: `1px solid ${parsedHighlightColor}` }
                   : {}
               }
+              ref={(el) => {
+                if (el && currentTab == tab.id) {
+                  el.style.setProperty('color', parsedHighlightColor, 'important');
+                }
+              }}
             >
               {tab.title}
             </a>


### PR DESCRIPTION
Fixes #2899