### PR TITLE
[Bugfix] For **Run the query on page load** and **Request confirmation before running the query.**, toasts are displayed in the preview apps.

### DIFF
--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -232,7 +232,7 @@ class Viewer extends React.Component {
           <Confirm
             show={showQueryConfirmation}
             message={'Do you want to run this query?'}
-            onConfirm={(queryConfirmationData) => onQueryConfirm(this, queryConfirmationData)}
+            onConfirm={(queryConfirmationData) => onQueryConfirm(this, queryConfirmationData, 'view')}
             onCancel={() => onQueryCancel(this)}
             queryConfirmationData={this.state.queryConfirmationData}
           />

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -781,10 +781,6 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode =
             });
           }
 
-          if (dataQuery.options.requestConfirmation) {
-            toast(`Query (${dataQuery.name}) completed.`);
-          }
-
           _self.setState(
             {
               currentState: {

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -128,11 +128,11 @@ export function onComponentClick(_ref, id, component, mode = 'edit') {
   executeActionsForEventId(_ref, 'onClick', component, mode);
 }
 
-export function onQueryConfirm(_ref, queryConfirmationData) {
+export function onQueryConfirm(_ref, queryConfirmationData, mode = 'edit') {
   _ref.setState({
     showQueryConfirmation: false,
   });
-  runQuery(_ref, queryConfirmationData.queryId, queryConfirmationData.queryName, true);
+  runQuery(_ref, queryConfirmationData.queryId, queryConfirmationData.queryName, true, mode);
 }
 
 export function onQueryCancel(_ref) {
@@ -730,7 +730,11 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode =
               () => {
                 resolve(data);
                 onEvent(_self, 'onDataQueryFailure', { definition: { events: dataQuery.options.events } });
-                if (mode !== 'view') toast.error(data.message);
+                console.log('onDataQueryFailure', data);
+                if (mode !== 'view') {
+                  const errorMessage = data.message || data.data.message;
+                  toast.error(errorMessage);
+                }
               }
             );
           }


### PR DESCRIPTION
Resolves #3871 

- fixes the empty error toast for the runJS query
- fixes: if the runjs2 is on run on page load, it runs, and even on the viewer we have the toast, as the mode is undefined and default `mode('edit')` is considered.