### PR TITLE
[multipages] disable: duplicate page

### DIFF
--- a/frontend/src/Editor/Box.jsx
+++ b/frontend/src/Editor/Box.jsx
@@ -282,7 +282,6 @@ export const Box = function Box({
         {inCanvas ? (
           !resetComponent ? (
             <ComponentToRender
-              key={`${id}${currentState.page.id}`}
               onComponentClick={onComponentClick}
               onComponentOptionChanged={onComponentOptionChanged}
               currentState={currentState}

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1600,6 +1600,8 @@ class EditorComponent extends React.Component {
   };
 
   switchPage = (pageId, queryParams = []) => {
+    if (this.state.currentPageId === pageId) return;
+
     const { name, handle, events } = this.state.appDefinition.pages[pageId];
     const currentPageId = this.state.currentPageId;
 

--- a/frontend/src/Editor/LeftSidebar/SidebarPageSelector/PageHandler.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPageSelector/PageHandler.jsx
@@ -13,7 +13,7 @@ export const PageHandler = ({
   switchPage,
   deletePage,
   renamePage,
-  clonePage,
+  // clonePage,
   hidePage,
   unHidePage,
   homePageId,
@@ -73,9 +73,9 @@ export const PageHandler = ({
         showSettings();
         break;
 
-      case 'duplicate-page':
-        clonePage(page.id);
-        break;
+      // case 'duplicate-page':
+      //   clonePage(page.id);
+      //   break;
 
       case 'hide-page':
         hidePage(page.id);

--- a/frontend/src/Editor/LeftSidebar/SidebarPageSelector/PagehandlerMenu.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPageSelector/PagehandlerMenu.jsx
@@ -41,13 +41,13 @@ export const PagehandlerMenu = ({ page, darkMode, handlePageCallback, showMenu, 
                   closeMenu={closeMenu}
                   callback={handlePageCallback}
                 />
-                <Field
+                {/* <Field
                   id="duplicate-page"
                   text="Duplicate"
                   iconSrc={'assets/images/icons/duplicate.svg'}
                   closeMenu={closeMenu}
                   callback={handlePageCallback}
-                />
+                /> */}
                 <Field
                   id="mark-as-home-page"
                   text="Mark home"

--- a/frontend/src/Editor/LeftSidebar/SidebarPageSelector/SettingsModal.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPageSelector/SettingsModal.jsx
@@ -24,7 +24,7 @@ export const SettingsModal = ({
     <div onClick={(event) => event.stopPropagation()}>
       <Modal
         show={show}
-        onHide={handleClose}
+        // onHide={handleClose}
         size="sm"
         centered
         className={`${darkMode && 'theme-dark'} page-handle-edit-modal`}

--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -399,6 +399,8 @@ class ViewerComponent extends React.Component {
   };
 
   switchPage = (id, queryParams = []) => {
+    if (this.state.currentPageId === id) return;
+
     const { handle, name, events } = this.state.appDefinition.pages[id];
 
     const queryParamsString = queryParams.map(([key, value]) => `${key}=${value}`).join('&');


### PR DESCRIPTION
- deprecated the ability to duplicate pages
- fixes: selecting a suggestion with a click event, closes the modal (multi-page settings modal)