### PR TITLE
Bugfix: update both comments collections when socket message is received

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -234,9 +234,17 @@ class EditorComponent extends React.Component {
 
   initEventListeners() {
     this.socket?.addEventListener('message', (event) => {
-      if (event.data === 'versionReleased') this.fetchApp();
-      else if (event.data === 'dataQueriesChanged') this.fetchDataQueries();
-      else if (event.data === 'dataSourcesChanged') this.fetchDataSources();
+      switch (event.data) {
+        case 'versionReleased':
+          this.fetchApp();
+          break;
+        case 'dataQueriesChanged':
+          this.fetchDataQueries();
+          break;
+        case 'dataSourcesChanged':
+          this.fetchDataSources();
+          break;
+      }
     });
   }
 


### PR DESCRIPTION
This PR fixes #3044 
I split both notification collections into resolved and unresolved, because setting the collection based on the state of the tab and using the same collection for both tabs feels weird. 
Also whenever a notifications message is received, it is not possible to determine whether an unresolved comment is marked as resolved or visa versa. Therefore I suggest we update both collections whenever a message is received. 