### PR TITLE
[Bugfix] If the query is successfully run, success toast should be fired despite its triggered by any source.

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -922,11 +922,7 @@ class Editor extends React.Component {
               style={{ marginTop: '3px' }}
               className="btn badge bg-light-1"
               onClick={() => {
-                runQuery(this, dataQuery.id, dataQuery.name).then(() => {
-                  toast(`Query (${dataQuery.name}) completed.`, {
-                    icon: '🚀',
-                  });
-                });
+                runQuery(this, dataQuery.id, dataQuery.name);
               }}
             >
               <div className={`query-icon ${this.props.darkMode && 'dark'}`}>

--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -122,7 +122,7 @@ class Viewer extends React.Component {
   runQueries = (data_queries) => {
     data_queries.forEach((query) => {
       if (query.options.runOnPageLoad) {
-        runQuery(this, query.id, query.name);
+        runQuery(this, query.id, query.name, undefined, 'view');
       }
     });
   };

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -716,6 +716,7 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode) 
               () => {
                 resolve(data);
                 onEvent(_self, 'onDataQueryFailure', { definition: { events: dataQuery.options.events } });
+                toast.error(data.message);
               }
             );
           }
@@ -789,6 +790,9 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode) 
             () => {
               resolve({ status: 'ok', data: finalData });
               onEvent(_self, 'onDataQuerySuccess', { definition: { events: dataQuery.options.events } }, mode);
+              toast(`Query (${queryName}) completed.`, {
+                icon: '🚀',
+              });
             }
           );
         })

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -108,7 +108,7 @@ export function runTransformation(_ref, rawData, transformation, query, mode = '
     console.log('Transformation failed for query: ', query.name, err);
     const $error = err.name;
     const $errorMessage = _.has(ERROR_TYPES, $error) ? `${$error} : ${err.message}` : err || 'Unknown error';
-    if (mode !== 'edit') toast.error($errorMessage);
+    if (mode === 'edit') toast.error($errorMessage);
     result = { message: err.stack.split('\n')[0], status: 'failed', data: data };
   }
 

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -790,9 +790,12 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode) 
             () => {
               resolve({ status: 'ok', data: finalData });
               onEvent(_self, 'onDataQuerySuccess', { definition: { events: dataQuery.options.events } }, mode);
-              toast(`Query (${queryName}) completed.`, {
-                icon: '🚀',
-              });
+              console.log('Editor Mode => ', mode);
+              if (mode !== 'view') {
+                toast(`Query (${queryName}) completed.`, {
+                  icon: '🚀',
+                });
+              }
             }
           );
         })

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -108,7 +108,7 @@ export function runTransformation(_ref, rawData, transformation, query, mode = '
     console.log('Transformation failed for query: ', query.name, err);
     const $error = err.name;
     const $errorMessage = _.has(ERROR_TYPES, $error) ? `${$error} : ${err.message}` : err || 'Unknown error';
-    if (mode === 'edit') toast.error($errorMessage);
+    if (mode !== 'edit') toast.error($errorMessage);
     result = { message: err.stack.split('\n')[0], status: 'failed', data: data };
   }
 
@@ -730,7 +730,7 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode =
               () => {
                 resolve(data);
                 onEvent(_self, 'onDataQueryFailure', { definition: { events: dataQuery.options.events } });
-                toast.error(data.message);
+                if (mode !== 'view') toast.error(data.message);
               }
             );
           }
@@ -814,7 +814,7 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode =
           );
         })
         .catch(({ error }) => {
-          toast.error(error);
+          if (mode !== 'view') toast.error(error);
           _self.setState(
             {
               currentState: {

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -82,7 +82,7 @@ export function getDataFromLocalStorage(key) {
   return localStorage.getItem(key);
 }
 
-export function runTransformation(_ref, rawData, transformation, query) {
+export function runTransformation(_ref, rawData, transformation, query, mode = 'edit') {
   const data = rawData;
 
   let result = [];
@@ -108,7 +108,7 @@ export function runTransformation(_ref, rawData, transformation, query) {
     console.log('Transformation failed for query: ', query.name, err);
     const $error = err.name;
     const $errorMessage = _.has(ERROR_TYPES, $error) ? `${$error} : ${err.message}` : err || 'Unknown error';
-    toast.error($errorMessage);
+    if (mode === 'edit') toast.error($errorMessage);
     result = { message: err.stack.split('\n')[0], status: 'failed', data: data };
   }
 
@@ -600,7 +600,7 @@ export function previewQuery(_ref, query, editorState, calledFromQuery = false) 
         let finalData = data.data;
 
         if (query.options.enableTransformation) {
-          finalData = runTransformation(_ref, finalData, query.options.transformation, query);
+          finalData = runTransformation(_ref, finalData, query.options.transformation, query, 'edit');
         }
 
         if (calledFromQuery) {
@@ -636,7 +636,7 @@ export function previewQuery(_ref, query, editorState, calledFromQuery = false) 
   });
 }
 
-export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode) {
+export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode = 'edit') {
   const query = _ref.state.app.data_queries.find((query) => query.id === queryId);
   let dataQuery = {};
 
@@ -739,7 +739,7 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode) 
           let finalData = data.data;
 
           if (dataQuery.options.enableTransformation) {
-            finalData = runTransformation(_self, rawData, dataQuery.options.transformation, dataQuery);
+            finalData = runTransformation(_self, rawData, dataQuery.options.transformation, dataQuery, mode);
             if (finalData.status === 'failed') {
               return _self.setState(
                 {
@@ -804,7 +804,7 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode) 
             () => {
               resolve({ status: 'ok', data: finalData });
               onEvent(_self, 'onDataQuerySuccess', { definition: { events: dataQuery.options.events } }, mode);
-              console.log('Editor Mode => ', mode);
+
               if (mode !== 'view') {
                 toast(`Query (${queryName}) completed.`, {
                   icon: '🚀',


### PR DESCRIPTION
Resolves #3767 