### PR TITLE
fix: Dashboard - show cursor pointer while hover on 'see all templates' link

### DIFF
--- a/frontend/src/HomePage/BlankPage.jsx
+++ b/frontend/src/HomePage/BlankPage.jsx
@@ -138,14 +138,13 @@ export const BlankPage = function BlankPage({
                 })}
               </div>
               <div className="m-auto text-center mt-4">
-                <span
-                  className="see-all-temlplates-link tj-text-sm font-weight-600"
+                <button
+                  className="see-all-temlplates-link tj-text-sm font-weight-600 bg-transparent border-0"
                   onClick={viewTemplateLibraryModal}
                   data-cy="see-all-apps-template-buton"
-                  role="button"
                 >
                   See all templates
-                </span>
+                </button>
               </div>
             </div>
           </div>

--- a/frontend/src/HomePage/BlankPage.jsx
+++ b/frontend/src/HomePage/BlankPage.jsx
@@ -142,6 +142,7 @@ export const BlankPage = function BlankPage({
                   className="see-all-temlplates-link tj-text-sm font-weight-600"
                   onClick={viewTemplateLibraryModal}
                   data-cy="see-all-apps-template-buton"
+                  role="button"
                 >
                   See all templates
                 </span>


### PR DESCRIPTION
### What is the expected behavior?
Hand cursor or pointer should appear on hovering over the 'See all templates' link on the dashboard screen

Fixes #6458


https://github.com/ToolJet/ToolJet/assets/85070570/653e9bb9-b2af-47b2-b236-29471675ca27

