### PR TITLE
Use only state setters as dependent functions for registerAction (Task id: CU-2vk03t9)

### DIFF
--- a/frontend/src/Editor/Components/DropDown.jsx
+++ b/frontend/src/Editor/Components/DropDown.jsx
@@ -51,7 +51,7 @@ export const DropDown = function DropDown({
     async function (value) {
       selectOption(value);
     },
-    [JSON.stringify(values), selectOption]
+    [JSON.stringify(values), setCurrentValue]
   );
 
   const validationData = validate(value);

--- a/frontend/src/Editor/Components/RadioButton.jsx
+++ b/frontend/src/Editor/Components/RadioButton.jsx
@@ -43,7 +43,7 @@ export const RadioButton = function RadioButton({
     async function (option) {
       onSelect(option);
     },
-    [onSelect]
+    [set]
   );
 
   return (


### PR DESCRIPTION
Resolves #4136

The bug occurred due to non-state-setting functions being passed as dependencies for `registerAction`. This fix simply replaces those functions with their dependent state-setting-functions in the dependency array of `registerAction`.