### PR TITLE
[Bug]: Fix for Build Error - Added close tag to CSS class 

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -5707,6 +5707,7 @@ a.step-item-disabled {
 // profile-settings css
 .confirm-input {
   padding-right: 8px !important;
+}
 
 .user-group-actions {
   display: flex;


### PR DESCRIPTION
Every PR with `run-ci` was failing due to the missing close tag in one of the CSS classes.

<img width="919" alt="image" src="https://user-images.githubusercontent.com/50441969/178956357-37ad063e-4f1d-4a79-9d83-ecfe17b48b4f.png">
