### PR TITLE
Update README: Run with root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Want to give ToolJet a quick spin on your local machine? You can run the followi
 ```bash
 docker run \
   --name tooljet \
+  --user root \
   --restart unless-stopped \
   -p 3000:3000 \
   -v tooljet_data:/var/lib/postgresql/13/main \


### PR DESCRIPTION
Based on the documentation running Tooljet locally will raise some access errors: 
```
[Error: EACCES: permission denied, open '/app/frontend/build/index.html'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/app/frontend/build/index.html'
}
[Error: EACCES: permission denied, open '/app/frontend/build/runtime.js'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/app/frontend/build/runtime.js'
}
[Error: EACCES: permission denied, open '/app/frontend/build/main.js'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/app/frontend/build/main.js'
}
```
The command should be invoked for the `root` user to resolve this issue (add `--user root`)
