### PR TITLE
[Fix] :: Copy to clipboard not visible in inspector after visiting Page panel from sidebar

### DIFF
--- a/frontend/src/_ui/JSONTreeViewer/JSONTreeViewer.jsx
+++ b/frontend/src/_ui/JSONTreeViewer/JSONTreeViewer.jsx
@@ -14,7 +14,7 @@ export class JSONTreeViewer extends React.Component {
       hoveredNode: null,
       darkTheme: false,
       showHideActions: false,
-      enableCopyToClipboard: false,
+      enableCopyToClipboard: props.enableCopyToClipboard ?? false,
       actionsList: props.actionsList || [],
       useActions: props.useActions ?? false,
     };


### PR DESCRIPTION
Resolves #5361 