### PR TITLE
Fixed dark mode on table's `Striped` and `Striped & Bordered` table type mode

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -635,7 +635,11 @@ export function Table({
       )}
 
       <div className="table-responsive jet-data-table">
-        <table {...getTableProps()} className={`table table-vcenter table-nowrap ${tableType}`} style={computedStyles}>
+        <table
+          {...getTableProps()}
+          className={`table table-vcenter table-nowrap ${tableType} ${darkMode && 'table-dark'}`}
+          style={computedStyles}
+        >
           <thead>
             {headerGroups.map((headerGroup, index) => (
               <DragDropContext


### PR DESCRIPTION
fixes: #4578 

https://user-images.githubusercontent.com/72064462/197938124-3cad44fd-3fca-491f-95aa-1d2bedb8950b.mov

