### PR TITLE
[feat] Extend webpack development server configuration to open docs path on development server start

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,3 +1,5 @@
+const devServerPlugin = require('./src/plugins/devServer/index.js');
+
 const isProd = process.env.NODE_ENV === 'production';
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
@@ -128,5 +130,8 @@ module.exports = {
           : undefined,
       },
     ],
+  ],
+  plugins: [
+    devServerPlugin,
   ],
 };

--- a/docs/src/plugins/devServer/index.js
+++ b/docs/src/plugins/devServer/index.js
@@ -1,0 +1,12 @@
+module.exports = function (context, options) {
+    return {
+      name: 'dev-server-plugin',
+      configureWebpack(config, isServer, utils) {
+        return {
+          devServer: {
+            open: '/docs',
+          },
+        };
+      },
+    };
+  };


### PR DESCRIPTION
Fixes https://github.com/ToolJet/ToolJet/issues/3877


https://user-images.githubusercontent.com/60817786/186831042-82fec95f-b990-463a-ada2-baccb7396bd3.mp4

