### PR TITLE
feat: Add is operator in tooljet db query manager

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DeleteRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DeleteRows.jsx
@@ -4,6 +4,7 @@ import { uniqueId } from 'lodash';
 import { CodeHinter } from '@/Editor/CodeBuilder/CodeHinter';
 import Select from '@/_ui/Select';
 import { operators } from '@/TooljetDatabase/constants';
+import { isOperatorOptions } from './util';
 
 export const DeleteRows = React.memo(({ currentState, darkMode }) => {
   const { columns, deleteOperationLimitOptionChanged, deleteRowsOptions, handleDeleteRowsOptionsChange } =
@@ -83,15 +84,25 @@ export const DeleteRows = React.memo(({ currentState, darkMode }) => {
             />
           </div>
           <div className="field col-4">
-            <CodeHinter
-              currentState={currentState}
-              initialValue={value ? (typeof value === 'string' ? value : JSON.stringify(value)) : value}
-              className="codehinter-plugins"
-              theme={darkMode ? 'monokai' : 'default'}
-              height={'32px'}
-              placeholder="key"
-              onChange={(newValue) => handleValueChange(newValue)}
-            />
+            {operator === 'is' ? (
+              <Select
+                useMenuPortal={true}
+                placeholder="Select value"
+                value={value}
+                options={isOperatorOptions}
+                onChange={handleValueChange}
+              />
+            ) : (
+              <CodeHinter
+                currentState={currentState}
+                initialValue={value ? (typeof value === 'string' ? value : JSON.stringify(value)) : value}
+                className="codehinter-plugins"
+                theme={darkMode ? 'monokai' : 'default'}
+                height={'32px'}
+                placeholder="key"
+                onChange={(newValue) => handleValueChange(newValue)}
+              />
+            )}
           </div>
           <div className="col-1 cursor-pointer m-1 mr-2">
             <svg

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ListRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ListRows.jsx
@@ -4,11 +4,7 @@ import { TooljetDatabaseContext } from '@/TooljetDatabase/index';
 import { uniqueId } from 'lodash';
 import Select from '@/_ui/Select';
 import { operators } from '@/TooljetDatabase/constants';
-
-const isOperatorOptions = [
-  { value: 'null', label: 'null' },
-  { value: 'notNull', label: 'not null' },
-];
+import { isOperatorOptions } from './util';
 
 export const ListRows = React.memo(({ currentState, darkMode }) => {
   const { columns, listRowsOptions, limitOptionChanged, handleOptionsChange } = useContext(TooljetDatabaseContext);
@@ -99,9 +95,6 @@ export const ListRows = React.memo(({ currentState, darkMode }) => {
       updateFilterOptionsChanged({ ...listRowsOptions?.where_filters[id], ...{ value: newValue } });
     };
 
-    console.log('value', value);
-    console.log('operator', operator);
-
     return (
       <div className="mt-1 row-container">
         <div className="d-flex fields-container">
@@ -127,7 +120,7 @@ export const ListRows = React.memo(({ currentState, darkMode }) => {
             {operator === 'is' ? (
               <Select
                 useMenuPortal={true}
-                placeholder="Select operation"
+                placeholder="Select value"
                 value={value}
                 options={isOperatorOptions}
                 onChange={handleValueChange}

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ListRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ListRows.jsx
@@ -5,6 +5,11 @@ import { uniqueId } from 'lodash';
 import Select from '@/_ui/Select';
 import { operators } from '@/TooljetDatabase/constants';
 
+const isOperatorOptions = [
+  { value: 'null', label: 'null' },
+  { value: 'notNull', label: 'not null' },
+];
+
 export const ListRows = React.memo(({ currentState, darkMode }) => {
   const { columns, listRowsOptions, limitOptionChanged, handleOptionsChange } = useContext(TooljetDatabaseContext);
 
@@ -94,6 +99,9 @@ export const ListRows = React.memo(({ currentState, darkMode }) => {
       updateFilterOptionsChanged({ ...listRowsOptions?.where_filters[id], ...{ value: newValue } });
     };
 
+    console.log('value', value);
+    console.log('operator', operator);
+
     return (
       <div className="mt-1 row-container">
         <div className="d-flex fields-container">
@@ -116,15 +124,25 @@ export const ListRows = React.memo(({ currentState, darkMode }) => {
             />
           </div>
           <div className="field col-4">
-            <CodeHinter
-              currentState={currentState}
-              initialValue={value ? (typeof value === 'string' ? value : JSON.stringify(value)) : value}
-              className="codehinter-plugins"
-              theme={darkMode ? 'monokai' : 'default'}
-              height={'32px'}
-              placeholder="key"
-              onChange={(newValue) => handleValueChange(newValue)}
-            />
+            {operator === 'is' ? (
+              <Select
+                useMenuPortal={true}
+                placeholder="Select operation"
+                value={value}
+                options={isOperatorOptions}
+                onChange={handleValueChange}
+              />
+            ) : (
+              <CodeHinter
+                currentState={currentState}
+                initialValue={value ? (typeof value === 'string' ? value : JSON.stringify(value)) : value}
+                className="codehinter-plugins"
+                theme={darkMode ? 'monokai' : 'default'}
+                height={'32px'}
+                placeholder="key"
+                onChange={(newValue) => handleValueChange(newValue)}
+              />
+            )}
           </div>
           <div className="col-1 cursor-pointer m-1 mr-2">
             <svg

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/UpdateRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/UpdateRows.jsx
@@ -4,6 +4,7 @@ import { TooljetDatabaseContext } from '@/TooljetDatabase/index';
 import Select from '@/_ui/Select';
 import { operators } from '@/TooljetDatabase/constants';
 import { uniqueId } from 'lodash';
+import { isOperatorOptions } from './util';
 
 export const UpdateRows = React.memo(({ currentState, darkMode }) => {
   const { columns, updateRowsOptions, handleUpdateRowsOptionsChange } = useContext(TooljetDatabaseContext);
@@ -109,15 +110,25 @@ export const UpdateRows = React.memo(({ currentState, darkMode }) => {
             />
           </div>
           <div className="field col-4">
-            <CodeHinter
-              currentState={currentState}
-              initialValue={value ? (typeof value === 'string' ? value : JSON.stringify(value)) : value}
-              className="codehinter-plugins"
-              theme={darkMode ? 'monokai' : 'default'}
-              height={'32px'}
-              placeholder="key"
-              onChange={(newValue) => handleValueChange(newValue)}
-            />
+            {operator === 'is' ? (
+              <Select
+                useMenuPortal={true}
+                placeholder="Select value"
+                value={value}
+                options={isOperatorOptions}
+                onChange={handleValueChange}
+              />
+            ) : (
+              <CodeHinter
+                currentState={currentState}
+                initialValue={value ? (typeof value === 'string' ? value : JSON.stringify(value)) : value}
+                className="codehinter-plugins"
+                theme={darkMode ? 'monokai' : 'default'}
+                height={'32px'}
+                placeholder="key"
+                onChange={(newValue) => handleValueChange(newValue)}
+              />
+            )}
           </div>
           <div className="col-1 cursor-pointer m-1 mr-2">
             <svg

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -49,11 +49,7 @@ function buildPostgrestQuery(filters) {
       }
     }
   });
-  let whereQuery = postgrestQueryBuilder.url.toString();
-  // if (whereQuery && whereQuery.includes('nulltest=isNotNull')) {
-  //   whereQuery = whereQuery.replace('nulltest=isNotNull', 'nulltest=not.is.null');
-  // }
-  return whereQuery;
+  return postgrestQueryBuilder.url.toString();
 }
 
 async function listRows(queryOptions, organizationId, currentState) {

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -49,8 +49,11 @@ function buildPostgrestQuery(filters) {
       }
     }
   });
-
-  return postgrestQueryBuilder.url.toString();
+  let whereQuery = postgrestQueryBuilder.url.toString();
+  // if (whereQuery && whereQuery.includes('nulltest=isNotNull')) {
+  //   whereQuery = whereQuery.replace('nulltest=isNotNull', 'nulltest=not.is.null');
+  // }
+  return whereQuery;
 }
 
 async function listRows(queryOptions, organizationId, currentState) {

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/util.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/util.js
@@ -1,4 +1,5 @@
 import { get } from 'lodash';
+
 /**
  * Checks if the queryOptions object contains a filter with an 'eq' (equal) operator and a value equal to '{{null}}'.
  *
@@ -34,3 +35,8 @@ export const hasEqualWithNull = (queryOptions, operation) => {
   }
   return false;
 };
+
+export const isOperatorOptions = [
+  { value: 'null', label: 'null' },
+  { value: 'notNull', label: 'not null' },
+];

--- a/frontend/src/TooljetDatabase/constants.js
+++ b/frontend/src/TooljetDatabase/constants.js
@@ -19,4 +19,5 @@ export const operators = [
   { value: 'match', label: 'match' },
   { value: 'imatch', label: 'imatch' },
   { value: 'in', label: 'in' },
+  { value: 'is', label: 'is' },
 ];

--- a/frontend/src/_helpers/postgrestQueryBuilder.js
+++ b/frontend/src/_helpers/postgrestQueryBuilder.js
@@ -132,9 +132,14 @@ export default class PostgrestQueryBuilder {
    * @param value  The value to filter with.
    */
   is(column, value) {
-    this.url.append(`${column}`, `is.${value}`);
+    if (value === 'notNull') {
+      this.url.append(`${column}`, `not.is.null`);
+    } else {
+      this.url.append(`${column}`, `is.${value}`);
+    }
     return this;
   }
+
   /**
    * Finds all rows whose value on the stated `column` is found on the
    * specified `values`.


### PR DESCRIPTION
closes #6186

UI Implementation view:
<img width="1120" alt="Screenshot 2023-04-28 at 2 25 10 PM" src="https://user-images.githubusercontent.com/50338945/235103047-0e47a2d2-003b-42c7-b59d-9df263427fde.png">

In testing, please test:-
 1. 'is' operator working with list rows, delete rows and update rows. 
 
 FYI: I have tested it, and it works good. 🙂 