### PR TITLE
[docs] added password login in sidebar

### DIFF
--- a/docs/docs/password-login/password-login.md
+++ b/docs/docs/password-login/password-login.md
@@ -1,13 +1,13 @@
 ---
-sidebar_position: 1
-sidebar_label: Password Login
+id: password-login
+title: Password Login
 ---
 
 # Password Login
 
 Password login is enabled by default for all workspaces. User with admin privilege can enable/disable it. 
 
-Select `Manage SSO` from workspace options
+- Select `Manage SSO` from workspace options
 
 <div style={{textAlign: 'center'}}>
 
@@ -15,7 +15,7 @@ Select `Manage SSO` from workspace options
 
 </div>
 
-Select `Password Login`. You can enable/disable it
+- Select `Password Login`. You can enable/disable it
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -52,6 +52,7 @@ const sidebars = {
         'tutorial/versioning-and-release',
         'tutorial/sharing-and-deploying',
         'tutorial/manage-users-groups',
+        'password-login/password-login',
         'tutorial/keyboard-shortcuts',
       ],
     },


### PR DESCRIPTION
### Summary
Docs for the password login were added to the documentation but were not included in the sidebar(to display in UI). There needs to be proper documentation for `Workspaces` so for the time being, I have added it under the Tutorial category next to Managing Users and Groups.

### Changes
- added front matter to `password-login.md`
- added included password login in `sidebar.js`