### PR TITLE
fix: Global datasource searchbar and page rename input-box text visibility in dark mode

### DIFF
--- a/frontend/src/Editor/LeftSidebar/SidebarPageSelector/index.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPageSelector/index.jsx
@@ -138,7 +138,7 @@ const LeftSidebarPageSelector = ({
           )}
         </HeaderSection>
 
-        <div className={`${darkMode && 'dark'} page-selector-panel-body`}>
+        <div className={`${darkMode && 'dark theme-dark'} page-selector-panel-body`}>
           <div>
             {allpages.length > 0 ? (
               <SortableList

--- a/frontend/src/_styles/left-sidebar.scss
+++ b/frontend/src/_styles/left-sidebar.scss
@@ -157,7 +157,7 @@
   background: transparent !important;
 
   &:hover {
-    background: $primary  !important;
+    background: $primary !important;
     color: #fffffc !important;
   }
 }
@@ -416,6 +416,15 @@
 
 .empty-state-wrapper {
   margin-left: 5rem !important;
+
+  input {
+    color: var(--slate12);
+    background-color: var(--base);
+  }
+
+  input:focus {
+    background-color: var(--base);
+  }
 }
 
 .close-btn {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1194,7 +1194,7 @@ button {
     .col{
       display: flex;
     }
-  }  
+  }
 }
 
 .fx-container-eventmanager *.fx-common {
@@ -4376,7 +4376,8 @@ input[type="text"] {
   }
 
   input:focus {
-    width: 300px;
+    width: 200px;
+    background-color: var(--base);
   }
 
   .input-icon .input-icon-addon {
@@ -10082,7 +10083,7 @@ tbody {
   border-radius: 0px !important;
 }
 
-// custom styles for users multiselect in manage users 
+// custom styles for users multiselect in manage users
 .manage-groups-users-multiselect {
   gap: 17px;
   width: 440px;
@@ -10271,7 +10272,7 @@ tbody {
       background-color: #121212;
       padding: 16px 18px 0px 16px;
       border-radius: 6px;
-  
+
       p {
         font-size: 14px;
         font-family: IBM Plex Sans;
@@ -10286,20 +10287,20 @@ tbody {
     backface-visibility: hidden;
     perspective: 10000px;
   }
-  
+
   @keyframes shake {
     10%, 90% {
       transform: translate3d(-1px, 0, 0);
     }
-    
+
     20%, 80% {
       transform: translate3d(2px, 0, 0);
     }
-  
+
     30%, 50%, 70% {
       transform: translate3d(-4px, 0, 0);
     }
-  
+
     40%, 60% {
       transform: translate3d(4px, 0, 0);
     }


### PR DESCRIPTION
### What is the expected behaviour?
The input string should be clearly visible to the user

Fixes #6554


https://github.com/ToolJet/ToolJet/assets/85070570/81351694-eb28-4fbf-80d0-03e31e52db0c


https://github.com/ToolJet/ToolJet/assets/85070570/9b52b9fc-cecf-4441-b62f-e2ac9a0ce7d1

