### PR TITLE
Issue : Adding support to generate PDF file using generate file action

### DIFF
--- a/frontend/src/Editor/Inspector/EventManager.jsx
+++ b/frontend/src/Editor/Inspector/EventManager.jsx
@@ -467,6 +467,7 @@ export const EventManager = ({
                       options={[
                         { name: 'CSV', value: 'csv' },
                         { name: 'Text', value: 'plaintext' },
+                        { name: 'PDF', value: 'pdf' }
                       ]}
                       value={event.fileType ?? 'csv'}
                       search={true}

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -479,6 +479,7 @@ function executeActionWithDebounce(_ref, event, mode, customVariables) {
         const fileData = {
           csv: generateCSV,
           plaintext: (plaintext) => plaintext,
+          pdf: (pdfData) => pdfData,
         }[fileType](data);
         generateFile(fileName, fileData, fileType);
         return Promise.resolve();

--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -27,9 +27,56 @@ function generatePDF(filename, data) {
   const pageWidth = doc.internal.pageSize.getWidth();
   const margin = 10;
   const x = margin;
-  const y = margin;
+  let y = margin;
 
-  doc.text(data, x, y, { align: 'left', maxWidth: pageWidth - 2 * margin });
+  const processValue = (value, indentLevel = 0) => {
+    const valueType = typeof value;
+
+    if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
+      doc.text(value.toString(), x + indentLevel * 10, y, {
+        align: 'left',
+        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
+      });
+      y += 10;
+    } else if (Array.isArray(value)) {
+      doc.text('[', x + indentLevel * 10, y, {
+        align: 'left',
+        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
+      });
+      y += 10;
+      value.forEach((item) => {
+        processValue(item, indentLevel + 1);
+      });
+      doc.text(']', x + indentLevel * 10, y, {
+        align: 'left',
+        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
+      });
+      y += 10;
+    } else if (valueType === 'object' && value !== null) {
+      doc.text('{', x + indentLevel * 10, y, {
+        align: 'left',
+        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
+      });
+      y += 10;
+      Object.keys(value).forEach((key) => {
+        doc.text(`${key}:`, x + (indentLevel + 1) * 10, y, {
+          align: 'left',
+          maxWidth: pageWidth - 2 * margin - (indentLevel + 1) * 10,
+        });
+        y += 10;
+        processValue(value[key], indentLevel + 1);
+      });
+      doc.text('}', x + indentLevel * 10, y, {
+        align: 'left',
+        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
+      });
+      y += 10;
+    } else {
+      throw new Error('Invalid data type. Expected string, number, boolean, object, or array.');
+    }
+  };
+
+  processValue(data);
 
   doc.save(filename);
 }

--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -25,7 +25,6 @@ export default function generateFile(filename, data, fileType) {
 function generatePDF(filename, data) {
   const doc = new jsPDF();
   const pageWidth = doc.internal.pageSize.getWidth();
-  const pageHeight = doc.internal.pageSize.getHeight();
   const margin = 10;
   const x = margin;
   const y = margin;

--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -31,44 +31,36 @@ function generatePDF(filename, data) {
   const processValue = (value, indentLevel = 0) => {
     const valueType = typeof value;
 
-    if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
-      doc.text(value.toString(), x + indentLevel * 10, y, {
+    if (valueType === 'string') {
+      doc.text(value, x, y, {
         align: 'left',
-        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
+        maxWidth: pageWidth - 2 * margin,
       });
       y += 10;
     } else if (Array.isArray(value)) {
-      doc.text('[', x + indentLevel * 10, y, {
-        align: 'left',
-        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
+      const columnNames = Object.keys(value[0]);
+
+      // Print table headers
+      doc.autoTable({
+        startY: y,
+        head: [columnNames],
+        body: value.map((item) => Object.values(item)),
       });
-      y += 10;
-      value.forEach((item) => {
-        processValue(item, indentLevel + 1);
-      });
-      doc.text(']', x + indentLevel * 10, y - 10, {
-        align: 'left',
-        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
-      });
+
+      y = doc.autoTable.previous.finalY + 10;
     } else if (valueType === 'object' && value !== null) {
-      doc.text('{', x + indentLevel * 10, y, {
-        align: 'left',
-        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
+      const columnNames = Object.keys(value);
+
+      // Print table headers
+      doc.autoTable({
+        startY: y,
+        head: [columnNames],
+        body: [Object.values(value)],
       });
-      y += 10;
-      Object.keys(value).forEach((key) => {
-        doc.text(`${key}: ${JSON.stringify(value[key])}`, x + (indentLevel + 1) * 10, y, {
-          align: 'left',
-          maxWidth: pageWidth - 2 * margin - (indentLevel + 1) * 10,
-        });
-        y += 10;
-      });
-      doc.text('}', x + indentLevel * 10, y - 10, {
-        align: 'left',
-        maxWidth: pageWidth - 2 * margin - indentLevel * 10,
-      });
+
+      y = doc.autoTable.previous.finalY + 10;
     } else {
-      throw new Error('Invalid data type. Expected string, number, boolean, object, or array.');
+      throw new Error('Invalid data type. Expected string, object, or array.');
     }
   };
 

--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -21,7 +21,6 @@ export default function generateFile(filename, data, fileType) {
     window.URL.revokeObjectURL(elem.href);
   }
 }
-
 function generatePDF(filename, data) {
   const doc = new jsPDF();
   const pageWidth = doc.internal.pageSize.getWidth();
@@ -47,11 +46,10 @@ function generatePDF(filename, data) {
       value.forEach((item) => {
         processValue(item, indentLevel + 1);
       });
-      doc.text(']', x + indentLevel * 10, y, {
+      doc.text(']', x + indentLevel * 10, y - 10, {
         align: 'left',
         maxWidth: pageWidth - 2 * margin - indentLevel * 10,
       });
-      y += 10;
     } else if (valueType === 'object' && value !== null) {
       doc.text('{', x + indentLevel * 10, y, {
         align: 'left',
@@ -59,18 +57,16 @@ function generatePDF(filename, data) {
       });
       y += 10;
       Object.keys(value).forEach((key) => {
-        doc.text(`${key}:`, x + (indentLevel + 1) * 10, y, {
+        doc.text(`${key}: ${JSON.stringify(value[key])}`, x + (indentLevel + 1) * 10, y, {
           align: 'left',
           maxWidth: pageWidth - 2 * margin - (indentLevel + 1) * 10,
         });
         y += 10;
-        processValue(value[key], indentLevel + 1);
       });
-      doc.text('}', x + indentLevel * 10, y, {
+      doc.text('}', x + indentLevel * 10, y - 10, {
         align: 'left',
         maxWidth: pageWidth - 2 * margin - indentLevel * 10,
       });
-      y += 10;
     } else {
       throw new Error('Invalid data type. Expected string, number, boolean, object, or array.');
     }

--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -1,6 +1,14 @@
+import jsPDF from 'jspdf';
+
 export default function generateFile(filename, data, fileType) {
+  if (fileType === 'pdf') {
+    generatePDF(filename, data);
+    return;
+  }
+
   const type = fileType === 'csv' ? 'text/csv' : 'text/plain';
   const blob = new Blob([data], { type });
+
   if (window.navigator.msSaveOrOpenBlob) {
     window.navigator.msSaveBlob(blob, filename);
   } else {
@@ -12,4 +20,17 @@ export default function generateFile(filename, data, fileType) {
     document.body.removeChild(elem);
     window.URL.revokeObjectURL(elem.href);
   }
+}
+
+function generatePDF(filename, data) {
+  const doc = new jsPDF();
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const margin = 10;
+  const x = margin;
+  const y = margin;
+
+  doc.text(data, x, y, { align: 'left', maxWidth: pageWidth - 2 * margin });
+
+  doc.save(filename);
 }


### PR DESCRIPTION
Resolves : https://github.com/ToolJet/ToolJet/issues/5981
 - Added an option to show PDF option to generate files as pdf.
 - Modified existing methods in appUtils.js and generae_fill.js to support pdf type 
 
 Image : 
 
<img width="200" alt="Screenshot 2023-06-22 at 7 17 55 PM" src="https://github.com/ToolJet/ToolJet/assets/35486999/e3e2fc4d-3b58-4609-8a63-5a92fe71630a">

<img width="200" alt="Screenshot 2023-06-22 at 7 13 56 PM" src="https://github.com/ToolJet/ToolJet/assets/35486999/ce453994-d2e4-4772-85f1-ff69dd891bfb">

<img width="200" alt="Screenshot 2023-06-22 at 7 17 13 PM" src="https://github.com/ToolJet/ToolJet/assets/35486999/0fd40c59-162a-44d9-8ecb-92bb9761f3d2">

<img width="200" alt="Screenshot 2023-06-22 at 7 17 26 PM" src="https://github.com/ToolJet/ToolJet/assets/35486999/9dcd77d2-0bb3-4f3a-a0d7-85f61601d86b">

