### PR TITLE
Fix for entrypoint.sh file to take default port value 5432 in database_url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ PG_PASS=<db password>
 
 
 #DATABASE CONFIG using string
-# If you intent you use the string and if the connection does not support ssl. Please use the below format.m
+# If you intent you use the string and if the connection does not support ssl. Please use the below format.
 # postgres://username:password@hostname:port/database_name?sslmode=disable
 
 

--- a/docs/docs/setup/env-vars.md
+++ b/docs/docs/setup/env-vars.md
@@ -46,6 +46,11 @@ ToolJet server uses PostgreSQL as the database.
 If you are using docker-compose setup, you can set PG_HOST as `postgres` which will be DNS resolved by docker
 :::
 
+:::info
+If you intent you use the string and if the connection does not support ssl. Please use the below format.
+`postgres://username:password@hostname:port/database_name?sslmode=disable`
+:::
+
 ### Disable database and extension creation (optional)
 
 ToolJet by default tries to create database based on `PG_DB` variable set and additionally my try to create postgres extensions. This requires the postgres user to have CREATEDB permission. If this cannot be granted you can disable this behaviour by setting `PG_DB_OWNER` as `false` and will have to manually run them.
@@ -96,6 +101,11 @@ Use `ENABLE_TOOLJET_DB` to enable/disable the feature that allows users to work 
 :::tip
 When this feature is enabled, the database name provided for `TOOLJET_DB` will be utilized to create a new database during server boot process in all of our production deploy setups.
 Incase you want to trigger it manually, use the command `npm run db:create` on ToolJet server.
