### PR TITLE
Chore: Add dependabot.yml

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    exclude:
+      - path: "docs/**"


### PR DESCRIPTION
Excludes docs folder for Docusaurus from dependabot checks 