### PR TITLE
[Bugfix] Multipages: widget inspector event popover unmounts

### DIFF
--- a/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
+++ b/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
@@ -14,7 +14,7 @@ export const DefaultComponent = ({ componentMeta, darkMode, ...restProps }) => {
     currentState,
     eventsChanged,
     apps,
-    allComponents,
+    components,
     pages,
   } = restProps;
 
@@ -33,7 +33,7 @@ export const DefaultComponent = ({ componentMeta, darkMode, ...restProps }) => {
     currentState,
     eventsChanged,
     apps,
-    allComponents,
+    components,
     validations,
     darkMode,
     pages

--- a/frontend/src/Editor/Inspector/Components/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table.jsx
@@ -969,7 +969,7 @@ class TableComponent extends React.Component {
 
     items.push({
       title: 'Events',
-      isOpen: false,
+      isOpen: true,
       children: (
         <EventManager
           component={component}

--- a/frontend/src/Editor/Inspector/EventManager.jsx
+++ b/frontend/src/Editor/Inspector/EventManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { ActionTypes } from '../ActionTypes';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';

--- a/frontend/src/Editor/Inspector/EventManager.jsx
+++ b/frontend/src/Editor/Inspector/EventManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ActionTypes } from '../ActionTypes';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';
@@ -26,6 +26,7 @@ export const EventManager = ({
   popoverPlacement,
   pages,
 }) => {
+  const [events, setEvents] = useState(() => component.component.definition.events || []);
   const [focusedEventIndex, setFocusedEventIndex] = useState(null);
   const { t } = useTranslation();
 
@@ -170,14 +171,14 @@ export const EventManager = ({
   }
 
   function handlerChanged(index, param, value) {
-    let newEvents = component.component.definition.events;
+    let newEvents = [...events];
 
     let updatedEvent = newEvents[index];
     updatedEvent[param] = value;
 
     newEvents[index] = updatedEvent;
 
-    eventsChanged(newEvents);
+    setEvents(newEvents);
   }
 
   function removeHandler(index) {
@@ -732,6 +733,7 @@ export const EventManager = ({
                               setFocusedEventIndex(index);
                             } else {
                               setFocusedEventIndex(null);
+                              eventsChanged(events);
                             }
                             if (typeof popOverCallback === 'function') popOverCallback(showing);
                           }}
@@ -834,7 +836,6 @@ export const EventManager = ({
     );
   };
 
-  const events = component.component.definition.events || [];
   const componentName = componentMeta.name ? componentMeta.name : 'query';
 
   if (events.length === 0) {

--- a/frontend/src/Editor/Inspector/Inspector.jsx
+++ b/frontend/src/Editor/Inspector/Inspector.jsx
@@ -18,6 +18,7 @@ import useFocus from '@/_hooks/use-focus';
 import Accordion from '@/_ui/Accordion';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
+import { useMounted } from '@/_hooks/use-mount';
 
 export const Inspector = ({
   selectedComponentId,
@@ -59,6 +60,8 @@ export const Inspector = ({
       setTabHeight(tabsRef.current.querySelector('.nav-tabs').clientHeight);
     }
   }, []);
+
+  const isMounted = useMounted();
 
   useEffect(() => {
     componentNameRef.current = newComponentName;
@@ -241,128 +244,6 @@ export const Inspector = ({
     componentDefinitionChanged(newComponent);
   }
 
-  function getAccordion(componentName) {
-    switch (componentName) {
-      case 'Table':
-        return (
-          <Table
-            layoutPropertyChanged={layoutPropertyChanged}
-            component={component}
-            paramUpdated={paramUpdated}
-            dataQueries={dataQueries}
-            componentMeta={componentMeta}
-            eventUpdated={eventUpdated}
-            eventOptionUpdated={eventOptionUpdated}
-            components={allComponents}
-            currentState={currentState}
-            darkMode={darkMode}
-            eventsChanged={eventsChanged}
-            apps={apps}
-            pages={pages}
-          />
-        );
-
-      case 'Chart':
-        return (
-          <Chart
-            layoutPropertyChanged={layoutPropertyChanged}
-            component={component}
-            paramUpdated={paramUpdated}
-            dataQueries={dataQueries}
-            componentMeta={componentMeta}
-            eventUpdated={eventUpdated}
-            eventOptionUpdated={eventOptionUpdated}
-            components={allComponents}
-            currentState={currentState}
-            darkMode={darkMode}
-          />
-        );
-
-      case 'FilePicker':
-        return (
-          <FilePicker
-            layoutPropertyChanged={layoutPropertyChanged}
-            component={component}
-            paramUpdated={paramUpdated}
-            dataQueries={dataQueries}
-            componentMeta={componentMeta}
-            currentState={currentState}
-            darkMode={darkMode}
-            eventsChanged={eventsChanged}
-            apps={apps}
-            allComponents={allComponents}
-          />
-        );
-
-      case 'Modal':
-        return (
-          <Modal
-            layoutPropertyChanged={layoutPropertyChanged}
-            component={component}
-            paramUpdated={paramUpdated}
-            dataQueries={dataQueries}
-            componentMeta={componentMeta}
-            currentState={currentState}
-            darkMode={darkMode}
-            eventsChanged={eventsChanged}
-            apps={apps}
-            allComponents={allComponents}
-          />
-        );
-
-      case 'CustomComponent':
-        return (
-          <CustomComponent
-            layoutPropertyChanged={layoutPropertyChanged}
-            component={component}
-            paramUpdated={paramUpdated}
-            dataQueries={dataQueries}
-            componentMeta={componentMeta}
-            currentState={currentState}
-            darkMode={darkMode}
-            eventsChanged={eventsChanged}
-            apps={apps}
-            allComponents={allComponents}
-          />
-        );
-
-      case 'Icon':
-        return (
-          <Icon
-            layoutPropertyChanged={layoutPropertyChanged}
-            component={component}
-            paramUpdated={paramUpdated}
-            dataQueries={dataQueries}
-            componentMeta={componentMeta}
-            currentState={currentState}
-            darkMode={darkMode}
-            eventsChanged={eventsChanged}
-            apps={apps}
-            allComponents={allComponents}
-            pages={pages}
-          />
-        );
-
-      default: {
-        return (
-          <DefaultComponent
-            layoutPropertyChanged={layoutPropertyChanged}
-            component={component}
-            paramUpdated={paramUpdated}
-            dataQueries={dataQueries}
-            componentMeta={componentMeta}
-            currentState={currentState}
-            darkMode={darkMode}
-            eventsChanged={eventsChanged}
-            apps={apps}
-            allComponents={allComponents}
-            pages={pages}
-          />
-        );
-      }
-    }
-  }
-
   const buildGeneralStyle = () => {
     const items = [];
 
@@ -436,7 +317,24 @@ export const Inspector = ({
                 </div>
               </div>
             </div>
-            {getAccordion(componentMeta.component)}
+            {isMounted && (
+              <GetAccordion
+                componentName={componentMeta.component}
+                layoutPropertyChanged={layoutPropertyChanged}
+                component={component}
+                paramUpdated={paramUpdated}
+                dataQueries={dataQueries}
+                componentMeta={componentMeta}
+                eventUpdated={eventUpdated}
+                eventOptionUpdated={eventOptionUpdated}
+                components={allComponents}
+                currentState={currentState}
+                darkMode={darkMode}
+                eventsChanged={eventsChanged}
+                apps={apps}
+                pages={pages}
+              />
+            )}
           </Tab>
           <Tab eventKey="styles" title={t('widget.common.styles', 'Styles')}>
             <div style={{ marginBottom: '6rem' }}>
@@ -564,5 +462,46 @@ const handleRenderingConditionalStyles = (
     ? renderElement(component, componentMeta, paramUpdated, dataQueries, style, 'styles', currentState, allComponents)
     : null;
 };
+
+const GetAccordion = React.memo(
+  ({ componentName, ...restProps }) => {
+    useEffect(() => {
+      console.log('checking => Inspector [Accordion] mounted');
+
+      return () => console.log('checking ==> Inspector [Accordion] unmounted');
+    }, []);
+
+    useEffect(() => {
+      console.log('checking => Inspector [Accordion] updated', restProps);
+    }, [JSON.stringify({ restProps })]);
+
+    switch (componentName) {
+      case 'Table':
+        return <Table {...restProps} />;
+
+      case 'Chart':
+        return <Chart {...restProps} />;
+
+      case 'FilePicker':
+        return <FilePicker {...restProps} />;
+
+      case 'Modal':
+        return <Modal {...restProps} />;
+
+      case 'CustomComponent':
+        return <CustomComponent {...restProps} />;
+
+      case 'Icon':
+        return <Icon {...restProps} />;
+
+      default: {
+        return <DefaultComponent {...restProps} />;
+      }
+    }
+  },
+  (prevProps, nextProps) => {
+    prevProps.componentName === nextProps.componentName;
+  }
+);
 
 Inspector.RenderStyleOptions = RenderStyleOptions;


### PR DESCRIPTION


When we update the events, it changes the component definition, which creates a new instance of a function which returns component's accordions for each property in the widget inspector.

when a single event param is updated, **all the children are not re-rendered, they are first unmounted, then re-mounted.** 

**EventManager -> Line: 718** the key prop tries to control the component instances. For each re-render, it's calling the functions to retrieve the new React elements that it uses to update the DOM, keeping the same nodes if the element type is never changed.
This means that all state that had existed in the component at the time is completely removed and the component is "re-initialized".

Fix: Introducing a component level state for managing events.