### PR TITLE
Fixes #6654: [docs] Replace the term toolbar to topbar in the app builder

### DIFF
--- a/docs/docs/app-builder/overview.md
+++ b/docs/docs/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/toolbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/docs/app-builder/toolbar.md
+++ b/docs/docs/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/newglobalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/newglobalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -198,7 +198,7 @@ const sidebars = {
       'label': 'App Builder',
       'items': [
         'app-builder/overview',
-        'app-builder/toolbar',
+        'app-builder/topbar',
         'app-builder/canvas',
         'app-builder/left-sidebar',
         'app-builder/components-library',

--- a/docs/versioned_docs/version-2.0.0/app-builder/overview.md
+++ b/docs/versioned_docs/version-2.0.0/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/toolbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[datasources](/docs/data-sources/overview)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/versioned_docs/version-2.0.0/app-builder/toolbar.md
+++ b/docs/versioned_docs/version-2.0.0/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/versioned_docs/version-2.1.0/app-builder/overview.md
+++ b/docs/versioned_docs/version-2.1.0/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/toolbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[datasources](/docs/data-sources/overview)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/versioned_docs/version-2.1.0/app-builder/toolbar.md
+++ b/docs/versioned_docs/version-2.1.0/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/versioned_docs/version-2.2.0/app-builder/overview.md
+++ b/docs/versioned_docs/version-2.2.0/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/toolbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[datasources](/docs/data-sources/overview)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/versioned_docs/version-2.2.0/app-builder/toolbar.md
+++ b/docs/versioned_docs/version-2.2.0/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/versioned_docs/version-2.3.0/app-builder/overview.md
+++ b/docs/versioned_docs/version-2.3.0/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/toolbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[datasources](/docs/data-sources/overview)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/versioned_docs/version-2.3.0/app-builder/toolbar.md
+++ b/docs/versioned_docs/version-2.3.0/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/versioned_docs/version-2.4.0/app-builder/overview.md
+++ b/docs/versioned_docs/version-2.4.0/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/toolbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[datasources](/docs/data-sources/overview)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/versioned_docs/version-2.4.0/app-builder/toolbar.md
+++ b/docs/versioned_docs/version-2.4.0/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/globalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/versioned_docs/version-2.5.0/app-builder/overview.md
+++ b/docs/versioned_docs/version-2.5.0/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/toolbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/versioned_docs/version-2.5.0/app-builder/toolbar.md
+++ b/docs/versioned_docs/version-2.5.0/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/newglobalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/newglobalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/versioned_docs/version-2.6.0/app-builder/overview.md
+++ b/docs/versioned_docs/version-2.6.0/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/toolbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/versioned_docs/version-2.6.0/app-builder/toolbar.md
+++ b/docs/versioned_docs/version-2.6.0/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/newglobalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/newglobalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/versioned_docs/version-2.7.0/app-builder/overview.md
+++ b/docs/versioned_docs/version-2.7.0/app-builder/overview.md
@@ -7,7 +7,7 @@ title: Overview
 
 ToolJet's App Builder allows you to build applications. ToolJet's app builder has the following major components:
 
-- **[Toolbar](/docs/app-builder/toolbar)**: configure app settings
+- **[Topbar](/docs/app-builder/topbar)**: configure app settings
 - **[Canvas](/docs/app-builder/canvas)**: Arrange the components to build the interface of app
 - **[Left-sidebar](/docs/app-builder/left-sidebar)**: Add **[pages](/docs/tutorial/pages)**, **[inspect](/docs/how-to/use-inspector)** the components, queries or variables, and **[debug](#debugger)** the errors.
 - **[Components library](/docs/app-builder/components-library)**(right sidebar): Drag any component or modify the property or styling

--- a/docs/versioned_docs/version-2.7.0/app-builder/toolbar.md
+++ b/docs/versioned_docs/version-2.7.0/app-builder/toolbar.md
@@ -1,25 +1,25 @@
 ---
-id: toolbar
-title: Toolbar
+id: topbar
+title: Topbar
 ---
 
-Toolbar is present at the top of the app-builder, and is used to configure the app settings.
+Topbar is present at the top of the app-builder, and is used to configure the app settings.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/toolbar.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### App name
 
-App name can be edited from the left side of the toolbar next to the ToolJet logo.
+App name can be edited from the left side of the topbar next to the ToolJet logo.
 
 When a new app is created, by default its name is set to **Untitled app**
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/name.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -35,13 +35,13 @@ To configure the app's global settings, click on the kebab menu(three vertical d
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/newglobalset.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/newglobalset.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Desktop or Mobile layout
 
-Switch the canvas mode in Mobile or Desktop layout from the toolbar.
+Switch the canvas mode in Mobile or Desktop layout from the topbar.
 
 #### Adding existing component to mobile layout
 
@@ -49,7 +49,7 @@ Click on the component handle to open component config inspector on the right si
 
 #### Adding a new component to mobile layout
 
-Switch the layout to mobile by clicking the button on the toolbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
+Switch the layout to mobile by clicking the button on the topbar. Drag and drop a component to the canvas. This widget will not be shown on desktop layout unless **Show on desktop** is enabled from the component config inspector.
 
 :::info
 Width of the component will be automatically adjusted to fit the screen while viewing the application in app viewer.
@@ -57,19 +57,19 @@ Width of the component will be automatically adjusted to fit the screen while vi
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/view.png" alt="App Builder: Topbar"/>
 
 </div>
 
 ### Undo or Redo
 
-Use the undo or redo buttons from the toolbar to undo or redo any change on the canvas.
+Use the undo or redo buttons from the topbar to undo or redo any change on the canvas.
 
 You can also **[Keyboard Shortcuts](/docs/tutorial/keyboard-shortcuts)** to perform such actions.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/undo.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -81,7 +81,7 @@ When many developers are working on an app, **Versioning** allows them to save t
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/version.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -91,7 +91,7 @@ Comment anywhere on the canvas and collaborate with other users in the workspace
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/comments.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -104,7 +104,7 @@ Share your applications with a unique URL generated automatically or edit the UR
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/share.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -114,7 +114,7 @@ Clicking on **Preview** button will open up the currently opened version of the 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/preview.png" alt="App Builder: Topbar"/>
 
 </div>
 
@@ -128,6 +128,6 @@ ToolJet will block editing of the Released version of an app and will display a 
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Toolbar"/>
+<img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/release.png" alt="App Builder: Topbar"/>
 
 </div>

--- a/docs/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.0.0-sidebars.json
@@ -185,7 +185,7 @@
       "label": "App Builder",
       "items": [
         "app-builder/overview",
-        "app-builder/toolbar",
+        "app-builder/topbar",
         "app-builder/canvas",
         "app-builder/left-sidebar",
         "app-builder/components-library",

--- a/docs/versioned_sidebars/version-2.1.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.1.0-sidebars.json
@@ -185,7 +185,7 @@
       "label": "App Builder",
       "items": [
         "app-builder/overview",
-        "app-builder/toolbar",
+        "app-builder/topbar",
         "app-builder/canvas",
         "app-builder/left-sidebar",
         "app-builder/components-library",

--- a/docs/versioned_sidebars/version-2.2.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.2.0-sidebars.json
@@ -186,7 +186,7 @@
       "label": "App Builder",
       "items": [
         "app-builder/overview",
-        "app-builder/toolbar",
+        "app-builder/topbar",
         "app-builder/canvas",
         "app-builder/left-sidebar",
         "app-builder/components-library",

--- a/docs/versioned_sidebars/version-2.3.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.3.0-sidebars.json
@@ -186,7 +186,7 @@
       "label": "App Builder",
       "items": [
         "app-builder/overview",
-        "app-builder/toolbar",
+        "app-builder/topbar",
         "app-builder/canvas",
         "app-builder/left-sidebar",
         "app-builder/components-library",

--- a/docs/versioned_sidebars/version-2.4.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.4.0-sidebars.json
@@ -186,7 +186,7 @@
       "label": "App Builder",
       "items": [
         "app-builder/overview",
-        "app-builder/toolbar",
+        "app-builder/topbar",
         "app-builder/canvas",
         "app-builder/left-sidebar",
         "app-builder/components-library",

--- a/docs/versioned_sidebars/version-2.5.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.5.0-sidebars.json
@@ -187,7 +187,7 @@
       "label": "App Builder",
       "items": [
         "app-builder/overview",
-        "app-builder/toolbar",
+        "app-builder/topbar",
         "app-builder/canvas",
         "app-builder/left-sidebar",
         "app-builder/components-library",

--- a/docs/versioned_sidebars/version-2.6.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.6.0-sidebars.json
@@ -188,7 +188,7 @@
       "label": "App Builder",
       "items": [
         "app-builder/overview",
-        "app-builder/toolbar",
+        "app-builder/topbar",
         "app-builder/canvas",
         "app-builder/left-sidebar",
         "app-builder/components-library",

--- a/docs/versioned_sidebars/version-2.7.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.7.0-sidebars.json
@@ -188,7 +188,7 @@
       "label": "App Builder",
       "items": [
         "app-builder/overview",
-        "app-builder/toolbar",
+        "app-builder/topbar",
         "app-builder/canvas",
         "app-builder/left-sidebar",
         "app-builder/components-library",


### PR DESCRIPTION
## Issue #6654
### Summary

Currently, we are calling the header in the app builder as toolbar, the correct term is topbar.
Make relevant corrections in the entire documentation and make sure no links are breaking.

### Issue Type

Documentation bug

### Documentation URL

No response

### Steps to reproduce the issue

No response

### Additional Information

<details>
<summary>Requested Changes #6749 </summary>

Refer #6749 

1. In the file "toolbar.md," you changed the "id" to "topbar." Consequently, you will also need to update the "sidebar.js" file accordingly. Failure to do so may result in a broken build. After making this change, I kindly request that you test the documentation locally to ensure that everything is functioning properly.
2. Furthermore, I would like you to apply the same alterations you made in the "docs/docs" folder to the versioned documentation spanning from version 2.0.0 to 2.6.0. You can locate the versioned documentation in the "tooljet/docs/versioned_docs" directory.


</details>



### Tasks

- [x] Replaced term toolbar to topbar in `docs/docs/app-builder/toolbar.md`.
- [x] Make relevant corrections in the entire documentation and make sure no links are breaking.
- [x] Update sidebar.js
- [x] Update documentation spanning from version 2.0.0 to 2.7.0 (Versioned Docs and Versioned sidebar.js)
- [ ] Update `/docs/app-builder/toolbar` to `/docs/app-builder/topbar`.
- [ ] Change the name of toolbar to topbar in respective image locations linked in `toolbar.md` ?

### Local Setup

<details>
<summary>Images</summary>


![Updated - Overview ToolJet](https://github.com/ToolJet/ToolJet/assets/122866331/33cca278-086a-467b-8205-9a3704a6e648)


![Updated - Topbar ToolJet](https://github.com/ToolJet/ToolJet/assets/122866331/43100c42-89e7-45bf-bae3-70da2f9b9dee)
</details>


### Code of Conduct

I agree to follow the ToolJet Code of Conduct.
