### PR TITLE
Hide result when suggesting data source

### DIFF
--- a/frontend/src/Editor/DataSourceManager/DataSourceManager.jsx
+++ b/frontend/src/Editor/DataSourceManager/DataSourceManager.jsx
@@ -270,7 +270,7 @@ class DataSourceManager extends React.Component {
                     ))}
                   </>
                 )}
-                {this.state.queryString && this.state.filteredDatasources.length === 0 && (
+                {!suggestingDatasources && this.state.queryString && this.state.filteredDatasources.length === 0 && (
                   <div className="empty-state-wrapper row">
                     <EmptyStateContainer
                       queryString={this.state.queryString}


### PR DESCRIPTION
#### Fixes #3033

#### Checklist
- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:
Hide the result when showing the `suggest` section

#### Screenshot
![Screenshot from 2022-05-11 06-29-28](https://user-images.githubusercontent.com/25791025/167748449-6ee5ab85-1963-4211-8100-c9140e68032b.png)

