### PR TITLE
Changed typography for run query confirmation box #3310

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1123,7 +1123,7 @@ class Editor extends React.Component {
         {/* This is for viewer to show query confirmations */}
         <Confirm
           show={showQueryConfirmation}
-          message={'Do you want to run this query?'}
+          message={'Do you want to run this query -'}
           onConfirm={(queryConfirmationData) => onQueryConfirm(this, queryConfirmationData)}
           onCancel={() => onQueryCancel(this)}
           queryConfirmationData={this.state.queryConfirmationData?.queryName}

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1126,7 +1126,7 @@ class Editor extends React.Component {
           message={'Do you want to run this query?'}
           onConfirm={(queryConfirmationData) => onQueryConfirm(this, queryConfirmationData)}
           onCancel={() => onQueryCancel(this)}
-          queryConfirmationData={this.state.queryConfirmationData}
+          queryConfirmationData={this.state.queryConfirmationData?.queryName}
           darkMode={this.props.darkMode}
         />
         <Confirm

--- a/frontend/src/Editor/Viewer/Confirm.jsx
+++ b/frontend/src/Editor/Viewer/Confirm.jsx
@@ -29,7 +29,7 @@ export function Confirm({ show, message, onConfirm, onCancel, queryConfirmationD
         contentClassName={darkMode ? 'theme-dark' : ''}
       >
         <div className="modal-status bg-danger"></div>
-        <Modal.Body>{message}</Modal.Body>
+        <Modal.Body>{`${message} ${queryConfirmationData ? queryConfirmationData + '?' : ""}`}</Modal.Body>
         <Modal.Footer>
           <Button variant="secondary" onClick={handleClose}>
             Cancel


### PR DESCRIPTION
Changed typography for run query confirmation box

<img width="1440" alt="Screenshot 2022-06-20 at 9 53 26 AM" src="https://user-images.githubusercontent.com/82027712/174524892-077b4f6a-8bd7-410e-867e-37a0fa015b55.png">
