### PR TITLE
[fix] Steps widget route to homepage

### DIFF
--- a/frontend/src/Editor/Components/Steps.jsx
+++ b/frontend/src/Editor/Components/Steps.jsx
@@ -28,7 +28,6 @@ export const Steps = function Button({ properties, styles, fireEvent, setExposed
         {steps?.map((item) => (
           <a
             key={item.id}
-            href="#"
             className={`step-item ${item.id == activeStep && 'active'} ${!stepsSelectable && 'step-item-disabled'}  ${
               color && `step-${color}`
             }`}


### PR DESCRIPTION
fix: removed line 31: href = '#' causing return to homepage.

fixes #4101 