### PR TITLE
Remove border-width for code hinter inside rest-methods-url div

### DIFF
--- a/frontend/src/_styles/queryManager.scss
+++ b/frontend/src/_styles/queryManager.scss
@@ -965,7 +965,6 @@ $border-radius: 4px;
     .code-hinter.codehinter-default-input{
       border-style: solid !important;
       border-color: $color-light-slate-07 !important;
-      border-width: 1px 1px 1px 0 !important;
       border-radius: 0 6px 6px 0 !important;
       &:focus-within{
         box-shadow: 0px 0px 0px 2px #C6D4F9 !important;


### PR DESCRIPTION
Resolves the issue that causes code hinter inside query manager to keep slipping when we click inside of it