### PR TITLE
Fix for REST API plugin: Convert to Base64 if response type image

### DIFF
--- a/plugins/packages/restapi/lib/index.ts
+++ b/plugins/packages/restapi/lib/index.ts
@@ -179,7 +179,7 @@ export default class RestapiQueryService implements QueryService {
 
     try {
       const response = await got(url, requestOptions);
-      result = this.isJson(response.body) ? JSON.parse(response.body) : response.body;
+      result = this.getResponse(response);
       requestObject = {
         requestUrl: response.request.requestUrl,
         method: response.request.options.method,
@@ -240,6 +240,20 @@ export default class RestapiQueryService implements QueryService {
         certificateAuthority: [...tls.rootCertificates, readFileSync(process.env.NODE_EXTRA_CA_CERTS)].join('\n'),
       },
     };
+  }
+
+  private getResponse(response) {
+    try {
+      if (this.isJson(response.body)) {
+        return JSON.parse(response.body);
+      }
+      if (response.body && response.headers?.['content-type']?.startsWith('image/')) {
+        return Buffer.from(response.body).toString('base64');
+      }
+    } catch (error) {
+      console.error('Error while parsing response', error);
+    }
+    return response.body;
   }
 
   checkIfContentTypeIsURLenc(headers: [] = []) {

--- a/plugins/packages/restapi/lib/index.ts
+++ b/plugins/packages/restapi/lib/index.ts
@@ -247,8 +247,8 @@ export default class RestapiQueryService implements QueryService {
       if (this.isJson(response.body)) {
         return JSON.parse(response.body);
       }
-      if (response.body && response.headers?.['content-type']?.startsWith('image/')) {
-        return Buffer.from(response.body).toString('base64');
+      if (response.rawBody && response.headers?.['content-type']?.startsWith('image/')) {
+        return Buffer.from(response.rawBody, 'binary').toString('base64');
       }
     } catch (error) {
       console.error('Error while parsing response', error);


### PR DESCRIPTION
Resolves https://github.com/ToolJet/ToolJet/issues/6280