### PR TITLE
onCellValueChanged event is fired upon change in the cell value in table

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -213,7 +213,7 @@ export function Table({
 
     const changesToBeSavedAndExposed = { dataUpdates: newDataUpdates, changeSet: newChangeset };
     mergeToTableDetails(changesToBeSavedAndExposed);
-
+    fireEvent('onCellValueChanged');
     return setExposedVariables({ ...changesToBeSavedAndExposed, updatedData: clonedTableData });
   }
 


### PR DESCRIPTION
Resolves - onCellValueChanged event is not firing upon a change in the cell value in the Table