### PR TITLE
Fix try-tooljet dependence with base image

### DIFF
--- a/docker/try-tooljet.Dockerfile
+++ b/docker/try-tooljet.Dockerfile
@@ -5,8 +5,7 @@ COPY --from=postgrest/postgrest:v10.1.1.20221215 /bin/postgrest /bin
 
 # Install Postgres
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main 13" | tee /etc/apt/sources.list.d/pgdg.list
-RUN echo "deb http://deb.debian.org/debian"
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg 11 main" | tee /etc/apt/sources.list.d/pgdg.list
 RUN apt update && apt -y install postgresql-13 postgresql-client-13 supervisor
 USER postgres
 RUN service postgresql start && \

--- a/docker/try-tooljet.Dockerfile
+++ b/docker/try-tooljet.Dockerfile
@@ -5,7 +5,7 @@ COPY --from=postgrest/postgrest:v10.1.1.20221215 /bin/postgrest /bin
 
 # Install Postgres
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg 11 main" | tee /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 RUN apt update && apt -y install postgresql-13 postgresql-client-13 supervisor
 USER postgres
 RUN service postgresql start && \


### PR DESCRIPTION
change buster-pgdg to bullseye-pgdg which helps to install debian bullseyes related dependence  
