### PR TITLE
fix: Change widget to component in editor

### DIFF
--- a/frontend/src/Editor/Inspector/Components/Chart.jsx
+++ b/frontend/src/Editor/Inspector/Components/Chart.jsx
@@ -111,7 +111,7 @@ class Chart extends React.Component {
             lineNumbers={false}
             className="chart-input pr-2"
             onChange={(value) => this.props.paramUpdated({ name: 'jsonDescription' }, 'value', value, 'properties')}
-            componentName={`widget/${this.props.component.component.name}::${chartType}`}
+            componentName={`component/${this.props.component.component.name}::${chartType}`}
           />
         ),
       });
@@ -141,7 +141,7 @@ class Chart extends React.Component {
             lineNumbers={false}
             className="chart-input pr-2"
             onChange={(value) => this.props.paramUpdated({ name: 'data' }, 'value', value, 'properties')}
-            componentName={`widget/${this.props.component.component.name}::${chartType}`}
+            componentName={`component/${this.props.component.component.name}::${chartType}`}
           />
         ),
       });

--- a/frontend/src/Editor/Inspector/Components/CustomComponent.jsx
+++ b/frontend/src/Editor/Inspector/Components/CustomComponent.jsx
@@ -26,7 +26,7 @@ export const CustomComponent = function CustomComponent({
         initialValue={args.value ?? {}}
         theme={darkMode ? 'monokai' : 'base16-light'}
         onChange={(value) => paramUpdated({ name: 'data' }, 'value', value, 'properties')}
-        componentName={`widget/${component.component.name}/data`}
+        componentName={`component/${component.component.name}/data`}
       />
     ),
   });
@@ -42,7 +42,7 @@ export const CustomComponent = function CustomComponent({
         lineNumbers
         className="custom-component"
         onChange={(value) => paramUpdated({ name: 'code' }, 'value', value, 'properties')}
-        componentName={`widget/${component.component.name}/code`}
+        componentName={`component/${component.component.name}/code`}
         enablePreview={false}
         height={400}
         hideSuggestion

--- a/frontend/src/Editor/Inspector/Components/Table/ProgramaticallyHandleToggleSwitch.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table/ProgramaticallyHandleToggleSwitch.jsx
@@ -30,7 +30,7 @@ export const ProgramaticallyHandleToggleSwitch = ({
         theme={darkMode ? 'monokai' : options.theme}
         lineWrapping={true}
         onChange={(value) => callbackFunction(index, property, value)}
-        componentName={`widget/${component?.component?.name}::${param.name}`}
+        componentName={`component/${component?.component?.name}::${param.name}`}
         type={paramMeta.type}
         paramName={param.name}
         paramLabel={paramMeta.displayName}

--- a/frontend/src/Editor/Inspector/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table/Table.jsx
@@ -894,7 +894,7 @@ class TableComponent extends React.Component {
   }
 
   getPopoverFieldSource = (column, field) =>
-    `widget/${this.props.component.component.name}/${column ?? 'default'}::${field}`;
+    `component/${this.props.component.component.name}/${column ?? 'default'}::${field}`;
 
   render() {
     const { dataQueries, component, paramUpdated, componentMeta, components, currentState, darkMode } = this.props;

--- a/frontend/src/Editor/Inspector/Elements/Code.jsx
+++ b/frontend/src/Editor/Inspector/Elements/Code.jsx
@@ -39,7 +39,7 @@ export const Code = ({
         lineWrapping={true}
         className={options.className}
         onChange={(value) => handleCodeChanged(value)}
-        componentName={`widget/${componentName}::${getfieldName}`}
+        componentName={`component/${componentName}::${getfieldName}`}
         type={paramMeta.type}
         paramName={param.name}
         paramLabel={displayName}

--- a/frontend/src/_helpers/createWalkThrough.js
+++ b/frontend/src/_helpers/createWalkThrough.js
@@ -44,7 +44,7 @@ export const initEditorWalkThrough = () => {
         element: '.left-sidebar-inspector',
         popover: {
           title: 'Inspector',
-          description: 'Inspector lets you check the properties of widgets, results of queries etc.',
+          description: 'Inspector lets you check the properties of components, results of queries, etc.',
           position: 'right',
           closeBtnText: 'Skip (3/6)',
         },


### PR DESCRIPTION
Fixes: #6657 

I also changed "widgets" to "components" in the walkthrough for consistency's sake.