### PR TITLE
[Bugfix] The sequence of primary columns in the table changes after updating rows using the query builder

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -92,7 +92,7 @@ async function updateRows(queryOptions, organizationId, currentState) {
 
   !isEmpty(whereQuery) && query.push(whereQuery);
 
-  return await tooljetDatabaseService.updateRows(organizationId, tableName, body, query.join('&'));
+  return await tooljetDatabaseService.updateRows(organizationId, tableName, body, query.join('&') + '&order=id');
 }
 
 async function deleteRows(queryOptions, organizationId, currentState) {


### PR DESCRIPTION
Fixes: #5373 