### PR TITLE
Fix/data sources update

### DIFF
--- a/frontend/src/_components/DynamicForm.jsx
+++ b/frontend/src/_components/DynamicForm.jsx
@@ -65,6 +65,14 @@ const DynamicForm = ({
     }
   };
 
+  const handleToggle = (controller) => {
+    if (controller) {
+      return !options?.[controller]?.value ? ' d-none' : '';
+    } else {
+      return '';
+    }
+  };
+
   const getElementProps = ({
     key,
     list,
@@ -80,6 +88,7 @@ const DynamicForm = ({
     width,
     ignoreBraces = false,
     className,
+    controller,
   }) => {
     const darkMode = localStorage.getItem('darkMode') === 'true';
     switch (type) {
@@ -88,8 +97,8 @@ const DynamicForm = ({
       case 'textarea':
         return {
           type,
-          placeholder: description,
-          className: 'form-control',
+          placeholder: options?.[key]?.encrypted ? '**************' : description,
+          className: `form-control${handleToggle(controller)}`,
           value: options?.[key]?.value,
           ...(type === 'textarea' && { rows: rows }),
           ...(helpText && { helpText }),

--- a/plugins/packages/s3/lib/index.ts
+++ b/plugins/packages/s3/lib/index.ts
@@ -65,6 +65,10 @@ export default class S3QueryService implements QueryService {
       accessKeyId: sourceOptions.access_key,
       secretAccessKey: sourceOptions.secret_key,
     };
-    return new S3Client({ region: sourceOptions.region, credentials });
+    const endpointOptions = sourceOptions.endpoint_enabled && {
+      endpoint: sourceOptions?.endpoint,
+      forcePathStyle: true,
+    };
+    return new S3Client({ region: sourceOptions.region, credentials, ...endpointOptions });
   }
 }

--- a/plugins/packages/s3/lib/manifest.json
+++ b/plugins/packages/s3/lib/manifest.json
@@ -41,7 +41,7 @@
       "value": ""
     },
     "endpoint_enabled": {
-      "value": "false"
+      "value": false
     }
   },
   "properties": {

--- a/plugins/packages/s3/lib/manifest.json
+++ b/plugins/packages/s3/lib/manifest.json
@@ -21,6 +21,9 @@
       },
       "region": {
         "type": "string"
+      },
+      "endpoint": {
+        "type": "string"
       }
     }
   },
@@ -33,6 +36,12 @@
     },
     "region": {
       "value": ""
+    },
+    "endpoint": {
+      "value": ""
+    },
+    "endpoint_enabled": {
+      "value": "false"
     }
   },
   "properties": {
@@ -155,6 +164,18 @@
           "value": "us-gov-west-1"
         }
       ]
+    },
+    "endpoint_enabled": {
+      "label": "Custom Endpoint",
+      "key": "endpoint_enabled",
+      "type": "toggle",
+      "description": "Toggle for endpoint_enabled"
+    },
+    "endpoint": {
+      "key": "endpoint",
+      "type": "text",
+      "description": "Enter custom endpoint",
+      "controller": "endpoint_enabled"
     }
   },
   "required": [

--- a/plugins/packages/s3/lib/types.ts
+++ b/plugins/packages/s3/lib/types.ts
@@ -2,6 +2,8 @@ export type SourceOptions = {
   access_key: string;
   secret_key: string;
   region: string;
+  endpoint_enabled: boolean;
+  endpoint: string;
 };
 export type QueryOptions = {
   operation?: Operation;

--- a/server/src/services/data_sources.service.ts
+++ b/server/src/services/data_sources.service.ts
@@ -119,7 +119,12 @@ export class DataSourcesService {
       const sourceOptions = {};
 
       for (const key of Object.keys(options)) {
-        sourceOptions[key] = options[key]['value'];
+        const credentialId = options[key]?.['credential_id'];
+        if (credentialId) {
+          sourceOptions[key] = await this.credentialsService.getValue(credentialId);
+        } else {
+          sourceOptions[key] = options[key]['value'];
+        }
       }
 
       const service = await this.pluginsHelper.getService(plugin_id, kind);
@@ -199,7 +204,7 @@ export class DataSourcesService {
           dataSource.options[option['key']] && dataSource.options[option['key']]['credential_id'];
 
         if (existingCredentialId) {
-          await this.credentialsService.update(existingCredentialId, option['value'] || '');
+          option['value'] && (await this.credentialsService.update(existingCredentialId, option['value'] || ''));
 
           parsedOptions[option['key']] = {
             credential_id: existingCredentialId,


### PR DESCRIPTION
1.  Added placeholder for saved credentials (encrypted) in data sources.
2. Fixed credentials reset behaviour on save action in data sources.
3. Fix test connection when nothing changed while in edit mode.
4. Added custom s3-compatible-storage endpoint for self-hosted s3 instances. (Checked and tested on a s3-compatible storage server hosted on a remote server)