### PR TITLE
[Bugfix] Widgets dropped to the Modal as its children, should be able to drag to the bottom with scroll active

### DIFF
--- a/frontend/src/Editor/Components/Modal.jsx
+++ b/frontend/src/Editor/Components/Modal.jsx
@@ -154,7 +154,7 @@ export const Modal = function Modal({
       >
         {!loadingState ? (
           <>
-            <SubContainer parent={id} {...containerProps} parentRef={parentRef} />
+            <SubContainer parent={id} {...containerProps} parentRef={parentRef} height={'100vh'} />
             <SubCustomDragLayer
               snapToGrid={true}
               parentRef={parentRef}

--- a/frontend/src/Editor/SubContainer.jsx
+++ b/frontend/src/Editor/SubContainer.jsx
@@ -44,6 +44,7 @@ export const SubContainer = ({
   exposedVariables,
   addDefaultChildren = false,
   setDraggingOrResizing = () => {},
+  height = '100%',
 }) => {
   //Todo add custom resolve vars for other widgets too
   const mounted = useMounted();
@@ -380,7 +381,7 @@ export const SubContainer = ({
 
   const styles = {
     width: '100%',
-    height: '100%',
+    height: height ?? '100%',
     position: 'absolute',
     backgroundSize: `${getContainerCanvasWidth() / 43}px 10px`,
   };


### PR DESCRIPTION
Resolves #4322 