### PR TITLE
[docs] moved architecture under Setup in `Contributing guide`

### DIFF
--- a/docs/docs/contributing-guide/setup/architecture.md
+++ b/docs/docs/contributing-guide/setup/architecture.md
@@ -1,6 +1,6 @@
 ---
-id: introduction
-title: Introduction
+id: architecture
+title: Architecture
 ---
 # Introduction
 

--- a/docs/docs/contributing-guide/setup/macos.md
+++ b/docs/docs/contributing-guide/setup/macos.md
@@ -4,7 +4,7 @@ title: Mac OS
 ---
 
 # Mac OS
-Follow these steps to setup and run ToolJet on macOS for development purposes. Open terminal and run the commands below. We recommend reading our guide on [architecture](/docs/setup/architecture) of ToolJet before proceeding.
+Follow these steps to setup and run ToolJet on macOS for development purposes. Open terminal and run the commands below. We recommend reading our guide on [architecture](/docs/contributing-guide/setup/architecture) of ToolJet before proceeding.
 
 ## Setting up
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -238,6 +238,7 @@ const sidebars = {
           type: 'category',
           label: 'Setup',
           items: [
+            'contributing-guide/setup/architecture',
             'contributing-guide/setup/macos',
             'contributing-guide/setup/docker',
             'contributing-guide/setup/ubuntu',


### PR DESCRIPTION
#### Changes
- Moved architecture from setup to `Setup` in `Contributing guide`