### PR TITLE
Chore: Add $HOME for npm commands on openshift

### DIFF
--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -79,6 +79,10 @@ spec:
                   key: tj_host
             - name: DEPLOYMENT_PLATFORM
               value: "openshift"
+            # Need to define missed HOME directory on openshift platform
+            # for npm commands to work with aribitrary user
+            - name: HOME
+              value: "/home/appuser"
             # Set the env values below for Tooljet Database
             # - name: ENABLE_TOOLJET_DB
             #   value: "true"


### PR DESCRIPTION
Openshift runs docker container with arbitrary user as a security precaution. Such container won't have $HOME defined in the env which fails when npm commands are invoked as a part of entryscript.
