### PR TITLE
#6120 Added pointer to dropdown in PopoverContent

### DIFF
--- a/frontend/src/_styles/popover.scss
+++ b/frontend/src/_styles/popover.scss
@@ -9,6 +9,10 @@
   box-shadow: 0px 12px 16px -4px rgba(16, 24, 40, 0.08), 0px 4px 6px -2px rgba(16, 24, 40, 0.03);
   border-radius: 0 8px 8px 0;
   overflow: auto;
+
+  select {
+    cursor: pointer;
+  }
 }
 
 .PopoverContent-dark {


### PR DESCRIPTION
Added a CSS clause to set the select dropdown inside the PopoverContent class to have a cursor: pointer.

<img width="1800" alt="Screenshot 2023-04-27 at 7 37 25 AM" src="https://user-images.githubusercontent.com/102206/234897390-ccaff594-6d0b-4056-8109-b6301e89a0c5.png">
