### PR TITLE
[fix] camel paths are converted with underscore while populating the OpenAPI plugin operations field causing internal server error & crashing OpenAPI queries when the user changes the datasource

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/Openapi.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Openapi.jsx
@@ -149,7 +149,11 @@ class OpenapiComponent extends React.Component {
       return servers.map((url) => {
         return url.url;
       });
-    } else if (path && this.state.spec.paths[path]['servers'] && this.state.spec?.paths[path]['servers'].length > 0) {
+    } else if (
+      path &&
+      this.state.spec.paths[path]?.['servers'] &&
+      this.state.spec.paths[path]?.['servers'].length > 0
+    ) {
       const servers = this.state.spec.paths[path]['servers'];
       return servers.map((url) => {
         return url.url;
@@ -167,7 +171,7 @@ class OpenapiComponent extends React.Component {
     const path = this.state.options.path;
 
     if (operation.parameters) {
-      if (this.state.spec.paths[path]['parameters']) {
+      if (this.state.spec.paths[path]?.['parameters']) {
         const generalParams = this.state.spec.paths[path]['parameters'].filter((param) => param.in === paramType);
         const operationParams = operation.parameters.filter((param) => param.in === paramType);
         const result = generalParams.concat(operationParams).filter(function (o) {
@@ -176,7 +180,7 @@ class OpenapiComponent extends React.Component {
         return result;
       }
       return operation.parameters.filter((param) => param.in === paramType);
-    } else if (this.state.spec.paths[path]['parameters'])
+    } else if (this.state.spec.paths[path]?.['parameters'])
       return this.state.spec.paths[path]['parameters'].filter((param) => param.in === paramType);
     else return [];
   }

--- a/server/src/controllers/global_data_sources.controller.ts
+++ b/server/src/controllers/global_data_sources.controller.ts
@@ -45,8 +45,7 @@ export class GlobalDataSourcesController {
       }
     }
 
-    const decamelizedDatasources = [];
-    dataSources.forEach((dataSource) => {
+    const decamelizedDatasources = dataSources.map((dataSource) => {
       if (dataSource.kind === 'openapi') {
         const { options, ...objExceptOptions } = dataSource;
         const tempDs = decamelizeKeys(objExceptOptions);
@@ -54,10 +53,9 @@ export class GlobalDataSourcesController {
         const decamelizedOptions = decamelizeKeys(objExceptSpec);
         decamelizedOptions['spec'] = spec;
         tempDs['options'] = decamelizedOptions;
-        return decamelizedDatasources.push(tempDs);
-      } else {
-        decamelizedDatasources.push(decamelizeKeys(dataSource));
+        return tempDs;
       }
+      return decamelizeKeys(dataSource);
     });
 
     return { data_sources: decamelizedDatasources };

--- a/server/src/controllers/global_data_sources.controller.ts
+++ b/server/src/controllers/global_data_sources.controller.ts
@@ -45,8 +45,8 @@ export class GlobalDataSourcesController {
       }
     }
     return decamelizeKeys({ data_sources: dataSources }, function (key, convert, options) {
-      const checkForKeysAsPath = /^(\/{0,1}(?!\/))[A-Za-z0-9/\-_]+(.([a-zA-Z]+))?$/gm;
-      return checkForKeysAsPath.test(key) ? key : convert(key, options);
+      const checkForKeysAsPath = key.startsWith('/');
+      return checkForKeysAsPath ? key : convert(key, options);
     });
   }
 

--- a/server/src/controllers/global_data_sources.controller.ts
+++ b/server/src/controllers/global_data_sources.controller.ts
@@ -44,10 +44,22 @@ export class GlobalDataSourcesController {
         );
       }
     }
-    return decamelizeKeys({ data_sources: dataSources }, function (key, convert, options) {
-      const checkForKeysAsPath = key.startsWith('/');
-      return checkForKeysAsPath ? key : convert(key, options);
+
+    const decamelizedDatasources = [];
+    dataSources.forEach((dataSource) => {
+      if (dataSource.kind === 'openapi') {
+        const { options, ...objExceptOptions } = dataSource;
+        const tempDs = decamelizeKeys(objExceptOptions);
+        const { spec, ...objExceptSpec } = options;
+        const decamelizedOptions = decamelizeKeys(objExceptSpec);
+        decamelizedOptions['spec'] = spec;
+        tempDs['options'] = decamelizedOptions;
+        return decamelizedDatasources.push(tempDs);
+      }
+      decamelizedDatasources.push(dataSource);
     });
+
+    return { data_sources: decamelizedDatasources };
   }
 
   @UseGuards(JwtAuthGuard)

--- a/server/src/controllers/global_data_sources.controller.ts
+++ b/server/src/controllers/global_data_sources.controller.ts
@@ -55,8 +55,9 @@ export class GlobalDataSourcesController {
         decamelizedOptions['spec'] = spec;
         tempDs['options'] = decamelizedOptions;
         return decamelizedDatasources.push(tempDs);
+      } else {
+        decamelizedDatasources.push(decamelizeKeys(dataSource));
       }
-      decamelizedDatasources.push(dataSource);
     });
 
     return { data_sources: decamelizedDatasources };


### PR DESCRIPTION
Resolves #6117