### PR TITLE
[Table widget] Boolean value is not coerce to string for default and string non-editable column

### DIFF
--- a/frontend/src/Editor/Components/Table/columns/index.jsx
+++ b/frontend/src/Editor/Components/Table/columns/index.jsx
@@ -80,7 +80,6 @@ export default function generateColumnsData({
           customResolvables[id] = { ...variablesExposedForPreview[id], rowData };
           exposeToCodeHinter((prevState) => ({ ...prevState, ...customResolvables }));
         }
-
         switch (columnType) {
           case 'string':
           case undefined:
@@ -151,7 +150,7 @@ export default function generateColumnsData({
                 </div>
               );
             }
-            return <span style={cellStyles}>{cellValue}</span>;
+            return <span style={cellStyles}>{String(cellValue)}</span>;
           }
           case 'number': {
             const textColor = resolveReferences(column.textColor, currentState, '', { cellValue, rowData });


### PR DESCRIPTION
fixes: Boolean data is not visible in the table widget