### PR TITLE
Query switching with the same type not working

### DIFF
--- a/frontend/src/Editor/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/Editor/QueryManager/Components/QueryManagerBody.jsx
@@ -60,6 +60,7 @@ export const QueryManagerBody = forwardRef(
     /* - Added the below line to cause re-rendering when the query is switched
        - QueryEditors are not updating when the query is switched
        - TODO: Remove the below line and make query editors update when the query is switched
+       - Ref PR #6763
     */
     const [selectedQueryId, setSelectedQueryId] = useState(selectedQuery?.id);
 
@@ -250,7 +251,6 @@ export const QueryManagerBody = forwardRef(
     };
 
     const renderQueryElement = () => {
-      if (selectedQueryId !== selectedQuery?.id) return;
       return (
         <div style={{ padding: '0 32px' }}>
           <div>
@@ -284,7 +284,6 @@ export const QueryManagerBody = forwardRef(
     };
 
     const renderEventManager = () => {
-      if (selectedQueryId !== selectedQuery?.id) return;
       const queryComponent = mockDataQueryAsComponent(options?.events || []);
       return (
         <>
@@ -370,7 +369,6 @@ export const QueryManagerBody = forwardRef(
     );
 
     const renderQueryOptions = () => {
-      if (selectedQueryId !== selectedQuery?.id) return;
       return (
         <div
           className={cx(`advanced-options-container font-weight-400 border-top query-manager-border-color`, {
@@ -387,7 +385,6 @@ export const QueryManagerBody = forwardRef(
     };
 
     const renderChangeDataSource = () => {
-      if (selectedQueryId !== selectedQuery?.id) return;
       return (
         <div className="mt-2 pb-4">
           <div
@@ -408,6 +405,8 @@ export const QueryManagerBody = forwardRef(
         </div>
       );
     };
+
+    if (selectedQueryId !== selectedQuery?.id) return;
 
     return (
       <div

--- a/frontend/src/Editor/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/Editor/QueryManager/Components/QueryManagerBody.jsx
@@ -57,6 +57,11 @@ export const QueryManagerBody = forwardRef(
     const { changeDataQuery } = useDataQueriesActions();
 
     const [dataSourceMeta, setDataSourceMeta] = useState(null);
+    /* - Added the below line to cause re-rendering when the query is switched
+       - QueryEditors are not updating when the query is switched
+       - TODO: Remove the below line and make query editors update when the query is switched
+    */
+    const [selectedQueryId, setSelectedQueryId] = useState(selectedQuery?.id);
 
     const queryName = selectedQuery?.name ?? '';
     const sourcecomponentName = selectedDataSource?.kind.charAt(0).toUpperCase() + selectedDataSource?.kind.slice(1);
@@ -70,6 +75,7 @@ export const QueryManagerBody = forwardRef(
           ? selectedQuery?.manifestFile?.data?.source
           : DataSourceTypes.find((source) => source.kind === selectedQuery?.kind)
       );
+      setSelectedQueryId(selectedQuery?.id);
       defaultOptions.current = selectedQuery?.options;
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedQuery?.id]);
@@ -244,6 +250,7 @@ export const QueryManagerBody = forwardRef(
     };
 
     const renderQueryElement = () => {
+      if (selectedQueryId !== selectedQuery?.id) return;
       return (
         <div style={{ padding: '0 32px' }}>
           <div>
@@ -277,6 +284,7 @@ export const QueryManagerBody = forwardRef(
     };
 
     const renderEventManager = () => {
+      if (selectedQueryId !== selectedQuery?.id) return;
       const queryComponent = mockDataQueryAsComponent(options?.events || []);
       return (
         <>
@@ -362,6 +370,7 @@ export const QueryManagerBody = forwardRef(
     );
 
     const renderQueryOptions = () => {
+      if (selectedQueryId !== selectedQuery?.id) return;
       return (
         <div
           className={cx(`advanced-options-container font-weight-400 border-top query-manager-border-color`, {
@@ -378,6 +387,7 @@ export const QueryManagerBody = forwardRef(
     };
 
     const renderChangeDataSource = () => {
+      if (selectedQueryId !== selectedQuery?.id) return;
       return (
         <div className="mt-2 pb-4">
           <div


### PR DESCRIPTION
While selecting the query with same type, the second query details are not updated and the UI still shows the old query details. This issue is fixed in this PR.

- When the query is switched, selected query is getting changed
- Once the selected query changes, the `QueryManagerBody.jsx` gets an update and cause a re-render
- This re-render causes all the components like `Transformations`, query editors like `Restapi`, `TooljetDb` etc to re-render
- But, the state is not updated for each component. So, it holds the old value and displays the same old query values
- As a fix, if query ID changes, then all the children components are unmounted and mounted again. This way, all the child components will get a new value