### PR TITLE
improvements to pagination

### DIFF
--- a/frontend/src/TooljetDatabase/Drawers/CreateRowDrawer/index.jsx
+++ b/frontend/src/TooljetDatabase/Drawers/CreateRowDrawer/index.jsx
@@ -6,7 +6,7 @@ import { TooljetDatabaseContext } from '../../index';
 import { tooljetDatabaseService } from '@/_services';
 
 const CreateRowDrawer = ({ isCreateRowDrawerOpen, setIsCreateRowDrawerOpen }) => {
-  const { organizationId, selectedTable, setSelectedTableData } = useContext(TooljetDatabaseContext);
+  const { organizationId, selectedTable, setSelectedTableData, setTotalRecords } = useContext(TooljetDatabaseContext);
 
   return (
     <>
@@ -28,13 +28,15 @@ const CreateRowDrawer = ({ isCreateRowDrawerOpen, setIsCreateRowDrawerOpen }) =>
       <Drawer isOpen={isCreateRowDrawerOpen} onClose={() => setIsCreateRowDrawerOpen(false)} position="right">
         <CreateRowForm
           onCreate={() => {
-            tooljetDatabaseService.findOne(organizationId, selectedTable).then(({ data = [], error }) => {
+            tooljetDatabaseService.findOne(organizationId, selectedTable).then(({ headers, data = [], error }) => {
               if (error) {
                 toast.error(error?.message ?? `Failed to fetch table "${selectedTable}"`);
                 return;
               }
 
               if (Array.isArray(data) && data?.length > 0) {
+                const totalContentRangeRecords = headers['content-range'].split('/')[1] || 0;
+                setTotalRecords(totalContentRangeRecords);
                 setSelectedTableData(data);
               }
             });

--- a/frontend/src/TooljetDatabase/Filter/index.jsx
+++ b/frontend/src/TooljetDatabase/Filter/index.jsx
@@ -6,7 +6,7 @@ import { FilterForm } from '../Forms/FilterForm';
 import { isEmpty } from 'lodash';
 import { pluralize } from '@/_helpers/utils';
 
-const Filter = ({ onClose, filters, setFilters }) => {
+const Filter = ({ filters, setFilters }) => {
   const [show, setShow] = useState(false);
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const filterKeys = Object.keys(filters);
@@ -52,7 +52,6 @@ const Filter = ({ onClose, filters, setFilters }) => {
         trigger="click"
         show={show}
         onToggle={(show) => {
-          if (!show) onClose(filters);
           if (show && isEmpty(filters)) setFilters({ 0: {} });
           setShow(show);
         }}

--- a/frontend/src/TooljetDatabase/Filter/index.jsx
+++ b/frontend/src/TooljetDatabase/Filter/index.jsx
@@ -58,7 +58,7 @@ const Filter = ({ filters, setFilters }) => {
         placement="bottom"
         overlay={popover}
       >
-        <button className={cx('btn border-0', { 'bg-light-green': areFiltersApplied })}>
+        <button className={cx('btn border-0 mx-1', { 'bg-light-green': areFiltersApplied })}>
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path
               fillRule="evenodd"

--- a/frontend/src/TooljetDatabase/Filter/index.jsx
+++ b/frontend/src/TooljetDatabase/Filter/index.jsx
@@ -6,11 +6,11 @@ import { FilterForm } from '../Forms/FilterForm';
 import { isEmpty } from 'lodash';
 import { pluralize } from '@/_helpers/utils';
 
-const Filter = ({ onClose, filters, setFilters }) => {
+const Filter = ({ onClose }) => {
+  const [filters, setFilters] = useState({ 0: {} });
   const [show, setShow] = useState(false);
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const filterKeys = Object.keys(filters);
-
   const popover = (
     <Popover id="storage-filter-popover" className={cx({ 'theme-dark': darkMode })}>
       <Popover.Content bsPrefix="storage-filter-popover">

--- a/frontend/src/TooljetDatabase/Filter/index.jsx
+++ b/frontend/src/TooljetDatabase/Filter/index.jsx
@@ -50,9 +50,7 @@ const Filter = ({ filters, setFilters, handleBuildFilterQuery, resetFilterQuery 
   React.useEffect(() => {
     if (Object.keys(filters).length === 0 && isMounted) {
       resetFilterQuery();
-    }
-
-    if (Object.keys(filters).length > 0) {
+    } else {
       Object.keys(filters).map((key) => {
         if (!isEmpty(filters[key])) {
           const { column, operator, value } = filters[key];

--- a/frontend/src/TooljetDatabase/Filter/index.jsx
+++ b/frontend/src/TooljetDatabase/Filter/index.jsx
@@ -6,11 +6,11 @@ import { FilterForm } from '../Forms/FilterForm';
 import { isEmpty } from 'lodash';
 import { pluralize } from '@/_helpers/utils';
 
-const Filter = ({ onClose }) => {
-  const [filters, setFilters] = useState({ 0: {} });
+const Filter = ({ onClose, filters, setFilters }) => {
   const [show, setShow] = useState(false);
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const filterKeys = Object.keys(filters);
+
   const popover = (
     <Popover id="storage-filter-popover" className={cx({ 'theme-dark': darkMode })}>
       <Popover.Content bsPrefix="storage-filter-popover">

--- a/frontend/src/TooljetDatabase/Filter/index.jsx
+++ b/frontend/src/TooljetDatabase/Filter/index.jsx
@@ -5,11 +5,13 @@ import Popover from 'react-bootstrap/Popover';
 import { FilterForm } from '../Forms/FilterForm';
 import { isEmpty } from 'lodash';
 import { pluralize } from '@/_helpers/utils';
+import { useMounted } from '@/_hooks/use-mount';
 
-const Filter = ({ filters, setFilters }) => {
+const Filter = ({ filters, setFilters, handleBuildFilterQuery, resetFilterQuery }) => {
   const [show, setShow] = useState(false);
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const filterKeys = Object.keys(filters);
+  const isMounted = useMounted();
 
   const popover = (
     <Popover id="storage-filter-popover" className={cx({ 'theme-dark': darkMode })}>
@@ -44,6 +46,24 @@ const Filter = ({ filters, setFilters }) => {
   const checkIsFilterObjectEmpty = (filter) =>
     !isEmpty(filter.column) && !isEmpty(filter.operator) && !isEmpty(filter.value);
   const areFiltersApplied = !show && Object.values(filters).some(checkIsFilterObjectEmpty);
+
+  React.useEffect(() => {
+    if (Object.keys(filters).length === 0 && isMounted) {
+      resetFilterQuery();
+    }
+
+    if (Object.keys(filters).length > 0) {
+      Object.keys(filters).map((key) => {
+        if (!isEmpty(filters[key])) {
+          const { column, operator, value } = filters[key];
+          if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
+            handleBuildFilterQuery(filters);
+          }
+        }
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(filters)]);
 
   return (
     <>

--- a/frontend/src/TooljetDatabase/Forms/FilterForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/FilterForm.jsx
@@ -1,10 +1,27 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import Select from '@/_ui/Select';
 import { TooljetDatabaseContext } from '../index';
 import { operators } from '../constants';
+import { debounce } from 'lodash';
 
 export const FilterForm = ({ filters, setFilters, index, column = '', operator = '', value = '' }) => {
   const { columns } = useContext(TooljetDatabaseContext);
+
+  const [filterInputValue, setFilterInputValue] = useState(value);
+
+  useEffect(() => {
+    const debouncedFilter = debounce(() => {
+      const prevFilters = { ...filters };
+      prevFilters[index].value = filterInputValue;
+
+      setFilters(prevFilters);
+    }, 500);
+
+    debouncedFilter();
+
+    return debouncedFilter.cancel;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterInputValue]);
 
   const handleColumnChange = (value) => {
     const prevFilters = { ...filters };
@@ -16,13 +33,6 @@ export const FilterForm = ({ filters, setFilters, index, column = '', operator =
   const handleOperatorChange = (value) => {
     const prevFilters = { ...filters };
     prevFilters[index].operator = value;
-
-    setFilters(prevFilters);
-  };
-
-  const handleValueChange = (event) => {
-    const prevFilters = { ...filters };
-    prevFilters[index].value = event.target.value;
 
     setFilters(prevFilters);
   };
@@ -59,11 +69,13 @@ export const FilterForm = ({ filters, setFilters, index, column = '', operator =
           </div>
           <div className="col-4">
             <input
-              value={value}
+              value={filterInputValue}
               type="text"
               className="form-control"
               placeholder="Value"
-              onChange={handleValueChange}
+              onChange={(event) => {
+                setFilterInputValue(event.target.value);
+              }}
             />
           </div>
         </div>

--- a/frontend/src/TooljetDatabase/Forms/FilterForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/FilterForm.jsx
@@ -1,27 +1,10 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import Select from '@/_ui/Select';
 import { TooljetDatabaseContext } from '../index';
 import { operators } from '../constants';
-import { debounce } from 'lodash';
 
 export const FilterForm = ({ filters, setFilters, index, column = '', operator = '', value = '' }) => {
   const { columns } = useContext(TooljetDatabaseContext);
-
-  const [filterInputValue, setFilterInputValue] = useState(value);
-
-  useEffect(() => {
-    const debouncedFilter = debounce(() => {
-      const prevFilters = { ...filters };
-      prevFilters[index].value = filterInputValue;
-
-      setFilters(prevFilters);
-    }, 500);
-
-    debouncedFilter();
-
-    return debouncedFilter.cancel;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterInputValue]);
 
   const handleColumnChange = (value) => {
     const prevFilters = { ...filters };
@@ -33,6 +16,13 @@ export const FilterForm = ({ filters, setFilters, index, column = '', operator =
   const handleOperatorChange = (value) => {
     const prevFilters = { ...filters };
     prevFilters[index].operator = value;
+
+    setFilters(prevFilters);
+  };
+
+  const handleValueChange = (event) => {
+    const prevFilters = { ...filters };
+    prevFilters[index].value = event.target.value;
 
     setFilters(prevFilters);
   };
@@ -69,13 +59,11 @@ export const FilterForm = ({ filters, setFilters, index, column = '', operator =
           </div>
           <div className="col-4">
             <input
-              value={filterInputValue}
+              value={value}
               type="text"
               className="form-control"
               placeholder="Value"
-              onChange={(event) => {
-                setFilterInputValue(event.target.value);
-              }}
+              onChange={handleValueChange}
             />
           </div>
         </div>

--- a/frontend/src/TooljetDatabase/Sort/index.jsx
+++ b/frontend/src/TooljetDatabase/Sort/index.jsx
@@ -7,8 +7,7 @@ import { pluralize } from '@/_helpers/utils';
 import { isEmpty } from 'lodash';
 import { useMounted } from '@/_hooks/use-mount';
 
-const Sort = ({ handleBuildSortQuery }) => {
-  const [filters, setFilters] = useState({});
+const Sort = ({ filters, setFilters, handleBuildSortQuery, resetSortQuery }) => {
   const [show, setShow] = useState(false);
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const filterKeys = Object.keys(filters);
@@ -23,20 +22,15 @@ const Sort = ({ handleBuildSortQuery }) => {
   useEffect(() => {
     if (Object.keys(filters).length === 0 && isMounted) {
       reset();
+      resetSortQuery();
     }
 
     if (Object.keys(filters).length > 0) {
-      Object.keys(filters).map((key) => {
-        if (!isEmpty(filters[key])) {
-          const { column, order } = filters[key];
-          if (column && order) {
-            setShow(true);
-            handleBuildSortQuery(filters);
-          }
-        }
-      });
+      setShow(true);
+      handleBuildSortQuery(filters);
     }
-  }, [filters]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(filters)]);
 
   const popover = (
     <Popover id="storage-filter-popover" className={cx({ 'theme-dark': darkMode })}>

--- a/frontend/src/TooljetDatabase/Sort/index.jsx
+++ b/frontend/src/TooljetDatabase/Sort/index.jsx
@@ -74,7 +74,6 @@ const Sort = ({ filters, setFilters, handleBuildSortQuery, resetSortQuery }) => 
     <OverlayTrigger
       rootClose
       onToggle={(show) => {
-        // if (!show) onClose(filters);
         if (show && isEmpty(filters)) setFilters({ 0: {} });
         setShow(show);
       }}

--- a/frontend/src/TooljetDatabase/Sort/index.jsx
+++ b/frontend/src/TooljetDatabase/Sort/index.jsx
@@ -23,9 +23,7 @@ const Sort = ({ filters, setFilters, handleBuildSortQuery, resetSortQuery }) => 
     if (Object.keys(filters).length === 0 && isMounted) {
       reset();
       resetSortQuery();
-    }
-
-    if (Object.keys(filters).length > 0) {
+    } else {
       setShow(true);
       Object.keys(filters).map((key) => {
         if (!isEmpty(filters[key])) {

--- a/frontend/src/TooljetDatabase/Sort/index.jsx
+++ b/frontend/src/TooljetDatabase/Sort/index.jsx
@@ -1,16 +1,43 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';
 import { SortForm } from '../Forms/SortForm';
 import { pluralize } from '@/_helpers/utils';
 import { isEmpty } from 'lodash';
+import { useMounted } from '@/_hooks/use-mount';
 
-const Sort = ({ onClose }) => {
-  const [filters, setFilters] = useState({ 0: {} });
+const Sort = ({ handleBuildSortQuery }) => {
+  const [filters, setFilters] = useState({});
   const [show, setShow] = useState(false);
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const filterKeys = Object.keys(filters);
+
+  const isMounted = useMounted();
+
+  const reset = () => {
+    setFilters({});
+    setShow(false);
+  };
+
+  useEffect(() => {
+    if (Object.keys(filters).length === 0 && isMounted) {
+      reset();
+    }
+
+    if (Object.keys(filters).length > 0) {
+      Object.keys(filters).map((key) => {
+        if (!isEmpty(filters[key])) {
+          const { column, order } = filters[key];
+          if (column && order) {
+            setShow(true);
+            handleBuildSortQuery(filters);
+          }
+        }
+      });
+    }
+  }, [filters]);
+
   const popover = (
     <Popover id="storage-filter-popover" className={cx({ 'theme-dark': darkMode })}>
       <Popover.Content bsPrefix="storage-filter-popover">
@@ -46,7 +73,7 @@ const Sort = ({ onClose }) => {
     <OverlayTrigger
       rootClose
       onToggle={(show) => {
-        if (!show) onClose(filters);
+        // if (!show) onClose(filters);
         if (show && isEmpty(filters)) setFilters({ 0: {} });
         setShow(show);
       }}

--- a/frontend/src/TooljetDatabase/Sort/index.jsx
+++ b/frontend/src/TooljetDatabase/Sort/index.jsx
@@ -27,7 +27,14 @@ const Sort = ({ filters, setFilters, handleBuildSortQuery, resetSortQuery }) => 
 
     if (Object.keys(filters).length > 0) {
       setShow(true);
-      handleBuildSortQuery(filters);
+      Object.keys(filters).map((key) => {
+        if (!isEmpty(filters[key])) {
+          const { column, order } = filters[key];
+          if (!isEmpty(column) && !isEmpty(order)) {
+            handleBuildSortQuery(filters);
+          }
+        }
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(filters)]);

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -10,8 +10,8 @@ const Footer = ({
   darkMode,
   openCreateRowDrawer,
   totalRecords,
-  fetchTableData,
   filters,
+  sortFilters,
   dataLoading,
   selectedTable,
   handleBuildFilterQuery,
@@ -80,17 +80,16 @@ const Footer = ({
   const reset = () => {
     setPageCount(1);
     setPageSize(50);
-    resetFilterQuery();
   };
 
   React.useEffect(() => {
     reset();
-  }, [totalRecords, selectedTable]);
+  }, [totalRecords, selectedTable, sortFilters]);
 
   React.useEffect(() => {
     if (Object.keys(filters).length === 0 && isMounted) {
       reset();
-      fetchTableData(`?limit=${pageSize}&offset=0`, pageSize, 1);
+      resetFilterQuery();
     }
 
     if (Object.keys(filters).length > 0) {

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import { Button } from '@/_ui/LeftSidebar';
 import Select from '@/_ui/Select';
 import Pagination from './Paginations';
-import { isEmpty } from 'lodash';
 import { useMounted } from '@/_hooks/use-mount';
 import Skeleton from 'react-loading-skeleton';
+import { isEmpty } from 'lodash';
 
 const Footer = ({
   darkMode,
@@ -14,6 +14,9 @@ const Footer = ({
   filters,
   dataLoading,
   selectedTable,
+  handleBuildFilterQuery,
+  buildPaginationQuery,
+  resetFilterQuery,
 }) => {
   const selectOptions = [
     { label: '50 records', value: 50 },
@@ -34,18 +37,15 @@ const Footer = ({
 
   const handleSelectChange = (value) => {
     setPageSize(value);
-
     setPageCount(1);
-    fetchTableData(`?limit=${value}&offset=0`, value, 1);
+    buildPaginationQuery(value, 0);
   };
 
   const handlePageCountChange = (value) => {
     setPageCount(value);
-
     const limit = pageSize;
     const offset = value === 1 ? 0 : (value - 1) * pageSize;
-
-    fetchTableData(`?limit=${limit}&offset=${offset}`, limit, value);
+    buildPaginationQuery(limit, offset);
   };
 
   const gotoNextPage = (fromInput = false, value = null) => {
@@ -60,7 +60,7 @@ const Footer = ({
     const limit = pageSize;
     const offset = pageCount * pageSize;
 
-    fetchTableData(`?limit=${limit}&offset=${offset}`, limit, pageCount + 1);
+    buildPaginationQuery(limit, offset);
   };
 
   const gotoPreviousPage = () => {
@@ -74,12 +74,13 @@ const Footer = ({
     const limit = pageSize;
     const offset = (pageCount - 2) * pageSize;
 
-    fetchTableData(`?limit=${limit}&offset=${offset}`, limit, pageCount - 1);
+    buildPaginationQuery(limit, offset);
   };
 
   const reset = () => {
     setPageCount(1);
     setPageSize(50);
+    resetFilterQuery();
   };
 
   React.useEffect(() => {
@@ -97,7 +98,7 @@ const Footer = ({
         if (!isEmpty(filters[key])) {
           const { column, operator, value } = filters[key];
           if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
-            fetchTableData(`?limit=${pageSize}&offset=0`, pageSize, 1, filters);
+            handleBuildFilterQuery(filters);
           }
         }
       });

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -25,6 +25,9 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData })
   const [pageSize, setPageSize] = useState(RecordEnum[selectedOption]);
 
   const totalPage = Math.ceil(totalRecords / pageSize);
+  const pageRange = `${(pageCount - 1) * pageSize + 1} - ${
+    pageCount * pageSize > totalRecords ? totalRecords : pageCount * pageSize
+  }`;
 
   const handleSelectChange = (value) => {
     setSelectedOption(value);
@@ -109,7 +112,7 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData })
           </div>
           <div className="col-4 mx-2">
             <span>
-              {pageCount}-{pageSize} of {totalRecords} Records
+              {pageRange} of {totalRecords} Records
             </span>
           </div>
         </div>

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -2,9 +2,8 @@ import React, { useState } from 'react';
 import { Button } from '@/_ui/LeftSidebar';
 import Select from '@/_ui/Select';
 import Pagination from './Paginations';
-import { isEmpty } from 'lodash';
 
-const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, filters }) => {
+const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData }) => {
   const selectOptions = [
     { label: '50 records', value: '50 per page' },
     { label: '100 records', value: '100 per page' },
@@ -81,21 +80,7 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
     setPageCount(1);
     setSelectedOption('50 per page');
     setPageSize(RecordEnum['50 per page']);
-  }, [RecordEnum, totalRecords]);
-
-  React.useEffect(() => {
-    if (Object.keys(filters).length > 0) {
-      Object.keys(filters).map((key) => {
-        if (!isEmpty(filters[key])) {
-          const { column, operator, value } = filters[key];
-          if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
-            fetchTableData(`?limit=${pageSize}&offset=0`, pageSize, 1, filters);
-          }
-        }
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(filters)]);
+  }, [totalRecords]);
 
   return (
     <div className="toojet-db-table-footer card-footer d-flex align-items-center jet-table-footer justify-content-center">

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -4,8 +4,9 @@ import Select from '@/_ui/Select';
 import Pagination from './Paginations';
 import { isEmpty } from 'lodash';
 import { useMounted } from '@/_hooks/use-mount';
+import Skeleton from 'react-loading-skeleton';
 
-const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, filters }) => {
+const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, filters, dataLoading }) => {
   const selectOptions = [
     { label: '50 records', value: '50 per page' },
     { label: '100 records', value: '100 per page' },
@@ -113,6 +114,7 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
       <div className="table-footer row gx-0">
         <div className="col-5">
           <Button
+            disabled={dataLoading}
             onClick={openCreateRowDrawer}
             darkMode={darkMode}
             size="sm"
@@ -129,10 +131,12 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
               gotoPreviousPage={gotoPreviousPage}
               currentPage={pageCount}
               totalPage={totalPage}
+              isDisabled={dataLoading}
             />
           </div>
           <div className="col mx-2">
             <Select
+              isLoading={dataLoading}
               className={`${darkMode ? 'select-search-dark' : 'select-search'}`}
               options={selectOptions}
               value={selectedOption}
@@ -144,9 +148,13 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
             />
           </div>
           <div className="col-4 mx-2">
-            <span>
-              {pageRange} of {totalRecords} Records
-            </span>
+            {dataLoading ? (
+              <Skeleton count={1} height={3} className="mt-3" />
+            ) : (
+              <span>
+                {pageRange} of {totalRecords} Records
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -1,19 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Button } from '@/_ui/LeftSidebar';
 import Select from '@/_ui/Select';
 import Pagination from './Paginations';
 import Skeleton from 'react-loading-skeleton';
+import { TooljetDatabaseContext } from '../index';
 
-const Footer = ({
-  darkMode,
-  openCreateRowDrawer,
-  totalRecords,
-  sortFilters,
-  dataLoading,
-  selectedTable,
-  buildPaginationQuery,
-  tableDataLength,
-}) => {
+const Footer = ({ darkMode, openCreateRowDrawer, dataLoading, tableDataLength }) => {
   const selectOptions = [
     { label: '50 records', value: 50 },
     { label: '100 records', value: 100 },
@@ -21,6 +13,8 @@ const Footer = ({
     { label: '500 records', value: 500 },
     { label: '1000 records', value: 1000 },
   ];
+
+  const { selectedTable, totalRecords, buildPaginationQuery } = useContext(TooljetDatabaseContext);
 
   const [pageCount, setPageCount] = useState(1);
   const [pageSize, setPageSize] = useState(50);

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -17,6 +17,7 @@ const Footer = ({
   handleBuildFilterQuery,
   buildPaginationQuery,
   resetFilterQuery,
+  tableDataLength,
 }) => {
   const selectOptions = [
     { label: '50 records', value: 50 },
@@ -119,40 +120,42 @@ const Footer = ({
             <Button.Content title={'Add new row'} iconSrc={'assets/images/icons/add-row.svg'} direction="right" />
           </Button>
         </div>
-        <div className="col d-flex align-items-center justify-content-end">
-          <div className="col">
-            <Pagination
-              darkMode={darkMode}
-              gotoNextPage={gotoNextPage}
-              gotoPreviousPage={gotoPreviousPage}
-              currentPage={pageCount}
-              totalPage={totalPage}
-              isDisabled={dataLoading}
-            />
+        {tableDataLength > 0 && (
+          <div className="col d-flex align-items-center justify-content-end">
+            <div className="col">
+              <Pagination
+                darkMode={darkMode}
+                gotoNextPage={gotoNextPage}
+                gotoPreviousPage={gotoPreviousPage}
+                currentPage={pageCount}
+                totalPage={totalPage}
+                isDisabled={dataLoading}
+              />
+            </div>
+            <div className="col mx-2">
+              <Select
+                isLoading={dataLoading}
+                className={`${darkMode ? 'select-search-dark' : 'select-search'}`}
+                options={selectOptions}
+                value={selectOptions.find((option) => option.value === pageSize)}
+                search={false}
+                onChange={(value) => handleSelectChange(value)}
+                placeholder={'Select page'}
+                useMenuPortal={false}
+                menuPlacement="top"
+              />
+            </div>
+            <div className="col-4 mx-2">
+              {dataLoading ? (
+                <Skeleton count={1} height={3} className="mt-3" />
+              ) : (
+                <span>
+                  {pageRange} of {totalRecords} Records
+                </span>
+              )}
+            </div>
           </div>
-          <div className="col mx-2">
-            <Select
-              isLoading={dataLoading}
-              className={`${darkMode ? 'select-search-dark' : 'select-search'}`}
-              options={selectOptions}
-              value={selectOptions.find((option) => option.value === pageSize)}
-              search={false}
-              onChange={(value) => handleSelectChange(value)}
-              placeholder={'Select page'}
-              useMenuPortal={false}
-              menuPlacement="top"
-            />
-          </div>
-          <div className="col-4 mx-2">
-            {dataLoading ? (
-              <Skeleton count={1} height={3} className="mt-3" />
-            ) : (
-              <span>
-                {pageRange} of {totalRecords} Records
-              </span>
-            )}
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import { Button } from '@/_ui/LeftSidebar';
 import Select from '@/_ui/Select';
 import Pagination from './Paginations';
+import { isEmpty } from 'lodash';
 
-const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData }) => {
+const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, filters }) => {
   const selectOptions = [
     { label: '50 records', value: '50 per page' },
     { label: '100 records', value: '100 per page' },
@@ -80,7 +81,21 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData })
     setPageCount(1);
     setSelectedOption('50 per page');
     setPageSize(RecordEnum['50 per page']);
-  }, [totalRecords]);
+  }, [RecordEnum, totalRecords]);
+
+  React.useEffect(() => {
+    if (Object.keys(filters).length > 0) {
+      Object.keys(filters).map((key) => {
+        if (!isEmpty(filters[key])) {
+          const { column, operator, value } = filters[key];
+          if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
+            fetchTableData(`?limit=${pageSize}&offset=0`, pageSize, 1, filters);
+          }
+        }
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(filters)]);
 
   return (
     <div className="toojet-db-table-footer card-footer d-flex align-items-center jet-table-footer justify-content-center">

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -79,7 +79,7 @@ const Footer = ({
 
   React.useEffect(() => {
     reset();
-  }, [totalRecords, selectedTable, sortFilters]);
+  }, [totalRecords, selectedTable]);
 
   return (
     <div className="toojet-db-table-footer card-footer d-flex align-items-center jet-table-footer justify-content-center">

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -8,25 +8,16 @@ import Skeleton from 'react-loading-skeleton';
 
 const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, filters, dataLoading }) => {
   const selectOptions = [
-    { label: '50 records', value: '50 per page' },
-    { label: '100 records', value: '100 per page' },
-    { label: '200 records', value: '200 per page' },
-    { label: '500 records', value: '500 per page' },
-    { label: '1000 records', value: '1000 per page' },
+    { label: '50 records', value: 50 },
+    { label: '100 records', value: 100 },
+    { label: '200 records', value: 200 },
+    { label: '500 records', value: 500 },
+    { label: '1000 records', value: 1000 },
   ];
 
-  const RecordEnum = Object.freeze({
-    '50 per page': 50,
-    '100 per page': 100,
-    '200 per page': 200,
-    '500 per page': 500,
-    '1000 per page': 1000,
-  });
-
   const isMounted = useMounted();
-  const [selectedOption, setSelectedOption] = useState('50 per page');
   const [pageCount, setPageCount] = useState(1);
-  const [pageSize, setPageSize] = useState(RecordEnum[selectedOption]);
+  const [pageSize, setPageSize] = useState(50);
 
   const totalPage = Math.ceil(totalRecords / pageSize);
   const pageRange = `${(pageCount - 1) * pageSize + 1} - ${
@@ -34,18 +25,17 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
   }`;
 
   const handleSelectChange = (value) => {
-    setSelectedOption(value);
-    setPageSize(RecordEnum[value]);
+    setPageSize(value);
 
     setPageCount(1);
-    fetchTableData(`?limit=${RecordEnum[value]}&offset=0`, RecordEnum[value], 1);
+    fetchTableData(`?limit=${value}&offset=0`, value, 1);
   };
 
   const handlePageCountChange = (value) => {
     setPageCount(value);
 
-    const limit = RecordEnum[selectedOption];
-    const offset = value === 1 ? 0 : (value - 1) * RecordEnum[selectedOption];
+    const limit = pageSize;
+    const offset = value === 1 ? 0 : (value - 1) * pageSize;
 
     fetchTableData(`?limit=${limit}&offset=${offset}`, limit, value);
   };
@@ -59,8 +49,8 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
       return prev + 1;
     });
 
-    const limit = RecordEnum[selectedOption];
-    const offset = pageCount * RecordEnum[selectedOption];
+    const limit = pageSize;
+    const offset = pageCount * pageSize;
 
     fetchTableData(`?limit=${limit}&offset=${offset}`, limit, pageCount + 1);
   };
@@ -73,16 +63,15 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
       return prev - 1;
     });
 
-    const limit = RecordEnum[selectedOption];
-    const offset = (pageCount - 2) * RecordEnum[selectedOption];
+    const limit = pageSize;
+    const offset = (pageCount - 2) * pageSize;
 
     fetchTableData(`?limit=${limit}&offset=${offset}`, limit, pageCount - 1);
   };
 
   const reset = () => {
     setPageCount(1);
-    setSelectedOption('50 per page');
-    setPageSize(RecordEnum['50 per page']);
+    setPageSize(50);
   };
 
   React.useEffect(() => {
@@ -139,7 +128,7 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
               isLoading={dataLoading}
               className={`${darkMode ? 'select-search-dark' : 'select-search'}`}
               options={selectOptions}
-              value={selectedOption}
+              value={selectOptions.find((option) => option.value === pageSize)}
               search={false}
               onChange={(value) => handleSelectChange(value)}
               placeholder={'Select page'}

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -3,6 +3,7 @@ import { Button } from '@/_ui/LeftSidebar';
 import Select from '@/_ui/Select';
 import Pagination from './Paginations';
 import { isEmpty } from 'lodash';
+import { useMounted } from '@/_hooks/use-mount';
 
 const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, filters }) => {
   const selectOptions = [
@@ -21,6 +22,7 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
     '1000 per page': 1000,
   });
 
+  const isMounted = useMounted();
   const [selectedOption, setSelectedOption] = useState('50 per page');
   const [pageCount, setPageCount] = useState(1);
   const [pageSize, setPageSize] = useState(RecordEnum[selectedOption]);
@@ -76,14 +78,23 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
     fetchTableData(`?limit=${limit}&offset=${offset}`, limit, pageCount - 1);
   };
 
-  React.useEffect(() => {
-    // reset to default values
+  const reset = () => {
     setPageCount(1);
     setSelectedOption('50 per page');
     setPageSize(RecordEnum['50 per page']);
-  }, [RecordEnum, totalRecords]);
+  };
 
   React.useEffect(() => {
+    reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [totalRecords]);
+
+  React.useEffect(() => {
+    if (Object.keys(filters).length === 0 && isMounted) {
+      reset();
+      fetchTableData(`?limit=${pageSize}&offset=0`, pageSize, 1);
+    }
+
     if (Object.keys(filters).length > 0) {
       Object.keys(filters).map((key) => {
         if (!isEmpty(filters[key])) {

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -24,6 +24,8 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData })
   const [pageCount, setPageCount] = useState(1);
   const [pageSize, setPageSize] = useState(RecordEnum[selectedOption]);
 
+  const totalPage = Math.ceil(totalRecords / pageSize);
+
   const handleSelectChange = (value) => {
     setSelectedOption(value);
     setPageSize(RecordEnum[value]);
@@ -90,7 +92,7 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData })
               gotoNextPage={gotoNextPage}
               gotoPreviousPage={gotoPreviousPage}
               currentPage={pageCount}
-              totalPage={pageSize}
+              totalPage={totalPage}
             />
           </div>
           <div className="col mx-2">

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -6,7 +6,15 @@ import { isEmpty } from 'lodash';
 import { useMounted } from '@/_hooks/use-mount';
 import Skeleton from 'react-loading-skeleton';
 
-const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, filters, dataLoading }) => {
+const Footer = ({
+  darkMode,
+  openCreateRowDrawer,
+  totalRecords,
+  fetchTableData,
+  filters,
+  dataLoading,
+  selectedTable,
+}) => {
   const selectOptions = [
     { label: '50 records', value: 50 },
     { label: '100 records', value: 100 },
@@ -76,8 +84,7 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData, f
 
   React.useEffect(() => {
     reset();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [totalRecords]);
+  }, [totalRecords, selectedTable]);
 
   React.useEffect(() => {
     if (Object.keys(filters).length === 0 && isMounted) {

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -2,21 +2,16 @@ import React, { useState } from 'react';
 import { Button } from '@/_ui/LeftSidebar';
 import Select from '@/_ui/Select';
 import Pagination from './Paginations';
-import { useMounted } from '@/_hooks/use-mount';
 import Skeleton from 'react-loading-skeleton';
-import { isEmpty } from 'lodash';
 
 const Footer = ({
   darkMode,
   openCreateRowDrawer,
   totalRecords,
-  filters,
   sortFilters,
   dataLoading,
   selectedTable,
-  handleBuildFilterQuery,
   buildPaginationQuery,
-  resetFilterQuery,
   tableDataLength,
 }) => {
   const selectOptions = [
@@ -27,7 +22,6 @@ const Footer = ({
     { label: '1000 records', value: 1000 },
   ];
 
-  const isMounted = useMounted();
   const [pageCount, setPageCount] = useState(1);
   const [pageSize, setPageSize] = useState(50);
 
@@ -86,25 +80,6 @@ const Footer = ({
   React.useEffect(() => {
     reset();
   }, [totalRecords, selectedTable, sortFilters]);
-
-  React.useEffect(() => {
-    if (Object.keys(filters).length === 0 && isMounted) {
-      reset();
-      resetFilterQuery();
-    }
-
-    if (Object.keys(filters).length > 0) {
-      Object.keys(filters).map((key) => {
-        if (!isEmpty(filters[key])) {
-          const { column, operator, value } = filters[key];
-          if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
-            handleBuildFilterQuery(filters);
-          }
-        }
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(filters)]);
 
   return (
     <div className="toojet-db-table-footer card-footer d-flex align-items-center jet-table-footer justify-content-center">

--- a/frontend/src/TooljetDatabase/Table/Footer.jsx
+++ b/frontend/src/TooljetDatabase/Table/Footer.jsx
@@ -75,6 +75,13 @@ const Footer = ({ darkMode, openCreateRowDrawer, totalRecords, fetchTableData })
     fetchTableData(`?limit=${limit}&offset=${offset}`, limit, pageCount - 1);
   };
 
+  React.useEffect(() => {
+    // reset to default values
+    setPageCount(1);
+    setSelectedOption('50 per page');
+    setPageSize(RecordEnum['50 per page']);
+  }, [totalRecords]);
+
   return (
     <div className="toojet-db-table-footer card-footer d-flex align-items-center jet-table-footer justify-content-center">
       <div className="table-footer row gx-0">

--- a/frontend/src/TooljetDatabase/Table/Paginations.jsx
+++ b/frontend/src/TooljetDatabase/Table/Paginations.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Button } from '@/_ui/LeftSidebar';
 
-const Pagination = ({ darkMode, gotoNextPage, gotoPreviousPage, currentPage, totalPage }) => {
+const Pagination = ({ darkMode, gotoNextPage, gotoPreviousPage, currentPage, totalPage, isDisabled }) => {
   const [currentPageNumber, setCurrentPageNumber] = React.useState(currentPage);
 
   const handleOnChange = (value) => {
@@ -25,13 +25,14 @@ const Pagination = ({ darkMode, gotoNextPage, gotoPreviousPage, currentPage, tot
         }}
         classNames={darkMode ? 'dark' : 'nothing'}
         styles={{ height: '20px', width: '20px' }}
-        disabled={currentPage === 1}
+        disabled={isDisabled || currentPage === 1}
       >
         <Button.Content iconSrc={'assets/images/icons/chevron-left.svg'} />
       </Button.UnstyledButton>
 
       <div className="d-flex">
         <input
+          disabled={isDisabled}
           type="text"
           className="form-control mx-1"
           value={currentPageNumber}
@@ -57,7 +58,7 @@ const Pagination = ({ darkMode, gotoNextPage, gotoPreviousPage, currentPage, tot
         }}
         classNames={darkMode && 'dark'}
         styles={{ height: '20px', width: '20px' }}
-        disabled={currentPage === totalPage}
+        disabled={isDisabled || currentPage === totalPage}
       >
         <Button.Content iconSrc={'assets/images/icons/chevron-right.svg'} />
       </Button.UnstyledButton>

--- a/frontend/src/TooljetDatabase/Table/Paginations.jsx
+++ b/frontend/src/TooljetDatabase/Table/Paginations.jsx
@@ -8,7 +8,7 @@ const Pagination = ({ darkMode, gotoNextPage, gotoPreviousPage, currentPage, tot
     const parsedValue = parseInt(value, 10);
 
     if (parsedValue > 0 && parsedValue <= totalPage && parsedValue !== currentPage) {
-      gotoNextPage(true, event.target.value);
+      gotoNextPage(true, parsedValue);
     }
   };
 

--- a/frontend/src/TooljetDatabase/Table/Paginations.jsx
+++ b/frontend/src/TooljetDatabase/Table/Paginations.jsx
@@ -40,6 +40,9 @@ const Pagination = ({ darkMode, gotoNextPage, gotoPreviousPage, currentPage, tot
               handleOnChange(event.target.value);
             }
           }}
+          onBlur={(event) => {
+            handleOnChange(event.target.value);
+          }}
           onChange={(event) => {
             setCurrentPageNumber(event.target.value);
           }}

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -13,13 +13,22 @@ import EditColumnForm from '../Forms/ColumnForm';
 import TableFooter from './Footer';
 
 const Table = ({ openCreateRowDrawer, filters }) => {
-  const { organizationId, columns, selectedTable, selectedTableData, setSelectedTableData, setColumns } =
-    useContext(TooljetDatabaseContext);
+  const {
+    organizationId,
+    columns,
+    selectedTable,
+    selectedTableData,
+    setSelectedTableData,
+    setColumns,
+    totalRecords,
+    setTotalRecords,
+    handleBuildFilterQuery,
+    buildPaginationQuery,
+    resetFilterQuery,
+  } = useContext(TooljetDatabaseContext);
   const [isEditColumnDrawerOpen, setIsEditColumnDrawerOpen] = useState(false);
   const [selectedColumn, setSelectedColumn] = useState();
   const [loading, setLoading] = useState(false);
-
-  const [totalRecords, setTotalRecords] = useState(0);
 
   const fetchTableMetadata = () => {
     tooljetDatabaseService.viewTable(organizationId, selectedTable).then(({ data = [], error }) => {
@@ -46,21 +55,6 @@ const Table = ({ openCreateRowDrawer, filters }) => {
     const defaultQueryParams = `limit=${pagesize}&offset=${(pagecount - 1) * pagesize}`;
     let params = queryParams ? queryParams : defaultQueryParams;
     setLoading(true);
-
-    if (Object.keys(filters).length > 0) {
-      Object.keys(filters).map((key) => {
-        if (!isEmpty(filters[key])) {
-          const { column, operator, value } = filters[key];
-          if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
-            if (isBoolean(value)) {
-              params = `${params}&${column}=${value}`;
-            } else {
-              params = `${params}&${column}=${operator}.${value}`;
-            }
-          }
-        }
-      });
-    }
 
     tooljetDatabaseService.findOne(organizationId, selectedTable, params).then(({ headers, data = [], error }) => {
       setLoading(false);
@@ -266,6 +260,9 @@ const Table = ({ openCreateRowDrawer, filters }) => {
           filters={filters}
           dataLoading={loading}
           selectedTable={selectedTable}
+          handleBuildFilterQuery={handleBuildFilterQuery}
+          buildPaginationQuery={buildPaginationQuery}
+          resetFilterQuery={resetFilterQuery}
         />
       </div>
       <Drawer isOpen={isEditColumnDrawerOpen} onClose={() => setIsEditColumnDrawerOpen(false)} position="right">

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -12,7 +12,7 @@ import Drawer from '@/_ui/Drawer';
 import EditColumnForm from '../Forms/ColumnForm';
 import TableFooter from './Footer';
 
-const Table = ({ openCreateRowDrawer, filters, sortFilters }) => {
+const Table = ({ openCreateRowDrawer }) => {
   const {
     organizationId,
     columns,
@@ -25,6 +25,8 @@ const Table = ({ openCreateRowDrawer, filters, sortFilters }) => {
     handleBuildFilterQuery,
     buildPaginationQuery,
     resetFilterQuery,
+    queryFilters,
+    sortFilters,
   } = useContext(TooljetDatabaseContext);
   const [isEditColumnDrawerOpen, setIsEditColumnDrawerOpen] = useState(false);
   const [selectedColumn, setSelectedColumn] = useState();
@@ -257,7 +259,7 @@ const Table = ({ openCreateRowDrawer, filters, sortFilters }) => {
           openCreateRowDrawer={openCreateRowDrawer}
           totalRecords={totalRecords}
           fetchTableData={fetchTableData}
-          filters={filters}
+          filters={queryFilters}
           sortFilters={sortFilters}
           dataLoading={loading}
           selectedTable={selectedTable}

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -25,8 +25,11 @@ const Table = ({ openCreateRowDrawer }) => {
     handleBuildFilterQuery,
     buildPaginationQuery,
     resetFilterQuery,
+    resetSortQuery,
     queryFilters,
+    setQueryFilters,
     sortFilters,
+    setSortFilters,
   } = useContext(TooljetDatabaseContext);
   const [isEditColumnDrawerOpen, setIsEditColumnDrawerOpen] = useState(false);
   const [selectedColumn, setSelectedColumn] = useState();
@@ -70,11 +73,21 @@ const Table = ({ openCreateRowDrawer }) => {
     });
   };
 
+  const onSelectedTableChange = () => {
+    resetFilterQuery();
+    resetSortQuery();
+    setSortFilters({});
+    setQueryFilters({});
+
+    fetchTableData();
+    fetchTableMetadata();
+  };
+
   useEffect(() => {
     if (selectedTable) {
-      fetchTableData();
-      fetchTableMetadata();
+      onSelectedTableChange();
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTable]);
 

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import cx from 'classnames';
 import { useTable, useRowSelect } from 'react-table';
-import { isBoolean, isEmpty } from 'lodash';
+import { isBoolean } from 'lodash';
 import { tooljetDatabaseService } from '@/_services';
 import { TooljetDatabaseContext } from '../index';
 import { toast } from 'react-hot-toast';
@@ -12,7 +12,7 @@ import Drawer from '@/_ui/Drawer';
 import EditColumnForm from '../Forms/ColumnForm';
 import TableFooter from './Footer';
 
-const Table = ({ openCreateRowDrawer, filters }) => {
+const Table = ({ openCreateRowDrawer, filters, sortFilters }) => {
   const {
     organizationId,
     columns,
@@ -258,6 +258,7 @@ const Table = ({ openCreateRowDrawer, filters }) => {
           totalRecords={totalRecords}
           fetchTableData={fetchTableData}
           filters={filters}
+          sortFilters={sortFilters}
           dataLoading={loading}
           selectedTable={selectedTable}
           handleBuildFilterQuery={handleBuildFilterQuery}

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -264,6 +264,7 @@ const Table = ({ openCreateRowDrawer, filters }) => {
           totalRecords={totalRecords}
           fetchTableData={fetchTableData}
           filters={filters}
+          dataLoading={loading}
         />
       </div>
       <Drawer isOpen={isEditColumnDrawerOpen} onClose={() => setIsEditColumnDrawerOpen(false)} position="right">

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -179,7 +179,12 @@ const Table = ({ openCreateRowDrawer }) => {
           </button>
         </div>
       )}
-      <div className={cx('table-responsive border-0 animation-fade')}>
+      <div
+        style={{
+          height: 'calc(100vh - 35px)',
+        }}
+        className={cx('table-responsive border-0 animation-fade')}
+      >
         <table
           {...getTableProps()}
           className="table w-auto card-table table-bordered table-vcenter text-nowrap datatable"

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -265,6 +265,7 @@ const Table = ({ openCreateRowDrawer, filters }) => {
           fetchTableData={fetchTableData}
           filters={filters}
           dataLoading={loading}
+          selectedTable={selectedTable}
         />
       </div>
       <Drawer isOpen={isEditColumnDrawerOpen} onClose={() => setIsEditColumnDrawerOpen(false)} position="right">

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -25,11 +25,11 @@ const Table = ({ openCreateRowDrawer }) => {
     handleBuildFilterQuery,
     buildPaginationQuery,
     resetFilterQuery,
-    resetSortQuery,
     queryFilters,
     setQueryFilters,
     sortFilters,
     setSortFilters,
+    resetAll,
   } = useContext(TooljetDatabaseContext);
   const [isEditColumnDrawerOpen, setIsEditColumnDrawerOpen] = useState(false);
   const [selectedColumn, setSelectedColumn] = useState();
@@ -74,12 +74,9 @@ const Table = ({ openCreateRowDrawer }) => {
   };
 
   const onSelectedTableChange = () => {
-    resetFilterQuery();
-    resetSortQuery();
+    resetAll();
     setSortFilters({});
     setQueryFilters({});
-
-    fetchTableData();
     fetchTableMetadata();
   };
 

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -64,8 +64,8 @@ const Table = ({ openCreateRowDrawer }) => {
         toast.error(error?.message ?? `Error fetching table "${selectedTable}" data`);
         return;
       }
-      const totalRecords = headers['content-range'].split('/')[1] || 0;
-      setTotalRecords(totalRecords);
+      const totalContentRangeRecords = headers['content-range'].split('/')[1] || 0;
+      setTotalRecords(totalContentRangeRecords);
       setSelectedTableData(data);
     });
   };
@@ -266,6 +266,7 @@ const Table = ({ openCreateRowDrawer }) => {
           handleBuildFilterQuery={handleBuildFilterQuery}
           buildPaginationQuery={buildPaginationQuery}
           resetFilterQuery={resetFilterQuery}
+          tableDataLength={tableData.length}
         />
       </div>
       <Drawer isOpen={isEditColumnDrawerOpen} onClose={() => setIsEditColumnDrawerOpen(false)} position="right">

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import cx from 'classnames';
 import { useTable, useRowSelect } from 'react-table';
-import { isBoolean, isEmpty } from 'lodash';
+import { isBoolean } from 'lodash';
 import { tooljetDatabaseService } from '@/_services';
 import { TooljetDatabaseContext } from '../index';
 import { toast } from 'react-hot-toast';
@@ -12,7 +12,7 @@ import Drawer from '@/_ui/Drawer';
 import EditColumnForm from '../Forms/ColumnForm';
 import TableFooter from './Footer';
 
-const Table = ({ openCreateRowDrawer, filters }) => {
+const Table = ({ openCreateRowDrawer }) => {
   const { organizationId, columns, selectedTable, selectedTableData, setSelectedTableData, setColumns } =
     useContext(TooljetDatabaseContext);
   const [isEditColumnDrawerOpen, setIsEditColumnDrawerOpen] = useState(false);
@@ -44,24 +44,8 @@ const Table = ({ openCreateRowDrawer, filters }) => {
 
   const fetchTableData = (queryParams = '', pagesize = 50, pagecount = 1) => {
     const defaultQueryParams = `limit=${pagesize}&offset=${(pagecount - 1) * pagesize}`;
-    let params = queryParams ? queryParams : defaultQueryParams;
+    const params = queryParams ? queryParams : defaultQueryParams;
     setLoading(true);
-
-    if (Object.keys(filters).length > 0) {
-      Object.keys(filters).map((key) => {
-        if (!isEmpty(filters[key])) {
-          const { column, operator, value } = filters[key];
-          if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
-            if (isBoolean(value)) {
-              params = `${params}&${column}=${value}`;
-            } else {
-              params = `${params}&${column}=${operator}.${value}`;
-            }
-          }
-        }
-      });
-    }
-
     tooljetDatabaseService.findOne(organizationId, selectedTable, params).then(({ headers, data = [], error }) => {
       setLoading(false);
       if (error) {
@@ -263,7 +247,6 @@ const Table = ({ openCreateRowDrawer, filters }) => {
           openCreateRowDrawer={openCreateRowDrawer}
           totalRecords={totalRecords}
           fetchTableData={fetchTableData}
-          filters={filters}
         />
       </div>
       <Drawer isOpen={isEditColumnDrawerOpen} onClose={() => setIsEditColumnDrawerOpen(false)} position="right">

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -267,15 +267,7 @@ const Table = ({ openCreateRowDrawer }) => {
         <TableFooter
           darkMode={darkMode}
           openCreateRowDrawer={openCreateRowDrawer}
-          totalRecords={totalRecords}
-          fetchTableData={fetchTableData}
-          filters={queryFilters}
-          sortFilters={sortFilters}
           dataLoading={loading}
-          selectedTable={selectedTable}
-          handleBuildFilterQuery={handleBuildFilterQuery}
-          buildPaginationQuery={buildPaginationQuery}
-          resetFilterQuery={resetFilterQuery}
           tableDataLength={tableData.length}
         />
       </div>

--- a/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
+++ b/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
@@ -13,6 +13,8 @@ const TooljetDatabasePage = () => {
     columns,
     selectedTable,
     handleBuildSortQuery,
+    handleBuildFilterQuery,
+    resetFilterQuery,
     resetSortQuery,
     queryFilters,
     setQueryFilters,
@@ -40,7 +42,12 @@ const TooljetDatabasePage = () => {
                     <CreateColumnDrawer />
                     {columns?.length > 0 && (
                       <>
-                        <Filter filters={queryFilters} setFilters={setQueryFilters} />
+                        <Filter
+                          filters={queryFilters}
+                          setFilters={setQueryFilters}
+                          handleBuildFilterQuery={handleBuildFilterQuery}
+                          resetFilterQuery={resetFilterQuery}
+                        />
                         <Sort
                           filters={sortFilters}
                           setFilters={setSortFilters}

--- a/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
+++ b/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
@@ -1,7 +1,5 @@
-import React, { useState, useContext, useRef } from 'react';
+import React, { useState, useContext } from 'react';
 import cx from 'classnames';
-import { toast } from 'react-hot-toast';
-import { isEmpty } from 'lodash';
 import Table from '../Table';
 import CreateColumnDrawer from '../Drawers/CreateColumnDrawer';
 import CreateRowDrawer from '../Drawers/CreateRowDrawer';
@@ -9,48 +7,9 @@ import Filter from '../Filter';
 import Sort from '../Sort';
 import Sidebar from '../Sidebar';
 import { TooljetDatabaseContext } from '../index';
-import { tooljetDatabaseService } from '@/_services';
-import PostgrestQueryBuilder from '@/_helpers/postgrestQueryBuilder';
 
 const TooljetDatabasePage = () => {
-  const { organizationId, columns, selectedTable, setSelectedTableData } = useContext(TooljetDatabaseContext);
-  const postgrestQueryBuilder = useRef({
-    filterQuery: new PostgrestQueryBuilder(),
-    sortQuery: new PostgrestQueryBuilder(),
-  });
-
-  const handleBuildSortQuery = (filters) => {
-    postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
-
-    Object.keys(filters).map((key) => {
-      if (!isEmpty(filters[key])) {
-        const { column, order } = filters[key];
-        if (!isEmpty(column) && !isEmpty(order)) {
-          postgrestQueryBuilder.current.sortQuery.order(column, order);
-        }
-      }
-    });
-
-    updateSelectedTableData();
-  };
-
-  const updateSelectedTableData = async () => {
-    const query =
-      postgrestQueryBuilder.current.filterQuery.url.toString() +
-      '&' +
-      postgrestQueryBuilder.current.sortQuery.url.toString();
-
-    const { data, error } = await tooljetDatabaseService.findOne(organizationId, selectedTable, query);
-
-    if (error) {
-      toast.error(error?.message ?? 'Something went wrong');
-      return;
-    }
-
-    if (Array.isArray(data)) {
-      setSelectedTableData(data);
-    }
-  };
+  const { columns, selectedTable, handleBuildSortQuery, resetSortQuery } = useContext(TooljetDatabaseContext);
 
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const [isCreateRowDrawerOpen, setIsCreateRowDrawerOpen] = useState(false);
@@ -75,7 +34,7 @@ const TooljetDatabasePage = () => {
                     {columns?.length > 0 && (
                       <>
                         <Filter filters={filters} setFilters={setFilters} />
-                        <Sort onClose={handleBuildSortQuery} />
+                        <Sort handleBuildSortQuery={handleBuildSortQuery} />
                         <CreateRowDrawer
                           isCreateRowDrawerOpen={isCreateRowDrawerOpen}
                           setIsCreateRowDrawerOpen={setIsCreateRowDrawerOpen}

--- a/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
+++ b/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
@@ -19,6 +19,21 @@ const TooljetDatabasePage = () => {
     sortQuery: new PostgrestQueryBuilder(),
   });
 
+  const handleBuildFilterQuery = (filters) => {
+    postgrestQueryBuilder.current.filterQuery = new PostgrestQueryBuilder();
+
+    Object.keys(filters).map((key) => {
+      if (!isEmpty(filters[key])) {
+        const { column, operator, value } = filters[key];
+        if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
+          postgrestQueryBuilder.current.filterQuery[operator](column, value);
+        }
+      }
+    });
+
+    updateSelectedTableData();
+  };
+
   const handleBuildSortQuery = (filters) => {
     postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
 
@@ -55,8 +70,6 @@ const TooljetDatabasePage = () => {
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const [isCreateRowDrawerOpen, setIsCreateRowDrawerOpen] = useState(false);
 
-  const [filters, setFilters] = useState({});
-
   return (
     <div className="row gx-0">
       <Sidebar />
@@ -74,7 +87,7 @@ const TooljetDatabasePage = () => {
                     <CreateColumnDrawer />
                     {columns?.length > 0 && (
                       <>
-                        <Filter filters={filters} setFilters={setFilters} />
+                        <Filter onClose={handleBuildFilterQuery} />
                         <Sort onClose={handleBuildSortQuery} />
                         <CreateRowDrawer
                           isCreateRowDrawerOpen={isCreateRowDrawerOpen}
@@ -87,7 +100,7 @@ const TooljetDatabasePage = () => {
               </div>
             </div>
             <div className={cx('col')}>
-              <Table openCreateRowDrawer={() => setIsCreateRowDrawerOpen(true)} filters={filters} />
+              <Table openCreateRowDrawer={() => setIsCreateRowDrawerOpen(true)} />
             </div>
           </>
         )}

--- a/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
+++ b/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
@@ -15,6 +15,7 @@ const TooljetDatabasePage = () => {
   const [isCreateRowDrawerOpen, setIsCreateRowDrawerOpen] = useState(false);
 
   const [filters, setFilters] = useState({});
+  const [sortFilters, setSortFilters] = useState({});
 
   return (
     <div className="row gx-0">
@@ -34,7 +35,12 @@ const TooljetDatabasePage = () => {
                     {columns?.length > 0 && (
                       <>
                         <Filter filters={filters} setFilters={setFilters} />
-                        <Sort handleBuildSortQuery={handleBuildSortQuery} />
+                        <Sort
+                          filters={sortFilters}
+                          setFilters={setSortFilters}
+                          handleBuildSortQuery={handleBuildSortQuery}
+                          resetSortQuery={resetSortQuery}
+                        />
                         <CreateRowDrawer
                           isCreateRowDrawerOpen={isCreateRowDrawerOpen}
                           setIsCreateRowDrawerOpen={setIsCreateRowDrawerOpen}
@@ -46,7 +52,11 @@ const TooljetDatabasePage = () => {
               </div>
             </div>
             <div className={cx('col')}>
-              <Table openCreateRowDrawer={() => setIsCreateRowDrawerOpen(true)} filters={filters} />
+              <Table
+                openCreateRowDrawer={() => setIsCreateRowDrawerOpen(true)}
+                filters={filters}
+                sortFilters={sortFilters}
+              />
             </div>
           </>
         )}

--- a/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
+++ b/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
@@ -9,13 +9,19 @@ import Sidebar from '../Sidebar';
 import { TooljetDatabaseContext } from '../index';
 
 const TooljetDatabasePage = () => {
-  const { columns, selectedTable, handleBuildSortQuery, resetSortQuery } = useContext(TooljetDatabaseContext);
+  const {
+    columns,
+    selectedTable,
+    handleBuildSortQuery,
+    resetSortQuery,
+    queryFilters,
+    setQueryFilters,
+    sortFilters,
+    setSortFilters,
+  } = useContext(TooljetDatabaseContext);
 
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const [isCreateRowDrawerOpen, setIsCreateRowDrawerOpen] = useState(false);
-
-  const [filters, setFilters] = useState({});
-  const [sortFilters, setSortFilters] = useState({});
 
   return (
     <div className="row gx-0">
@@ -34,7 +40,7 @@ const TooljetDatabasePage = () => {
                     <CreateColumnDrawer />
                     {columns?.length > 0 && (
                       <>
-                        <Filter filters={filters} setFilters={setFilters} />
+                        <Filter filters={queryFilters} setFilters={setQueryFilters} />
                         <Sort
                           filters={sortFilters}
                           setFilters={setSortFilters}
@@ -52,11 +58,7 @@ const TooljetDatabasePage = () => {
               </div>
             </div>
             <div className={cx('col')}>
-              <Table
-                openCreateRowDrawer={() => setIsCreateRowDrawerOpen(true)}
-                filters={filters}
-                sortFilters={sortFilters}
-              />
+              <Table openCreateRowDrawer={() => setIsCreateRowDrawerOpen(true)} />
             </div>
           </>
         )}

--- a/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
+++ b/frontend/src/TooljetDatabase/TooljetDatabasePage/index.jsx
@@ -19,21 +19,6 @@ const TooljetDatabasePage = () => {
     sortQuery: new PostgrestQueryBuilder(),
   });
 
-  const handleBuildFilterQuery = (filters) => {
-    postgrestQueryBuilder.current.filterQuery = new PostgrestQueryBuilder();
-
-    Object.keys(filters).map((key) => {
-      if (!isEmpty(filters[key])) {
-        const { column, operator, value } = filters[key];
-        if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
-          postgrestQueryBuilder.current.filterQuery[operator](column, value);
-        }
-      }
-    });
-
-    updateSelectedTableData();
-  };
-
   const handleBuildSortQuery = (filters) => {
     postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
 
@@ -70,6 +55,8 @@ const TooljetDatabasePage = () => {
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const [isCreateRowDrawerOpen, setIsCreateRowDrawerOpen] = useState(false);
 
+  const [filters, setFilters] = useState({});
+
   return (
     <div className="row gx-0">
       <Sidebar />
@@ -87,7 +74,7 @@ const TooljetDatabasePage = () => {
                     <CreateColumnDrawer />
                     {columns?.length > 0 && (
                       <>
-                        <Filter onClose={handleBuildFilterQuery} />
+                        <Filter filters={filters} setFilters={setFilters} />
                         <Sort onClose={handleBuildSortQuery} />
                         <CreateRowDrawer
                           isCreateRowDrawerOpen={isCreateRowDrawerOpen}
@@ -100,7 +87,7 @@ const TooljetDatabasePage = () => {
               </div>
             </div>
             <div className={cx('col')}>
-              <Table openCreateRowDrawer={() => setIsCreateRowDrawerOpen(true)} />
+              <Table openCreateRowDrawer={() => setIsCreateRowDrawerOpen(true)} filters={filters} />
             </div>
           </>
         )}

--- a/frontend/src/TooljetDatabase/index.jsx
+++ b/frontend/src/TooljetDatabase/index.jsx
@@ -16,6 +16,13 @@ export const TooljetDatabaseContext = createContext({
   setTables: () => {},
   columns: [],
   setColumns: () => {},
+  totalRecords: 0,
+  setTotalRecords: () => {},
+  handleBuildFilterQuery: () => {},
+  handleBuildSortQuery: () => {},
+  buildPaginationQuery: () => {},
+  resetSortQuery: () => {},
+  resetFilterQuery: () => {},
 });
 
 export const TooljetDatabase = (props) => {
@@ -29,19 +36,13 @@ export const TooljetDatabase = (props) => {
 
   const [totalRecords, setTotalRecords] = useState(0);
 
-  const {
-    handleBuildFilterQuery,
-    handleBuildSortQuery,
-    buildPaginationQuery,
-
-    resetSortQuery,
-    resetFilterQuery,
-  } = usePostgrestQueryBuilder({
-    organizationId,
-    selectedTable,
-    setSelectedTableData,
-    setTotalRecords,
-  });
+  const { handleBuildFilterQuery, handleBuildSortQuery, buildPaginationQuery, resetSortQuery, resetFilterQuery } =
+    usePostgrestQueryBuilder({
+      organizationId,
+      selectedTable,
+      setSelectedTableData,
+      setTotalRecords,
+    });
 
   const value = useMemo(
     () => ({

--- a/frontend/src/TooljetDatabase/index.jsx
+++ b/frontend/src/TooljetDatabase/index.jsx
@@ -23,6 +23,10 @@ export const TooljetDatabaseContext = createContext({
   buildPaginationQuery: () => {},
   resetSortQuery: () => {},
   resetFilterQuery: () => {},
+  queryFilters: {},
+  setQueryFilters: () => {},
+  sortFilters: {},
+  setSortFilters: () => {},
 });
 
 export const TooljetDatabase = (props) => {
@@ -35,6 +39,9 @@ export const TooljetDatabase = (props) => {
   const [selectedTableData, setSelectedTableData] = useState([]);
 
   const [totalRecords, setTotalRecords] = useState(0);
+
+  const [queryFilters, setQueryFilters] = useState({});
+  const [sortFilters, setSortFilters] = useState({});
 
   const { handleBuildFilterQuery, handleBuildSortQuery, buildPaginationQuery, resetSortQuery, resetFilterQuery } =
     usePostgrestQueryBuilder({
@@ -65,8 +72,23 @@ export const TooljetDatabase = (props) => {
       buildPaginationQuery,
       resetSortQuery,
       resetFilterQuery,
+      queryFilters,
+      setQueryFilters,
+      sortFilters,
+      setSortFilters,
     }),
-    [searchParam, organizationId, tables, columns, selectedTable, selectedTableData, totalRecords]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      searchParam,
+      organizationId,
+      tables,
+      columns,
+      selectedTable,
+      selectedTableData,
+      totalRecords,
+      queryFilters,
+      sortFilters,
+    ]
   );
 
   return (

--- a/frontend/src/TooljetDatabase/index.jsx
+++ b/frontend/src/TooljetDatabase/index.jsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useMemo } from 'react';
 import Layout from '@/_ui/Layout';
 import TooljetDatabasePage from './TooljetDatabasePage';
+import { usePostgrestQueryBuilder } from './usePostgrestQueryBuilder';
 
 export const TooljetDatabaseContext = createContext({
   organizationId: null,
@@ -26,6 +27,22 @@ export const TooljetDatabase = (props) => {
   const [selectedTable, setSelectedTable] = useState('');
   const [selectedTableData, setSelectedTableData] = useState([]);
 
+  const [totalRecords, setTotalRecords] = useState(0);
+
+  const {
+    handleBuildFilterQuery,
+    handleBuildSortQuery,
+    buildPaginationQuery,
+
+    resetSortQuery,
+    resetFilterQuery,
+  } = usePostgrestQueryBuilder({
+    organizationId,
+    selectedTable,
+    setSelectedTableData,
+    setTotalRecords,
+  });
+
   const value = useMemo(
     () => ({
       searchParam,
@@ -40,8 +57,15 @@ export const TooljetDatabase = (props) => {
       setSelectedTable,
       selectedTableData,
       setSelectedTableData,
+      totalRecords,
+      setTotalRecords,
+      handleBuildFilterQuery,
+      handleBuildSortQuery,
+      buildPaginationQuery,
+      resetSortQuery,
+      resetFilterQuery,
     }),
-    [searchParam, organizationId, tables, columns, selectedTable, selectedTableData]
+    [searchParam, organizationId, tables, columns, selectedTable, selectedTableData, totalRecords]
   );
 
   return (

--- a/frontend/src/TooljetDatabase/index.jsx
+++ b/frontend/src/TooljetDatabase/index.jsx
@@ -43,13 +43,19 @@ export const TooljetDatabase = (props) => {
   const [queryFilters, setQueryFilters] = useState({});
   const [sortFilters, setSortFilters] = useState({});
 
-  const { handleBuildFilterQuery, handleBuildSortQuery, buildPaginationQuery, resetSortQuery, resetFilterQuery } =
-    usePostgrestQueryBuilder({
-      organizationId,
-      selectedTable,
-      setSelectedTableData,
-      setTotalRecords,
-    });
+  const {
+    handleBuildFilterQuery,
+    handleBuildSortQuery,
+    buildPaginationQuery,
+    resetSortQuery,
+    resetFilterQuery,
+    resetAll,
+  } = usePostgrestQueryBuilder({
+    organizationId,
+    selectedTable,
+    setSelectedTableData,
+    setTotalRecords,
+  });
 
   const value = useMemo(
     () => ({
@@ -76,6 +82,7 @@ export const TooljetDatabase = (props) => {
       setQueryFilters,
       sortFilters,
       setSortFilters,
+      resetAll,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [

--- a/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
+++ b/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
@@ -89,11 +89,23 @@ export const usePostgrestQueryBuilder = ({ organizationId, selectedTable, setSel
     handleBuildFilterQuery({});
   };
 
+  const resetAll = () => {
+    postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
+
+    postgrestQueryBuilder.current.paginationQuery.limit(50);
+    postgrestQueryBuilder.current.paginationQuery.offset(0);
+
+    postgrestQueryBuilder.current.filterQuery = new PostgrestQueryBuilder();
+
+    handleBuildSortQuery({});
+  };
+
   return {
     handleBuildFilterQuery,
     handleBuildSortQuery,
     buildPaginationQuery,
     resetSortQuery,
     resetFilterQuery,
+    resetAll,
   };
 };

--- a/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
+++ b/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
@@ -12,17 +12,11 @@ export const usePostgrestQueryBuilder = ({ organizationId, selectedTable, setSel
   });
 
   const handleBuildSortQuery = (filters) => {
+    postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
     Object.keys(filters).map((key) => {
       if (!isEmpty(filters[key])) {
         const { column, order } = filters[key];
         if (!isEmpty(column) && !isEmpty(order)) {
-          if (postgrestQueryBuilder.current.sortQuery.url.toString().includes(column)) {
-            const sortQuery = new PostgrestQueryBuilder();
-            sortQuery.order(column, order);
-            postgrestQueryBuilder.current.sortQuery = sortQuery;
-            return;
-          }
-
           postgrestQueryBuilder.current.sortQuery.order(column, order);
         }
       }
@@ -54,19 +48,11 @@ export const usePostgrestQueryBuilder = ({ organizationId, selectedTable, setSel
   };
 
   const handleBuildFilterQuery = (filters) => {
+    postgrestQueryBuilder.current.filterQuery = new PostgrestQueryBuilder();
     Object.keys(filters).map((key) => {
       if (!isEmpty(filters[key])) {
         const { column, operator, value } = filters[key];
         if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
-          const currentFilterQuery = postgrestQueryBuilder.current.filterQuery.url.toString();
-
-          if (currentFilterQuery.includes(column)) {
-            const filterQuery = new PostgrestQueryBuilder();
-            filterQuery.filter(column, operator, value);
-            postgrestQueryBuilder.current.filterQuery = filterQuery;
-            return;
-          }
-
           postgrestQueryBuilder.current.filterQuery.filter(column, operator, value);
         }
       }

--- a/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
+++ b/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
@@ -1,0 +1,97 @@
+import React, { useRef } from 'react';
+import PostgrestQueryBuilder from '@/_helpers/postgrestQueryBuilder';
+import { tooljetDatabaseService } from '@/_services';
+import { isEmpty } from 'lodash';
+import { toast } from 'react-hot-toast';
+
+export const usePostgrestQueryBuilder = ({ organizationId, selectedTable, setSelectedTableData, setTotalRecords }) => {
+  const postgrestQueryBuilder = useRef({
+    filterQuery: new PostgrestQueryBuilder(),
+    sortQuery: new PostgrestQueryBuilder(),
+    paginationQuery: new PostgrestQueryBuilder(),
+  });
+
+  const handleBuildSortQuery = (filters) => {
+    postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
+
+    Object.keys(filters).map((key) => {
+      if (!isEmpty(filters[key])) {
+        const { column, order } = filters[key];
+        if (!isEmpty(column) && !isEmpty(order)) {
+          postgrestQueryBuilder.current.sortQuery.order(column, order);
+        }
+      }
+    });
+    updateSelectedTableData();
+  };
+
+  const updateSelectedTableData = async () => {
+    const query =
+      postgrestQueryBuilder.current.filterQuery.url.toString() +
+      '&' +
+      postgrestQueryBuilder.current.sortQuery.url.toString() +
+      '&' +
+      postgrestQueryBuilder.current.paginationQuery.url.toString();
+
+    const { headers, data, error } = await tooljetDatabaseService.findOne(organizationId, selectedTable, query);
+
+    if (error) {
+      toast.error(error?.message ?? 'Something went wrong');
+      return;
+    }
+
+    const totalRecords = headers['content-range'].split('/')[1] || 0;
+
+    if (Array.isArray(data)) {
+      setTotalRecords(totalRecords);
+      setSelectedTableData(data);
+    }
+  };
+
+  const handleBuildFilterQuery = (filters) => {
+    Object.keys(filters).map((key) => {
+      if (!isEmpty(filters[key])) {
+        const { column, operator, value } = filters[key];
+        if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
+          const currentFilterQuery = postgrestQueryBuilder.current.filterQuery.url.toString();
+
+          if (currentFilterQuery.includes(column)) {
+            const filterQuery = new PostgrestQueryBuilder();
+            filterQuery.filter(column, operator, value);
+            postgrestQueryBuilder.current.filterQuery = filterQuery;
+            return;
+          }
+
+          postgrestQueryBuilder.current.filterQuery.filter(column, operator, value);
+        }
+      }
+    });
+
+    updateSelectedTableData();
+  };
+
+  const buildPaginationQuery = (limit, offset) => {
+    postgrestQueryBuilder.current.paginationQuery.limit(limit);
+    postgrestQueryBuilder.current.paginationQuery.offset(offset);
+
+    updateSelectedTableData();
+  };
+
+  const resetSortQuery = () => {
+    postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
+    updateSelectedTableData();
+  };
+
+  const resetFilterQuery = () => {
+    postgrestQueryBuilder.current.filterQuery = new PostgrestQueryBuilder();
+    updateSelectedTableData();
+  };
+
+  return {
+    handleBuildFilterQuery,
+    handleBuildSortQuery,
+    buildPaginationQuery,
+    resetSortQuery,
+    resetFilterQuery,
+  };
+};

--- a/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
+++ b/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import PostgrestQueryBuilder from '@/_helpers/postgrestQueryBuilder';
 import { tooljetDatabaseService } from '@/_services';
 import { isEmpty } from 'lodash';
@@ -12,8 +12,6 @@ export const usePostgrestQueryBuilder = ({ organizationId, selectedTable, setSel
   });
 
   const handleBuildSortQuery = (filters) => {
-    postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
-
     Object.keys(filters).map((key) => {
       if (!isEmpty(filters[key])) {
         const { column, order } = filters[key];
@@ -79,12 +77,16 @@ export const usePostgrestQueryBuilder = ({ organizationId, selectedTable, setSel
 
   const resetSortQuery = () => {
     postgrestQueryBuilder.current.sortQuery = new PostgrestQueryBuilder();
-    updateSelectedTableData();
+    postgrestQueryBuilder.current.paginationQuery.limit(50);
+    postgrestQueryBuilder.current.paginationQuery.offset(0);
+    handleBuildSortQuery({});
   };
 
   const resetFilterQuery = () => {
     postgrestQueryBuilder.current.filterQuery = new PostgrestQueryBuilder();
-    updateSelectedTableData();
+    postgrestQueryBuilder.current.paginationQuery.limit(50);
+    postgrestQueryBuilder.current.paginationQuery.offset(0);
+    handleBuildFilterQuery({});
   };
 
   return {

--- a/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
+++ b/frontend/src/TooljetDatabase/usePostgrestQueryBuilder.jsx
@@ -16,6 +16,13 @@ export const usePostgrestQueryBuilder = ({ organizationId, selectedTable, setSel
       if (!isEmpty(filters[key])) {
         const { column, order } = filters[key];
         if (!isEmpty(column) && !isEmpty(order)) {
+          if (postgrestQueryBuilder.current.sortQuery.url.toString().includes(column)) {
+            const sortQuery = new PostgrestQueryBuilder();
+            sortQuery.order(column, order);
+            postgrestQueryBuilder.current.sortQuery = sortQuery;
+            return;
+          }
+
           postgrestQueryBuilder.current.sortQuery.order(column, order);
         }
       }

--- a/frontend/src/_helpers/postgrestQueryBuilder.js
+++ b/frontend/src/_helpers/postgrestQueryBuilder.js
@@ -310,4 +310,14 @@ export default class PostgrestQueryBuilder {
     });
     return this;
   }
+
+  limit(size) {
+    this.url.set(`limit`, size);
+    return this;
+  }
+
+  offset(offset) {
+    this.url.set(`offset`, offset);
+    return this;
+  }
 }

--- a/frontend/src/_ui/Select/SelectComponent.jsx
+++ b/frontend/src/_ui/Select/SelectComponent.jsx
@@ -50,6 +50,7 @@ export const SelectComponent = ({ options = [], value, onChange, ...restProps })
       {...restProps}
       defaultValue={defaultValue}
       isLoading={isLoading}
+      isDisabled={isLoading}
       options={selectOptions}
       value={currentValue}
       search={hasSearch}


### PR DESCRIPTION
Resolves:
- last rows are not scrollable for large data set
- pagination works onBlur event as well as on enter
- bugfix: displaying wrong total pages and wrong number of records 
- change/switching tables, pagination should be reset according to the table data
- added support to paginate with filters
- minor css fixes
- fixed: pagination buttons are clickable along with dropdown while fresh data is being loaded
- perf optimisation: fixes: without any change in filters, on filter menu close event api gets called