### PR TITLE
fixed addition of application to folder more than once

### DIFF
--- a/server/src/services/folder_apps.service.ts
+++ b/server/src/services/folder_apps.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FolderApp } from '../../src/entities/folder_app.entity';
@@ -11,6 +11,14 @@ export class FolderAppsService {
   ) {}
 
   async create(folderId: string, appId: string): Promise<FolderApp> {
+    const existingFolderApp = await this.folderAppsRepository.findOne({
+      where: { appId, folderId },
+    });
+
+    if (existingFolderApp != null && existingFolderApp !== undefined) {
+      throw new BadRequestException('App has been already added to the folder');
+    }
+
     const newFolderApp = this.folderAppsRepository.create({
       folderId,
       appId,

--- a/server/src/services/folder_apps.service.ts
+++ b/server/src/services/folder_apps.service.ts
@@ -15,7 +15,7 @@ export class FolderAppsService {
       where: { appId, folderId },
     });
 
-    if (existingFolderApp != null && existingFolderApp !== undefined) {
+    if (existingFolderApp) {
       throw new BadRequestException('App has been already added to the folder');
     }
 


### PR DESCRIPTION
Fixes #2916 

Please review and let me know if any changes are required.

## Tests 
- [x] Manually Tested on local
- [x] Test Case written

## Screenshots
![test](https://user-images.githubusercontent.com/19568165/166443067-745b2142-1326-4ef5-b27a-7f6742667f77.png)


## Approach
I have used repository to find if record already exists by querieng before creating folderApp record, please let me know 
if any factory method available which can be used to find if app id is already referenced with folder id which can be used.

