### PR TITLE
Update docker.md

### DIFF
--- a/docs/versioned_docs/version-2.5.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.5.0/contributing-guide/setup/docker.md
@@ -181,4 +181,4 @@ docker-compose run --rm server npm --prefix server run test <path-to-file>
 
 ## Troubleshooting
 
-Please open a new issue at https://github.com/ToolJet/ToolJet/issues or join our [Slack Community](https://tooljet.com/slack) if you encounter any issues when trying to run ToolJet locally.
+Please open a new issue at https://github.com/ToolJet/ToolJet/issues or Join our community on [Slack](https://tooljet.com/slack) if you encounter any issues when trying to run ToolJet locally.


### PR DESCRIPTION
Corrected the Slack channel hyperlink #5703

I have reviewed the documentation and found that the Slack hyperlink has already been fixed. Therefore, I have only made changes to the hyperlink format. The changes have been made, and the links now direct to the correct pages.