### PR TITLE
fix: show layout accordion settings by default for custom component widget

### DIFF
--- a/frontend/src/Editor/Inspector/Components/CustomComponent.jsx
+++ b/frontend/src/Editor/Inspector/Components/CustomComponent.jsx
@@ -52,7 +52,7 @@ export const CustomComponent = function CustomComponent({
 
   items.push({
     title: 'Layout',
-    isOpen: false,
+    isOpen: true,
     children: (
       <>
         {renderElement(


### PR DESCRIPTION
closes #4239 