### PR TITLE
Fix: release pipleline

### DIFF
--- a/.github/workflows/tooljet-release-docker-image-build.yml
+++ b/.github/workflows/tooljet-release-docker-image-build.yml
@@ -3,8 +3,6 @@ name: Tooljet release docker images build
 on:
   release: 
     types: [published]
-    branches:
-      - main
 
   workflow_dispatch:
     inputs:

--- a/deploy/ec2/variables.pkr.hcl
+++ b/deploy/ec2/variables.pkr.hcl
@@ -9,7 +9,7 @@ variable "instance_type" {
 
 variable "ami_region" {
   type    = string
-  default = "us-west-2"
+  default = "us-west-1"
 }
 
 variable "ami_groups" {


### PR DESCRIPTION
1. packer build failed due to exceed in cpu usage in the region us-west-2. Hence changes the region to us-west-1. 
2. for docker build removed the branch name