### PR TITLE
fix: return object correctly while the value is {}

### DIFF
--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -140,7 +140,7 @@ export function resolveReferences(object, state, defaultValue, customObjects = {
 
         if (withError) return [new_array, error];
         return new_array;
-      } else if (!_.isEmpty(object)) {
+      } else if (!_.isEmpty(object) || _.isEqual(object, {})) {
         console.log(`[Resolver] Resolving as object ${typeof object}, state: ${state}`);
         Object.keys(object).forEach((key) => {
           const resolved_object = resolveReferences(object[key], state);


### PR DESCRIPTION
```javascript
resolveReferences({
  foo: {}
}, ...)
```
the above code will return `{ foo: undefined }`