### PR TITLE
[Bug]: Fixed Query Panel Expand Issue

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryPanel.jsx
+++ b/frontend/src/Editor/QueryManager/QueryPanel.jsx
@@ -7,7 +7,9 @@ const QueryPanel = ({ queryPanelHeight, children }) => {
   const isComponentMounted = useRef(false);
   const queryPaneRef = useRef(null);
   const [isDragging, setDragging] = useState(false);
-  const [height, setHeight] = useState(queryManagerPreferences?.queryPanelHeight ?? queryPanelHeight);
+  const [height, setHeight] = useState(
+    queryManagerPreferences?.queryPanelHeight > 95 ? 30 : queryManagerPreferences.queryPanelHeight ?? queryPanelHeight
+  );
   const [isTopOfQueryPanel, setTopOfQueryPanel] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
Fixed query panel height issue for the users who have dragged the query panel to the bottom of the screen. Added a check to determine if the height is more than 95, then the height of the query panel is set to 30