### PR TITLE
[Bugfix]: Tabs widget - Not able to navigate to all the tabs for reduced widget widths

### DIFF
--- a/frontend/src/Editor/Components/Tabs.jsx
+++ b/frontend/src/Editor/Components/Tabs.jsx
@@ -104,7 +104,7 @@ export const Tabs = function Tabs({
       <ul
         className="nav nav-tabs"
         data-bs-toggle="tabs"
-        style={{ display: parsedHideTabs && 'none', backgroundColor: '#fff', margin: '-1px' }}
+        style={{ zIndex: 1, display: parsedHideTabs && 'none', backgroundColor: '#fff', margin: '-1px' }}
       >
         {parsedTabs.map((tab) => (
           <li


### PR DESCRIPTION
Resolves #3684 