### PR TITLE
set max size of contributors grid to 360 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Kindly read our [Contributing Guide](CONTRIBUTING.md) to learn and understand ab
 
 ## Contributors
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
   <img src="https://us-central1-tooljet-hub.cloudfunctions.net/github" width="0" height="0" />
 </a>
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -239,7 +239,7 @@ To contribute to ToolJet code, plugins, and documentation, refer to our **[Contr
 [![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
 
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
 </a>
 
 ## Help and Support

--- a/docs/versioned_docs/version-2.0.0/getting-started.md
+++ b/docs/versioned_docs/version-2.0.0/getting-started.md
@@ -239,7 +239,7 @@ To contribute to ToolJet code, plugins, and documentation, refer to our **[Contr
 [![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
 
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
 </a>
 
 ## Help and Support

--- a/docs/versioned_docs/version-2.1.0/getting-started.md
+++ b/docs/versioned_docs/version-2.1.0/getting-started.md
@@ -239,7 +239,7 @@ To contribute to ToolJet code, plugins, and documentation, refer to our **[Contr
 [![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
 
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
 </a>
 
 ## Help and Support

--- a/docs/versioned_docs/version-2.2.0/getting-started.md
+++ b/docs/versioned_docs/version-2.2.0/getting-started.md
@@ -239,7 +239,7 @@ To contribute to ToolJet code, plugins, and documentation, refer to our **[Contr
 [![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
 
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
 </a>
 
 ## Help and Support

--- a/docs/versioned_docs/version-2.3.0/getting-started.md
+++ b/docs/versioned_docs/version-2.3.0/getting-started.md
@@ -239,7 +239,7 @@ To contribute to ToolJet code, plugins, and documentation, refer to our **[Contr
 [![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
 
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
 </a>
 
 ## Help and Support

--- a/docs/versioned_docs/version-2.4.0/getting-started.md
+++ b/docs/versioned_docs/version-2.4.0/getting-started.md
@@ -239,7 +239,7 @@ To contribute to ToolJet code, plugins, and documentation, refer to our **[Contr
 [![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
 
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
 </a>
 
 ## Help and Support

--- a/docs/versioned_docs/version-2.5.0/getting-started.md
+++ b/docs/versioned_docs/version-2.5.0/getting-started.md
@@ -238,7 +238,7 @@ To contribute to ToolJet code, plugins, and documentation, refer to our **[Contr
 [![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
 
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
 </a>
 
 ## Help and Support

--- a/docs/versioned_docs/version-2.6.0/getting-started.md
+++ b/docs/versioned_docs/version-2.6.0/getting-started.md
@@ -239,7 +239,7 @@ To contribute to ToolJet code, plugins, and documentation, refer to our **[Contr
 [![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
 
 <a href="https://github.com/tooljet/tooljet/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=300&columns=20" />
+  <img src="https://contrib.rocks/image?repo=tooljet/tooljet&max=360&columns=20" />
 </a>
 
 ## Help and Support


### PR DESCRIPTION
Contributors grid is set to 360 
### Files updated 

- README
- Getting Started file in `tooljet/docs/docs`
- Getting Started file of each version in the `tooljet/docs/versioned_docs/` except the `v1.x.x`

### Issue number 

#6515 