### PR TITLE
fix: pass-down dataQueries to allow runQuery on modals, closes #4099

### DIFF
--- a/frontend/src/Editor/SubContainer.jsx
+++ b/frontend/src/Editor/SubContainer.jsx
@@ -33,6 +33,7 @@ export const SubContainer = ({
   darkMode,
   containerCanvasWidth,
   readOnly,
+  dataQueries,
   customResolvables,
   parentComponent,
   onComponentHover,
@@ -422,6 +423,7 @@ export const SubContainer = ({
             onComponentOptionChanged={onComponentOptionChangedForSubcontainer}
             onComponentOptionsChanged={onComponentOptionsChanged}
             key={key}
+            dataQueries={dataQueries}
             currentState={currentState}
             onResizeStop={onResizeStop}
             onDragStop={onDragStop}


### PR DESCRIPTION
fixes #4099 