### PR TITLE
Bug fixed : export with two identical column titles fills data in wrong column

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -250,17 +250,17 @@ export function Table({
     let headers = columns.map((column) => {
       return { exportValue: String(column.exportValue), key: column.key ? String(column.key) : column.key };
     });
-    const data = globalFilteredRows.map((row) => {
+    let data = globalFilteredRows.map((row) => {
       return headers.reduce((accumulator, header) => {
         let value = undefined;
         if (header.key && header.key !== header.exportValue) {
-          value = row.original[header.key];
+          value = _.get(row.original, header.key);
         } else {
           value = row.original[header.exportValue];
         }
-        accumulator[header.exportValue.toUpperCase()] = value;
+        accumulator.push(value);
         return accumulator;
-      }, {});
+      }, []);
     });
     headers = headers.map((header) => header.exportValue.toUpperCase());
     if (fileType === 'csv') {
@@ -281,11 +281,11 @@ export function Table({
         theme: 'grid',
       });
       doc.save(`${fileName}.pdf`);
+      return;
     } else if (fileType === 'xlsx') {
+      data.unshift(headers); //adding headers array at the beginning of data
       let wb = XLSX.utils.book_new();
-      let ws1 = XLSX.utils.json_to_sheet(data, {
-        headers,
-      });
+      let ws1 = XLSX.utils.aoa_to_sheet(data);
       XLSX.utils.book_append_sheet(wb, ws1, 'React Table Data');
       XLSX.writeFile(wb, `${fileName}.xlsx`);
       // Returning false as downloading of file is already taken care of


### PR DESCRIPTION
Resolves #6440
Also, when the column key contains ` .` like `company.name`, in such cases entire columns are exported with empty cells (values).