### PR TITLE
Update dead docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can use ToolJet cloud for a fully managed solution. If you want to self-host
 
 
 ## Community support
-For general help using ToolJet, please refer to the official [documentation](https://docs.tooljet.com/docs/intro/). For additional help, you can use one of these channels to ask a question:
+For general help using ToolJet, please refer to the official [documentation](https://docs.tooljet.com/docs/). For additional help, you can use one of these channels to ask a question:
 
 - [Slack](https://join.slack.com/t/tooljet/shared_invite/zt-r2neyfcw-KD1COL6t2kgVTlTtAV5rtg) - Discussions with the community and the team.
 - [GitHub](https://github.com/ToolJet/ToolJet/issues) - For bug reports and feature requests.


### PR DESCRIPTION
The current documentation link in the readme appears to be out of date, and gives a 404.