### PR TITLE
bug-fix: 🐛 - handle when a filter exist for equal & null

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -56,7 +56,6 @@ function buildPostgrestQuery(filters) {
 async function listRows(queryOptions, organizationId, currentState) {
   let query = [];
   const resolvedOptions = resolveReferences(queryOptions, currentState);
-  console.log('resolvedOptions', resolvedOptions);
   if (hasEqualWithNull(resolvedOptions, 'list_rows')) {
     return {
       status: 'failed',

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -60,7 +60,7 @@ async function listRows(queryOptions, organizationId, currentState) {
     return {
       status: 'failed',
       statusText: 'failed',
-      message: 'Null value comparison not allowed with equal/not equal operator, Please use IS operator instead.',
+      message: 'Null value comparison not allowed, To check null values Please use IS operator instead.',
       description: 'Is operator should be used with null value comparision.',
       data: {},
     };
@@ -105,7 +105,7 @@ async function updateRows(queryOptions, organizationId, currentState) {
     return {
       status: 'failed',
       statusText: 'failed',
-      message: 'Null value comparison not allowed with equal/not equal operator, Please use IS operator instead.',
+      message: 'Null value comparison not allowed, To check null values Please use IS operator instead.',
       description: 'Is operator should be used with null value comparision.',
       data: {},
     };
@@ -131,7 +131,7 @@ async function deleteRows(queryOptions, organizationId, currentState) {
     return {
       status: 'failed',
       statusText: 'failed',
-      message: 'Null value comparison not allowed with equal/not equal operator, Please use IS operator instead.',
+      message: 'Null value comparison not allowed, To check null values Please use IS operator instead.',
       description: 'Is operator should be used with null value comparision.',
       data: {},
     };

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -2,12 +2,25 @@ import { tooljetDatabaseService } from '@/_services';
 import { isEmpty } from 'lodash';
 import PostgrestQueryBuilder from '@/_helpers/postgrestQueryBuilder';
 import { resolveReferences } from '@/_helpers/utils';
+import { hasEqualWithNull } from './util';
 
 export const tooljetDbOperations = {
   perform,
 };
 
 async function perform(queryOptions, organizationId, currentState) {
+  const hasNullWithEqual = hasEqualWithNull(queryOptions);
+  // SQL does not support equal operation with null value, so let's handle it here.
+  if (hasNullWithEqual) {
+    return {
+      status: 'failed',
+      statusText: 'failed',
+      message: 'Query can not run, because app can not perform equal operation with null value',
+      description: 'Please use IS operator with the null value comparision.',
+      data: {},
+    };
+  }
+
   switch (queryOptions.operation) {
     case 'list_rows':
       return listRows(queryOptions, organizationId, currentState);

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -9,18 +9,6 @@ export const tooljetDbOperations = {
 };
 
 async function perform(queryOptions, organizationId, currentState) {
-  const hasNullWithEqual = hasEqualWithNull(queryOptions);
-  // SQL does not support equal operation with null value, so let's handle it here.
-  if (hasNullWithEqual) {
-    return {
-      status: 'failed',
-      statusText: 'failed',
-      message: 'Query can not run, because app can not perform equal operation with null value',
-      description: 'Please use IS operator with the null value comparision.',
-      data: {},
-    };
-  }
-
   switch (queryOptions.operation) {
     case 'list_rows':
       return listRows(queryOptions, organizationId, currentState);
@@ -68,6 +56,16 @@ function buildPostgrestQuery(filters) {
 async function listRows(queryOptions, organizationId, currentState) {
   let query = [];
   const resolvedOptions = resolveReferences(queryOptions, currentState);
+  console.log('resolvedOptions', resolvedOptions);
+  if (hasEqualWithNull(resolvedOptions, 'list_rows')) {
+    return {
+      status: 'failed',
+      statusText: 'failed',
+      message: 'Null value comparison not allowed with equal/not equal operator, Please use IS operator instead.',
+      description: 'Is operator should be used with null value comparision.',
+      data: {},
+    };
+  }
   const { table_name: tableName, list_rows: listRows } = resolvedOptions;
 
   if (!isEmpty(listRows)) {
@@ -104,6 +102,15 @@ async function createRow(queryOptions, organizationId, currentState) {
 
 async function updateRows(queryOptions, organizationId, currentState) {
   const resolvedOptions = resolveReferences(queryOptions, currentState);
+  if (hasEqualWithNull(resolvedOptions, 'update_rows')) {
+    return {
+      status: 'failed',
+      statusText: 'failed',
+      message: 'Null value comparison not allowed with equal/not equal operator, Please use IS operator instead.',
+      description: 'Is operator should be used with null value comparision.',
+      data: {},
+    };
+  }
   const { table_name: tableName, update_rows: updateRows } = resolvedOptions;
   const { where_filters: whereFilters, columns } = updateRows;
 
@@ -121,6 +128,15 @@ async function updateRows(queryOptions, organizationId, currentState) {
 
 async function deleteRows(queryOptions, organizationId, currentState) {
   const resolvedOptions = resolveReferences(queryOptions, currentState);
+  if (hasEqualWithNull(resolvedOptions, 'delete_rows')) {
+    return {
+      status: 'failed',
+      statusText: 'failed',
+      message: 'Null value comparison not allowed with equal/not equal operator, Please use IS operator instead.',
+      description: 'Is operator should be used with null value comparision.',
+      data: {},
+    };
+  }
   const { table_name: tableName, delete_rows: deleteRows = { whereFilters: {} } } = resolvedOptions;
   const { where_filters: whereFilters, limit = 1 } = deleteRows;
 

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/util.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/util.js
@@ -21,13 +21,13 @@ import { get } from 'lodash';
  *
  * const result = hasEqualWithNull(queryOptions); // true
  */
-export const hasEqualWithNull = (queryOptions) => {
-  const filters = get(queryOptions, 'list_rows.where_filters');
+export const hasEqualWithNull = (queryOptions, operation) => {
+  const filters = get(queryOptions, `${operation}.where_filters`);
   if (filters) {
     const filterKeys = Object.keys(filters);
     for (let i = 0; i < filterKeys.length; i++) {
       const filter = filters[filterKeys[i]];
-      if (filter.operator === 'eq' && filter.value === '{{null}}') {
+      if ((filter.operator === 'eq' || filter.operator === 'neq') && filter.value === null) {
         return true;
       }
     }

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/util.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/util.js
@@ -27,7 +27,7 @@ export const hasEqualWithNull = (queryOptions, operation) => {
     const filterKeys = Object.keys(filters);
     for (let i = 0; i < filterKeys.length; i++) {
       const filter = filters[filterKeys[i]];
-      if ((filter.operator === 'eq' || filter.operator === 'neq') && filter.value === null) {
+      if (filter.operator !== 'is' && filter.value === null) {
         return true;
       }
     }

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/util.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/util.js
@@ -1,0 +1,36 @@
+import { get } from 'lodash';
+/**
+ * Checks if the queryOptions object contains a filter with an 'eq' (equal) operator and a value equal to '{{null}}'.
+ *
+ * @function hasEqualWithNull
+ * @param {Object} queryOptions - The query options object to check for the presence of the specified filter.
+ * @property {Object} queryOptions.list_rows.where_filters - An object containing the filters to be checked.
+ * @returns {boolean} - Returns true if the specified filter is found, false otherwise.
+ *
+ * @example
+ * const queryOptions = {
+ *   list_rows: {
+ *     where_filters: {
+ *       filter1: {
+ *         operator: 'eq',
+ *         value: '{{null}}',
+ *       },
+ *     },
+ *   },
+ * };
+ *
+ * const result = hasEqualWithNull(queryOptions); // true
+ */
+export const hasEqualWithNull = (queryOptions) => {
+  const filters = get(queryOptions, 'list_rows.where_filters');
+  if (filters) {
+    const filterKeys = Object.keys(filters);
+    for (let i = 0; i < filterKeys.length; i++) {
+      const filter = filters[filterKeys[i]];
+      if (filter.operator === 'eq' && filter.value === '{{null}}') {
+        return true;
+      }
+    }
+  }
+  return false;
+};


### PR DESCRIPTION
- This code change handles when a user selects `equal` filter with `null` value. It stops the query execution and thorws an error message with the text `Query can not run, because app can not perform equal operation with null value`

Closes #5616 