### PR TITLE
[Bugfix] Query Manager: Creating a query, the options are set to their previous state used to create the last query from the same datasource/plugin

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -86,6 +86,7 @@ class QueryManagerComponent extends React.Component {
         isQueryPaneDragging: props.isQueryPaneDragging,
         currentState: props.currentState,
         selectedSource: source,
+        options: props.options ?? {},
         dataSourceMeta,
         paneHeightChanged,
         isSourceSelected: paneHeightChanged || queryPaneDragged ? this.state.isSourceSelected : props.isSourceSelected,
@@ -220,6 +221,7 @@ class QueryManagerComponent extends React.Component {
   handleBackButton = () => {
     this.setState({
       isSourceSelected: true,
+      options: {},
     });
   };
 
@@ -360,7 +362,7 @@ class QueryManagerComponent extends React.Component {
     }
     if (isFieldsChanged) this.props.setStateOfUnsavedQueries(true);
     this.setState({
-      options: newOptions,
+      options: { ...this.state.options, ...newOptions },
       isFieldsChanged,
       restArrayValuesChanged: headersChanged,
     });
@@ -585,6 +587,7 @@ class QueryManagerComponent extends React.Component {
                             this.setState({
                               isSourceSelected: false,
                               selectedDataSource: null,
+                              options: {},
                             });
                           }}
                           style={{ marginTop: '-7px' }}

--- a/frontend/src/Editor/QueryManager/Transformation.jsx
+++ b/frontend/src/Editor/QueryManager/Transformation.jsx
@@ -16,7 +16,6 @@ export const Transformation = ({ changeOption, currentState, options, darkMode, 
 
   const [lang, setLang] = React.useState(options?.transformationLanguage ?? 'javascript');
 
-  // console.log('from query manager', options);
   const defaultValue = {
     javascript: `// write your code here
 // return value will be set as data and the original data will be available as rawData
@@ -49,7 +48,7 @@ return [row for row in data if row['amount'] > 1000]
   useEffect(() => {
     if (options.enableTransformation) {
       changeOption('transformationLanguage', lang);
-      setState({ ...state, [lang]: options.transformation });
+      setState({ ...state, [lang]: options.transformation ?? defaultValue[lang] });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(options.transformation)]);
@@ -57,7 +56,7 @@ return [row for row in data if row['amount'] > 1000]
   useEffect(() => {
     const selectedQueryId = localStorage.getItem('selectedQuery') ?? null;
 
-    if (!options.enableTransformation) {
+    if (!options.enableTransformation || !queryId) {
       setState(defaultValue);
       return;
     }
@@ -65,7 +64,7 @@ return [row for row in data if row['amount'] > 1000]
       const nonLangdefaultCode = getNonActiveTransformations(options?.transformationLanguage ?? 'javascript');
       const finalState = _.merge(
         {},
-        { [options?.transformationLanguage ?? lang]: options.transformation },
+        { [options?.transformationLanguage ?? lang]: options.transformation ?? defaultValue[lang] },
         nonLangdefaultCode
       );
 


### PR DESCRIPTION
Resolves #4711 