### PR TITLE
Change default server listen addr to '::' for dual IPv6/IPv4 support

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -97,9 +97,10 @@ async function bootstrap() {
     defaultVersion: VERSION_NEUTRAL,
   });
 
+  const listen_addr = process.env.LISTEN_ADDR || "::";
   const port = parseInt(process.env.PORT) || 3000;
 
-  await app.listen(port, '0.0.0.0', function () {
+  await app.listen(port, listen_addr, function () {
     const tooljetHost = configService.get<string>('TOOLJET_HOST');
     console.log(`Ready to use at ${tooljetHost} 🚀`);
   });


### PR DESCRIPTION
Add a `LISTEN_ADDR` environment variable for configuration of the IP address/hostname the server binds to.

`LISTEN_ADDR` defaults to `'::'` so the server supports both IPv6 and IPv4 by default.