### PR TITLE
[ Bug fixed ] :  able to rename a query name to existing one

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -878,7 +878,8 @@ class EditorComponent extends React.Component {
   };
 
   updateQueryName = (selectedQueryId, newName) => {
-    if (newName && newName !== this.state.selectedQuery.name) {
+    const isNewQueryNameAlreadyExists = this.state.allDataQueries.some((query) => query.name === newName);
+    if (newName && newName !== this.state.selectedQuery.name && !isNewQueryNameAlreadyExists) {
       dataqueryService
         .update(selectedQueryId, newName)
         .then(() => {

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -879,7 +879,7 @@ class EditorComponent extends React.Component {
 
   updateQueryName = (selectedQueryId, newName) => {
     const isNewQueryNameAlreadyExists = this.state.allDataQueries.some((query) => query.name === newName);
-    if (newName && newName !== this.state.selectedQuery.name && !isNewQueryNameAlreadyExists) {
+    if (newName && !isNewQueryNameAlreadyExists) {
       dataqueryService
         .update(selectedQueryId, newName)
         .then(() => {
@@ -896,6 +896,9 @@ class EditorComponent extends React.Component {
           toast.error(error);
         });
     } else {
+      if (isNewQueryNameAlreadyExists) {
+        toast.error('Query name already exists');
+      }
       this.setState({ renameQueryName: false });
       this.renameQueryNameId.current = null;
     }

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -383,7 +383,8 @@ class QueryManagerComponent extends React.Component {
     this.setState({ renameQuery: true });
   };
   executeQueryNameUpdation = (newName) => {
-    if (newName && newName !== this.state.selectedQuery.name) {
+    const isNewQueryNameAlreadyExists = this.state.dataQueries.some((query) => query.name === newName);
+    if (newName && newName !== this.state.selectedQuery.name && !isNewQueryNameAlreadyExists) {
       if (this.state.mode === 'create') {
         this.setState({
           queryName: newName,

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -384,7 +384,7 @@ class QueryManagerComponent extends React.Component {
   };
   executeQueryNameUpdation = (newName) => {
     const isNewQueryNameAlreadyExists = this.state.dataQueries.some((query) => query.name === newName);
-    if (newName && newName !== this.state.selectedQuery.name && !isNewQueryNameAlreadyExists) {
+    if (newName && !isNewQueryNameAlreadyExists) {
       if (this.state.mode === 'create') {
         this.setState({
           queryName: newName,
@@ -406,6 +406,7 @@ class QueryManagerComponent extends React.Component {
           });
       }
     } else {
+      if (isNewQueryNameAlreadyExists) toast.error('Query name already exists');
       this.setState({ renameQuery: false });
     }
   };


### PR DESCRIPTION
Resolves: able to have renamed a query to an existing one
Description: While renaming the query name in the query manager, if the new name already exists in the list of queries, the respective query should not be updated with a new query name

[Untitled app - Tooljet - 21 December 2022 - Watch Video](https://www.loom.com/share/c655989fbaea432e82ce79cd5b26cb93)