### PR TITLE
[Bugfix]  On Saving or discarding changes with **Show bulk update actions** toggled on, the bulk update action buttons are always displayed.

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -147,14 +147,14 @@ export function Table({
     setExposedVariables({
       changeSet: {},
       dataUpdates: [],
-    });
+    }).then(() => mergeToTableDetails({ dataUpdates: {}, changeSet: {} }));
   }
 
   function handleChangesDiscarded() {
     setExposedVariables({
       changeSet: {},
       dataUpdates: [],
-    });
+    }).then(() => mergeToTableDetails({ dataUpdates: {}, changeSet: {} }));
   }
 
   const changeSet = tableDetails?.changeSet ?? {};


### PR DESCRIPTION
Resolves #4113 