### PR TITLE
Fix error in create version modal

### DIFF
--- a/frontend/src/Editor/AppVersionsManager.jsx
+++ b/frontend/src/Editor/AppVersionsManager.jsx
@@ -243,7 +243,7 @@ const CreateVersionModal = function CreateVersionModal({
     }
   };
   const options = appVersions.map((version) => {
-    return { ...version, label: version.name, value: version.name };
+    return { ...version, label: version.name, value: version };
   });
   const width = '100%';
   const height = 32;


### PR DESCRIPTION
This commit fixes a bug that occurs in the app version modal popup when
an existing version is chosen from the dropdown menu.

Fixes #2941