+:::
+
+:::info
+If you intent you use the string and if the connection does not support ssl. Please use the below format.
+`postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
 #### Server Host ( optional )

--- a/docs/docs/setup/env-vars.md
+++ b/docs/docs/setup/env-vars.md
@@ -47,7 +47,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the string and if the connection does not support ssl. Please use the below format.
+If you intent you use the string and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -104,7 +104,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the string and if the connection does not support ssl. Please use the below format.
+If you intent you use the string and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/docs/setup/env-vars.md
+++ b/docs/docs/setup/env-vars.md
@@ -11,9 +11,9 @@ Both the ToolJet server and client requires some environment variables to start 
 
 #### ToolJet host ( required )
 
-| variable     | description                                                     |
-| ------------ | --------------------------------------------------------------- |
-| TOOLJET_HOST | the public URL of ToolJet client ( eg: https://app.tooljet.com )  |
+| variable     | description                                                      |
+| ------------ | ---------------------------------------------------------------- |
+| TOOLJET_HOST | the public URL of ToolJet client ( eg: https://app.tooljet.com ) |
 
 #### Lockbox configuration ( required )
 
@@ -47,7 +47,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the string and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -63,38 +63,38 @@ Self-hosted version of ToolJet pings our server to fetch the latest product upda
 
 Use this environment variable to enable/disable the feature that allows you to add comments on the canvas.
 
-| variable | value            |
-| -------- | ---------------------- |
-| COMMENT_FEATURE_ENABLE  | `true` or `false` |
+| variable               | value             |
+| ---------------------- | ----------------- |
+| COMMENT_FEATURE_ENABLE | `true` or `false` |
 
 #### Multiplayer feature enable ( optional )
 
 Use this environment variable to enable/disable the feature that allows users to collaboratively work on the canvas.
 
-| variable | value            |
-| -------- | ---------------------- |
-| ENABLE_MULTIPLAYER_EDITING  | `true` or `false` |
+| variable                   | value             |
+| -------------------------- | ----------------- |
+| ENABLE_MULTIPLAYER_EDITING | `true` or `false` |
 
 #### Marketplace feature enable ( optional )
 
 Use this environment variable to enable/disable the feature that allows users to use the [marketplace](/docs/marketplace).
 
-| variable | value            |
-| -------- | ---------------------- |
-| ENABLE_MARKETPLACE_FEATURE  | `true` or `false` |
+| variable                   | value             |
+| -------------------------- | ----------------- |
+| ENABLE_MARKETPLACE_FEATURE | `true` or `false` |
 
 #### Enable ToolJet Database ( optional )
 
-| variable           | description                                  |
-| ------------------ | -------------------------------------------- |
-| ENABLE_TOOLJET_DB  | `true` or `false`                            |
-| TOOLJET_DB         | Default value is `tooljet_db`                |
-| TOOLJET_DB_HOST    | database host                                |
-| TOOLJET_DB_USER    | database username                            |
-| TOOLJET_DB_PASS    | database password                            |
-| TOOLJET_DB_PORT    | database port                                |
-| PGRST_JWT_SECRET   | JWT token client provided for authentication |
-| PGRST_HOST         | postgrest database host                      |
+| variable          | description                                  |
+| ----------------- | -------------------------------------------- |
+| ENABLE_TOOLJET_DB | `true` or `false`                            |
+| TOOLJET_DB        | Default value is `tooljet_db`                |
+| TOOLJET_DB_HOST   | database host                                |
+| TOOLJET_DB_USER   | database username                            |
+| TOOLJET_DB_PASS   | database password                            |
+| TOOLJET_DB_PORT   | database port                                |
+| PGRST_JWT_SECRET  | JWT token client provided for authentication |
+| PGRST_HOST        | postgrest database host                      |
 
 Use `ENABLE_TOOLJET_DB` to enable/disable the feature that allows users to work with inbuilt data store to build apps with. Inorder to set it up, [follow the instructions here](/docs/tooljet-database#enabling-the-tooljet-database-for-your-instance).
 
@@ -104,7 +104,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the string and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -112,9 +112,9 @@ If you intent you use the string and if the connection does not support ssl. Ple
 
 You can specify a different server for backend if it is hosted on another server.
 
-| variable | value            |
-| -------- | ---------------------- |
-| SERVER_HOST  | Configure a hostname for the server as a proxy pass. If no value is set, it defaults to `server`. |
+| variable    | value                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------- |
+| SERVER_HOST | Configure a hostname for the server as a proxy pass. If no value is set, it defaults to `server`. |
 
 #### Disable Multi-Workspace ( optional )
 
@@ -190,24 +190,24 @@ Specify application monitoring vendor. Currently supported values - `sentry`.
 
 #### SENTRY DNS ( optional )
 
-| variable   | description                               |
-| ---------- | ----------------------------------------- |
-| SENTRY_DNS |  DSN tells a Sentry SDK where to send events so the events are associated with the correct project  |
+| variable   | description                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| SENTRY_DNS | DSN tells a Sentry SDK where to send events so the events are associated with the correct project |
 
 #### SENTRY DEBUG ( optional )
 
 Prints logs for sentry.
 
-| variable   | description                               |
-| ---------- | ----------------------------------------- |
+| variable     | description                                 |
+| ------------ | ------------------------------------------- |
 | SENTRY_DEBUG | `true` or `false`. Default value is `false` |
 
 #### Server URL ( optional)
 
 This is used to set up for CSP headers and put trace info to be used with APM vendors.
 
-| variable           | description                                                 |
-| ------------------ | ----------------------------------------------------------- |
+| variable           | description                                                  |
+| ------------------ | ------------------------------------------------------------ |
 | TOOLJET_SERVER_URL | the URL of ToolJet server ( eg: https://server.tooljet.com ) |
 
 #### RELEASE VERSION ( optional)
@@ -218,34 +218,35 @@ Once set any APM provider that supports segregation with releases will track it.
 
 Tooljet needs to be configured for custom CA certificate to be able to trust and establish connection over https. This requires you to configure an additional env var `NODE_EXTRA_CA_CERTS` to have absolute path to your CA certificates. This file named `cert.pem` needs to be in PEM format and can have more than one certificates.
 
-| variable            | description                                                       |
-| ------------------  | ----------------------------------------------------------------- |
+| variable            | description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
 | NODE_EXTRA_CA_CERTS | absolute path to certificate PEM file ( eg: /ToolJet/ca/cert.pem ) |
-
 
 #### Disable telemetry ( optional )
 
 Pings our server to update the total user count every 24 hours. You can disable this by setting the value of `DISABLE_TOOLJET_TELEMETRY` environment variable to `true`. This feature is enabled by default.
 
 #### Password Retry Limit (Optional)
+
 The maximum retry limit of login password for a user is by default set to 5, account will be locked after 5 unsuccessful login attempts. Use the variables mentioned below to control this behavior:
 
-| variable                              | description                                                   |
-| ------------------------------------- | -----------------------------------------------------------   |
-| DISABLE_PASSWORD_RETRY_LIMIT          | (true/false) To disable the password retry check, if value is `true` then no limits for password retry |
-| PASSWORD_RETRY_LIMIT                  | To change the default password retry limit (5) |
+| variable                     | description                                                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| DISABLE_PASSWORD_RETRY_LIMIT | (true/false) To disable the password retry check, if value is `true` then no limits for password retry |
+| PASSWORD_RETRY_LIMIT         | To change the default password retry limit (5)                                                         |
 
 #### SSO Configurations (Optional)
+
 Configurations for instance level SSO. Valid only if `DISABLE_MULTI_WORKSPACE` is not `true`.
 
-| variable                              | description                                                   |
-| ------------------------------------- | -----------------------------------------------------------   |
-| SSO_GOOGLE_OAUTH2_CLIENT_ID           | Google OAuth client id |
-| SSO_GIT_OAUTH2_CLIENT_ID              | GitHub OAuth client id |
-| SSO_GIT_OAUTH2_CLIENT_SECRET          | GitHub OAuth client secret |
-| SSO_GIT_OAUTH2_HOST                   | GitHub OAuth host name if GitHub is self hosted |
-| SSO_ACCEPTED_DOMAINS                  | comma separated email domains that supports SSO authentication |
-| SSO_DISABLE_SIGNUPS                   | Disable user sign up if authenticated user does not exist |
+| variable                     | description                                                    |
+| ---------------------------- | -------------------------------------------------------------- |
+| SSO_GOOGLE_OAUTH2_CLIENT_ID  | Google OAuth client id                                         |
+| SSO_GIT_OAUTH2_CLIENT_ID     | GitHub OAuth client id                                         |
+| SSO_GIT_OAUTH2_CLIENT_SECRET | GitHub OAuth client secret                                     |
+| SSO_GIT_OAUTH2_HOST          | GitHub OAuth host name if GitHub is self hosted                |
+| SSO_ACCEPTED_DOMAINS         | comma separated email domains that supports SSO authentication |
+| SSO_DISABLE_SIGNUPS          | Disable user sign up if authenticated user does not exist      |
 
 ## ToolJet client
 
@@ -253,29 +254,26 @@ Configurations for instance level SSO. Valid only if `DISABLE_MULTI_WORKSPACE` i
 
 This is required when client is built separately.
 
-| variable           | description                                                 |
-| ------------------ | ----------------------------------------------------------- |
+| variable           | description                                                  |
+| ------------------ | ------------------------------------------------------------ |
 | TOOLJET_SERVER_URL | the URL of ToolJet server ( eg: https://server.tooljet.com ) |
-
 
 #### Server Port ( optional)
 
 This could be used to for local development, it will set the server url like so: `http://localhost:<TOOLJET_SERVER_PORT>`
 
 | variable            | description                             |
