### PR TITLE
bugfix: Multipage - events should update definition on blur of the popover

### DIFF
--- a/frontend/src/Editor/Inspector/EventManager.jsx
+++ b/frontend/src/Editor/Inspector/EventManager.jsx
@@ -730,7 +730,10 @@ export const EventManager = ({
                           placement={popoverPlacement || 'left'}
                           rootClose={true}
                           overlay={eventPopover(event, index)}
-                          onHide={() => setFocusedEventIndex(null)}
+                          onHide={() => {
+                            eventsChanged(events);
+                            setFocusedEventIndex(null);
+                          }}
                           onToggle={(showing) => {
                             if (showing) {
                               setFocusedEventIndex(index);

--- a/frontend/src/Editor/Inspector/EventManager.jsx
+++ b/frontend/src/Editor/Inspector/EventManager.jsx
@@ -179,7 +179,6 @@ export const EventManager = ({
     newEvents[index] = updatedEvent;
 
     setEvents(newEvents);
-    eventsChanged(newEvents);
   }
 
   function removeHandler(index) {


### PR DESCRIPTION
events should update definition on blur of the popover