### PR TITLE
Place text 'unsaved changes' instead of loader for whole saving process in editor. 

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -143,7 +143,6 @@ class Editor extends React.Component {
       isSourceSelected: false,
       isSaving: false,
       isUnsavedQueriesAvailable: false,
-      versionSaving: false,
     };
 
     this.autoSave = debounce(this.saveEditingVersion, 3000);
@@ -572,6 +571,7 @@ class Editor extends React.Component {
     if (config.ENABLE_MULTIPLAYER_EDITING && !opts.skipYmapUpdate) {
       this.props.ymap?.set('appDef', { newDefinition, editingVersionId: this.state.editingVersion?.id });
     }
+
     produce(
       this.state.appDefinition,
       (draft) => {
@@ -1049,13 +1049,11 @@ class Editor extends React.Component {
     if (this.isVersionReleased()) {
       this.setState({ isSaving: false, showCreateVersionModalPrompt: true });
     } else if (!isEmpty(this.state.editingVersion)) {
-      this.setState({ versionSaving: true });
       appVersionService
         .save(this.state.appId, this.state.editingVersion.id, { definition: this.state.appDefinition })
         .then(() => {
           this.setState(
             {
-              versionSaving: false,
               saveError: false,
               editingVersion: {
                 ...this.state.editingVersion,
@@ -1221,21 +1219,17 @@ class Editor extends React.Component {
               )}
               <span
                 className={cx('autosave-indicator', {
-                  'autosave-indicator-saving': this.state.versionSaving,
+                  'autosave-indicator-saving': this.state.isSaving,
                   'text-danger': this.state.saveError,
                   'd-none': this.isVersionReleased(),
                 })}
                 data-cy="autosave-indicator"
               >
-                {this.state.versionSaving ? (
-                  <Spinner size="small" />
-                ) : this.state.isSaving ? (
-                  'Unsaved changes'
-                ) : this.state.saveError ? (
-                  'Could not save changes'
-                ) : (
-                  'All changes are saved'
-                )}
+                {this.state.isSaving
+                  ? 'Saving . . .'
+                  : this.state.saveError
+                  ? 'Could not save changes'
+                  : 'All changes are saved'}
               </span>
               {config.ENABLE_MULTIPLAYER_EDITING && <RealtimeAvatars />}
               {editingVersion && (

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1221,7 +1221,7 @@ class Editor extends React.Component {
               )}
               <span
                 className={cx('autosave-indicator', {
-                  'autosave-indicator-saving': this.state.isSaving,
+                  'autosave-indicator-saving': this.state.versionSaving,
                   'text-danger': this.state.saveError,
                   'd-none': this.isVersionReleased(),
                 })}

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -143,6 +143,7 @@ class Editor extends React.Component {
       isSourceSelected: false,
       isSaving: false,
       isUnsavedQueriesAvailable: false,
+      versionSaving: false,
     };
 
     this.autoSave = debounce(this.saveEditingVersion, 3000);
@@ -571,7 +572,6 @@ class Editor extends React.Component {
     if (config.ENABLE_MULTIPLAYER_EDITING && !opts.skipYmapUpdate) {
       this.props.ymap?.set('appDef', { newDefinition, editingVersionId: this.state.editingVersion?.id });
     }
-
     produce(
       this.state.appDefinition,
       (draft) => {
@@ -1049,11 +1049,13 @@ class Editor extends React.Component {
     if (this.isVersionReleased()) {
       this.setState({ isSaving: false, showCreateVersionModalPrompt: true });
     } else if (!isEmpty(this.state.editingVersion)) {
+      this.setState({ versionSaving: true });
       appVersionService
         .save(this.state.appId, this.state.editingVersion.id, { definition: this.state.appDefinition })
         .then(() => {
           this.setState(
             {
+              versionSaving: false,
               saveError: false,
               editingVersion: {
                 ...this.state.editingVersion,
@@ -1225,8 +1227,10 @@ class Editor extends React.Component {
                 })}
                 data-cy="autosave-indicator"
               >
-                {this.state.isSaving ? (
+                {this.state.versionSaving ? (
                   <Spinner size="small" />
+                ) : this.state.isSaving ? (
+                  'Unsaved changes'
                 ) : this.state.saveError ? (
                   'Could not save changes'
                 ) : (

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1226,7 +1226,7 @@ class Editor extends React.Component {
                 data-cy="autosave-indicator"
               >
                 {this.state.isSaving
-                  ? 'Saving . . .'
+                  ? 'Saving...'
                   : this.state.saveError
                   ? 'Could not save changes'
                   : 'All changes are saved'}

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -5372,7 +5372,7 @@ div#driver-page-overlay {
 }
 
 .autosave-indicator-saving {
-  left: 34.5%;
+  left: 30%;
 }
 .zoom-buttons {
   width: 20px !important;

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -5372,7 +5372,7 @@ div#driver-page-overlay {
 }
 
 .autosave-indicator-saving {
-  left: 30%;
+  left: 34.5%;
 }
 .zoom-buttons {
   width: 20px !important;


### PR DESCRIPTION
closes #3658 