### PR TITLE
Delete static postgres connection option "statement_timeout"

### DIFF
--- a/plugins/packages/postgresql/lib/index.ts
+++ b/plugins/packages/postgresql/lib/index.ts
@@ -90,7 +90,6 @@ export default class PostgresqlQueryService implements QueryService {
       database: sourceOptions.database,
       password: sourceOptions.password,
       port: sourceOptions.port,
-      statement_timeout: 10000,
       connectionTimeoutMillis: 10000,
       ...this.connectionOptions(sourceOptions),
     };


### PR DESCRIPTION
### Summary

This pull request removes the static `statement_timeout` option from the Postgres connection configuration in the `plugins/packages/postgresql/lib/index.ts` file.

### Motivation

The `statement_timeout` option was causing compatibility issues with certain versions of Postgres and certain managed Postgres services, as not all of them support this option. This issue was reported in [#3981](https://github.com/ToolJet/ToolJet/issues/3981). By removing this option, we aim to increase the compatibility of our tool with various Postgres setups.

### Changes

- Removed the `statement_timeout` option from the Postgres connection configuration.

### Testing

Please ensure that connections to various Postgres versions and services are still functioning as expected after this change.
