### PR TITLE
fix(LoginPage): missing whitespace

### DIFF
--- a/frontend/src/ForgotPassword/ForgotPasswordPage.jsx
+++ b/frontend/src/ForgotPassword/ForgotPasswordPage.jsx
@@ -86,7 +86,7 @@ class ForgotPasswordComponent extends React.Component {
             </div>
           </form>
           <div className="text-center text-muted mt-3">
-            {this.props.t('loginSignupPage.dontHaveAccount', `Don't have account yet?`)}
+            {this.props.t('loginSignupPage.dontHaveAccount', `Don't have account yet?`)}&nbsp;
             <Link to={'/signup'} tabIndex="-1">
               {this.props.t('loginSignupPage.signUp', `Sign up`)}
             </Link>

--- a/frontend/src/LoginPage/LoginPage.jsx
+++ b/frontend/src/LoginPage/LoginPage.jsx
@@ -251,7 +251,7 @@ class LoginPageComponent extends React.Component {
           </form>
           {!this.organizationId && configs?.form?.enabled && configs?.form?.enable_sign_up && (
             <div className="text-center text-secondary mt-3" data-cy="sign-up-message">
-              {this.props.t('loginSignupPage.dontHaveAccount', `Don't have account yet?`)}
+              {this.props.t('loginSignupPage.dontHaveAccount', `Don't have account yet?`)}&nbsp;
               <Link to={'/signup'} tabIndex="-1" data-cy="sign-up-link">
                 {this.props.t('loginSignupPage.signUp', `Sign up`)}
               </Link>


### PR DESCRIPTION
### What's changed

- added missing whitespace in Login / Password Reset page

**before**
<img width="435" alt="Capture d’écran 2022-10-24 à 12 06 15 PM" src="https://user-images.githubusercontent.com/9987732/197502374-63d63320-c5b0-4bc0-9adf-e2f3c40a6cd0.png">


**after**
<img width="435" alt="Capture d’écran 2022-10-24 à 11 52 57 AM" src="https://user-images.githubusercontent.com/9987732/197502297-7e5ffc19-b32c-4199-9751-5dd10c9cbb63.png">
