### PR TITLE
Events accordion of widget inspector in Table Component changed to open by default

### DIFF
--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -854,7 +854,7 @@ class TableComponent extends React.Component {
 
     items.push({
       title: 'Events',
-      isOpen: false,
+      isOpen: true,
       children: (
         <EventManager
           component={component}


### PR DESCRIPTION
Hello,
I am a bit new to this. I tried fixing the issue of making Events accordion in Table Component open by default.
Please do let me know if any changes are required. Will be happy to learn and grow.
Fixes #4241 
Thank you