### PR TITLE
add: custom endpoint for s3 hosts

### DIFF
--- a/frontend/src/_components/DynamicForm.jsx
+++ b/frontend/src/_components/DynamicForm.jsx
@@ -65,6 +65,14 @@ const DynamicForm = ({
     }
   };
 
+  const handleToggle = (controller) => {
+    if (controller) {
+      return !options?.[controller]?.value ? ' d-none' : '';
+    } else {
+      return '';
+    }
+  };
+
   const getElementProps = ({
     key,
     list,
@@ -80,6 +88,7 @@ const DynamicForm = ({
     width,
     ignoreBraces = false,
     className,
+    controller,
   }) => {
     const darkMode = localStorage.getItem('darkMode') === 'true';
     switch (type) {
@@ -89,7 +98,7 @@ const DynamicForm = ({
         return {
           type,
           placeholder: description,
-          className: 'form-control',
+          className: `form-control${handleToggle(controller)}`,
           value: options?.[key]?.value,
           ...(type === 'textarea' && { rows: rows }),
           ...(helpText && { helpText }),

--- a/plugins/packages/s3/lib/index.ts
+++ b/plugins/packages/s3/lib/index.ts
@@ -65,6 +65,10 @@ export default class S3QueryService implements QueryService {
       accessKeyId: sourceOptions.access_key,
       secretAccessKey: sourceOptions.secret_key,
     };
-    return new S3Client({ region: sourceOptions.region, credentials });
+    const endpointOptions = sourceOptions.endpoint_enabled && {
+      endpoint: sourceOptions?.endpoint,
+      forcePathStyle: true,
+    };
+    return new S3Client({ region: sourceOptions.region, credentials, ...endpointOptions });
   }
 }

--- a/plugins/packages/s3/lib/manifest.json
+++ b/plugins/packages/s3/lib/manifest.json
@@ -21,6 +21,9 @@
       },
       "region": {
         "type": "string"
+      },
+      "endpoint": {
+        "type": "string"
       }
     }
   },
@@ -33,6 +36,12 @@
     },
     "region": {
       "value": ""
+    },
+    "endpoint": {
+      "value": ""
+    },
+    "endpoint_enabled": {
+      "value": false
     }
   },
   "properties": {
@@ -155,6 +164,18 @@
           "value": "us-gov-west-1"
         }
       ]
+    },
+    "endpoint_enabled": {
+      "label": "Custom Endpoint",
+      "key": "endpoint_enabled",
+      "type": "toggle",
+      "description": "Toggle for endpoint_enabled"
+    },
+    "endpoint": {
+      "key": "endpoint",
+      "type": "text",
+      "description": "Enter custom endpoint",
+      "controller": "endpoint_enabled"
     }
   },
   "required": [

--- a/plugins/packages/s3/lib/types.ts
+++ b/plugins/packages/s3/lib/types.ts
@@ -2,6 +2,8 @@ export type SourceOptions = {
   access_key: string;
   secret_key: string;
   region: string;
+  endpoint_enabled: boolean;
+  endpoint: string;
 };
 export type QueryOptions = {
   operation?: Operation;


### PR DESCRIPTION
Added custom s3-compatible-storage endpoint for self-hosted s3 instances. (Checked and tested on a s3-compatible storage server hosted on a remote server)