### PR TITLE
adds **eval-cheap-source-map** as the source map options for Webpack development mode

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
       '@assets': path.resolve(__dirname, 'assets/'),
     },
   },
-  devtool: environment === 'development' ? 'inline-source-map' : false,
+  devtool: environment === 'development' ? 'eval-cheap-source-map' : false,
   module: {
     rules: [
       {


### PR DESCRIPTION
adds **eval-cheap-source-map** as the source map options for Webpack development mode

It generates a source map that is based on the eval devtool, which is a faster option compared to the traditional source-map devtool. 

Ref: #5555 

