### PR TITLE
Removing a tip from Heroku

### DIFF
--- a/docs/docs/setup/heroku.md
+++ b/docs/docs/setup/heroku.md
@@ -51,9 +51,6 @@ title: Heroku
 
 </div>
 
-:::tip
-The one click deployment will create a **free dyno** and a **free postgresql database**.
-:::
 
 :::tip
 ToolJet server and client can be deployed as standalone applications. If you do not want to deploy the client on Heroku, modify `package.json` accordingly. We have a [guide](/docs/setup/client) on deploying ToolJet client using services such as Firebase.


### PR DESCRIPTION
Removing the Tip - 

:::tip
The one click deployment will create a **free dyno** and a **free postgresql database**. :::

Since free dyno and postgressql database are longer available.