### PR TITLE
Fixed fx text alignment

### DIFF
--- a/frontend/src/Editor/CodeBuilder/Elements/AlignButtons.jsx
+++ b/frontend/src/Editor/CodeBuilder/Elements/AlignButtons.jsx
@@ -7,7 +7,7 @@ export const AlignButtons = ({ value, onChange, forceCodeBox, meta }) => {
   }
 
   return (
-    <div className="row">
+    <div className="row fx-container">
       <div className="col">
         <div className={`mb-3 field ${meta?.options?.className}`}>
           <div style={{ display: 'flex', gap: 10 }}>
@@ -98,7 +98,7 @@ export const AlignButtons = ({ value, onChange, forceCodeBox, meta }) => {
           </div>
         </div>
       </div>
-      <div className="col-auto pt-0">
+      <div className="col-auto pt-0 style-fx fx-common">
         <FxButton active={false} onPress={forceCodeBox} />
       </div>
     </div>


### PR DESCRIPTION
Fixes #3268 by adding fx classes in `AlignButtons.jsx`.