### PR TITLE
fix:#6720 text of the name of global datasource listitem overflows

### DIFF
--- a/frontend/src/GlobalDatasources/LIstItem/index.jsx
+++ b/frontend/src/GlobalDatasources/LIstItem/index.jsx
@@ -41,13 +41,13 @@ export const ListItem = ({ dataSource, key, active, onDelete, updateSelectedData
           focusModal();
           updateSelectedDatasource(dataSource?.name);
         }}
-        className="col d-flex align-items-center"
+        className="col d-flex align-items-center overflow-hidden"
         data-cy={`${String(dataSource.name).toLowerCase().replace(/\s+/g, '-')}-button`}
       >
         {icon}
-        <span className="font-400 tj-text-xsm" style={{ paddingLeft: '6px' }}>
-          {dataSource.name}
-        </span>
+        <div className="font-400 tj-text-xsm text-truncate" style={{ paddingLeft: '6px' }}>
+          {dataSource.name.length > 30 ? `${dataSource.name.slice(0, 35)}` : dataSource.name}
+        </div>
       </div>
       <div className="col-auto">
         <button

--- a/frontend/src/GlobalDatasources/LIstItem/index.jsx
+++ b/frontend/src/GlobalDatasources/LIstItem/index.jsx
@@ -44,9 +44,10 @@ export const ListItem = ({ dataSource, key, active, onDelete, updateSelectedData
         className="col d-flex align-items-center overflow-hidden"
         data-cy={`${String(dataSource.name).toLowerCase().replace(/\s+/g, '-')}-button`}
       >
-        {icon}
+        <div>{icon}</div>
+
         <div className="font-400 tj-text-xsm text-truncate" style={{ paddingLeft: '6px' }}>
-          {dataSource.name.length > 30 ? `${dataSource.name.slice(0, 35)}` : dataSource.name}
+          {dataSource.name}
         </div>
       </div>
       <div className="col-auto">

--- a/frontend/src/_styles/global-datasources.scss
+++ b/frontend/src/_styles/global-datasources.scss
@@ -33,7 +33,7 @@
             border-radius: 6px;
 
             .ds-delete-btn {
-                display: block;
+                visibility: visible;
             }
         }
 
@@ -44,7 +44,8 @@
 
 
         .ds-delete-btn {
-            display: none;
+            display: block;
+            visibility:hidden;
             border: none;
             background: none;
         }


### PR DESCRIPTION
Resolves #6720 
**before**
![image](https://github.com/ToolJet/ToolJet/assets/117254052/0594fc23-8a5f-4266-b68e-e400dce89f1b)

When text-overflow fixed using ellipsis,another problem came in
datasource-listItem-icon size reducing respectively with text increases
so limited the letters taken in List item  to  35 for keeping the icon size
 


**after**
![image](https://github.com/ToolJet/ToolJet/assets/117254052/c8f8a025-1271-41e6-a8d2-2fa1ef261218)

