### PR TITLE
Fix :: trim version name input

### DIFF
--- a/frontend/src/Editor/AppVersionsManager.jsx
+++ b/frontend/src/Editor/AppVersionsManager.jsx
@@ -80,7 +80,8 @@ export const AppVersionsManager = function AppVersionsManager({
   };
 
   const createVersion = (versionName, createAppVersionFrom) => {
-    if (versionName.trim() !== '') {
+    versionName = versionName.trim();
+    if (versionName !== '') {
       setIsCreatingVersion(true);
       appVersionService
         .create(appId, versionName, createAppVersionFrom.id)


### PR DESCRIPTION
Fixes #4450 

Trim leading and trailing spaces from version name input so that the `/apps/${appId}/versions` API will treat existing versions as duplicates regardless of leading/trailing spaces.

https://github.com/ToolJet/ToolJet/blob/08c86493f91d4b4292c6f7216008cc71ad43f85e/frontend/src/Editor/AppVersionsManager.jsx#L85-L86
https://github.com/ToolJet/ToolJet/blob/08c86493f91d4b4292c6f7216008cc71ad43f85e/frontend/src/_services/appVersion.service.js#L22-L33
https://github.com/ToolJet/ToolJet/blob/08c86493f91d4b4292c6f7216008cc71ad43f85e/server/src/controllers/apps.controller.ts#L249-L263
https://github.com/ToolJet/ToolJet/blob/08c86493f91d4b4292c6f7216008cc71ad43f85e/server/src/services/apps.service.ts#L299-L310