### PR TITLE
Chore: Update try-tj image with tooljet database

### DIFF
--- a/docker/preview.Dockerfile
+++ b/docker/preview.Dockerfile
@@ -76,7 +76,9 @@ WORKDIR /app
 # ENV defaults
 ENV TOOLJET_HOST=http://localhost:80 \
     PGRST_HOST=http://localhost:3000 \
-    PGRST_JWT_SECRET=replace_pgrst_jwt_secret \
+    PGRST_JWT_SECRET=r9iMKoe5CRMgvJBBtp4HrqN7QiPpUToj \
+    TOOLJET_DB=tooljet_db \
+    ENABLE_TOOLJET_DB=true \
     PORT=80 \
     LOCKBOX_MASTER_KEY=replace_with_lockbox_master_key \
     SECRET_KEY_BASE=replace_with_secret_key_base \

--- a/docs/docs/setup/try-tooljet.md
+++ b/docs/docs/setup/try-tooljet.md
@@ -12,14 +12,14 @@ You can run the command below to have ToolJet up and running right away.
 docker run \
   --name tooljet \
   --restart unless-stopped \
-  -p 3000:3000 \
+  -p 80:80 \
   -v tooljet_data:/var/lib/postgresql/13/main \
   tooljet/try:latest
 ```
 
 #### Setup information
 
-- Runs the ToolJet server on the port 3000 on your machine.
+- Runs the ToolJet server on the port 80 on your machine.
 - Container has postgres already configured within. All the data will be available in the docker volume `tooljet_data`.
 - Default user credentials to login (email: `dev@tooljet.io`, password: `password`).
 - You can make use of `--env` or `--env-file` flag to test against various env configurables mentioned [here](https://docs.tooljet.com/docs/setup/env-vars).
@@ -36,5 +36,5 @@ You can deploy ToolJet on PWD for free with the one-click-deployment button belo
 #### Setup information
 
 - Default user credentials to login (email: `dev@tooljet.io`, password: `password`).
-- Open port 3000 after the docker containers are up and running
+- Open port 80 after the docker containers are up and running
 - Visit the url shared on the dashboard to try out tooljet

--- a/docs/docs/setup/try-tooljet.md
+++ b/docs/docs/setup/try-tooljet.md
@@ -12,14 +12,14 @@ You can run the command below to have ToolJet up and running right away.
 docker run \
   --name tooljet \
   --restart unless-stopped \
-  -p 80:80 \
+  -p 3000:3000 \
   -v tooljet_data:/var/lib/postgresql/13/main \
   tooljet/try:latest
 ```
 
 #### Setup information
 
-- Runs the ToolJet server on the port 80 on your machine.
+- Runs the ToolJet server on the port 3000 on your machine.
 - Container has postgres already configured within. All the data will be available in the docker volume `tooljet_data`.
 - Default user credentials to login (email: `dev@tooljet.io`, password: `password`).
 - You can make use of `--env` or `--env-file` flag to test against various env configurables mentioned [here](https://docs.tooljet.com/docs/setup/env-vars).
@@ -36,5 +36,5 @@ You can deploy ToolJet on PWD for free with the one-click-deployment button belo
 #### Setup information
 
 - Default user credentials to login (email: `dev@tooljet.io`, password: `password`).
-- Open port 80 after the docker containers are up and running
+- Open port 3000 after the docker containers are up and running
 - Visit the url shared on the dashboard to try out tooljet

--- a/docs/versioned_docs/version-2.0.0-beta/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.0.0-beta/setup/try-tooljet.md
@@ -12,14 +12,14 @@ You can run the command below to have ToolJet up and running right away.
 docker run \
   --name tooljet \
   --restart unless-stopped \
-  -p 3000:3000 \
+  -p 80:80 \
   -v tooljet_data:/var/lib/postgresql/13/main \
   tooljet/try:latest
 ```
 
 #### Setup information
 
-- Runs the ToolJet server on the port 3000 on your machine.
+- Runs the ToolJet server on the port 80 on your machine.
 - Container has postgres already configured within. All the data will be available in the docker volume `tooljet_data`.
 - Default user credentials to login (email: `dev@tooljet.io`, password: `password`).
 - You can make use of `--env` or `--env-file` flag to test against various env configurables mentioned [here](https://docs.tooljet.com/docs/setup/env-vars).
@@ -36,5 +36,5 @@ You can deploy ToolJet on PWD for free with the one-click-deployment button belo
 #### Setup information
 
 - Default user credentials to login (email: `dev@tooljet.io`, password: `password`).
-- Open port 3000 after the docker containers are up and running
+- Open port 80 after the docker containers are up and running
 - Visit the url shared on the dashboard to try out tooljet


### PR DESCRIPTION
- Makes use of supervisord to run postgrest and tooljet server in single container