### PR TITLE
[docs]: link The Ada initiative on slack code of conduct

### DIFF
--- a/docs/docs/contributing-guide/slackcoc.md
+++ b/docs/docs/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---

--- a/docs/versioned_docs/version-1.x.x/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-1.x.x/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---

--- a/docs/versioned_docs/version-2.0.0/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-2.0.0/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---

--- a/docs/versioned_docs/version-2.1.0/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-2.1.0/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---

--- a/docs/versioned_docs/version-2.2.0/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-2.2.0/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---

--- a/docs/versioned_docs/version-2.3.0/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-2.3.0/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---

--- a/docs/versioned_docs/version-2.4.0/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-2.4.0/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---

--- a/docs/versioned_docs/version-2.5.0/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-2.5.0/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](http://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---

--- a/docs/versioned_docs/version-2.6.0/contributing-guide/slackcoc.md
+++ b/docs/versioned_docs/version-2.6.0/contributing-guide/slackcoc.md
@@ -60,7 +60,7 @@ In addition, violations of this code outside our spaces may affect a person’s 
 - If violations occur, organizers will take any action they deem appropriate for the infraction, up to and including expulsion.
 
 :::info
-Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) under a Creative Commons Attribution-ShareAlike license.
+Portions derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/), [The Rust Code of Conduct](https://www.rust-lang.org/conduct.html) and [The Ada Initiative](https://adainitiative.org) under a Creative Commons Attribution-ShareAlike license.
 :::
 
 ---


### PR DESCRIPTION
**Description**
A PR (https://github.com/ToolJet/ToolJet/pull/6383/files) was made to remove The Ada initiative from the slack code of conduct. I added it again from where it was removed and change the URL to `https://adainitiative.org/`

fixed issue: [#6419](https://github.com/ToolJet/ToolJet/issues/6419)