### PR TITLE
[BUG]Fixes rich text editor select heading re-direct to dashboard

### DIFF
--- a/frontend/src/Editor/Components/DraftEditor.jsx
+++ b/frontend/src/Editor/Components/DraftEditor.jsx
@@ -87,7 +87,7 @@ const BlockStyleControls = (props) => {
         </button>
         <div className="dropdown-content bg-white">
           {HEADINGS.map((type) => (
-            <a className="dropitem m-0 p-0" href="#" key={type.label}>
+            <div className="dropitem m-0 p-0" key={type.label}>
               <StyleButton
                 key={type.label}
                 active={type.style === blockType}
@@ -95,7 +95,7 @@ const BlockStyleControls = (props) => {
                 onToggle={props.onToggle}
                 style={type.style}
               />
-            </a>
+            </div>
           ))}
         </div>
       </div>

--- a/frontend/src/Editor/Components/DraftEditor.jsx
+++ b/frontend/src/Editor/Components/DraftEditor.jsx
@@ -87,7 +87,7 @@ const BlockStyleControls = (props) => {
         </button>
         <div className="dropdown-content bg-white">
           {HEADINGS.map((type) => (
-            <div className="dropitem m-0 p-0" key={type.label}>
+            <a className="dropitem m-0 p-0" key={type.label}>
               <StyleButton
                 key={type.label}
                 active={type.style === blockType}
@@ -95,7 +95,7 @@ const BlockStyleControls = (props) => {
                 onToggle={props.onToggle}
                 style={type.style}
               />
-            </div>
+            </a>
           ))}
         </div>
       </div>


### PR DESCRIPTION
fixes the re-directing on changing header type: [#4460](https://github.com/ToolJet/ToolJet/issues/4460)

![image](https://user-images.githubusercontent.com/95110820/196244349-f6838199-0621-41ef-8fbc-de915ae63907.png)
