### PR TITLE
Allow configuration of MySQL connections via socket path

### DIFF
--- a/plugins/packages/mysql/lib/index.ts
+++ b/plugins/packages/mysql/lib/index.ts
@@ -66,16 +66,22 @@ export default class MysqlQueryService implements QueryService {
   }
 
   async buildConnection(sourceOptions: SourceOptions) {
+    // either use socket_path or host/port + ssl
+    const props = sourceOptions.socket_path
+      ? { socketPath: sourceOptions.socket_path }
+      : {
+          host: sourceOptions.host,
+          port: +sourceOptions.port,
+          ssl: sourceOptions.ssl_enabled ?? false, // Disabling by default for backward compatibility
+        };
     const config: Knex.Config = {
       client: 'mysql',
       connection: {
-        host: sourceOptions.host,
+        ...props,
         user: sourceOptions.username,
         password: sourceOptions.password,
         database: sourceOptions.database,
-        port: +sourceOptions.port,
         multipleStatements: true,
-        ssl: sourceOptions.ssl_enabled ?? false, // Disabling by default for backward compatibility
       },
     };
 

--- a/plugins/packages/mysql/lib/types.ts
+++ b/plugins/packages/mysql/lib/types.ts
@@ -2,6 +2,7 @@ export type SourceOptions = {
   database: string;
   host: string;
   port: string;
+  socket_path: string;
   username: string;
   password: string;
   ssl_enabled: boolean;


### PR DESCRIPTION
Add `socket_path` property for MySQL plugin

- Add new property `socket_path`
- If `socket_path` is set, ignore host/port and ssl settings when setting up the connection

Resolves #5600 