### PR TITLE
[chore] Disable/removing AWS S3 plugin from marketplace

### DIFF
--- a/server/src/assets/marketplace/plugins.json
+++ b/server/src/assets/marketplace/plugins.json
@@ -1,13 +1,5 @@
 [
   {
-    "name": "AWS S3 plugin",
-    "description": "Datasource plugin for AWS S3",
-    "version": "1.0.1",
-    "id": "s3",
-    "author": "Tooljet",
-    "timestamp": "Mon, 31 Oct 2022 11:02:10 GMT"
-  },
-  {
     "name": "plivo",
     "repo": "",
     "description": "Datasource plugin for Plivo",


### PR DESCRIPTION
We are considering deprecating or removing the AWS S3 plugin from the marketplace. The newer version of the AWS S3 (datasource/plugin), which is updated and well-documented, offers advanced features like instance authentication and custom URLs. However, the marketplace version (v1) is outdated and lacks documentation. It would be ideal to focus on the updated plugin and remove the marketplace version to avoid confusion and provide users with the best experience.