### PR TITLE
[Docs]: Updated google sheet integration video

### DIFF
--- a/docs/docs/data-sources/google.sheets.md
+++ b/docs/docs/data-sources/google.sheets.md
@@ -7,6 +7,14 @@ title: Google Sheets
 
 ToolJet can connect to Google Sheet using OAuth 2.0, which helps us to limit an application's access to a user's account.
 
+## How to integrate Google Sheets
+
+<div style={{textAlign: 'left'}}>
+    <figure class="video_container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/3PO41waW2CQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </figure>
+</div>
+
 ## Self-Hosted Configuration
 
 If you are self-hosting the application, you will need to perform some additional steps.


### PR DESCRIPTION
Updated how to integrate google sheets on ToolJet video in the data source docs.