### PR TITLE
[Bugfix] multipages / viewer : On preview (first load) the home page should be render

### DIFF
--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -85,7 +85,12 @@ class ViewerComponent extends React.Component {
         let currentPageId = Object.keys(pagesObj).find((key) => pagesObj[key].handle === pageHandle);
 
         if (!currentPageId) {
-          currentPageId = copyDefinition.homePageId;
+          // if pageHandle is not found, and homepage is set to hidden, then show the first non-hidden page in the list
+          currentPageId = pagesObj[copyDefinition.homePageId]?.hidden
+            ? Object.entries(data.definition.pages).filter(([_, page]) => {
+                return !page.hidden;
+              })[0][0]
+            : copyDefinition.homePageId;
           this.switchPage(currentPageId);
         }
       }

--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -91,7 +91,7 @@ class ViewerComponent extends React.Component {
                 return !page.hidden;
               })[0][0]
             : copyDefinition.homePageId;
-          this.switchPage(currentPageId);
+          this.switchPage(currentPageId, [], true);
         }
       }
     );
@@ -276,7 +276,7 @@ class ViewerComponent extends React.Component {
     this.props.switchDarkMode(newMode);
   };
 
-  switchPage = (id, queryParams = []) => {
+  switchPage = (id, queryParams = [], initialLoad = false) => {
     const { handle, name, events } = this.state.appDefinition.pages[id];
 
     const queryParamsString = queryParams.map(([key, value]) => `${key}=${value}`).join('&');
@@ -308,14 +308,15 @@ class ViewerComponent extends React.Component {
           );
         computeComponentState(this, this.state.appDefinition?.pages[id].components).then(async () => {
           for (const event of events ?? []) {
-            await this.handleEvent(event.eventId, event);
+            console.log('events triggered in veiwer');
+            await this.handleEvent(event.eventId, event, initialLoad);
           }
         });
       }
     );
   };
 
-  handleEvent = (eventName, options) => onEvent(this, eventName, options, 'view');
+  handleEvent = (eventName, options, initialLoad = false) => !initialLoad && onEvent(this, eventName, options, 'view');
 
   render() {
     const {

--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -85,7 +85,7 @@ class ViewerComponent extends React.Component {
         let currentPageId = Object.keys(pagesObj).find((key) => pagesObj[key].handle === pageHandle);
 
         if (!currentPageId) {
-          currentPageId = Object.keys(pagesObj)[0];
+          currentPageId = copyDefinition.homePageId;
           this.switchPage(currentPageId);
         }
       }


### PR DESCRIPTION
**Current**
On rearranging the home page, the initial load from the editor on clicking preview button, renders the first page in the list (which may/may not be the homepage) as the currentPageId is undefined.
Even if the page is set to hide from the editor, the very first page is rendered.

**Fixes**
- On the initial load or currentPageId is undefined, home page is rendered. 
Hidden pages can only be accessible via url. 
- if pageHandle is not found, and homepage is set to hidden, then show the first non-hidden page in the list
- When preview is clicked (initial load), on page load events are run twice