### PR TITLE
[fix] Open api queries doesn't redirect to google OAuth page if there isn't refresh token 

### DIFF
--- a/server/src/services/data_queries.service.ts
+++ b/server/src/services/data_queries.service.ts
@@ -216,7 +216,7 @@ export class DataQueriesService {
               app: { id: app?.id, isPublic: app?.isPublic },
             }
           );
-        } else if (dataSource.kind === 'restapi') {
+        } else if (dataSource.kind === 'restapi' || dataSource.kind === 'openapi') {
           return {
             status: 'needs_oauth',
             data: {


### PR DESCRIPTION
Open api queries doesn't redirect to OAuth accept credentials page if refresh token is empty