### PR TITLE
[Docs]: Modal widget's video

### DIFF
--- a/docs/docs/widgets/modal.md
+++ b/docs/docs/widgets/modal.md
@@ -6,11 +6,10 @@ title: Modal
 
 Modal widget renders in front of a backdrop, and it blocks interaction with the rest of the application until the modal is closed. It can be used to add dialog boxes to your app for lightboxes, user notifications, forms, etc.
 
-<div style={{textAlign: 'center'}}>
 
-![ToolJet - Widget Reference - Modal](/img/widgets/modal/modal1.gif)
+## How To Use Datepicker Widget
 
-</div>
+<iframe height="500" src="https://www.youtube.com/embed/co-UZCGpfMI" title="Datepicker Widget" frameborder="0" allowfullscreen width="100%"></iframe>
 
 ## Add widgets to Modal
 


### PR DESCRIPTION
Replaced the gif with the widget's video on the documentation page.