### PR TITLE
[ Bug fixed ] : select custom component styles not getting applied in query manager

### DIFF
--- a/frontend/src/Editor/Components/Table/Filter.jsx
+++ b/frontend/src/Editor/Components/Table/Filter.jsx
@@ -144,6 +144,7 @@ export function Filter(props) {
                 placeholder={t('globals.select', 'Select') + '...'}
                 className={`${darkMode ? 'select-search-dark' : 'select-search'} mb-0`}
                 styles={selectStyles('100%')}
+                useCustomStyles={true}
               />
             </div>
             <div data-cy={`select-operation-dropdown-${index ?? ''}`} className="col" style={{ maxWidth: '180px' }}>
@@ -171,6 +172,7 @@ export function Filter(props) {
                 placeholder={t('globals.select', 'Select') + '...'}
                 styles={selectStyles('100%')}
                 dataCy={`select-coloumn-dropdown-${index ?? ''}`}
+                useCustomStyles={true}
               />
             </div>
             <div className="col">

--- a/frontend/src/Editor/Inspector/ActionConfigurationPanels/GotoApp.jsx
+++ b/frontend/src/Editor/Inspector/ActionConfigurationPanels/GotoApp.jsx
@@ -59,6 +59,7 @@ export function GotoApp({ getAllApps, currentState, event, handlerChanged, event
         styles={styles}
         useMenuPortal={false}
         className={`${darkMode ? 'select-search-dark' : 'select-search'}`}
+        useCustomStyles={true}
       />
       <label className="form-label mt-2">Query params</label>
 

--- a/frontend/src/Editor/Inspector/ActionConfigurationPanels/SwitchPage.jsx
+++ b/frontend/src/Editor/Inspector/ActionConfigurationPanels/SwitchPage.jsx
@@ -59,6 +59,7 @@ export function SwitchPage({ getPages, currentState, event, handlerChanged, even
         styles={styles}
         useMenuPortal={false}
         className={`${darkMode ? 'select-search-dark' : 'select-search'}`}
+        useCustomStyles={true}
       />
       <label className="form-label mt-2">Query params</label>
 

--- a/frontend/src/Editor/Inspector/EventManager.jsx
+++ b/frontend/src/Editor/Inspector/EventManager.jsx
@@ -223,6 +223,7 @@ export const EventManager = ({
                 placeholder={t('globals.select', 'Select') + '...'}
                 styles={styles}
                 useMenuPortal={false}
+                useCustomStyles={true}
               />
             </div>
           </div>
@@ -240,6 +241,7 @@ export const EventManager = ({
                 placeholder={t('globals.select', 'Select') + '...'}
                 styles={styles}
                 useMenuPortal={false}
+                useCustomStyles={true}
               />
             </div>
           </div>
@@ -280,6 +282,7 @@ export const EventManager = ({
                       placeholder={t('globals.select', 'Select') + '...'}
                       styles={styles}
                       useMenuPortal={false}
+                      useCustomStyles={true}
                     />
                   </div>
                 </div>
@@ -325,6 +328,7 @@ export const EventManager = ({
                     placeholder={t('globals.select', 'Select') + '...'}
                     styles={styles}
                     useMenuPortal={false}
+                    useCustomStyles={true}
                   />
                 </div>
               </div>
@@ -345,6 +349,7 @@ export const EventManager = ({
                     placeholder={t('globals.select', 'Select') + '...'}
                     styles={styles}
                     useMenuPortal={false}
+                    useCustomStyles={true}
                   />
                 </div>
               </div>
@@ -382,6 +387,7 @@ export const EventManager = ({
                     placeholder={t('globals.select', 'Select') + '...'}
                     styles={styles}
                     useMenuPortal={false}
+                    useCustomStyles={true}
                   />
                 </div>
               </div>
@@ -436,6 +442,7 @@ export const EventManager = ({
                       placeholder={t('globals.select', 'Select') + '...'}
                       styles={styles}
                       useMenuPortal={false}
+                      useCustomStyles={true}
                     />
                   </div>
                 </div>
@@ -481,6 +488,7 @@ export const EventManager = ({
                       placeholder={t('globals.select', 'Select') + '...'}
                       styles={styles}
                       useMenuPortal={false}
+                      useCustomStyles={true}
                     />
                   </div>
                 </div>
@@ -616,6 +624,7 @@ export const EventManager = ({
                       placeholder={t('globals.select', 'Select') + '...'}
                       styles={styles}
                       useMenuPortal={false}
+                      useCustomStyles={true}
                     />
                   </div>
                 </div>
@@ -640,6 +649,7 @@ export const EventManager = ({
                       placeholder={t('globals.select', 'Select') + '...'}
                       styles={styles}
                       useMenuPortal={false}
+                      useCustomStyles={true}
                     />
                   </div>
                 </div>

--- a/frontend/src/Editor/QueryManager/QueryEditors/Openapi.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Openapi.jsx
@@ -234,6 +234,7 @@ class OpenapiComponent extends React.Component {
                     customOption={this.renderHostOptions}
                     placeholder={this.props.t('openApi.selectHost', 'Select a host')}
                     styles={queryManagerSelectComponentStyle(this.props.darkMode, '100%')}
+                    useCustomStyles={true}
                   />
                 </div>
               </div>
@@ -251,6 +252,7 @@ class OpenapiComponent extends React.Component {
                   customOption={this.renderOperationOption}
                   placeholder={this.props.t('openApi.selectOperation', 'Select an operation')}
                   styles={queryManagerSelectComponentStyle(this.props.darkMode, '100%')}
+                  useCustomStyles={true}
                 />
 
                 {selectedOperation && (

--- a/frontend/src/Editor/QueryManager/QueryEditors/Restapi/index.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Restapi/index.jsx
@@ -145,6 +145,7 @@ class Restapi extends React.Component {
               width={100}
               height={32}
               styles={this.customSelectStyles(this.props.darkMode, 91)}
+              useCustomStyles={true}
             />
           </div>
 

--- a/frontend/src/Editor/QueryManager/QueryEditors/Stripe.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Stripe.jsx
@@ -199,6 +199,7 @@ class StripeComponent extends React.Component {
                   useMenuPortal={true}
                   customOption={this.renderOperationOption}
                   styles={queryManagerSelectComponentStyle(this.props.darkMode, '100%')}
+                  useCustomStyles={true}
                 />
 
                 {selectedOperation && (

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
@@ -7,8 +7,13 @@ import { UpdateRows } from './UpdateRows';
 import { DeleteRows } from './DeleteRows';
 import { toast } from 'react-hot-toast';
 import Select from '@/_ui/Select';
+import { queryManagerSelectComponentStyle } from '@/_ui/Select/styles';
 
 const ToolJetDbOperations = ({ currentState, optionchanged, options, darkMode }) => {
+  const computeSelectStyles = (darkMode, width) => {
+    return queryManagerSelectComponentStyle(darkMode, width);
+  };
+
   const { organization_id: organizationId } = JSON.parse(localStorage.getItem('currentUser')) || {};
   const [operation, setOperation] = useState(options['operation']);
   const [columns, setColumns] = useState([]);
@@ -115,7 +120,9 @@ const ToolJetDbOperations = ({ currentState, optionchanged, options, darkMode })
             value={selectedTable}
             onChange={(value) => handleTableNameSelect(value)}
             width="100%"
-            useMenuPortal={false}
+            // useMenuPortal={false}
+            useCustomStyles={true}
+            styles={computeSelectStyles(darkMode, '100%')}
           />
         </div>
       </div>
@@ -134,7 +141,9 @@ const ToolJetDbOperations = ({ currentState, optionchanged, options, darkMode })
             value={operation}
             onChange={(value) => setOperation(value)}
             width="100%"
-            useMenuPortal={false}
+            // useMenuPortal={false}
+            useCustomStyles={true}
+            styles={computeSelectStyles(darkMode, '100%')}
           />
         </div>
       </div>

--- a/frontend/src/Editor/QueryManager/Transformation.jsx
+++ b/frontend/src/Editor/QueryManager/Transformation.jsx
@@ -192,6 +192,7 @@ return [row for row in data if row['amount'] > 1000]
               }}
               placeholder={t('globals.select', 'Select') + '...'}
               styles={computeSelectStyles(darkMode, 140)}
+              useCustomStyles={true}
             />
           </div>
           <div className="border-top mx-3"></div>

--- a/frontend/src/_components/DynamicForm.jsx
+++ b/frontend/src/_components/DynamicForm.jsx
@@ -153,6 +153,7 @@ const DynamicForm = ({
           width: width || '100%',
           useMenuPortal: queryName ? true : false,
           styles: computeSelectStyles ? computeSelectStyles('100%') : {},
+          useCustomStyles: computeSelectStyles ? true : false,
         };
       case 'react-component-headers':
         return {
@@ -363,6 +364,7 @@ const DynamicForm = ({
                 <Select
                   {...getElementProps(flipComponentDropdown)}
                   styles={computeSelectStyles ? computeSelectStyles('100%') : {}}
+                  useCustomStyles={computeSelectStyles ? true : false}
                 />
               </div>
               {flipComponentDropdown.helpText && (

--- a/frontend/src/_ui/Select/SelectComponent.jsx
+++ b/frontend/src/_ui/Select/SelectComponent.jsx
@@ -20,7 +20,7 @@ export const SelectComponent = ({ options = [], value, onChange, ...restProps })
     menuPlacement = 'auto',
   } = restProps;
 
-  const customStyles = defaultStyles(darkMode, width, height, styles);
+  const customStyles = _.isEmpty(styles) ? defaultStyles(darkMode, width, height, styles) : styles;
   const selectOptions =
     Array.isArray(options) && options.length === 0
       ? options

--- a/frontend/src/_ui/Select/SelectComponent.jsx
+++ b/frontend/src/_ui/Select/SelectComponent.jsx
@@ -6,7 +6,7 @@ import defaultStyles from './styles';
 export const SelectComponent = ({ options = [], value, onChange, ...restProps }) => {
   const darkMode = localStorage.getItem('darkMode') === 'true';
   const {
-    styles,
+    styles = {},
     isLoading = false,
     hasSearch = true,
     height,
@@ -18,9 +18,10 @@ export const SelectComponent = ({ options = [], value, onChange, ...restProps })
     maxMenuHeight = 250,
     menuPortalTarget = null,
     menuPlacement = 'auto',
+    useCustomStyles = false,
   } = restProps;
 
-  const customStyles = _.isEmpty(styles) ? defaultStyles(darkMode, width, height, styles) : styles;
+  const customStyles = useCustomStyles ? styles : defaultStyles(darkMode, width, height, styles);
   const selectOptions =
     Array.isArray(options) && options.length === 0
       ? options


### PR DESCRIPTION
Resolves :
Operation dropdown options are not fully visible in ToolJetDB
<img width="324" alt="Screenshot 2023-01-03 at 4 46 38 PM" src="https://user-images.githubusercontent.com/37823141/210347070-3560eb5e-a625-4049-a3a6-aa18b186de64.png">



Styles are not getting applied for the custom select component in the entire query manager according to the query manager design
Components in which select component styles are affected :
1. restAPI
2. openAPI
3. Stripe
4. Dynamic form

<img width="1231" alt="Screenshot 2023-01-02 at 12 24 30 PM" src="https://user-images.githubusercontent.com/37823141/210201951-a7c3885b-8e0a-4069-8f07-03dff6218ff3.png">


<img width="1231" alt="Screenshot 2023-01-02 at 12 24 38 PM" src="https://user-images.githubusercontent.com/37823141/210201900-84287eab-9cf0-4a6d-bccb-8791305b03e6.png">

Desired Design. :

<img width="274" alt="Screenshot 2023-01-02 at 12 26 55 PM" src="https://user-images.githubusercontent.com/37823141/210202028-316657e1-bbd3-4016-b94c-4f3d42610b51.png">

