### PR TITLE
fixes: app crash on selecting page switch event for query manager

### DIFF
--- a/frontend/src/Editor/Inspector/Components/Form.jsx
+++ b/frontend/src/Editor/Inspector/Components/Form.jsx
@@ -16,6 +16,7 @@ export const Form = ({
   eventsChanged,
   apps,
   allComponents,
+  pages,
 }) => {
   const properties = Object.keys(componentMeta.properties);
   const events = Object.keys(componentMeta.events);
@@ -44,7 +45,8 @@ export const Form = ({
     apps,
     allComponents,
     validations,
-    darkMode
+    darkMode,
+    pages
   );
 
   return <Accordion items={accordionItems} />;
@@ -63,7 +65,8 @@ export const baseComponentProperties = (
   apps,
   allComponents,
   validations,
-  darkMode
+  darkMode,
+  pages
 ) => {
   let items = [];
   if (properties.length > 0) {
@@ -99,6 +102,7 @@ export const baseComponentProperties = (
           eventsChanged={eventsChanged}
           apps={apps}
           darkMode={darkMode}
+          pages={pages}
         />
       ),
     });

--- a/frontend/src/Editor/LeftSidebar/SidebarPageSelector/PageHandler.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPageSelector/PageHandler.jsx
@@ -23,7 +23,7 @@ export const PageHandler = ({
   updateOnPageLoadEvents,
   currentState,
   apps,
-  allPages,
+  pages,
   components,
   dataQueries,
 }) => {
@@ -181,7 +181,7 @@ export const PageHandler = ({
               updateOnPageLoadEvents={updateOnPageLoadEvents}
               currentState={currentState}
               apps={apps}
-              pages={allPages}
+              pages={pages}
               components={components}
               dataQueries={dataQueries}
             />

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -72,6 +72,11 @@ class QueryManagerComponent extends React.Component {
     const paneHeightChanged = this.state.queryPaneHeight !== props.queryPaneHeight;
     const dataQueries = props.dataQueries?.length ? props.dataQueries : this.state.dataQueries;
     const queryPaneDragged = this.state.isQueryPaneDragging !== props.isQueryPaneDragging;
+
+    const pages = props.appDefinition?.pages
+      ? Object.entries(props.appDefinition?.pages).map(([id, page]) => ({ ...page, id }))
+      : [];
+
     this.setState(
       {
         appId: props.appId,
@@ -87,6 +92,7 @@ class QueryManagerComponent extends React.Component {
         currentState: props.currentState,
         selectedSource: source,
         options: props.options ?? {},
+        pages: pages,
         dataSourceMeta,
         paneHeightChanged,
         isSourceSelected: paneHeightChanged || queryPaneDragged ? this.state.isSourceSelected : props.isSourceSelected,
@@ -801,6 +807,7 @@ class QueryManagerComponent extends React.Component {
                     components={this.props.allComponents}
                     apps={this.props.apps}
                     popoverPlacement="top"
+                    pages={this.state.pages}
                   />
                 </div>
               </div>

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -73,10 +73,6 @@ class QueryManagerComponent extends React.Component {
     const dataQueries = props.dataQueries?.length ? props.dataQueries : this.state.dataQueries;
     const queryPaneDragged = this.state.isQueryPaneDragging !== props.isQueryPaneDragging;
 
-    const pages = props.appDefinition?.pages
-      ? Object.entries(props.appDefinition?.pages).map(([id, page]) => ({ ...page, id }))
-      : [];
-
     this.setState(
       {
         appId: props.appId,
@@ -92,7 +88,6 @@ class QueryManagerComponent extends React.Component {
         currentState: props.currentState,
         selectedSource: source,
         options: props.options ?? {},
-        pages: pages,
         dataSourceMeta,
         paneHeightChanged,
         isSourceSelected: paneHeightChanged || queryPaneDragged ? this.state.isSourceSelected : props.isSourceSelected,
@@ -807,7 +802,11 @@ class QueryManagerComponent extends React.Component {
                     components={this.props.allComponents}
                     apps={this.props.apps}
                     popoverPlacement="top"
-                    pages={this.state.pages}
+                    pages={
+                      this.props.appDefinition?.pages
+                        ? Object.entries(this.props.appDefinition?.pages).map(([id, page]) => ({ ...page, id }))
+                        : []
+                    }
                   />
                 </div>
               </div>


### PR DESCRIPTION
Fixes:
App crash for add page switch event for
- [x] queries (Query manager)
- [x] form widget
- [x] page event handler (page handler menu)