### PR TITLE
[docs]: Fix typos

### DIFF
--- a/docs/docs/data-sources/google.sheets.md
+++ b/docs/docs/data-sources/google.sheets.md
@@ -36,7 +36,7 @@ You can create a Google Sheets data source with one of either of the two permiss
 
 ## Operations
 
-Using Google sheets data source you can perfom several operations from your applications like:
+Using Google sheets data source you can perform several operations from your applications like:
 
   1. **[Read data from a sheet](/docs/data-sources/google.sheets#read-data-from-a-sheet)**
   2. **[Append data to a sheet](/docs/data-sources/google.sheets#append-data-to-a-sheet)**

--- a/docs/docs/setup/heroku.md
+++ b/docs/docs/setup/heroku.md
@@ -35,7 +35,7 @@ title: Heroku
 
 4. Click on `Deploy app` button at the bottom to initiate the build.
 
-5. After the succesful build, you'll see two buttons at the bottom: `Manage App` and `View`. Click on the `View` to open the app or click on `Manage App` to configure any settings.
+5. After the successful build, you'll see two buttons at the bottom: `Manage App` and `View`. Click on the `View` to open the app or click on `Manage App` to configure any settings.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/widgets/dropdown.md
+++ b/docs/docs/widgets/dropdown.md
@@ -100,7 +100,7 @@ This is to control the visibility of the widget. If `{{false}}` the widget will 
 
 ### Selected text color
 
-Change the text color of the selected option in the widget by providing the `HEX color code` or choosing the the color from color picker.
+Change the text color of the selected option in the widget by providing the `HEX color code` or choosing the color from color picker.
 
 ### Disable
 
@@ -109,4 +109,3 @@ This property only accepts boolean values. If set to `{{true}}`, the widget will
 :::info
 Any property having `Fx` button next to its field can be **programmatically configured**.
 :::
-

--- a/docs/docs/widgets/range-slider.md
+++ b/docs/docs/widgets/range-slider.md
@@ -54,7 +54,7 @@ Enter the hexcode to set the color for slider's handler.
 ### Track color
 
 Enter the hexcode to set the color for slider's active portion on the track. 
-### Visiblity
+### Visibility
 
 Set the visivlity of the slider programmatically. The default value is `{{true}}`.
 


### PR DESCRIPTION
```sed
s/perfom/perform/
s/succesful/successful/
s/the the/the/
s/Visiblity/Visibility/
```