### PR TITLE
[Bug Fix #2921] Reset password shows invalid error message when email is not found

### DIFF
--- a/frontend/src/ForgotPassword/ForgotPasswordPage.jsx
+++ b/frontend/src/ForgotPassword/ForgotPasswordPage.jsx
@@ -88,7 +88,7 @@ class ForgotPassword extends React.Component {
                   data-testid="emailField"
                 />
                 {this.state.buttonClicked && !this.state.isEmailFound && (
-                  <p style={{ color: '#b72525' }}>Email address is not associated with a ToolJet cloud account.</p>
+                  <p style={{ color: '#b72525' }}>Email address not found.</p>
                 )}
               </div>
               <div className="form-footer">


### PR DESCRIPTION
 Fixes [#2921](https://github.com/ToolJet/ToolJet/issues/2921)
Changed the Error Message From `Email address is not associated with a ToolJet cloud account.`  to  `Email address not found.`