### PR TITLE
Fix :: Filepicker allowing all types even after providing accepted file types

### DIFF
--- a/frontend/src/Editor/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Components/FilePicker.jsx
@@ -89,7 +89,7 @@ export const FilePicker = ({
 
   const { getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject, acceptedFiles, fileRejections } =
     useDropzone({
-      accept: parsedFileType,
+      accept: { parsedFileType: [parsedFileType] },
       noClick: !parsedEnablePicker || disablePicker,
       noDrag: !parsedEnableDropzone || disablePicker,
       noKeyboard: true,


### PR DESCRIPTION
closes #6162
