### PR TITLE
[ hotfixed ] : Datepicker widget height is not consistent with the parent container

### DIFF
--- a/frontend/src/Editor/Components/Datepicker.jsx
+++ b/frontend/src/Editor/Components/Datepicker.jsx
@@ -102,7 +102,7 @@ export const Datepicker = function Datepicker({
         showYearDropdown
         dropdownMode="select"
         excludeDates={excludedDates}
-        customInput={<input style={{ borderRadius: `${borderRadius}px` }} />}
+        customInput={<input style={{ borderRadius: `${borderRadius}px`, height }} />}
       />
 
       <div data-cy="date-picker-invalid-feedback" className={`invalid-feedback ${isValid ? '' : 'd-flex'}`}>


### PR DESCRIPTION
Resolves #4143 