### PR TITLE
[Bugfix] Query Manager: Creating a query, the options are set to their previous state used to create the last query from the same datasource/plugin

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -222,6 +222,7 @@ class QueryManagerComponent extends React.Component {
   handleBackButton = () => {
     this.setState({
       isSourceSelected: true,
+      options: {},
     });
   };
 

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -80,6 +80,7 @@ class QueryManagerComponent extends React.Component {
         dataQueries: dataQueries,
         appDefinition: props.appDefinition,
         mode: props.mode,
+        options: props.mode === 'edit' ? props?.options : {},
         currentTab: 1,
         addingQuery: props.addingQuery,
         editingQuery: props.editingQuery,

--- a/frontend/src/Editor/QueryManager/Transformation.jsx
+++ b/frontend/src/Editor/QueryManager/Transformation.jsx
@@ -57,7 +57,7 @@ return [row for row in data if row['amount'] > 1000]
   useEffect(() => {
     const selectedQueryId = localStorage.getItem('selectedQuery') ?? null;
 
-    if (!options.enableTransformation || !queryId) {
+    if (!options.enableTransformation) {
       setState(defaultValue);
       return;
     }

--- a/frontend/src/Editor/QueryManager/Transformation.jsx
+++ b/frontend/src/Editor/QueryManager/Transformation.jsx
@@ -57,7 +57,7 @@ return [row for row in data if row['amount'] > 1000]
   useEffect(() => {
     const selectedQueryId = localStorage.getItem('selectedQuery') ?? null;
 
-    if (!options.enableTransformation) {
+    if (!options.enableTransformation || !queryId) {
       setState(defaultValue);
       return;
     }


### PR DESCRIPTION
Resolves #4711 