### PR TITLE
Fixes error for setting up default value for on creating a new column (Tooljet database)

### DIFF
--- a/server/src/dto/tooljet-db.dto.ts
+++ b/server/src/dto/tooljet-db.dto.ts
@@ -68,7 +68,13 @@ export class SQLInjectionValidator implements ValidatorConstraintInterface {
   validate(value: any) {
     // Todo: add validations to overcome for SQL Injection
     const sql_meta = new RegExp('^[a-zA-Z0-9_ .]*$', 'i');
+    const email_meta = new RegExp('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$', 'i');
+
     if (sql_meta.test(value)) {
+      return true;
+    }
+
+    if (email_meta.test(value)) {
       return true;
     }
 

--- a/server/src/dto/tooljet-db.dto.ts
+++ b/server/src/dto/tooljet-db.dto.ts
@@ -68,13 +68,14 @@ export class SQLInjectionValidator implements ValidatorConstraintInterface {
   validate(value: any) {
     // Todo: add validations to overcome for SQL Injection
     const sql_meta = new RegExp('^[a-zA-Z0-9_ .]*$', 'i');
-    const email_meta = new RegExp('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$', 'i');
+    // . and @ are allowed in email
+    const allowedSpecialChars = new RegExp('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$', 'i');
 
     if (sql_meta.test(value)) {
       return true;
     }
 
-    if (email_meta.test(value)) {
+    if (allowedSpecialChars.test(value)) {
       return true;
     }
 
@@ -149,7 +150,7 @@ export class PostgrestTableColumnDto {
   @Match('data_type', {
     message: 'Default value must match the data type',
   })
-  @Validate(SQLInjectionValidator, { message: 'Default value does not support special characters' })
+  @Validate(SQLInjectionValidator, { message: 'Default value does not support special characters except "." and "@"' })
   default: string | number | boolean;
 }
 


### PR DESCRIPTION
Fixes: #5594 
Allows only "." and "@"