### PR TITLE
[bug-fix] couldn't create Tooljet DB boolean columns with empty value

### DIFF
--- a/frontend/src/TooljetDatabase/Forms/RowForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/RowForm.jsx
@@ -67,7 +67,7 @@ const RowForm = ({ onCreate, onClose }) => {
             <input
               className="form-check-input"
               type="checkbox"
-              defaultChecked={defaultValue}
+              defaultChecked={defaultValue === 'true'}
               onChange={handleToggleChange(columnName)}
             />
           </label>

--- a/server/src/dto/create-postgrest-table.dto.ts
+++ b/server/src/dto/create-postgrest-table.dto.ts
@@ -15,8 +15,7 @@ import {
   ValidationArguments,
   ValidationOptions,
 } from 'class-validator';
-
-import { sanitizeInput } from 'src/helpers/utils.helper';
+import { sanitizeInput, validateDefaultValue } from 'src/helpers/utils.helper';
 
 export function Match(property: string, validationOptions?: ValidationOptions) {
   return (object: any, propertyName: string) => {
@@ -109,7 +108,10 @@ export class PostgrestTableColumnDto {
   constraint: string;
 
   @IsOptional()
-  @Transform(({ value }) => sanitizeInput(value))
+  @Transform(({ value, obj }) => {
+    const sanitizedValue = sanitizeInput(value);
+    return validateDefaultValue(sanitizedValue, obj);
+  })
   @Match('data_type', {
     message: 'Default value must match the data type',
   })

--- a/server/src/helpers/utils.helper.ts
+++ b/server/src/helpers/utils.helper.ts
@@ -82,3 +82,9 @@ export const defaultAppEnvironments = [{ name: 'production', isDefault: true }];
 export function isPlural(data: Array<any>) {
   return data?.length > 1 ? 's' : '';
 }
+
+export function validateDefaultValue(value: any, params: any) {
+  const { data_type } = params;
+  if (data_type === 'boolean') return value || 'false';
+  return value;
+}


### PR DESCRIPTION
- [x] This PR includes the fix for "always showing the true value for the boolean column while creating new rows even if the default value is false"

Resolves #5244