### PR TITLE
Tooljet db - with empty col name, we should not be able to create new cols

### DIFF
--- a/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
@@ -7,7 +7,7 @@ import { tooljetDatabaseService } from '@/_services';
 import { TooljetDatabaseContext } from '../index';
 import { dataTypes } from '../constants';
 
-const ColumnForm = ({ onCreate, onEdit, onClose, selectedColumn }) => {
+const ColumnForm = ({ onCreate, onClose }) => {
   const [columnName, setColumnName] = useState('');
   const [defaultValue, setDefaultValue] = useState('');
   const [dataType, setDataType] = useState();
@@ -29,7 +29,7 @@ const ColumnForm = ({ onCreate, onEdit, onClose, selectedColumn }) => {
     }
 
     setFetching(true);
-  
+
     const { error } = await tooljetDatabaseService.createColumn(
       organizationId,
       selectedTable,
@@ -37,7 +37,7 @@ const ColumnForm = ({ onCreate, onEdit, onClose, selectedColumn }) => {
       dataType,
       defaultValue
     );
-  
+
     setFetching(false);
 
     if (error) {

--- a/frontend/src/TooljetDatabase/Forms/TableForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableForm.jsx
@@ -42,6 +42,12 @@ const TableForm = ({
   const handleCreate = async () => {
     if (!validateTableName()) return;
 
+    const columnNames = Object.values(columns).map((column) => column.column_name);
+    if (columnNames.some((columnName) => isEmpty(columnName))) {
+      toast.error('Column names cannot be empty');
+      return;
+    }
+
     setFetching(true);
     const { error } = await tooljetDatabaseService.createTable(organizationId, tableName, Object.values(columns));
     setFetching(false);


### PR DESCRIPTION
**Current**
With empty column name, columns can be created