### PR TITLE
fix: change client.Dockerfile.dev node_modules path

### DIFF
--- a/docker/client.Dockerfile.dev
+++ b/docker/client.Dockerfile.dev
@@ -10,8 +10,8 @@ WORKDIR /app
 
 COPY ./package.json ./package.json
 
-# add `/app/node_modules/.bin` to $PATH
-ENV PATH /app/node_modules/.bin:$PATH
+# add `/app/frontend/node_modules/.bin` to $PATH
+ENV PATH /app/frontend/node_modules/.bin:$PATH
 
 # Fix for heap limit allocation issue
 ENV NODE_OPTIONS="--max-old-space-size=4096"


### PR DESCRIPTION
Fix #4823.

According to git blame, this bug should have been there for 10 months at least. I suppose that the dev images are not tested or used. I am trying to make them work.