### PR TITLE
[Bugfix] internal storage toast  | trigger toasts for running preview db queries

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -769,7 +769,10 @@ export function previewQuery(_ref, query, editorState, calledFromQuery = false) 
             break;
           }
           case 'ok':
-          case 'OK': {
+          case 'OK':
+          case 'Created':
+          case 'Accepted':
+          case 'No Content': {
             toast(`Query completed.`, {
               icon: '🚀',
             });

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -757,7 +757,8 @@ export function previewQuery(_ref, query, editorState, calledFromQuery = false) 
         } else {
           _ref.setState({ previewLoading: false, queryPreviewData: finalData });
         }
-        switch (data.status) {
+        const queryStatus = query.kind === 'tooljetdb' ? data.statusText : data.status;
+        switch (queryStatus) {
           case 'failed': {
             toast.error(`${data.message}: ${data.description}`);
             break;
@@ -767,7 +768,8 @@ export function previewQuery(_ref, query, editorState, calledFromQuery = false) 
             fetchOAuthToken(url, query.data_source_id);
             break;
           }
-          case 'ok': {
+          case 'ok':
+          case 'OK': {
             toast(`Query completed.`, {
               icon: '🚀',
             });


### PR DESCRIPTION
Resolves:
**Preview Query** should trigger a toast according to the query status returned similar to other queries (default queries and datasource queries)