### PR TITLE
Bug/postgres gui bulkupdate null issue

### DIFF
--- a/plugins/packages/postgresql/lib/index.ts
+++ b/plugins/packages/postgresql/lib/index.ts
@@ -146,7 +146,7 @@ export default class PostgresqlQueryService implements QueryService {
 
       for (const key of Object.keys(record)) {
         if (key !== primaryKey) {
-          queryText = ` ${queryText} ${key} = '${record[key]}',`;
+          queryText = ` ${queryText} ${key} = ${record[key] === null ? null : `'${record[key]}'`},`;
         }
       }
 


### PR DESCRIPTION
Bug Fix
1. PostgreSQL plugin in GUI mode `BulkUpdate` operation, was wrongly updating NULL as 'null' string in database. In the Bug fix, null has been handled and it properly updates as NULL to the database.