### PR TITLE
Fix: broken link of doc on doc readme page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
   <h1 align="center">ToolJet Documentation</h1>
 </p>
 
-This repository contains the ToolJet documentation website code and Markdown source files for [docs.tooljet.com](docs.tooljet.com)
+This repository contains the ToolJet documentation website code and Markdown source files for [docs.tooljet.com](https://docs.tooljet.com)
 
 ## Index
 - [Feedback](#feedback)


### PR DESCRIPTION
Fixed the broken link of the documentation site on doc's github readme page.