### PR TITLE
fixes broken viewer screen with one single widget

### DIFF
--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -467,7 +467,9 @@ export const Container = ({
               removeComponent={removeComponent}
               currentLayout={currentLayout}
               deviceWindowWidth={deviceWindowWidth}
-              isSelectedComponent={selectedComponents.find((component) => component.id === key)}
+              isSelectedComponent={
+                mode === 'edit' ? selectedComponents.find((component) => component.id === key) : false
+              }
               darkMode={darkMode}
               onComponentHover={onComponentHover}
               hoveredComponent={hoveredComponent}


### PR DESCRIPTION
followup to #2979 

 `selectedWidget` should only be computed in **edit** mode