### PR TITLE
fix: rich text editor does not accept html (#4819)

### DIFF
--- a/frontend/src/Editor/Components/DraftEditor.jsx
+++ b/frontend/src/Editor/Components/DraftEditor.jsx
@@ -148,8 +148,10 @@ const InlineStyleControls = (props) => {
 class DraftEditor extends React.Component {
   constructor(props) {
     super(props);
+    const blocksFromHTML = ContentState.convertFromHTML(this.props.defaultValue);
+    const contentState = ContentState.createFromBlockArray(blocksFromHTML.contentBlocks, blocksFromHTML.entityMap);
     this.state = {
-      editorState: EditorState.createWithContent(ContentState.createFromText(this.props.defaultValue)),
+      editorState: EditorState.createWithContent(contentState),
     };
 
     this.focus = () => this.refs.editor.focus();
@@ -167,7 +169,8 @@ class DraftEditor extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.defaultValue !== this.props.defaultValue) {
-      const newContentState = ContentState.createFromText(this.props.defaultValue);
+      const newBlocksFromHTML = ContentState.convertFromHTML(this.props.defaultValue);
+      const newContentState = ContentState.createFromBlockArray(newBlocksFromHTML.contentBlocks, newBlocksFromHTML.entityMap);
       const newEditorState = EditorState.createWithContent(newContentState);
       const newEditorStateWithFocus = EditorState.moveFocusToEnd(newEditorState);
       const html = stateToHTML(newContentState);


### PR DESCRIPTION
Should fix #4819.
I still need to test this PR, as I cannot test locally, due to a problem with the Docker development environment: #4820.