### PR TITLE
fix broken image in deployment doc for google cloud run issue #6312

### DIFF
--- a/docs/versioned_docs/version-2.0.0/setup/google-cloud-run.md
+++ b/docs/versioned_docs/version-2.0.0/setup/google-cloud-run.md
@@ -47,7 +47,7 @@ Follow the steps below to deploy ToolJet on Cloud run with `gcloud` CLI.
 4. Under containers tab, please make sure the port is set 3000 and command `npm, run, start:prod` is entered in container argument field with CPU capacity is set to 2GiB.
 
   <div style={{textAlign: 'center'}}>
-  <img className="screenshot-full" src="/img/cloud-run/port-and-capacity-tooljet.png" alt="port-and-capacity-tooljet" />
+  <img className="screenshot-full" src="/img/cloud-run/port-and-capacity-postgrest.png" alt="port-and-capacity-postgrest.png" />
   </div>
 
 


### PR DESCRIPTION
Solves issue #6312

have changed the prev URL ("/img/cloud-run/port-and-capacity-tooljet.png")
to new URL ("/img/cloud-run/port-and-capacity-postgrest.png") 
and tested it its working fine 
SS of which is attached below

![image](https://github.com/ToolJet/ToolJet/assets/29349136/be4fe69a-0ff7-42fc-a46b-14cf644433ad)
