### PR TITLE
[Table]Refactor/bugfix: Existing tables in the canvas without actions break the widget

### DIFF
--- a/frontend/src/Editor/Components/Table/load-properties-and-styles.js
+++ b/frontend/src/Editor/Components/Table/load-properties-and-styles.js
@@ -39,7 +39,7 @@ export default function loadPropertiesAndStyles(properties, styles, darkMode, co
 
   const actionButtonRadius = styles.actionButtonRadius ? parseFloat(styles.actionButtonRadius) : 0;
 
-  const actions = (component.definition.properties.actions.value ?? []).map((action) => ({
+  const actions = (component.definition.properties.actions?.value ?? []).map((action) => ({
     ...action,
     actionButtonRadius,
   }));


### PR DESCRIPTION
Fixes: Existing tables in the canvas without actions break the widget.