### PR TITLE
docs: Update setup link for macos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We love your input! We want to make contributing to this project as easy and tra
 
 ## Setup 
 
-[Mac OS](https://docs.tooljet.io/docs/contributing-guide/setup/Mac%20OS)
+[Mac OS](https://docs.tooljet.io/docs/contributing-guide/setup/macos)
 [Docker](https://docs.tooljet.io/docs/contributing-guide/setup/docker)
 [Ubuntu](https://docs.tooljet.io/docs/contributing-guide/setup/ubuntu)
 


### PR DESCRIPTION
Link to setup macos on CONTRIBUTING.md is broken as of now.