### PR TITLE
[Bug fixed ] : restAPI is getting created everytime on query panel after adding any data source or deleting a data source

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryManager.jsx
+++ b/frontend/src/Editor/QueryManager/QueryManager.jsx
@@ -21,7 +21,7 @@ import { CustomToggleSwitch } from './CustomToggleSwitch';
 const queryNameRegex = new RegExp('^[A-Za-z0-9_-]*$');
 
 const staticDataSources = [
-  { kind: 'restapi', id: 'null', name: 'REST API' },
+  { kind: 'restapi', id: 'restapi', name: 'REST API' },
   { kind: 'runjs', id: 'runjs', name: 'Run JavaScript code' },
   { kind: 'tooljetdb', id: 'null', name: 'Run ToolJetDb query' },
   { kind: 'runpy', id: 'runpy', name: 'Run Python code' },


### PR DESCRIPTION
Resolves:

1. REST API does not behave consistently with light/dark mode when the application is created in the dark/light mode.

https://user-images.githubusercontent.com/37823141/210004467-40435a86-c048-4cea-882f-88bbbbecde04.mp4




2. Rest API is getting created every time on the query panel after adding any data source or deleting a data source

https://user-images.githubusercontent.com/37823141/209998034-bef8b36f-26f9-4c51-8a4a-c97983606546.mp4


https://user-images.githubusercontent.com/37823141/209998037-8827d8f3-f3f9-457c-adba-f1d820ca6cdc.mp4

