### PR TITLE
[ Bug fixed ] : not able to view single query upon clicking on breadcrum

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1633,6 +1633,17 @@ class EditorComponent extends React.Component {
     return Object.entries(this.state.appDefinition.pages).map(([id, page]) => ({ ...page, id }));
   };
 
+  addNewQueryAndDeselectSelectedQuery = () => {
+    this.setState({
+      options: {},
+      selectedDataSource: null,
+      selectedQuery: {},
+      editingQuery: false,
+      addingQuery: true,
+      isSourceSelected: false,
+    });
+  };
+
   render() {
     const {
       currentSidebarTab,
@@ -1983,14 +1994,7 @@ class EditorComponent extends React.Component {
                               this.props.darkMode && 'theme-dark'
                             }`}
                             onClick={() => {
-                              this.setState({
-                                options: {},
-                                selectedDataSource: null,
-                                selectedQuery: {},
-                                editingQuery: false,
-                                addingQuery: true,
-                                isSourceSelected: false,
-                              });
+                              this.addNewQueryAndDeselectSelectedQuery();
                             }}
                           >
                             <span
@@ -2038,6 +2042,7 @@ class EditorComponent extends React.Component {
                       <div className="query-definition-pane">
                         <div>
                           <QueryManager
+                            addNewQueryAndDeselectSelectedQuery={this.addNewQueryAndDeselectSelectedQuery}
                             toggleQueryEditor={this.toggleQueryEditor}
                             dataSources={dataSources}
                             dataQueries={dataQueries}

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -462,21 +462,7 @@ class QueryManagerComponent extends React.Component {
                     this.props.darkMode ? 'color-light-gray-c3c3c3' : 'color-light-slate-11'
                   } cursor-pointer font-weight-400`}
                   onClick={() => {
-                    if (mode === 'edit') {
-                      this.setState({
-                        selectedDataSource: null,
-                        selectedQuery: {},
-                        options: {},
-                        isSourceSelected: false,
-                        mode: 'create',
-                      });
-                    } else {
-                      this.setState({
-                        isSourceSelected: false,
-                        selectedDataSource: null,
-                        options: {},
-                      });
-                    }
+                    this.props.addNewQueryAndDeselectSelectedQuery();
                   }}
                 >
                   {mode === 'create' ? 'New Query' : 'Queries'}


### PR DESCRIPTION
Resolves : 

- click on the breadcrumbs,  root one (Queries [this] > query_name). Select datasource query component renders with the current query selected. If we have only one query we cant go back or view the query's UI.
- click on the breadcrumbs root to go the selecting the datasource for the query, instead of create button we have save button for a new query 

[Untitled app - Tooljet - 21 December 2022 - Watch Video](https://www.loom.com/share/16c374d27b994529ac76eff151ae83ed)