### PR TITLE
fix: Edit Workspace popup related observations

### DIFF
--- a/frontend/src/_components/OrganizationManager/EditOrganization.jsx
+++ b/frontend/src/_components/OrganizationManager/EditOrganization.jsx
@@ -30,6 +30,11 @@ export const EditOrganization = ({ showEditOrg, setShowEditOrg }) => {
     setShowEditOrg(false);
   };
 
+  const cancelEditOrganization = () => {
+    setNewOrgName('');
+    setShowEditOrg(false);
+  };
+
   return (
     <AlertDialog
       show={showEditOrg}
@@ -53,7 +58,7 @@ export const EditOrganization = ({ showEditOrg, setShowEditOrg }) => {
       </div>
       <div className="row">
         <div className="col d-flex justify-content-end gap-2">
-          <ButtonSolid variant="tertiary" onClick={() => setShowEditOrg(false)}>
+          <ButtonSolid variant="tertiary" onClick={cancelEditOrganization}>
             {t('globals.cancel', 'Cancel')}
           </ButtonSolid>
           <ButtonSolid isLoading={isCreating} onClick={editOrganization}>


### PR DESCRIPTION
### What is the expected behaviour?
When user clicks on pencil icon besides the selected workspace, the popup should appear and display the name of selected workspace by default.
When user enters workspace name and clicks on Cancel button or cross icon, on reopening the same popup the prior input should get vanished.

Fixes #6567


https://github.com/ToolJet/ToolJet/assets/85070570/b1ff8335-b590-4f3c-b06b-f10b5d3c933c

