### PR TITLE
[Bugix]: Trailing white spaces at the end of the input should not update the widget definitions on the blur event

### DIFF
--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -332,7 +332,7 @@ export function CodeHinter({
                   height={'100%'}
                   onFocus={() => setFocused(true)}
                   onBlur={(editor) => {
-                    const value = editor.getValue();
+                    const value = editor.getValue()?.trimEnd();
                     onChange(value);
                     if (!isPreviewFocused.current) {
                       setFocused(false);


### PR DESCRIPTION
Resolves #4619 