### PR TITLE
Bugfix for default value of components not exposed on viewer load (Task ID - 32xje8x)

### DIFF
--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -166,6 +166,7 @@ class ViewerComponent extends React.Component {
       },
       () => {
         computeComponentState(this, data?.definition?.pages[currentPage.id]?.components).then(() => {
+          this.setState({ initialComputationOfStateDone: true });
           console.log('Default component state computed and set');
           this.runQueries(data.data_queries);
         });
@@ -288,7 +289,7 @@ class ViewerComponent extends React.Component {
       this.loadApplicationBySlug(this.props.match.params.slug);
     }
 
-    this.handlePageSwitchingBasedOnURLparam();
+    if (this.state.initialComputationOfStateDone) this.handlePageSwitchingBasedOnURLparam();
   }
 
   handlePageSwitchingBasedOnURLparam() {


### PR DESCRIPTION
This PR ensures that default values of components and applied and exposed properly to the current state when viewer is loaded.