### PR TITLE
fixes: runpy queries from v1 is not created in v2

### DIFF
--- a/server/src/services/app_import_export.service.ts
+++ b/server/src/services/app_import_export.service.ts
@@ -312,6 +312,10 @@ export class AppImportExportService {
         dsKindsToCreate.push('tooljetdb');
       }
 
+      if (!dataSources?.some((ds) => ds.kind === 'runpy' && ds.type === DataSourceTypes.STATIC)) {
+        dsKindsToCreate.push('runpy');
+      }
+
       if (dsKindsToCreate.length > 0) {
         // Create default data sources
         defaultDataSourceIdMapping[appVersion.id] = await this.createDefaultDataSourceForVersion(


### PR DESCRIPTION
**runPy** queries created in v1 apps is not created when the app is exported to v2