### PR TITLE
chore: setup custom-component onUpdate event

### DIFF
--- a/docs/docs/widgets/custom-component.md
+++ b/docs/docs/widgets/custom-component.md
@@ -14,6 +14,19 @@ Custom Component can be used to do create your own React component when the need
 </div>
 
 ## Properties
+### Event: On update data
+
+Custom components can interact with the outer application through `updateData()` calls, those changes will trigger the `onUpdate` event.
+
+To add an event to a custom component, click on the widget handle to open the widget properties on the right sidebar. Go to the **Events** section and click on **Add handler**.
+
+**On update data** event is triggered when the component's data is updated. Just like any other event on ToolJet, you can set multiple handlers for this event.
+
+:::info
+Check [Action Reference](/docs/actions/show-alert) docs to get the detailed information about all the **Actions**.
+:::
+
+## Properties
 
 ### Data
 

--- a/frontend/src/Editor/Components/CustomComponent/CustomComponent.jsx
+++ b/frontend/src/Editor/Components/CustomComponent/CustomComponent.jsx
@@ -40,6 +40,7 @@ export const CustomComponent = (props) => {
         if (e.data.from === 'customComponent' && e.data.componentId === id) {
           if (e.data.message === 'UPDATE_DATA') {
             setCustomProps({ ...customPropRef.current, ...e.data.updatedObj });
+            requestAnimationFrame(() => fireEvent('onUpdate'));
           } else if (e.data.message === 'RUN_QUERY') {
             const filteredQuery = dataQueryRef.current.filter((query) => query.name === e.data.queryName);
             filteredQuery.length === 1 &&

--- a/frontend/src/Editor/Inspector/Components/CustomComponent.jsx
+++ b/frontend/src/Editor/Inspector/Components/CustomComponent.jsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import { renderElement } from '../Utils';
 import { CodeHinter } from '../../CodeBuilder/CodeHinter';
+import { EventManager } from '../EventManager';
 import Accordion from '@/_ui/Accordion';
 
-export const CustomComponent = function CustomComponent({
-  dataQueries,
-  component,
-  paramUpdated,
-  componentMeta,
-  components,
-  darkMode,
-  currentState,
-  layoutPropertyChanged,
-}) {
+export const CustomComponent = function CustomComponent(props) {
+  const {
+    dataQueries,
+    component,
+    paramUpdated,
+    componentMeta,
+    components,
+    darkMode,
+    currentState,
+    layoutPropertyChanged,
+  } = props;
   const code = component.component.definition.properties.code;
   const args = component.component.definition.properties.data;
 
@@ -46,6 +48,22 @@ export const CustomComponent = function CustomComponent({
         enablePreview={false}
         height={400}
         hideSuggestion
+      />
+    ),
+  });
+
+  items.push({
+    title: 'Events',
+    isOpen: false,
+    children: (
+      <EventManager
+        component={component}
+        componentMeta={componentMeta}
+        currentState={currentState}
+        dataQueries={dataQueries}
+        components={components}
+        eventsChanged={props.eventsChanged}
+        apps={props.apps}
       />
     ),
   });

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -4126,7 +4126,9 @@ export const widgets = [
       showOnDesktop: { type: 'toggle', displayName: 'Show on desktop' },
       showOnMobile: { type: 'toggle', displayName: 'Show on mobile' },
     },
-    events: {},
+    events: {
+      onUpdate: { displayName: 'On update data' },
+    },
     styles: {
       visibility: {
         type: 'toggle',

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -516,6 +516,7 @@ export async function onEvent(_ref, eventName, options, mode = 'edit') {
       'onSelectionChange',
       'onSelect',
       'onClick',
+      'onUpdate',
       'onFileSelected',
       'onFileLoaded',
       'onFileDeselected',


### PR DESCRIPTION
Hi, this PR would enable the `onUpdate` event for the CustomComponent widget that will be fired whenever `updateData()` is called.

This is very useful to run queries that would consume the component's data, I hope you like it.