### PR TITLE
Bugfix/Rename un set page variable to unset page variable

### DIFF
--- a/frontend/src/Editor/CodeBuilder/utils.js
+++ b/frontend/src/Editor/CodeBuilder/utils.js
@@ -46,7 +46,7 @@ export function getSuggestionKeys(refState, refSource) {
     'goToApp',
     'generateFile',
     'setPageVariable',
-    'unSetPageVariable',
+    'unsetPageVariable',
     'switchPage',
   ];
 

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -463,7 +463,7 @@ export async function executeMultilineJS(
       };
       return executeAction(_ref, event, mode, {});
     },
-    unSetPageVariable: function (key = '') {
+    unsetPageVariable: function (key = '') {
       const event = {
         actionId: 'unset-page-variable',
         key,


### PR DESCRIPTION
This PR renames the function `unSetPageVariable` to `unsetPageVariable`