### PR TITLE
adding permission for render-suspend-labeler

### DIFF
--- a/.github/workflows/render-suspend-labeler.yml
+++ b/.github/workflows/render-suspend-labeler.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   label-stale-deploys:
     runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write    
     steps:
     - uses: akshaysasidrn/stale-label-fetch@v1.1
       id: stale-label


### PR DESCRIPTION
Fixes error on adding labels for auto suspension for active render preview apps.