### PR TITLE
fix: retain query param on redirection to home page from base url

### DIFF
--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -556,7 +556,7 @@ class ViewerComponent extends React.Component {
           if (this.state.slug) {
             url = `/applications/${this.state.slug}/${homeHandle}`;
           }
-          return <Navigate to={url} replace />;
+          return <Navigate to={`${url}${this.props.params.pageHandle ? '' : window.location.search}`} replace />;
         }
 
         return (


### PR DESCRIPTION
When user hits the base url of the app it redirects him to the home page url. But if the url contains any query/search params, those are not retained while redirecting. This PR takes care of retaining it.