### PR TITLE
[improvement] validation error message for columns includes the column name

### DIFF
--- a/server/src/dto/tooljet-db.dto.ts
+++ b/server/src/dto/tooljet-db.dto.ts
@@ -114,10 +114,11 @@ export class PostgrestTableColumnDto {
   @MaxLength(31, { message: 'Column name must be less than 32 characters' })
   @MinLength(1, { message: 'Column name must be at least 1 character' })
   @Matches(/^[a-zA-Z_][a-zA-Z0-9_]*$/, {
-    message: 'Column name must start with a letter or underscore and can only contain letters, numbers and underscores',
+    message:
+      '  $value : Column name must start with a letter or underscore and can only contain letters, numbers and underscores',
   })
   @Validate(ReservedKeywordConstraint, {
-    message: 'Column name cannot be a reserved keyword',
+    message: ' $value : Column name cannot be a reserved keyword',
   })
   @Validate(SQLInjectionValidator, { message: 'Column name does not support special characters' })
   column_name: string;


### PR DESCRIPTION
Resolves: validation error message for columns should include the column name