### PR TITLE
Bugfix: Remove the unnecessary `Apps` text from breadcrumbs

### DIFF
--- a/frontend/src/_ui/Breadcrumbs/index.jsx
+++ b/frontend/src/_ui/Breadcrumbs/index.jsx
@@ -3,8 +3,7 @@ import { Link } from 'react-router-dom';
 import useBreadcrumbs from 'use-react-router-breadcrumbs';
 
 export const Breadcrumbs = () => {
-  const breadcrumbs = useBreadcrumbs(routes, { excludePaths: ['/'] });
-
+  const breadcrumbs = useBreadcrumbs(routes, { excludePaths: ['/', '/:workspace'] });
   return (
     <ol className="breadcrumb breadcrumb-arrows">
       {breadcrumbs.length === 0 && (


### PR DESCRIPTION
There was an issue that `Apps` was coming on other pages also. 
<img width="223" alt="Screenshot 2023-04-19 at 5 20 01 PM" src="https://user-images.githubusercontent.com/50338945/233066026-30d1eec0-63e3-4c3c-9e5f-76a233e60231.png">

The issue was coming because multiple routes matched with the `/:workspace` route string, so the first route was getting attached to every other route which had `/:workspace` in the route name.

To remove the `Apps` text from the table and workspace setting routes, I am just excluding the `/: workspace` route, because we already take care of that part when we compare `breadcrumbs.length === 0` or not.