### PR TITLE
Bug Fixed : Overflow dropdown in the columns section inside table widget inspector  is not consistent with the dark theme

### DIFF
--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -206,6 +206,7 @@ class Table extends React.Component {
             <div className="field mb-2">
               <label className="form-label">Overflow</label>
               <SelectSearch
+                className={`${this.props.darkMode ? 'select-search-dark' : 'select-search'}`}
                 options={[
                   { name: 'Wrap', value: 'wrap' },
                   { name: 'Scroll', value: 'scroll' },


### PR DESCRIPTION
Resolves #3899 