### PR TITLE
Added functionality to save edited workspace name on pressing 'Enter'

### DIFF
--- a/frontend/src/_components/OrganizationManager/EditOrganization.jsx
+++ b/frontend/src/_components/OrganizationManager/EditOrganization.jsx
@@ -48,6 +48,12 @@ export const EditOrganization = ({ showEditOrg, setShowEditOrg, currentValue }) 
     setNewOrgName(e.target.value);
   };
 
+  const handleKeyDown = (e) => {
+    if (e.keyCode === 13) {
+      editOrganization();
+    }
+  };
+
   const closeModal = () => {
     setShowEditOrg(false);
     setErrorText('');
@@ -66,6 +72,7 @@ export const EditOrganization = ({ showEditOrg, setShowEditOrg, currentValue }) 
           <input
             type="text"
             onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
             className="form-control"
             placeholder={t('header.organization.workspaceName', 'workspace name')}
             disabled={isCreating}


### PR DESCRIPTION
This PR addresses #6759.

**Description**:
An `onKeyPress` event is added to the input to check for an Enter key press. If yes, the [`editOrganization` function](https://github.com/ToolJet/ToolJet/blob/c55e83eec94c42a02524602a83c47c629435a183/frontend/src/_components/OrganizationManager/EditOrganization.jsx#L18) is invoked which makes the required update.