### PR TITLE
Allow multi-line editing of Text column in Table component

### DIFF
--- a/frontend/src/Editor/Components/Table/columns/index.jsx
+++ b/frontend/src/Editor/Components/Table/columns/index.jsx
@@ -269,7 +269,7 @@ export default function generateColumnsData({
                 }}
                 onKeyDown={(e) => {
                   e.persist();
-                  if (e.key === 'Enter' && isEditable) {
+                  if (e.key === 'Enter' && !e.shiftKey && isEditable) {
                     handleCellValueChange(cell.row.index, column.key || column.name, e.target.value, cell.row.original);
                   }
                 }}

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -1826,7 +1826,10 @@ button {
       background: white;
       box-shadow: rgba(15, 15, 15, 0.05) 0px 0px 0px 1px,
         rgba(15, 15, 15, 0.1) 0px 3px 6px, rgba(15, 15, 15, 0.2) 0px 9px 24px;
-      white-space: initial;
+
+      :not(textarea) {
+        white-space: initial;
+      }
     }
 
     .text-container:focus-visible,
@@ -2906,8 +2909,9 @@ input:focus-visible {
   .was-validated .form-control:invalid {
     border-color: #ffb0b0;
   }
-  .form-check-input{
-    cursor:pointer;
+
+  .form-check-input {
+    cursor: pointer;
   }
 }
 
@@ -7541,7 +7545,7 @@ tbody {
   .tj-text-xsm {
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;  
+    text-overflow: ellipsis;
   }
 
   .tj-folder-list {
@@ -10631,6 +10635,7 @@ tbody {
     padding: 4px 0px 20px 0px;
   }
 }
+
 .jet-container-loading {
   margin: 0 auto;
   justify-content: center;


### PR DESCRIPTION
This PR adds support for multi-line editing of the Text type column in the Table component by:

1. When holding the Shift key, hitting Enter adds a new line instead of saving the changes. This is a common pattern in many text inputs (especially chat inputs), where Enter is used to save the current changes by default.
2. Adjusting the CSS `white-space` for <textarea> so newlines are visible. Before, it would add the newline, but all the text was collapsed and it was not visible.

Thank you.