### PR TITLE
Database drawer is not opening from the left sidebar

### DIFF
--- a/frontend/src/Editor/LeftSidebar/SidebarDatasources.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarDatasources.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-named-as-default */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { HeaderSection } from '@/_ui/LeftSidebar';
+import { HeaderSection, Button } from '@/_ui/LeftSidebar';
 import { DataSourceManager } from '../DataSourceManager';
 import { DataSourceTypes } from '../DataSourceManager/SourceComponents';
 import { getSvgIcon } from '@/_helpers/appUtils';
@@ -28,11 +28,19 @@ export const LeftSidebarDataSources = ({
   showDataSourceManagerModal,
   isVersionReleased,
   setReleasedVersionPopupState,
+  onDeleteofAllDataSources,
+  setPinned,
+  pinned,
 }) => {
   const dataSources = useDataSources();
   const [selectedDataSource, setSelectedDataSource] = React.useState(null);
   const [isDeleteModalVisible, setDeleteModalVisibility] = React.useState(false);
   const [isDeletingDatasource, setDeletingDatasource] = React.useState(false);
+  useEffect(() => {
+    if (dataSources.length === 0) {
+      onDeleteofAllDataSources();
+    }
+  }, [dataSources.length]);
 
   const { admin } = authenticationService.currentSessionValue;
 
@@ -202,6 +210,8 @@ export const LeftSidebarDataSources = ({
         toggleDataSourceManagerModal={toggleDataSourceManagerModal}
         isVersionReleased={isVersionReleased}
         setReleasedVersionPopupState={setReleasedVersionPopupState}
+        setPinned={setPinned}
+        pinned={pinned}
       />
       <DataSourceManager
         appId={appId}
@@ -227,12 +237,29 @@ const LeftSidebarDataSourcesContainer = ({
   dataSources = [],
   isVersionReleased,
   setReleasedVersionPopupState,
+  setPinned,
+  pinned,
 }) => {
   const { t } = useTranslation();
   return (
     <div>
       <HeaderSection darkMode={darkMode}>
-        <HeaderSection.PanelHeader title="Datasources"></HeaderSection.PanelHeader>
+        <HeaderSection.PanelHeader title="Datasources">
+          <div className="d-flex justify-content-end">
+            <Button
+              title={`${pinned ? 'Unpin' : 'Pin'}`}
+              onClick={() => setPinned(!pinned)}
+              darkMode={darkMode}
+              size="sm"
+              styles={{ width: '28px', padding: 0 }}
+            >
+              <Button.Content
+                iconSrc={`assets/images/icons/editor/left-sidebar/pinned${pinned ? 'off' : ''}.svg`}
+                direction="left"
+              />
+            </Button>
+          </div>
+        </HeaderSection.PanelHeader>
       </HeaderSection>
       <div className="card-body pb-5">
         <div className="d-flex w-100 flex-column align-items-start">

--- a/frontend/src/Editor/LeftSidebar/SidebarDatasources.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarDatasources.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-named-as-default */
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { LeftSidebarItem } from './SidebarItem';
 import { HeaderSection } from '@/_ui/LeftSidebar';
 import { DataSourceManager } from '../DataSourceManager';
 import { DataSourceTypes } from '../DataSourceManager/SourceComponents';
@@ -10,7 +9,6 @@ import { datasourceService, globalDatasourceService, authenticationService } fro
 import { ConfirmDialog } from '@/_components';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import Popover from '@/_ui/Popover';
 import { Popover as PopoverBS, OverlayTrigger } from 'react-bootstrap';
 // eslint-disable-next-line import/no-unresolved
 import TrashIcon from '@assets/images/icons/query-trash-icon.svg';
@@ -22,15 +20,12 @@ import { useDataSources } from '@/_stores/dataSourcesStore';
 export const LeftSidebarDataSources = ({
   appId,
   editingVersionId,
-  selectedSidebarItem,
-  setSelectedSidebarItem,
   darkMode,
   dataSourcesChanged,
   globalDataSourcesChanged,
   dataQueriesChanged,
   toggleDataSourceManagerModal,
   showDataSourceManagerModal,
-  popoverContentHeight,
   isVersionReleased,
   setReleasedVersionPopupState,
 }) => {
@@ -101,6 +96,7 @@ export const LeftSidebarDataSources = ({
     convertToGlobal,
     showDeleteIcon = true,
     enableEdit = true,
+    // eslint-disable-next-line no-unused-vars
     setReleasedVersionPopupState,
     isVersionReleased,
   }) => {
@@ -187,17 +183,6 @@ export const LeftSidebarDataSources = ({
     );
   };
 
-  const popoverContent = (
-    <LeftSidebarDataSources.Container
-      darkMode={darkMode}
-      RenderDataSource={RenderDataSource}
-      dataSources={dataSources}
-      toggleDataSourceManagerModal={toggleDataSourceManagerModal}
-      isVersionReleased={isVersionReleased}
-      setReleasedVersionPopupState={setReleasedVersionPopupState}
-    />
-  );
-
   if (dataSources?.length <= 0) return;
 
   return (
@@ -210,24 +195,14 @@ export const LeftSidebarDataSources = ({
         onCancel={() => cancelDeleteDataSource()}
         darkMode={darkMode}
       />
-      <Popover
-        handleToggle={(open) => {
-          if (!open) setSelectedSidebarItem('');
-        }}
-        popoverContentClassName="p-0 sidebar-h-100-popover"
-        side="right"
-        popoverContent={popoverContent}
-        popoverContentHeight={popoverContentHeight}
-      >
-        <LeftSidebarItem
-          selectedSidebarItem={selectedSidebarItem}
-          onClick={() => setSelectedSidebarItem('database')}
-          icon="database"
-          className={`left-sidebar-item sidebar-datasources left-sidebar-layout`}
-          tip="Sources"
-        />
-      </Popover>
-
+      <LeftSidebarDataSources.Container
+        darkMode={darkMode}
+        RenderDataSource={RenderDataSource}
+        dataSources={dataSources}
+        toggleDataSourceManagerModal={toggleDataSourceManagerModal}
+        isVersionReleased={isVersionReleased}
+        setReleasedVersionPopupState={setReleasedVersionPopupState}
+      />
       <DataSourceManager
         appId={appId}
         showDataSourceManagerModal={showDataSourceManagerModal}

--- a/frontend/src/Editor/LeftSidebar/index.jsx
+++ b/frontend/src/Editor/LeftSidebar/index.jsx
@@ -117,8 +117,10 @@ export const LeftSidebar = forwardRef((props, ref) => {
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line no-unused-vars
       setUnReadErrorCount((prev) => ({ read: errorLogs.length, unread: 0 }));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   useEffect(() => {
@@ -126,6 +128,7 @@ export const LeftSidebar = forwardRef((props, ref) => {
     setUnReadErrorCount((prev) => {
       return { ...prev, unread: unReadErrors };
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errorLogs.length]);
 
   useEffect(() => {
@@ -139,6 +142,7 @@ export const LeftSidebar = forwardRef((props, ref) => {
     } else {
       setEditorMarginLeft(350);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedSidebarItem]);
 
   useImperativeHandle(ref, () => ({
@@ -222,6 +226,20 @@ export const LeftSidebar = forwardRef((props, ref) => {
         pinned={pinned}
       />
     ),
+    database: (
+      <LeftSidebarDataSources
+        darkMode={darkMode}
+        appId={appId}
+        editingVersionId={appVersionsId}
+        dataSourcesChanged={dataSourcesChanged}
+        globalDataSourcesChanged={globalDataSourcesChanged}
+        dataQueriesChanged={dataQueriesChanged}
+        toggleDataSourceManagerModal={toggleDataSourceManagerModal}
+        showDataSourceManagerModal={showDataSourceManagerModal}
+        isVersionReleased={isVersionReleased}
+        setReleasedVersionPopupState={setReleasedVersionPopupState}
+      />
+    ),
     debugger: (
       <LeftSidebarDebugger
         darkMode={darkMode}
@@ -258,6 +276,14 @@ export const LeftSidebar = forwardRef((props, ref) => {
         tip="Inspector"
         ref={setSideBarBtnRefs('inspect')}
       />
+      <LeftSidebarItem
+        selectedSidebarItem={selectedSidebarItem}
+        onClick={() => handleSelectedSidebarItem('database')}
+        icon="database"
+        className={`left-sidebar-item left-sidebar-layout sidebar-datasources`}
+        tip="Sources"
+        ref={setSideBarBtnRefs('database')}
+      />
 
       <Popover
         onInteractOutside={handleInteractOutside}
@@ -266,22 +292,6 @@ export const LeftSidebar = forwardRef((props, ref) => {
         side="right"
         popoverContent={SELECTED_ITEMS[selectedSidebarItem]}
         popoverContentHeight={popoverContentHeight}
-      />
-
-      <LeftSidebarDataSources
-        darkMode={darkMode}
-        selectedSidebarItem={selectedSidebarItem}
-        setSelectedSidebarItem={handleSelectedSidebarItem}
-        appId={appId}
-        editingVersionId={appVersionsId}
-        dataSourcesChanged={dataSourcesChanged}
-        globalDataSourcesChanged={globalDataSourcesChanged}
-        dataQueriesChanged={dataQueriesChanged}
-        toggleDataSourceManagerModal={toggleDataSourceManagerModal}
-        showDataSourceManagerModal={showDataSourceManagerModal}
-        popoverContentHeight={popoverContentHeight}
-        isVersionReleased={isVersionReleased}
-        setReleasedVersionPopupState={setReleasedVersionPopupState}
       />
 
       {config.COMMENT_FEATURE_ENABLE && (
@@ -306,6 +316,7 @@ export const LeftSidebar = forwardRef((props, ref) => {
         <LeftSidebarItem
           icon="debugger"
           selectedSidebarItem={selectedSidebarItem}
+          // eslint-disable-next-line no-unused-vars
           onClick={(e) => handleSelectedSidebarItem('debugger')}
           className={`left-sidebar-item  left-sidebar-layout`}
           badge={true}

--- a/frontend/src/Editor/LeftSidebar/index.jsx
+++ b/frontend/src/Editor/LeftSidebar/index.jsx
@@ -53,8 +53,13 @@ export const LeftSidebar = forwardRef((props, ref) => {
     isVersionReleased,
     setReleasedVersionPopupState,
   } = props;
+
+  const dataSources = useDataSources();
+  const prevSelectedSidebarItem = localStorage.getItem('selectedSidebarItem');
   const queryPanelHeight = usePanelHeight();
-  const [selectedSidebarItem, setSelectedSidebarItem] = useState(localStorage.getItem('selectedSidebarItem'));
+  const [selectedSidebarItem, setSelectedSidebarItem] = useState(
+    dataSources?.length === 0 && prevSelectedSidebarItem === 'database' ? 'inspect' : prevSelectedSidebarItem
+  );
   const [showLeaveDialog, setShowLeaveDialog] = useState(false);
   const [showDataSourceManagerModal, toggleDataSourceManagerModal] = useState(false);
   const [popoverContentHeight, setPopoverContentHeight] = useState(queryPanelHeight);
@@ -182,8 +187,6 @@ export const LeftSidebar = forwardRef((props, ref) => {
   const setSideBarBtnRefs = (page) => (ref) => {
     sideBarBtnRefs.current[page] = ref;
   };
-
-  const dataSources = useDataSources();
 
   const SELECTED_ITEMS = {
     page: (

--- a/frontend/src/Editor/LeftSidebar/index.jsx
+++ b/frontend/src/Editor/LeftSidebar/index.jsx
@@ -245,8 +245,9 @@ export const LeftSidebar = forwardRef((props, ref) => {
         isVersionReleased={isVersionReleased}
         setReleasedVersionPopupState={setReleasedVersionPopupState}
         onDeleteofAllDataSources={() => {
-          setSelectedSidebarItem();
-          setPinned(false);
+          handleSelectedSidebarItem(null);
+          handlePin(false);
+          delete sideBarBtnRefs.current['database'];
         }}
         setPinned={handlePin}
         pinned={pinned}

--- a/frontend/src/Editor/LeftSidebar/index.jsx
+++ b/frontend/src/Editor/LeftSidebar/index.jsx
@@ -13,6 +13,7 @@ import config from 'config';
 import { LeftSidebarItem } from './SidebarItem';
 import Popover from '@/_ui/Popover';
 import { usePanelHeight } from '@/_stores/queryPanelStore';
+import { useDataSources } from '@/_stores/dataSourcesStore';
 
 export const LeftSidebar = forwardRef((props, ref) => {
   const router = useRouter();
@@ -182,6 +183,8 @@ export const LeftSidebar = forwardRef((props, ref) => {
     sideBarBtnRefs.current[page] = ref;
   };
 
+  const dataSources = useDataSources();
+
   const SELECTED_ITEMS = {
     page: (
       <LeftSidebarPageSelector
@@ -276,15 +279,16 @@ export const LeftSidebar = forwardRef((props, ref) => {
         tip="Inspector"
         ref={setSideBarBtnRefs('inspect')}
       />
-      <LeftSidebarItem
-        selectedSidebarItem={selectedSidebarItem}
-        onClick={() => handleSelectedSidebarItem('database')}
-        icon="database"
-        className={`left-sidebar-item left-sidebar-layout sidebar-datasources`}
-        tip="Sources"
-        ref={setSideBarBtnRefs('database')}
-      />
-
+      {dataSources?.length > 0 && (
+        <LeftSidebarItem
+          selectedSidebarItem={selectedSidebarItem}
+          onClick={() => handleSelectedSidebarItem('database')}
+          icon="database"
+          className={`left-sidebar-item left-sidebar-layout sidebar-datasources`}
+          tip="Sources"
+          ref={setSideBarBtnRefs('database')}
+        />
+      )}
       <Popover
         onInteractOutside={handleInteractOutside}
         open={pinned || !!selectedSidebarItem}

--- a/frontend/src/Editor/LeftSidebar/index.jsx
+++ b/frontend/src/Editor/LeftSidebar/index.jsx
@@ -244,6 +244,12 @@ export const LeftSidebar = forwardRef((props, ref) => {
         showDataSourceManagerModal={showDataSourceManagerModal}
         isVersionReleased={isVersionReleased}
         setReleasedVersionPopupState={setReleasedVersionPopupState}
+        onDeleteofAllDataSources={() => {
+          setSelectedSidebarItem();
+          setPinned(false);
+        }}
+        setPinned={handlePin}
+        pinned={pinned}
       />
     ),
     debugger: (


### PR DESCRIPTION
Resolves - In the upcoming release 2.7.0, we are not able to open the database drawer from the left sidebar in the editor