### PR TITLE
[Bug]: Unsaved Changes Popup on TooljetDB

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/CreateRow.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/CreateRow.jsx
@@ -5,10 +5,13 @@ import { TooljetDatabaseContext } from '@/TooljetDatabase/index';
 import { toast } from 'react-hot-toast';
 import Select from '@/_ui/Select';
 import { uniqueId } from 'lodash';
+import { useMounted } from '@/_hooks/use-mount';
 
 export const CreateRow = ({ currentState, optionchanged, options, darkMode }) => {
   const { organizationId, selectedTable, columns, setColumns } = useContext(TooljetDatabaseContext);
   const [columnOptions, setColumnOptions] = useState(options['create_row'] || {});
+
+  const mounted = useMounted();
 
   useEffect(() => {
     fetchTableInformation(selectedTable);
@@ -19,7 +22,7 @@ export const CreateRow = ({ currentState, optionchanged, options, darkMode }) =>
   }, []);
 
   useEffect(() => {
-    optionchanged('create_row', columnOptions);
+    mounted && optionchanged('create_row', columnOptions);
   }, [columnOptions, optionchanged]);
 
   function handleColumnOptionChange(columnOptions) {

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DeleteRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DeleteRows.jsx
@@ -6,10 +6,13 @@ import { uniqueId } from 'lodash';
 import { CodeHinter } from '@/Editor/CodeBuilder/CodeHinter';
 import Select from '@/_ui/Select';
 import { operators } from '@/TooljetDatabase/constants';
+import { useMounted } from '@/_hooks/use-mount';
 
 export const DeleteRows = ({ currentState, optionchanged, options, darkMode }) => {
   const { organizationId, selectedTable, columns, setColumns } = useContext(TooljetDatabaseContext);
   const [deleteRowsOptions, setDeleteRowsOptions] = useState(options['delete_rows'] || {});
+
+  const mounted = useMounted();
 
   useEffect(() => {
     fetchTableInformation(selectedTable);
@@ -17,7 +20,7 @@ export const DeleteRows = ({ currentState, optionchanged, options, darkMode }) =
   }, []);
 
   useEffect(() => {
-    optionchanged('delete_rows', deleteRowsOptions);
+    mounted && optionchanged('delete_rows', deleteRowsOptions);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deleteRowsOptions]);
 
@@ -56,7 +59,7 @@ export const DeleteRows = ({ currentState, optionchanged, options, darkMode }) =
   }
 
   const updateLimitOptions = (limit) => {
-    setDeleteRowsOptions({ ...deleteRowsOptions, ...{ limit } });
+    if (deleteRowsOptions?.limit ?? 1 !== limit) setDeleteRowsOptions({ ...deleteRowsOptions, ...{ limit } });
   };
 
   async function fetchTableInformation(table) {

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ListRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ListRows.jsx
@@ -6,10 +6,13 @@ import { toast } from 'react-hot-toast';
 import { uniqueId } from 'lodash';
 import Select from '@/_ui/Select';
 import { operators } from '@/TooljetDatabase/constants';
+import { useMounted } from '@/_hooks/use-mount';
 
 export const ListRows = ({ currentState, optionchanged, options, darkMode }) => {
   const { organizationId, selectedTable, columns, setColumns } = useContext(TooljetDatabaseContext);
   const [listRowsOptions, setListRowsOptions] = useState(() => options['list_rows'] || {});
+
+  const mounted = useMounted();
 
   useEffect(() => {
     fetchTableInformation(selectedTable);
@@ -20,7 +23,7 @@ export const ListRows = ({ currentState, optionchanged, options, darkMode }) => 
   }, []);
 
   useEffect(() => {
-    optionchanged('list_rows', listRowsOptions);
+    mounted && optionchanged('list_rows', listRowsOptions);
   }, [listRowsOptions, optionchanged]);
 
   function handleWhereFiltersChange(filters) {
@@ -246,7 +249,7 @@ export const ListRows = ({ currentState, optionchanged, options, darkMode }) => 
   };
 
   const updateLimitOptions = (limit) => {
-    setListRowsOptions({ ...listRowsOptions, ...{ limit } });
+    if (listRowsOptions?.limit ?? '' !== limit) setListRowsOptions({ ...listRowsOptions, ...{ limit } });
   };
 
   return (

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
@@ -8,6 +8,7 @@ import { DeleteRows } from './DeleteRows';
 import { toast } from 'react-hot-toast';
 import Select from '@/_ui/Select';
 import { queryManagerSelectComponentStyle } from '@/_ui/Select/styles';
+import { useMounted } from '@/_hooks/use-mount';
 
 const ToolJetDbOperations = ({ currentState, optionchanged, options, darkMode }) => {
   const computeSelectStyles = (darkMode, width) => {
@@ -19,13 +20,16 @@ const ToolJetDbOperations = ({ currentState, optionchanged, options, darkMode })
   const [columns, setColumns] = useState([]);
   const [tables, setTables] = useState([]);
   const [selectedTable, setSelectedTable] = useState(options['table_name']);
+
+  const mounted = useMounted();
+
   useEffect(() => {
     fetchTables();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    optionchanged('operation', operation);
+    mounted && optionchanged('operation', operation);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [operation]);
 

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/UpdateRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/UpdateRows.jsx
@@ -6,12 +6,15 @@ import Select from '@/_ui/Select';
 import { toast } from 'react-hot-toast';
 import { operators } from '@/TooljetDatabase/constants';
 import { uniqueId } from 'lodash';
+import { useMounted } from '@/_hooks/use-mount';
 
 export const UpdateRows = ({ currentState, optionchanged, options, darkMode }) => {
   const { organizationId, selectedTable, columns, setColumns } = useContext(TooljetDatabaseContext);
   const [updateRowsOptions, setUpdateRowsOptions] = useState(
     options['update_rows'] || { columns: {}, where_filters: {} }
   );
+
+  const mounted = useMounted();
 
   useEffect(() => {
     fetchTableInformation(selectedTable);
@@ -22,7 +25,7 @@ export const UpdateRows = ({ currentState, optionchanged, options, darkMode }) =
   }, []);
 
   useEffect(() => {
-    optionchanged('update_rows', updateRowsOptions);
+    mounted && optionchanged('update_rows', updateRowsOptions);
   }, [optionchanged, updateRowsOptions]);
 
   function handleColumnOptionChange(columnOptions) {


### PR DESCRIPTION
Whenever tooljetDB is selected with any operation, without any changes unsaved popup is shown