### PR TITLE
Add setState functions of components as dependencies for registerAction

### DIFF
--- a/frontend/src/Editor/Components/Button.jsx
+++ b/frontend/src/Editor/Components/Button.jsx
@@ -47,21 +47,37 @@ export const Button = function Button({
     fireEvent('onClick');
   });
 
-  registerAction('setText', async function (text) {
-    setLabel(text);
-  });
+  registerAction(
+    'setText',
+    async function (text) {
+      setLabel(text);
+    },
+    [setLabel]
+  );
 
-  registerAction('disable', async function (value) {
-    setDisable(value);
-  });
+  registerAction(
+    'disable',
+    async function (value) {
+      setDisable(value);
+    },
+    [setDisable]
+  );
 
-  registerAction('visibility', async function (value) {
-    setVisibility(value);
-  });
+  registerAction(
+    'visibility',
+    async function (value) {
+      setVisibility(value);
+    },
+    [setVisibility]
+  );
 
-  registerAction('loading', async function (value) {
-    setLoading(value);
-  });
+  registerAction(
+    'loading',
+    async function (value) {
+      setLoading(value);
+    },
+    [setLoading]
+  );
 
   return (
     <div className="widget-button">

--- a/frontend/src/Editor/Components/Checkbox.jsx
+++ b/frontend/src/Editor/Components/Checkbox.jsx
@@ -33,10 +33,14 @@ export const Checkbox = function Checkbox({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultValueFromProperties]);
 
-  registerAction('setChecked', async function (status) {
-    setExposedVariable('value', status).then(() => (status ? fireEvent('onCheck') : fireEvent('onUnCheck')));
-    setChecked(status);
-  });
+  registerAction(
+    'setChecked',
+    async function (status) {
+      setExposedVariable('value', status).then(() => (status ? fireEvent('onCheck') : fireEvent('onUnCheck')));
+      setChecked(status);
+    },
+    [setChecked]
+  );
 
   return (
     <div data-disabled={disabledState} className="row py-1" style={{ height, display: visibility ? '' : 'none' }}>

--- a/frontend/src/Editor/Components/ColorPicker.jsx
+++ b/frontend/src/Editor/Components/ColorPicker.jsx
@@ -44,19 +44,23 @@ export const ColorPicker = function ({
     return `rgba(${rgbaArray[0]}, ${rgbaArray[1]}, ${rgbaArray[2]})`;
   };
 
-  registerAction('setColor', async function (color) {
-    if (/^#(([\dA-Fa-f]{3}){1,2}|([\dA-Fa-f]{4}){1,2})$/.test(color)) {
-      setExposedVariable('selectedColorHex', `${color}`);
-      setExposedVariable('selectedColorRGB', hexToRgb(color));
-      setExposedVariable('selectedColorRGBA', hexToRgba(color));
-      setColor(color);
-    } else {
-      setExposedVariable('selectedColorHex', 'undefined');
-      setExposedVariable('selectedColorRGB', 'undefined');
-      setExposedVariable('selectedColorRGBA', 'undefined');
-      setColor('Invalid Color');
-    }
-  });
+  registerAction(
+    'setColor',
+    async function (color) {
+      if (/^#(([\dA-Fa-f]{3}){1,2}|([\dA-Fa-f]{4}){1,2})$/.test(color)) {
+        setExposedVariable('selectedColorHex', `${color}`);
+        setExposedVariable('selectedColorRGB', hexToRgb(color));
+        setExposedVariable('selectedColorRGBA', hexToRgba(color));
+        setColor(color);
+      } else {
+        setExposedVariable('selectedColorHex', 'undefined');
+        setExposedVariable('selectedColorRGB', 'undefined');
+        setExposedVariable('selectedColorRGBA', 'undefined');
+        setColor('Invalid Color');
+      }
+    },
+    [setColor]
+  );
 
   useEffect(() => {
     if (/^#(([\dA-Fa-f]{3}){1,2}|([\dA-Fa-f]{4}){1,2})$/.test(defaultColor)) {

--- a/frontend/src/Editor/Components/DropDown.jsx
+++ b/frontend/src/Editor/Components/DropDown.jsx
@@ -51,7 +51,7 @@ export const DropDown = function DropDown({
     async function (value) {
       selectOption(value);
     },
-    [JSON.stringify(values)]
+    [JSON.stringify(values), selectOption]
   );
 
   const validationData = validate(value);

--- a/frontend/src/Editor/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Components/FilePicker.jsx
@@ -293,9 +293,13 @@ export const FilePicker = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFiles]);
 
-  registerAction('clearFiles', async function () {
-    setSelectedFiles([]);
-  });
+  registerAction(
+    'clearFiles',
+    async function () {
+      setSelectedFiles([]);
+    },
+    [setSelectedFiles]
+  );
 
   return (
     <section>

--- a/frontend/src/Editor/Components/Map/Map.jsx
+++ b/frontend/src/Editor/Components/Map/Map.jsx
@@ -125,9 +125,13 @@ export const Map = function Map({
     setAutoComplete(autocompleteInstance);
   }
 
-  registerAction('setLocation', async function (lat, lng) {
-    if (lat && lng) setMapCenter(resolveReferences({ lat, lng }, currentState));
-  });
+  registerAction(
+    'setLocation',
+    async function (lat, lng) {
+      if (lat && lng) setMapCenter(resolveReferences({ lat, lng }, currentState));
+    },
+    [setMapCenter]
+  );
 
   return (
     <div

--- a/frontend/src/Editor/Components/Modal.jsx
+++ b/frontend/src/Editor/Components/Modal.jsx
@@ -34,14 +34,22 @@ export const Modal = function Modal({
   const title = properties.title ?? '';
   const size = properties.size ?? 'lg';
 
-  registerAction('open', async function () {
-    setExposedVariable('show', true);
-    setShowModal(true);
-  });
-  registerAction('close', async function () {
-    setShowModal(false);
-    setExposedVariable('show', false);
-  });
+  registerAction(
+    'open',
+    async function () {
+      setExposedVariable('show', true);
+      setShowModal(true);
+    },
+    [setShowModal]
+  );
+  registerAction(
+    'close',
+    async function () {
+      setShowModal(false);
+      setExposedVariable('show', false);
+    },
+    [setShowModal]
+  );
 
   useEffect(() => {
     if (exposedVariables.show !== showModal) {

--- a/frontend/src/Editor/Components/Multiselect.jsx
+++ b/frontend/src/Editor/Components/Multiselect.jsx
@@ -87,7 +87,7 @@ export const Multiselect = function Multiselect({
         newSelected.map((item) => item.value)
       ).then(() => fireEvent('onSelect'));
     },
-    [selected]
+    [selected, setSelected]
   );
   registerAction(
     'deselectOption',
@@ -103,12 +103,16 @@ export const Multiselect = function Multiselect({
         newSelected.map((item) => item.value)
       ).then(() => fireEvent('onSelect'));
     },
-    [selected]
+    [selected, setSelected]
   );
-  registerAction('clearSelections', async function () {
-    setSelected([]);
-    setExposedVariable('values', []).then(() => fireEvent('onSelect'));
-  });
+  registerAction(
+    'clearSelections',
+    async function () {
+      setSelected([]);
+      setExposedVariable('values', []).then(() => fireEvent('onSelect'));
+    },
+    [setSelected]
+  );
 
   return (
     <div

--- a/frontend/src/Editor/Components/RadioButton.jsx
+++ b/frontend/src/Editor/Components/RadioButton.jsx
@@ -38,9 +38,13 @@ export const RadioButton = function RadioButton({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
-  registerAction('selectOption', async function (option) {
-    onSelect(option);
-  });
+  registerAction(
+    'selectOption',
+    async function (option) {
+      onSelect(option);
+    },
+    [onSelect]
+  );
 
   return (
     <div data-disabled={disabledState} className="row py-1" style={{ height, display: visibility ? '' : 'none' }}>

--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -321,7 +321,7 @@ export function Table({
       setExposedVariable('pageIndex', targetPageIndex);
       if (!serverSidePagination && clientSidePagination) gotoPage(targetPageIndex - 1);
     },
-    [serverSidePagination, clientSidePagination]
+    [serverSidePagination, clientSidePagination, setPaginationInternalPageIndex]
   );
 
   useEffect(() => {

--- a/frontend/src/Editor/Components/Tabs.jsx
+++ b/frontend/src/Editor/Components/Tabs.jsx
@@ -96,12 +96,16 @@ export const Tabs = function Tabs({
     return id === currentTab ? 'visible' : 'hidden';
   }
 
-  registerAction('setTab', async function (id) {
-    if (id) {
-      setCurrentTab(id);
-      setExposedVariable('currentTab', id).then(() => fireEvent('onTabSwitch'));
-    }
-  });
+  registerAction(
+    'setTab',
+    async function (id) {
+      if (id) {
+        setCurrentTab(id);
+        setExposedVariable('currentTab', id).then(() => fireEvent('onTabSwitch'));
+      }
+    },
+    [setCurrentTab]
+  );
 
   const renderTabContent = (id, tab) => (
     <div

--- a/frontend/src/Editor/Components/Text.jsx
+++ b/frontend/src/Editor/Components/Text.jsx
@@ -30,12 +30,20 @@ export const Text = function Text({ height, properties, styles, darkMode, regist
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => setText(() => computeText()), [properties.text]);
 
-  registerAction('setText', async function (text) {
-    setText(text);
-  });
-  registerAction('visibility', async function (value) {
-    setVisibility(value);
-  });
+  registerAction(
+    'setText',
+    async function (text) {
+      setText(text);
+    },
+    [setText]
+  );
+  registerAction(
+    'visibility',
+    async function (value) {
+      setVisibility(value);
+    },
+    [setVisibility]
+  );
 
   function computeText() {
     return properties.text === 0 || properties.text === false ? properties.text?.toString() : properties.text;

--- a/frontend/src/Editor/Components/TextArea.jsx
+++ b/frontend/src/Editor/Components/TextArea.jsx
@@ -8,14 +8,22 @@ export const TextArea = function TextArea({ height, properties, styles, setExpos
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [properties.value]);
 
-  registerAction('setText', async function (text) {
-    setValue(text);
-    setExposedVariable('value', text);
-  });
-  registerAction('clear', async function () {
-    setValue('');
-    setExposedVariable('value', '');
-  });
+  registerAction(
+    'setText',
+    async function (text) {
+      setValue(text);
+      setExposedVariable('value', text);
+    },
+    [setValue]
+  );
+  registerAction(
+    'clear',
+    async function () {
+      setValue('');
+      setExposedVariable('value', '');
+    },
+    [setValue]
+  );
   return (
     <textarea
       disabled={styles.disabledState}

--- a/frontend/src/Editor/Components/TextInput.jsx
+++ b/frontend/src/Editor/Components/TextInput.jsx
@@ -24,14 +24,22 @@ export const TextInput = function TextInput({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [properties.value]);
 
-  registerAction('setText', async function (text) {
-    setValue(text);
-    setExposedVariable('value', text).then(fireEvent('onChange'));
-  });
-  registerAction('clear', async function () {
-    setValue('');
-    setExposedVariable('value', '').then(fireEvent('onChange'));
-  });
+  registerAction(
+    'setText',
+    async function (text) {
+      setValue(text);
+      setExposedVariable('value', text).then(fireEvent('onChange'));
+    },
+    [setValue]
+  );
+  registerAction(
+    'clear',
+    async function () {
+      setValue('');
+      setExposedVariable('value', '').then(fireEvent('onChange'));
+    },
+    [setValue]
+  );
 
   return (
     <div className="text-input">


### PR DESCRIPTION
Resolves #4119

The problem occurs due to the state setting functions of components getting reset when the components are re-rendered during opening and closing of modal.

The solution is to re-register each action whenever the state setting functions get changed, by adding them to the dependency array of `registerAction`.