### PR TITLE
Fixed hyperlink of ToolJet logo

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -35,7 +35,7 @@ module.exports = {
     },
     navbar: {
       logo: {
-        href: '/docs/intro',
+        href: '/docs',
         alt: 'ToolJet Logo',
         src: 'img/logo.svg',
         width: 90


### PR DESCRIPTION
Issue: #2974
Hyperlink of ToolJet logo now redirects to updated landing page URL of documentation.