### PR TITLE
Added widget property filters, and filtered general from modal widget

### DIFF
--- a/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
+++ b/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
@@ -53,6 +53,14 @@ export const baseComponentProperties = (
   validations,
   darkMode
 ) => {
+  // Add widget title to section key to filter that property section from specified widgets' settings
+  const accordionFilters = {
+    Properties: [],
+    Events: [],
+    Validation: [],
+    General: ['Modal'],
+    Layout: [],
+  };
   let items = [];
   items.push({
     title: 'Properties',
@@ -157,5 +165,7 @@ export const baseComponentProperties = (
     ),
   });
 
-  return items;
+  return items.filter(
+    (item) => !(item.title in accordionFilters && accordionFilters[item.title].includes(componentMeta.component))
+  );
 };


### PR DESCRIPTION
- Noticed a number of issues in the queue relate to filtering various widget setting's from the accordions list
- Change in this commit adds on the ability to filter various sections from a widget's settings by adding it to a filter object to the relevant section
- This will prevent if statements getting too long if more sections need to be filtered from a widget's settings in the future
- Added in filtering for the Modal widget's General section as specified in the linked issue

Fixes: #3579