### PR TITLE
[Bug fix] : FIlePicker - if Parse content is disabled, the "File type" dropdown should be hidden 

### DIFF
--- a/frontend/src/Editor/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Components/FilePicker.jsx
@@ -24,8 +24,10 @@ export const FilePicker = ({
   const fileType = component.definition.properties.fileType?.value ?? 'image/*';
   const maxSize = component.definition.properties.maxSize?.value ?? 1048576;
   const minSize = component.definition.properties.minSize?.value ?? 0;
-  let parseContent = component.definition.properties.parseContent?.value ?? false;
-  parseContent = typeof parseContent !== 'boolean' ? resolveWidgetFieldValue(parseContent, currentState) : false;
+  const parseContent = resolveWidgetFieldValue(
+    component.definition.properties.parseContent?.value ?? false,
+    currentState
+  );
   const fileTypeFromExtension = component.definition.properties.parseFileType?.value ?? 'auto-detect';
   const parsedEnableDropzone =
     typeof enableDropzone !== 'boolean' ? resolveWidgetFieldValue(enableDropzone, currentState) : true;

--- a/frontend/src/Editor/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Components/FilePicker.jsx
@@ -24,9 +24,9 @@ export const FilePicker = ({
   const fileType = component.definition.properties.fileType?.value ?? 'image/*';
   const maxSize = component.definition.properties.maxSize?.value ?? 1048576;
   const minSize = component.definition.properties.minSize?.value ?? 0;
-  const parseContent = component.definition.properties.parseContent?.value ?? false;
+  let parseContent = component.definition.properties.parseContent?.value ?? false;
+  parseContent = typeof parseContent !== 'boolean' ? resolveWidgetFieldValue(parseContent, currentState) : false;
   const fileTypeFromExtension = component.definition.properties.parseFileType?.value ?? 'auto-detect';
-
   const parsedEnableDropzone =
     typeof enableDropzone !== 'boolean' ? resolveWidgetFieldValue(enableDropzone, currentState) : true;
   const parsedEnablePicker =

--- a/frontend/src/Editor/Inspector/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Inspector/Components/FilePicker.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Accordion from '@/_ui/Accordion';
 import { renderElement } from '../Utils';
 import { baseComponentProperties } from './DefaultComponent';
+import { resolveReferences } from '@/_helpers/utils';
 
 export const FilePicker = ({ componentMeta, darkMode, ...restProps }) => {
   const {
@@ -19,7 +20,10 @@ export const FilePicker = ({ componentMeta, darkMode, ...restProps }) => {
     return renderElement(component, componentMeta, paramUpdated, dataQueries, param, paramType, currentState);
   };
   const conditionalAccordionItems = (component) => {
-    const parseContent = component.component.definition.properties.parseContent?.value ?? false;
+    const parseContent = resolveReferences(
+      component.component.definition.properties.parseContent?.value ?? false,
+      currentState
+    );
     const accordionItems = [];
     const options = ['parseContent'];
 
@@ -27,7 +31,7 @@ export const FilePicker = ({ componentMeta, darkMode, ...restProps }) => {
 
     options.map((option) => renderOptions.push(renderCustomElement(option)));
 
-    const conditionalOptions = [{ name: 'parseFileType', condition: parseContent === '{{true}}' }];
+    const conditionalOptions = [{ name: 'parseFileType', condition: parseContent }];
 
     conditionalOptions.map(({ name, condition }) => {
       if (condition) renderOptions.push(renderCustomElement(name));

--- a/frontend/src/Editor/Inspector/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Inspector/Components/FilePicker.jsx
@@ -30,7 +30,7 @@ export const FilePicker = ({ componentMeta, darkMode, ...restProps }) => {
     const conditionalOptions = [{ name: 'parseFileType', condition: parseContent }];
 
     conditionalOptions.map(({ name, condition }) => {
-      if (condition) renderOptions.push(renderCustomElement(name));
+      if (condition === '{{true}}') renderOptions.push(renderCustomElement(name));
     });
 
     accordionItems.push({

--- a/frontend/src/Editor/Inspector/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Inspector/Components/FilePicker.jsx
@@ -27,10 +27,10 @@ export const FilePicker = ({ componentMeta, darkMode, ...restProps }) => {
 
     options.map((option) => renderOptions.push(renderCustomElement(option)));
 
-    const conditionalOptions = [{ name: 'parseFileType', condition: parseContent }];
+    const conditionalOptions = [{ name: 'parseFileType', condition: parseContent === '{{true}}' }];
 
     conditionalOptions.map(({ name, condition }) => {
-      if (condition === '{{true}}') renderOptions.push(renderCustomElement(name));
+      if (condition) renderOptions.push(renderCustomElement(name));
     });
 
     accordionItems.push({


### PR DESCRIPTION
Resolve #3621
Fixed: If Parse content is disabled, the "File type" dropdown should be hidden