### PR TITLE
Fixed auto generated workspace name issue

### DIFF
--- a/server/ee/services/oauth/oauth.service.ts
+++ b/server/ee/services/oauth/oauth.service.ts
@@ -79,7 +79,7 @@ export class OauthService {
     }
 
     if (!user) {
-      const organizationName = await generateNextName('Untitled workspace', Organization, {}, manager);
+      const organizationName = await generateNextName('My workspace');
       defaultOrganization = await this.organizationService.create(organizationName, null, manager);
     }
 
@@ -221,7 +221,7 @@ export class OauthService {
           let defaultOrganization: DeepPartial<Organization> = organization;
 
           // Not logging in to specific organization, creating new
-          const organizationName = await generateNextName('Untitled workspace', Organization, {}, manager);
+          const organizationName = await generateNextName('My workspace');
           defaultOrganization = await this.organizationService.create(organizationName, null, manager);
 
           const groups = ['all_users', 'admin'];
@@ -263,7 +263,7 @@ export class OauthService {
             organizationDetails = organizationList[0];
           } else {
             // no SSO login enabled organization available for user - creating new one
-            const organizationName = await generateNextName('Untitled workspace', Organization, {}, manager);
+            const organizationName = await generateNextName('My workspace');
             organizationDetails = await this.organizationService.create(organizationName, userDetails, manager);
           }
         } else if (!userDetails) {

--- a/server/src/helpers/utils.helper.ts
+++ b/server/src/helpers/utils.helper.ts
@@ -125,17 +125,6 @@ export async function getServiceAndRpcNames(protoDefinition) {
   return serviceNamesAndMethods;
 }
 
-export const generateNextName = async (
-  firstWord: string,
-  entityClass: EntityTarget<unknown>,
-  options = {},
-  manager: EntityManager
-) => {
-  const count = await manager.count(entityClass, {
-    where: {
-      ...options,
-      name: Like(`%${firstWord}%`),
-    },
-  });
-  return `${firstWord} ${count == 0 ? 1 : count + 1}`;
+export const generateNextName = async (firstWord: string) => {
+  return `${firstWord} ${Date.now()}`;
 };

--- a/server/src/helpers/utils.helper.ts
+++ b/server/src/helpers/utils.helper.ts
@@ -1,6 +1,6 @@
 import { QueryError } from 'src/modules/data_sources/query.errors';
 import * as sanitizeHtml from 'sanitize-html';
-import { EntityManager, EntityTarget, getManager, Like } from 'typeorm';
+import { EntityManager, getManager } from 'typeorm';
 import { isEmpty } from 'lodash';
 import { ConflictException } from '@nestjs/common';
 import { DataBaseConstraints } from './db_constraints.constants';

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -259,7 +259,7 @@ export class AuthService {
       // Create default organization
       //TODO: check if there any case available that the firstname will be nil
 
-      const organizationName = await generateNextName('Untitled workspace', Organization, {}, manager);
+      const organizationName = await generateNextName('My workspace');
       organization = await this.organizationsService.create(organizationName, null, manager);
       const user = await this.usersService.create(
         {

--- a/server/src/services/organizations.service.ts
+++ b/server/src/services/organizations.service.ts
@@ -559,7 +559,7 @@ export class OrganizationsService {
         // User not exist
         shouldSendWelcomeMail = true;
         // Create default organization if user not exist
-        const organizationName = await generateNextName('Untitled workspace', Organization, {}, manager);
+        const organizationName = await generateNextName('My workspace');
         defaultOrganization = await this.create(organizationName, null, manager);
       } else if (user.invitationToken) {
         // User not setup

--- a/server/test/controllers/app.e2e-spec.ts
+++ b/server/test/controllers/app.e2e-spec.ts
@@ -89,7 +89,7 @@ describe('Authentication', () => {
         });
 
         expect(user.defaultOrganizationId).toBe(user?.organizationUsers?.[0]?.organizationId);
-        expect(organization?.name).toContain('Untitled workspace');
+        expect(organization?.name).toContain('My workspace');
 
         const groupPermissions = await user.groupPermissions;
         const groupNames = groupPermissions.map((x) => x.group);


### PR DESCRIPTION
More about the workspace name changes
- the fix for the auto-generated workspace name issue
the fix will be appending a timestamp at the end of the string `My workspace` instead of `Untitled workspace {count}`

Also from now on.
We will add a timestamp at the end of all the same workspace names (through migration) to avoid the unique constraint error.