### PR TITLE
[Fix] :: Header icon/buttons not visible on preview for newly created apps

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -178,6 +178,7 @@ class EditorComponent extends React.Component {
   }
 
   componentDidMount() {
+    this.autoSave();
     this.fetchApps(0);
     this.fetchApp(this.props.match.params.pageHandle);
     this.fetchOrgEnvironmentVariables();


### PR DESCRIPTION
Resolves: 
when no components are added or an empty app is launched the icon is hidden even if we don't change the header setting