### PR TITLE
feat: Add customizable border color for text input component

### DIFF
--- a/frontend/src/Editor/Components/TextInput.jsx
+++ b/frontend/src/Editor/Components/TextInput.jsx
@@ -13,12 +13,17 @@ export const TextInput = function TextInput({
 }) {
   const textInputRef = useRef();
 
-  const textColor = darkMode && styles.textColor === '#000' ? '#fff' : styles.textColor;
-
   const [disable, setDisable] = useState(styles.disabledState);
   const [value, setValue] = useState(properties.value);
   const [visibility, setVisibility] = useState(styles.visibility);
   const { isValid, validationError } = validate(value);
+
+  const computedStyles = {
+    height,
+    borderRadius: `${styles.borderRadius}px`,
+    color: darkMode && styles.textColor === '#000' ? '#fff' : styles.textColor,
+    borderColor: styles.borderColor ?? "transparent"
+  }
 
   useEffect(() => {
     disable !== styles.disabledState && setDisable(styles.disabledState);
@@ -98,7 +103,7 @@ export const TextInput = function TextInput({
           darkMode && 'dark-theme-placeholder'
         }`}
         placeholder={properties.placeholder}
-        style={{ height, borderRadius: `${styles.borderRadius}px`, color: textColor }}
+        style={computedStyles}
         value={value}
         data-cy={`draggable-widget-${String(component.name).toLowerCase()}`}
       />

--- a/frontend/src/Editor/Components/TextInput.jsx
+++ b/frontend/src/Editor/Components/TextInput.jsx
@@ -22,8 +22,8 @@ export const TextInput = function TextInput({
     height,
     borderRadius: `${styles.borderRadius}px`,
     color: darkMode && styles.textColor === '#000' ? '#fff' : styles.textColor,
-    borderColor: styles.borderColor ?? "transparent"
-  }
+    borderColor: styles.borderColor,
+  };
 
   useEffect(() => {
     disable !== styles.disabledState && setDisable(styles.disabledState);

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -944,6 +944,7 @@ export const widgets = [
       events: [],
       styles: {
         textColor: { value: '#000' },
+        borderColor: { value: '#dadcde' },
         borderRadius: { value: '{{0}}' },
         visibility: { value: '{{true}}' },
         disabledState: { value: '{{false}}' },

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -881,6 +881,11 @@ export const widgets = [
         displayName: 'Text Color',
         validation: { schema: { type: 'string' } },
       },
+      borderColor: {
+        type: 'color',
+        displayName: 'Border Color',
+        validation: { schema: { type: 'string' } },
+      },
       borderRadius: {
         type: 'code',
         displayName: 'Border radius',


### PR DESCRIPTION
fixes: #4165 

Example:
<img width="852" alt="Screen Shot 2022-10-01 at 1 34 05 PM" src="https://user-images.githubusercontent.com/23402178/193399124-9680c54b-8167-4abc-8b86-b45108cc7e0c.png">

**NOTE**: The right most input is the default text input without any border color defined.

