### PR TITLE
Bug Fix: text of the name of global datasource overflows in the query panel 

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -218,7 +218,6 @@ button {
     border: 1px solid rgba(101, 109, 119, 0.16);
     border-radius: 4px;
     height: 46px;
-    width: 200px;
     padding: 10px;
     align-items: center;
     cursor: pointer;


### PR DESCRIPTION
I have made the required changes and fixed this issue #6721 

Attached the screenshot after bug fix for your reference.

![image](https://github.com/ToolJet/ToolJet/assets/68153692/a0dd407c-f53e-4d6f-a99b-20d257062af0)
