### PR TITLE
Layout accordion of widget inspector in Table widget should be open default

### DIFF
--- a/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
+++ b/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
@@ -142,7 +142,7 @@ export const baseComponentProperties = (
 
   items.push({
     title: `${i18next.t('widget.common.layout', 'Layout')}`,
-    isOpen: true,
+    isOpen: false,
     children: (
       <>
         {renderElement(

--- a/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
+++ b/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
@@ -142,7 +142,7 @@ export const baseComponentProperties = (
 
   items.push({
     title: `${i18next.t('widget.common.layout', 'Layout')}`,
-    isOpen: false,
+    isOpen: true,
     children: (
       <>
         {renderElement(

--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -905,7 +905,7 @@ class TableComponent extends React.Component {
 
     items.push({
       title: 'Layout',
-      isOpen: false,
+      isOpen: true,
       children: (
         <>
           {renderElement(


### PR DESCRIPTION
fixes #4240 
<img width="1553" alt="Screenshot 2022-10-12 at 2 17 50 PM" src="https://user-images.githubusercontent.com/24625561/195303276-baa9d0ee-78db-410b-b56e-230deeb60902.png">
