### PR TITLE
[ Bug fixed ] : UI is not consistent when query name is large in query panel header

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -578,7 +578,11 @@ class QueryManagerComponent extends React.Component {
                   </svg>
                 </span>
                 <div className="query-name-breadcrum d-flex align-items-center">
-                  <span className="query-manager-header-query-name font-weight-400">
+                  <span
+                    className={`query-manager-header-query-name font-weight-400 ${
+                      !this.state.renameQuery && 'ellipsis'
+                    }`}
+                  >
                     {this.state.renameQuery ? (
                       <input
                         type="text"

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -596,7 +596,7 @@ class QueryManagerComponent extends React.Component {
                         onBlur={({ target }) => this.executeQueryNameUpdation(target.value)}
                       />
                     ) : (
-                      queryName.substring(0, 20) + `${queryName.length > 20 ? '...' : ''}`
+                      queryName
                     )}
                   </span>
                   <span

--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -596,7 +596,7 @@ class QueryManagerComponent extends React.Component {
                         onBlur={({ target }) => this.executeQueryNameUpdation(target.value)}
                       />
                     ) : (
-                      queryName
+                      queryName.substring(0, 20) + `${queryName.length > 20 ? '...' : ''}`
                     )}
                   </span>
                   <span

--- a/frontend/src/_styles/queryManager.scss
+++ b/frontend/src/_styles/queryManager.scss
@@ -213,6 +213,8 @@ $border-radius: 4px;
       font-weight: 500 !important;
       .query-manager-header-query-name{
         color: $color-light-slate-12;
+      }
+      .ellipsis{
         width: 100px; 
         white-space: nowrap;
         overflow: hidden; 

--- a/frontend/src/_styles/queryManager.scss
+++ b/frontend/src/_styles/queryManager.scss
@@ -213,6 +213,10 @@ $border-radius: 4px;
       font-weight: 500 !important;
       .query-manager-header-query-name{
         color: $color-light-slate-12;
+        width: 100px; 
+        white-space: nowrap;
+        overflow: hidden; 
+        text-overflow: ellipsis;
       }
       .query-header-buttons{
         gap: 8px;


### PR DESCRIPTION
Resolves :
In the query panel header, when the query name is too long, it overlaps with buttons present in the query panel header

![Screenshot - 2022-12-28T112709 641](https://user-images.githubusercontent.com/37823141/209931320-97862504-2de5-476d-9975-e190c2064533.png)
