### PR TITLE
[Bugfix] Internal storage - empty filters deletes all rows

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/ToolJetDb/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/ToolJetDb/operations.js
@@ -85,7 +85,6 @@ async function deleteRows(queryOptions, organizationId, currentState) {
   const { where_filters: whereFilters } = deleteRows;
 
   if (isEmpty(whereFilters) || isEmpty(whereFilters['0'])) {
-    // throw new Error('Where filters are empty');
     return { statusText: 'failed', status: 400, message: 'Where filters are empty' };
   }
 

--- a/frontend/src/Editor/QueryManager/QueryEditors/ToolJetDb/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/ToolJetDb/operations.js
@@ -84,6 +84,11 @@ async function deleteRows(queryOptions, organizationId, currentState) {
   const { table_name: tableName, delete_rows: deleteRows } = resolvedOptions;
   const { where_filters: whereFilters } = deleteRows;
 
+  if (isEmpty(whereFilters) || isEmpty(whereFilters['0'])) {
+    // throw new Error('Where filters are empty');
+    return { statusText: 'failed', status: 400, message: 'Where filters are empty' };
+  }
+
   let query = [];
   const whereQuery = buildPostgrestQuery(whereFilters);
   !isEmpty(whereQuery) && query.push(whereQuery);

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -760,7 +760,8 @@ export function previewQuery(_ref, query, editorState, calledFromQuery = false) 
         const queryStatus = query.kind === 'tooljetdb' ? data.statusText : data.status;
         switch (queryStatus) {
           case 'failed': {
-            toast.error(`${data.message}: ${data.description}`);
+            const errorMessage = data.description ? `${data.message}: ${data.description}` : data.message;
+            toast.error(errorMessage);
             break;
           }
           case 'needs_oauth': {


### PR DESCRIPTION
Resolves: 
**Delete row operation**
if filter options are not passed, i.e., with empty options all rows are deleted

Depends: #5019 