### PR TITLE
Tooljet db query - Filter condition should resolved dynamic variables used in the editor

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -1,5 +1,5 @@
 import { tooljetDatabaseService } from '@/_services';
-import { isEmpty } from 'lodash';
+import { isEmpty, isNull, isUndefined } from 'lodash';
 import PostgrestQueryBuilder from '@/_helpers/postgrestQueryBuilder';
 import { resolveReferences } from '@/_helpers/utils';
 
@@ -33,7 +33,7 @@ function buildPostgrestQuery(filters) {
         postgrestQueryBuilder.order(column, order);
       }
 
-      if (!isEmpty(column) && !isEmpty(operator) && value !== '') {
+      if (!isEmpty(column) && !isEmpty(operator) && value && value !== '') {
         postgrestQueryBuilder[operator](column, value.toString());
       }
     }

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -33,7 +33,7 @@ function buildPostgrestQuery(filters) {
         postgrestQueryBuilder.order(column, order);
       }
 
-      if (!isEmpty(column) && !isEmpty(operator) && !isEmpty(value)) {
+      if (!isEmpty(column) && !isEmpty(operator) && value !== '') {
         postgrestQueryBuilder[operator](column, value.toString());
       }
     }
@@ -56,7 +56,6 @@ async function listRows(queryOptions, organizationId, currentState) {
     !isEmpty(orderQuery) && query.push(orderQuery);
     !isEmpty(limit) && query.push(`limit=${limit}`);
   }
-
   return await tooljetDatabaseService.findOne(organizationId, tableName, query.join('&'));
 }
 

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -1,5 +1,5 @@
 import { tooljetDatabaseService } from '@/_services';
-import { isEmpty, isNull, isUndefined } from 'lodash';
+import { isEmpty } from 'lodash';
 import PostgrestQueryBuilder from '@/_helpers/postgrestQueryBuilder';
 import { resolveReferences } from '@/_helpers/utils';
 


### PR DESCRIPTION
Fixes:
Tooljet db query - Filter condition should resolved dynamic variables used in the editor