### PR TITLE
Fix: make tooltip text for hide query visible

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -341,7 +341,6 @@ button {
   .editor-sidebar {
     height: 100%;
     position: fixed;
-    z-index: 1;
     right: 0;
     overflow-x: hidden;
     width: 300px;


### PR DESCRIPTION
This pull request closes issue #3917 

- I removed the z-index from the `.editor-sidebar` class in the `theme.scss` file.

Image:
![image (8)](https://user-images.githubusercontent.com/71691473/187691450-0ec1cb5d-2436-4f37-8267-d8f929e97c9d.png)

