### PR TITLE
[Hotfix] Multi select widget's menu gets overlaps with parent container when added to nested listview widgets

### DIFF
--- a/frontend/src/Editor/Components/Listview.jsx
+++ b/frontend/src/Editor/Components/Listview.jsx
@@ -67,7 +67,7 @@ export const Listview = function Listview({
         {(_.isArray(data) ? data : []).map((listItem, index) => (
           <div
             className={`list-item w-100 ${showBorder ? 'border-bottom' : ''}`}
-            style={{ position: 'relative', height: `${rowHeight}px`, width: '100%' }}
+            style={{ height: `${rowHeight}px`, width: '100%' }}
             key={index}
             onClick={(event) => {
               event.stopPropagation();


### PR DESCRIPTION
fixes: multi-select dropdown menu overlaps inside nested listview