### PR TITLE
[Doc]: Linked Custom Component Doc

### DIFF
--- a/docs/docs/widgets/custom-component.md
+++ b/docs/docs/widgets/custom-component.md
@@ -1,3 +1,8 @@
+---
+id: custom-component
+title: Custom Component
+---
+
 # Custom Component
 
 Custom Component can be used to do create your own React component when the needed functionality isn't available in other components.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -103,6 +103,7 @@ const sidebars = {
         'widgets/circular-progress-bar',
         'widgets/code-editor',
         'widgets/container',
+        'widgets/custom-component',
         'widgets/date-range-picker',
         'widgets/datepicker',
         'widgets/divider',


### PR DESCRIPTION
The custom component doc was not linked to the sidebar in the documentation. 

This PR links the custom-component doc page to the sidebar