-|---------------------|-----------------------------------------|
+| ------------------- | --------------------------------------- |
 | TOOLJET_SERVER_PORT | the port of ToolJet server ( eg: 3000 ) |
-
 
 #### Asset path ( optionally required )
 
 This is required when the assets for the client are to be loaded from elsewhere (eg: CDN).
 This can be an absolute path, or relative to main HTML file.
 
-| variable           | description                                                   |
-| ------------------ | -----------------------------------------------------------   |
-| ASSET_PATH         | the asset path for the website ( eg: https://app.tooljet.com/) |
-
+| variable   | description                                                    |
+| ---------- | -------------------------------------------------------------- |
+| ASSET_PATH | the asset path for the website ( eg: https://app.tooljet.com/) |
 
 #### Serve client as a server end-point ( optional )
 
@@ -284,11 +282,11 @@ If you intend to use client separately then can set `SERVE_CLIENT` to `false`.
 
 ## PostgREST server (Optional)
 
-| variable           | description                                     |
-| ------------------ | ----------------------------------------------- |
-| PGRST_JWT_SECRET   | JWT token client provided for authentication    |
-| PGRST_DB_URI       | database connection string for tooljet database |
-| PGRST_LOG_LEVEL    | `info`                                          |
+| variable         | description                                     |
+| ---------------- | ----------------------------------------------- |
+| PGRST_JWT_SECRET | JWT token client provided for authentication    |
+| PGRST_DB_URI     | database connection string for tooljet database |
+| PGRST_LOG_LEVEL  | `info`                                          |
 
 If you intent to make changes in the above configuration. Please refer [PostgREST configuration docs](https://postgrest.org/en/stable/configuration.html#environment-variables).
 

--- a/docs/versioned_docs/version-2.2.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.2.0/setup/env-vars.md
@@ -46,6 +46,11 @@ ToolJet server uses PostgreSQL as the database.
 If you are using docker-compose setup, you can set PG_HOST as `postgres` which will be DNS resolved by docker
 :::
 
+:::info
+If you intent you use the string and if the connection does not support ssl. Please use the below format.
+`postgres://username:password@hostname:port/database_name?sslmode=disable`
+:::
+
 ### Disable database and extension creation (optional)
 
 ToolJet by default tries to create database based on `PG_DB` variable set and additionally my try to create postgres extensions. This requires the postgres user to have CREATEDB permission. If this cannot be granted you can disable this behaviour by setting `PG_DB_OWNER` as `false` and will have to manually run them.
@@ -96,6 +101,11 @@ Use `ENABLE_TOOLJET_DB` to enable/disable the feature that allows users to work 
 :::tip
 When this feature is enabled, the database name provided for `TOOLJET_DB` will be utilized to create a new database during server boot process in all of our production deploy setups.
 Incase you want to trigger it manually, use the command `npm run db:create` on ToolJet server.
+:::
+
+:::info
+If you intent you use the string and if the connection does not support ssl. Please use the below format.
+`postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
 #### Server Host ( optional )

--- a/docs/versioned_docs/version-2.2.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.2.0/setup/env-vars.md
@@ -47,7 +47,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the string and if the connection does not support ssl. Please use the below format.
+If you intent you use the string and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -104,7 +104,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the string and if the connection does not support ssl. Please use the below format.
+If you intent you use the string and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.2.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.2.0/setup/env-vars.md
@@ -11,9 +11,9 @@ Both the ToolJet server and client requires some environment variables to start 
 
 #### ToolJet host ( required )
 
-| variable     | description                                                     |
-| ------------ | --------------------------------------------------------------- |
-| TOOLJET_HOST | the public URL of ToolJet client ( eg: https://app.tooljet.com )  |
+| variable     | description                                                      |
+| ------------ | ---------------------------------------------------------------- |
+| TOOLJET_HOST | the public URL of ToolJet client ( eg: https://app.tooljet.com ) |
 
 #### Lockbox configuration ( required )
 
@@ -47,7 +47,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the string and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -63,38 +63,38 @@ Self-hosted version of ToolJet pings our server to fetch the latest product upda
 
 Use this environment variable to enable/disable the feature that allows you to add comments on the canvas.
 
-| variable | value            |
-| -------- | ---------------------- |
-| COMMENT_FEATURE_ENABLE  | `true` or `false` |
+| variable               | value             |
+| ---------------------- | ----------------- |
+| COMMENT_FEATURE_ENABLE | `true` or `false` |
 
 #### Multiplayer feature enable ( optional )
 
 Use this environment variable to enable/disable the feature that allows users to collaboratively work on the canvas.
 
-| variable | value            |
-| -------- | ---------------------- |
-| ENABLE_MULTIPLAYER_EDITING  | `true` or `false` |
+| variable                   | value             |
+| -------------------------- | ----------------- |
+| ENABLE_MULTIPLAYER_EDITING | `true` or `false` |
 
 #### Marketplace feature enable ( optional )
 
 Use this environment variable to enable/disable the feature that allows users to use the [marketplace](/docs/marketplace).
 
-| variable | value            |
-| -------- | ---------------------- |
-| ENABLE_MARKETPLACE_FEATURE  | `true` or `false` |
+| variable                   | value             |
+| -------------------------- | ----------------- |
+| ENABLE_MARKETPLACE_FEATURE | `true` or `false` |
 
 #### Enable ToolJet Database ( optional )
 
-| variable           | description                                  |
-| ------------------ | -------------------------------------------- |
-| ENABLE_TOOLJET_DB  | `true` or `false`                            |
-| TOOLJET_DB         | Default value is `tooljet_db`                |
-| TOOLJET_DB_HOST    | database host                                |
-| TOOLJET_DB_USER    | database username                            |
-| TOOLJET_DB_PASS    | database password                            |
-| TOOLJET_DB_PORT    | database port                                |
-| PGRST_JWT_SECRET   | JWT token client provided for authentication |
-| PGRST_HOST         | postgrest database host                      |
+| variable          | description                                  |
+| ----------------- | -------------------------------------------- |
+| ENABLE_TOOLJET_DB | `true` or `false`                            |
+| TOOLJET_DB        | Default value is `tooljet_db`                |
+| TOOLJET_DB_HOST   | database host                                |
+| TOOLJET_DB_USER   | database username                            |
+| TOOLJET_DB_PASS   | database password                            |
+| TOOLJET_DB_PORT   | database port                                |
+| PGRST_JWT_SECRET  | JWT token client provided for authentication |
+| PGRST_HOST        | postgrest database host                      |
 
 Use `ENABLE_TOOLJET_DB` to enable/disable the feature that allows users to work with inbuilt data store to build apps with. Inorder to set it up, [follow the instructions here](/docs/tooljet-database#enabling-the-tooljet-database-for-your-instance).
 
@@ -104,7 +104,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the string and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -112,9 +112,9 @@ If you intent you use the string and if the connection does not support ssl. Ple
 
 You can specify a different server for backend if it is hosted on another server.
 
-| variable | value            |
-| -------- | ---------------------- |
-| SERVER_HOST  | Configure a hostname for the server as a proxy pass. If no value is set, it defaults to `server`. |
+| variable    | value                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------- |
+| SERVER_HOST | Configure a hostname for the server as a proxy pass. If no value is set, it defaults to `server`. |
 
 #### Disable Multi-Workspace ( optional )
 
@@ -190,24 +190,24 @@ Specify application monitoring vendor. Currently supported values - `sentry`.
 
 #### SENTRY DNS ( optional )
 
-| variable   | description                               |
-| ---------- | ----------------------------------------- |
-| SENTRY_DNS |  DSN tells a Sentry SDK where to send events so the events are associated with the correct project  |
+| variable   | description                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| SENTRY_DNS | DSN tells a Sentry SDK where to send events so the events are associated with the correct project |
 
 #### SENTRY DEBUG ( optional )
 
 Prints logs for sentry.
 
-| variable   | description                               |
-| ---------- | ----------------------------------------- |
+| variable     | description                                 |
+| ------------ | ------------------------------------------- |
 | SENTRY_DEBUG | `true` or `false`. Default value is `false` |
 
 #### Server URL ( optional)
 
 This is used to set up for CSP headers and put trace info to be used with APM vendors.
 
-| variable           | description                                                 |
-| ------------------ | ----------------------------------------------------------- |
+| variable           | description                                                  |
+| ------------------ | ------------------------------------------------------------ |
 | TOOLJET_SERVER_URL | the URL of ToolJet server ( eg: https://server.tooljet.com ) |
 
 #### RELEASE VERSION ( optional)
@@ -218,34 +218,35 @@ Once set any APM provider that supports segregation with releases will track it.
 
 Tooljet needs to be configured for custom CA certificate to be able to trust and establish connection over https. This requires you to configure an additional env var `NODE_EXTRA_CA_CERTS` to have absolute path to your CA certificates. This file named `cert.pem` needs to be in PEM format and can have more than one certificates.
 
-| variable            | description                                                       |
-| ------------------  | ----------------------------------------------------------------- |
+| variable            | description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
 | NODE_EXTRA_CA_CERTS | absolute path to certificate PEM file ( eg: /ToolJet/ca/cert.pem ) |
-
 
 #### Disable telemetry ( optional )
 
 Pings our server to update the total user count every 24 hours. You can disable this by setting the value of `DISABLE_TOOLJET_TELEMETRY` environment variable to `true`. This feature is enabled by default.
 
 #### Password Retry Limit (Optional)
+
 The maximum retry limit of login password for a user is by default set to 5, account will be locked after 5 unsuccessful login attempts. Use the variables mentioned below to control this behavior:
 
-| variable                              | description                                                   |
-| ------------------------------------- | -----------------------------------------------------------   |
-| DISABLE_PASSWORD_RETRY_LIMIT          | (true/false) To disable the password retry check, if value is `true` then no limits for password retry |
-| PASSWORD_RETRY_LIMIT                  | To change the default password retry limit (5) |
+| variable                     | description                                                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| DISABLE_PASSWORD_RETRY_LIMIT | (true/false) To disable the password retry check, if value is `true` then no limits for password retry |
+| PASSWORD_RETRY_LIMIT         | To change the default password retry limit (5)                                                         |
 
 #### SSO Configurations (Optional)
+
 Configurations for instance level SSO. Valid only if `DISABLE_MULTI_WORKSPACE` is not `true`.
 
-| variable                              | description                                                   |
-| ------------------------------------- | -----------------------------------------------------------   |
-| SSO_GOOGLE_OAUTH2_CLIENT_ID           | Google OAuth client id |
-| SSO_GIT_OAUTH2_CLIENT_ID              | GitHub OAuth client id |
-| SSO_GIT_OAUTH2_CLIENT_SECRET          | GitHub OAuth client secret |
-| SSO_GIT_OAUTH2_HOST                   | GitHub OAuth host name if GitHub is self hosted |
-| SSO_ACCEPTED_DOMAINS                  | comma separated email domains that supports SSO authentication |
-| SSO_DISABLE_SIGNUPS                   | Disable user sign up if authenticated user does not exist |
+| variable                     | description                                                    |
+| ---------------------------- | -------------------------------------------------------------- |
+| SSO_GOOGLE_OAUTH2_CLIENT_ID  | Google OAuth client id                                         |
+| SSO_GIT_OAUTH2_CLIENT_ID     | GitHub OAuth client id                                         |
+| SSO_GIT_OAUTH2_CLIENT_SECRET | GitHub OAuth client secret                                     |
+| SSO_GIT_OAUTH2_HOST          | GitHub OAuth host name if GitHub is self hosted                |
+| SSO_ACCEPTED_DOMAINS         | comma separated email domains that supports SSO authentication |
+| SSO_DISABLE_SIGNUPS          | Disable user sign up if authenticated user does not exist      |
 
 ## ToolJet client
 
@@ -253,29 +254,26 @@ Configurations for instance level SSO. Valid only if `DISABLE_MULTI_WORKSPACE` i
 
 This is required when client is built separately.
 
-| variable           | description                                                 |
-| ------------------ | ----------------------------------------------------------- |
+| variable           | description                                                  |
+| ------------------ | ------------------------------------------------------------ |
 | TOOLJET_SERVER_URL | the URL of ToolJet server ( eg: https://server.tooljet.com ) |
-
 
 #### Server Port ( optional)
 
 This could be used to for local development, it will set the server url like so: `http://localhost:<TOOLJET_SERVER_PORT>`
 
 | variable            | description                             |
-|---------------------|-----------------------------------------|
+| ------------------- | --------------------------------------- |
 | TOOLJET_SERVER_PORT | the port of ToolJet server ( eg: 3000 ) |
-
 
 #### Asset path ( optionally required )
 
 This is required when the assets for the client are to be loaded from elsewhere (eg: CDN).
 This can be an absolute path, or relative to main HTML file.
 
-| variable           | description                                                   |
-| ------------------ | -----------------------------------------------------------   |
-| ASSET_PATH         | the asset path for the website ( eg: https://app.tooljet.com/) |
-
+| variable   | description                                                    |
+| ---------- | -------------------------------------------------------------- |
+| ASSET_PATH | the asset path for the website ( eg: https://app.tooljet.com/) |
 
 #### Serve client as a server end-point ( optional )
 
@@ -284,11 +282,11 @@ If you intend to use client separately then can set `SERVE_CLIENT` to `false`.
 
 ## PostgREST server (Optional)
 
-| variable           | description                                     |
-| ------------------ | ----------------------------------------------- |
-| PGRST_JWT_SECRET   | JWT token client provided for authentication    |
-| PGRST_DB_URI       | database connection string for tooljet database |
-| PGRST_LOG_LEVEL    | `info`                                          |
+| variable         | description                                     |
+| ---------------- | ----------------------------------------------- |
+| PGRST_JWT_SECRET | JWT token client provided for authentication    |
+| PGRST_DB_URI     | database connection string for tooljet database |
+| PGRST_LOG_LEVEL  | `info`                                          |
 
 If you intent to make changes in the above configuration. Please refer [PostgREST configuration docs](https://postgrest.org/en/stable/configuration.html#environment-variables).
 

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -17,8 +17,8 @@ if [ -z "$DATABASE_URL" ]
 then
      ./server/scripts/wait-for-it.sh $PG_HOST:${PG_PORT:-5432} --strict --timeout=300 -- $SETUP_CMD
 else 
-     PG_HOST=$(echo "$DATABASE_URL" | sed -e 's/postgres:\/\///' -e 's/\([^@]*@\)\?//' | cut -d ':' -f 1)
-     PG_PORT=$(echo "$DATABASE_URL" | sed -e 's/postgres:\/\///' -e 's/\([^@]*@\)\?//' | cut -d ':' -f 2 | cut -d '/' -f 1)
+     PG_HOST=$(echo "$DATABASE_URL" | awk -F[@/:] '{print $4}')
+     PG_PORT=$(echo "$DATABASE_URL" | awk -F'[@/]' '{split($5,a,":"); print a[2] ? a[2] : "5432"}')
      ./server/scripts/wait-for-it.sh "$PG_HOST:$PG_PORT" --strict --timeout=300 -- $SETUP_CMD
 fi
 

--- a/server/scripts/database-config-utils.ts
+++ b/server/scripts/database-config-utils.ts
@@ -31,8 +31,8 @@ export function getEnvVars() {
 }
 
 function buildDbConfigFromDatabaseURL(data): any {
-  const config = buildDbConfigFromUrl(data.DATABASE_URL)
-  const TJDBconfig = buildDbConfigFromUrl(data.TOOLJET_DB_URL)
+  const config = buildDbConfigFromUrl(data.DATABASE_URL);
+  const TJDBconfig = buildDbConfigFromUrl(data.TOOLJET_DB_URL);
 
   const { value: dbConfig, error } = validateDatabaseConfig({
     DATABASE_URL: data.DATBASE_URL,
@@ -54,9 +54,7 @@ function buildDbConfigFromDatabaseURL(data): any {
   if (error) {
     throw new Error(`Config validation error: ${error.message}`);
   }
-
   return removeEmptyKeys(dbConfig);
-
 }
 
 function buildDbConfigFromUrl(dbURL): any {

--- a/server/scripts/database-config-utils.ts
+++ b/server/scripts/database-config-utils.ts
@@ -94,7 +94,7 @@ function validateDatabaseConfig(dbConfig: any): Joi.ValidationResult {
       PG_USER: Joi.string().required(),
       PG_DB: Joi.string().default('tooljet_production'),
       PG_DB_OWNER: Joi.string().default('true'),
-      ...((dbConfig.ENABLE_TOOLJET_DB === 'true') && {
+      ...(dbConfig.ENABLE_TOOLJET_DB === 'true' && {
         TOOLJET_DB_HOST: Joi.string().default('localhost'),
         TOOLJET_DB_PORT: Joi.number().positive().default(5432),
         TOOLJET_DB_PASS: Joi.string().default(''),


### PR DESCRIPTION
- The issue was that when we pass a string without the port value (eg: postgre://postgres:postgres@postgres/tooljet_development), It was not taking a default port value to 5432. Also instead of using sed, changed it to awk and pulled the value according to the field.

- Also added the information in env-vars document.

- Fixed the issue lint action in ci 