### PR TITLE
Hotfix :: Removing ellipsis on text overflow in legend labels in chart widget

### DIFF
--- a/frontend/src/Editor/Components/Chart.jsx
+++ b/frontend/src/Editor/Components/Chart.jsx
@@ -77,6 +77,7 @@ export const Chart = function Chart({ width, height, darkMode, properties, style
       b: padding,
       t: padding,
     },
+    hoverlabel: { namelength: -1 },
   };
 
   const computeChartData = (data, dataString) => {


### PR DESCRIPTION
<img width="1040" alt="Screenshot 2023-05-03 at 1 39 06 PM" src="https://user-images.githubusercontent.com/31006028/235862992-f06f5b06-5475-48f7-a37e-ef1dd1e4b038.png">
*Chart data points on hover didn't show the whole label