### PR TITLE
Fixed Chart layout accordion issue

### DIFF
--- a/frontend/src/Editor/Inspector/Components/Chart.jsx
+++ b/frontend/src/Editor/Inspector/Components/Chart.jsx
@@ -193,7 +193,6 @@ class Chart extends React.Component {
 
     items.push({
       title: 'Layout',
-      isOpen: false,
       children: (
         <>
           {renderElement(


### PR DESCRIPTION
Closes https://github.com/ToolJet/ToolJet/issues/4238
I have Removed the **isOpen:false** property to show the Layout by default.