### PR TITLE
Update Footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -69,8 +69,8 @@ module.exports = {
           title: 'Community',
           items: [
             {
-              label: 'Stack Overflow',
-              href: 'https://stackoverflow.com/questions/tagged/tooljet',
+              label: 'Slack',
+              href: 'https://join.slack.com/t/tooljet/shared_invite/zt-r2neyfcw-KD1COL6t2kgVTlTtAV5rtg',
             },
           ],
         },
@@ -82,8 +82,8 @@ module.exports = {
               href: 'https://github.com/ToolJet/ToolJet',
             },
             {
-              label: 'Slack',
-              href: 'https://join.slack.com/t/tooljet/shared_invite/zt-r2neyfcw-KD1COL6t2kgVTlTtAV5rtg',
+              label: 'YouTube',
+              href: 'https://www.youtube.com/channel/UCf1p2G5Z7fPpvlBPf4l2I1w',
             },
             {
               label: 'Twitter',


### PR DESCRIPTION
Replaced Stack Overflow link with Slack link and Slack under More with YouTube link

Actually there was a problem in displaying the slack link in issues tab so I used the removed slack link itself to add it in here