### PR TITLE
[hotfix] Table widget's column text colour option didn't work as expected 

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -720,6 +720,7 @@ export function Table({
     () => [...leftActionsCellData, ...columnData, ...rightActionsCellData],
     [
       JSON.stringify(columnData),
+      JSON.stringify(tableData),
       JSON.stringify(actions),
       leftActionsCellData.length,
       rightActionsCellData.length,


### PR DESCRIPTION
Fixes #3297