### PR TITLE
[Bugfix] Clear groups input field after creating a new group

### DIFF
--- a/frontend/src/ManageGroupPermissions/ManageGroupPermissions.jsx
+++ b/frontend/src/ManageGroupPermissions/ManageGroupPermissions.jsx
@@ -73,6 +73,7 @@ class ManageGroupPermissionsComponent extends React.Component {
         this.setState({
           creatingGroup: false,
           showNewGroupForm: false,
+          newGroupName: null,
         });
         toast.success('Group has been created', {
           position: 'top-center',


### PR DESCRIPTION
Fixes #4235 

In this PR :-
- Resetting newGroupName to null after group is created