### PR TITLE
Avoid creation of system group names

### DIFF
--- a/server/src/services/group_permissions.service.ts
+++ b/server/src/services/group_permissions.service.ts
@@ -27,11 +27,17 @@ export class GroupPermissionsService {
     private appRepository: Repository<App>,
 
     private usersService: UsersService
-  ) {}
+  ) { }
 
   async create(user: User, group: string): Promise<GroupPermission> {
     if (!group || group === '') {
       throw new BadRequestException('Cannot create group without name');
+    }
+
+    const reservedGroups = ['All Users', 'all_users', 'Admin', 'admin'];
+
+    if (reservedGroups.includes(group)) {
+      throw new BadRequestException('Cannot create group with system reserved group name');
     }
 
     const groupToFind = await this.groupPermissionsRepository.findOne({

--- a/server/src/services/group_permissions.service.ts
+++ b/server/src/services/group_permissions.service.ts
@@ -27,17 +27,17 @@ export class GroupPermissionsService {
     private appRepository: Repository<App>,
 
     private usersService: UsersService
-  ) { }
+  ) {}
 
   async create(user: User, group: string): Promise<GroupPermission> {
     if (!group || group === '') {
       throw new BadRequestException('Cannot create group without name');
     }
 
-    const reservedGroups = ['All Users', 'all_users', 'Admin', 'admin'];
+    const reservedGroups = ['All Users', 'Admin'];
 
     if (reservedGroups.includes(group)) {
-      throw new BadRequestException('Cannot create group with system reserved group name');
+      throw new BadRequestException('Group name already exist');
     }
 
     const groupToFind = await this.groupPermissionsRepository.findOne({

--- a/server/test/controllers/group_permissions.e2e-spec.ts
+++ b/server/test/controllers/group_permissions.e2e-spec.ts
@@ -52,7 +52,7 @@ describe('group permissions controller', () => {
         organization: { adminUser },
       } = await setupOrganizations(nestApp);
 
-      const reservedGroups = ['All Users', 'all_users', 'Admin', 'admin'];
+      const reservedGroups = ['All Users', 'Admin'];
 
       for (let i = 0; i < reservedGroups.length; i += 1) {
         const response = await request(nestApp.getHttpServer())
@@ -61,7 +61,7 @@ describe('group permissions controller', () => {
           .send({ group: reservedGroups[i] });
 
         expect(response.statusCode).toBe(400);
-        expect(response.body.message).toBe('Cannot create group with system reserved group name');
+        expect(response.body.message).toBe('Group name already exist');
       }
     });
 

--- a/server/test/controllers/group_permissions.e2e-spec.ts
+++ b/server/test/controllers/group_permissions.e2e-spec.ts
@@ -47,6 +47,24 @@ describe('group permissions controller', () => {
       expect(response.body.updated_at).toBeDefined();
     });
 
+    it('should not allow to create system defined group names', async () => {
+      const {
+        organization: { adminUser },
+      } = await setupOrganizations(nestApp);
+
+      const reservedGroups = ['All Users', 'all_users', 'Admin', 'admin'];
+
+      for (let i = 0; i < reservedGroups.length; i += 1) {
+        const response = await request(nestApp.getHttpServer())
+          .post('/api/group_permissions')
+          .set('Authorization', authHeaderForUser(adminUser))
+          .send({ group: reservedGroups[i] });
+
+        expect(response.statusCode).toBe(400);
+        expect(response.body.message).toBe('Cannot create group with system reserved group name');
+      }
+    });
+
     it('should validate uniqueness of group permission group name', async () => {
       const {
         organization: { adminUser },


### PR DESCRIPTION
#### Fixes #2969 and #2824 (Dublicate)

#### Checklist
- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:
Check for possible values like `'All Users', 'all_users', 'Admin', 'admin'`

#### Reviewers should focus on:
Currently hard cording all the possible values in the create method in `GroupPermissionsService`
```javascript
    const reservedGroups = ['All Users', 'all_users', 'Admin', 'admin'];
```
