### PR TITLE
Hotfix - backfill for runpy quries v1

### DIFF
--- a/server/data-migrations/1676545162064-BackfillRunpyDatasources.ts
+++ b/server/data-migrations/1676545162064-BackfillRunpyDatasources.ts
@@ -16,7 +16,6 @@ export class BackfillRunpyDatasources1676545162064 implements MigrationInterface
       .getRawMany();
 
     for (const version of allVersions) {
-      console.log('version ========> test', version);
       await this.createDefaultVersionAndAttachQueries(entityManager, version);
     }
   }
@@ -26,12 +25,12 @@ export class BackfillRunpyDatasources1676545162064 implements MigrationInterface
       "select data_queries.id from data_queries inner join data_sources on data_queries.data_source_id = data_sources.id where data_queries.options->> 'code' is not null and data_sources.kind = 'restapi' and data_sources.type = 'static' and data_sources.app_version_id = $1",
       [version.id]
     );
-    console.log('version ========> wronglyAttachedRunpyQueries', wronglyAttachedRunpyQueries);
+
     if (wronglyAttachedRunpyQueries.length > 0) {
       let runpyDS = await entityManager.query(
         "select data_sources.id from data_sources where data_sources.kind = 'runpy' and data_sources.type = 'static'"
       );
-      console.log('version ========> runpyDS  ', runpyDS);
+
       if (runpyDS.length === 0) {
         runpyDS = await entityManager.query(
           'insert into data_sources (name, kind, app_version_id, type) values ($1, $2, $3, $4) returning "id"',

--- a/server/data-migrations/1676545162064-BackfillRunpyDatasources.ts
+++ b/server/data-migrations/1676545162064-BackfillRunpyDatasources.ts
@@ -1,0 +1,53 @@
+import { EntityManager, MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * finds all the queries which are attached to restapi datasource with type static  but have a non-null code option, which indicates that they are actually associated with a runpy data source.
+ * creates a new runpy data source and attaches all such queries to it.
+ */
+
+export class BackfillRunpyDatasources1676545162064 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const entityManager = queryRunner.manager;
+
+    const allVersions = await entityManager
+      .createQueryBuilder()
+      .select()
+      .from('app_versions', 'app_versions')
+      .getRawMany();
+
+    for (const version of allVersions) {
+      console.log('version ========> test', version);
+      await this.createDefaultVersionAndAttachQueries(entityManager, version);
+    }
+  }
+
+  async createDefaultVersionAndAttachQueries(entityManager: EntityManager, version: any) {
+    const wronglyAttachedRunpyQueries = await entityManager.query(
+      "select data_queries.id from data_queries inner join data_sources on data_queries.data_source_id = data_sources.id where data_queries.options->> 'code' is not null and data_sources.kind = 'restapi' and data_sources.type = 'static' and data_sources.app_version_id = $1",
+      [version.id]
+    );
+    console.log('version ========> wronglyAttachedRunpyQueries', wronglyAttachedRunpyQueries);
+    if (wronglyAttachedRunpyQueries.length > 0) {
+      let runpyDS = await entityManager.query(
+        "select data_sources.id from data_sources where data_sources.kind = 'runpy' and data_sources.type = 'static'"
+      );
+      console.log('version ========> runpyDS  ', runpyDS);
+      if (runpyDS.length === 0) {
+        runpyDS = await entityManager.query(
+          'insert into data_sources (name, kind, app_version_id, type) values ($1, $2, $3, $4) returning "id"',
+          ['runpydefault', 'runpy', version.id, 'static']
+        );
+      }
+      await entityManager.query(
+        `update data_queries set data_source_id = $1 where id in (${wronglyAttachedRunpyQueries
+          .map(({ id }) => `'${id}'`)
+          .join()})`,
+        [runpyDS[0].id]
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}
+
+// sql query to Edit change the data source id

--- a/server/data-migrations/1676545162064-BackfillRunpyDatasources.ts
+++ b/server/data-migrations/1676545162064-BackfillRunpyDatasources.ts
@@ -48,5 +48,3 @@ export class BackfillRunpyDatasources1676545162064 implements MigrationInterface
 
   public async down(queryRunner: QueryRunner): Promise<void> {}
 }
-
-// sql query to Edit change the data source id


### PR DESCRIPTION
finds all the queries which are attached to restapi datasource with type static  but have a non-null code option, which indicates that they are actually associated with a runpy data source. creates a new runpy data source and attaches all such queries to it.