### PR TITLE
Fixed use CSS `overflow: auto` instead of `overflow: overlay`

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1839,8 +1839,8 @@ button {
 }
 
 .jet-data-table:hover {
-  overflow-x: overlay;
-  overflow-y: overlay;
+  overflow-x: auto;
+  overflow-y: auto;
 }
 
 .jet-data-table {


### PR DESCRIPTION
Fixes #3262 by using `overflow: auto` instead of `overflow: overlay` as `overlay` property is not compatible with firefox.