### PR TITLE
Implemented Feature #1737 #1738 for DynamoDB

### DIFF
--- a/plugins/packages/dynamodb/lib/manifest.json
+++ b/plugins/packages/dynamodb/lib/manifest.json
@@ -21,6 +21,12 @@
       "secret_key": {
         "type": "string",
         "encrypted": true
+      },
+      "useInstanceMetadataCredentials": {
+        "type": "boolean"
+      },
+      "roleArn": {
+        "type": "string"
       }
     }
   },
@@ -32,6 +38,9 @@
       "value": ""
     },
     "secret_key": {
+      "value": ""
+    },
+    "roleArn": {
       "value": ""
     }
   },
@@ -155,11 +164,21 @@
       "key": "secret_key",
       "type": "password",
       "description": "Enter secret key"
+    },
+    "useInstanceMetadataCredentials": {
+      "label": "Use AWS IAM Credentials from instance metadata? (EC2, ECS, EKS)",
+      "key": "useInstanceMetadataCredentials",
+      "type": "toggle",
+      "description": "Leverage AWS IAM Credentials from instance metadata"
+    },
+    "roleArn": {
+      "label": "Role to assume (leave empty if not necessary)",
+      "key": "roleArn",
+      "type": "text",
+      "description": "The role to be assume if necessary"
     }
   },
   "required": [
-    "region",
-    "access_key",
-    "secret_key"
+    "region"
   ]
 }

--- a/plugins/packages/dynamodb/lib/types.ts
+++ b/plugins/packages/dynamodb/lib/types.ts
@@ -14,11 +14,6 @@ export type QueryOptions = {
   operation: string;
 };
 
-export type IAMUserCredentials = {
-  accessKeyId: string;
-  secretAccessKey: string;
-};
-
 export type AssumeRoleCredentials = {
   accessKeyId: string;
   secretAccessKey: string;

--- a/plugins/packages/dynamodb/lib/types.ts
+++ b/plugins/packages/dynamodb/lib/types.ts
@@ -1,8 +1,26 @@
-export type SourceOptions = { access_key: string; secret_key: string; region: string };
+export type SourceOptions = {
+  access_key: string;
+  secret_key: string;
+  region: string;
+  useInstanceMetadataCredentials: boolean;
+  roleArn: string;
+};
+
 export type QueryOptions = {
   table: string;
   key: string;
   scan_condition: string;
   query_condition: string;
   operation: string;
+};
+
+export type IAMUserCredentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+};
+
+export type AssumeRoleCredentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
 };


### PR DESCRIPTION
This PR adds the aforementioned features.

- Use AWS Instance Metadata (EC2, ECS, EKS) - #1737
- Supports both same-account and cross-account role assuming - #1738

The core functionality of AWS IAM Access Key and AWS IAM Secret Access Key was retained, with the addition of the ability for those long-term credentials to additionally assume roles.

This PR was tested in an AWS ECS Cluster.

**If all fields are filled in and the toggle is set to true, AWS Instance Metadata takes priority over IAM User.**

----

Some screenshots:

- Using instance metadata
![cddda5d2d78324274c8d1493e003ec561c3e02869d4509cff848d6d096ee2333](https://user-images.githubusercontent.com/9402773/213009748-e5cd3da9-1002-4afb-aa90-d9e34a7507de.png)

- Instance Metadata + Assuming a role that we don't have permissions
![f60a680385414e6822c40f3f4a9acefaf7a2ee64f3708ed56d75c36dba004c66](https://user-images.githubusercontent.com/9402773/213009986-8d3814ba-65eb-4c87-861e-383b270cbd46.png)

- Instance Metadata + Assuming a role that we have permissions
![960ac77f1add3938bcff2620290e7b0af993f7bfbbf9382c7983c727c7930e19](https://user-images.githubusercontent.com/9402773/213010155-3855f6c7-bd44-4015-a9df-193443c38040.png)

- Using IAM User (check that still works)
![2ec631246d771afd380f646507de1830fc64c5efb9716ca57867c3fc360c5aed](https://user-images.githubusercontent.com/9402773/213010336-bd0e518e-af67-4093-a04f-5ad313fb8eba.png)

The connection was tested in every possible case.

