### PR TITLE
changed class 'widget-button-label' (theme.scss) text color to be visible in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -5194,6 +5194,7 @@ div#driver-page-overlay {
 .widget-buttongroup-label{
   font-weight: 600;
   margin-right: 10px;
+  color: #3e525b;
 }
 .editor-actions {
   border-bottom: 1px solid #eee;


### PR DESCRIPTION
The button label color was hard to read in dark mode. class "widget-button-label" was given "color: #3e525b;"