### PR TITLE
Add Option to Use Existing Secret for Helm Chart

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -3,6 +3,15 @@
 This chart can be used to install ToolJet in a Kubernetes Cluster via [Helm v3](https://helm.sh).\
 This setup is very rudimentary and comes with an included PostgreSQL server out of the box.
 
+## Secret management
+You can use an existing secret to configure psql auth and additional ToolJet secret env vars.
+`.Values.apps.tooljet.useExistingSecret: true`
+
+See deploy/helm/templates/tooljet/secret.yaml for desired format.
+`.Values.apps.tooljet.secret.name` must be the name of the manually created secret.
+
+If `.Values.apps.tooljet.useExistingSecret: true`, `.Values.apps.tooljet.secret.data` will not be used by helm chart.
+
 ## Installation
 
 To install, follow these steps:

--- a/deploy/helm/templates/tooljet/secret.yaml
+++ b/deploy/helm/templates/tooljet/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.apps.tooljet.useExistingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ data:
   pg_db: {{ .Values.apps.tooljet.secret.data.pg_db | b64enc | quote }}
   lockbox_key: {{ .Values.apps.tooljet.secret.data.lockbox_key | b64enc | quote }}
   secret_key_base: {{ .Values.apps.tooljet.secret.data.secret_key_base | b64enc | quote }}
+{{- end -}}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -17,6 +17,7 @@ apps:
       threshold:
         cpu: 0.75
         ram: 768Mi
+    useExistingSecret: false
     secret:
       name: tooljet-server
       data:


### PR DESCRIPTION
This PR adds the option to use an existing secret for ToolJet's Helm chart, which prevents secret environment variables from being exposed when viewing the deployed app's values.

Changes:
- Update `deploy/helm/README.md` to include instructions for secret management using an existing secret
- Modify `deploy/helm/templates/tooljet/secret.yaml` to conditionally create a secret only if `.Values.apps.tooljet.useExistingSecret` is set to `false`
- Add `useExistingSecret: false` to `deploy/helm/values.yaml` under `apps` section