### PR TITLE
New version creation flow enhancement while building an app #5732 Solved

### DIFF
--- a/frontend/src/Editor/AppVersionsManager/CreateVersionModal.jsx
+++ b/frontend/src/Editor/AppVersionsManager/CreateVersionModal.jsx
@@ -97,7 +97,7 @@ export const CreateVersion = ({
           <div className="ts-control" data-cy="create-version-from-input-field">
             <Select
               options={options}
-              defaultValue={options[options.length - 1]}
+              defaultValue={options[0]}
               onChange={(version) => {
                 setAppDefinitionFromVersion(version, false);
               }}


### PR DESCRIPTION
Made changes to the file https://github.com/ToolJet/ToolJet/blob/develop/frontend/src/Editor/AppVersionsManager/CreateVersionModal.jsx on line 100. The dialog was always showing the first version and not the latest one. 
The problem was that the default value was set to the last element of array which was the first element as the array was passed in descending order. Just had to put default value as first element of array.