### PR TITLE
[ Bug fix ] : made left sidebar icon consistent with the dark theme

### DIFF
--- a/frontend/src/_styles/left-sidebar.scss
+++ b/frontend/src/_styles/left-sidebar.scss
@@ -486,12 +486,6 @@
       &:hover {
         background: #2F3C4C;
       }
-      svg{
-        path{
-          fill: white !important;
-        }
-      }
     }
-    
   } 
 }


### PR DESCRIPTION
Resolves:
<img width="53" alt="Screenshot 2023-01-05 at 12 04 35 AM" src="https://user-images.githubusercontent.com/37823141/210625404-4ed82501-780e-402b-9767-9d01b7aec916.png">
