### PR TITLE
Showing page "1 of 1 " instead of "1 of 0" when no data is available in the table for client side pagination

### DIFF
--- a/frontend/src/Editor/Components/Table/Pagination.jsx
+++ b/frontend/src/Editor/Components/Table/Pagination.jsx
@@ -70,7 +70,7 @@ export const Pagination = function Pagination({
         {serverSide && <strong>{pageIndex}</strong>}
         {!serverSide && (
           <strong>
-            {pageIndex} of {autoPageOptions.length}
+            {pageIndex} of {autoPageOptions.length || 1}
           </strong>
         )}
       </small>


### PR DESCRIPTION
Resolves #4963