### PR TITLE
Hotfix - passes correct state to preview query

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -817,7 +817,7 @@ export function getQueryVariables(options, state) {
 }
 
 export function previewQuery(_ref, query, calledFromQuery = false) {
-  const options = getQueryVariables(query.options, _ref.props.currentState);
+  const options = getQueryVariables(query.options, _ref?.state?.currentState);
 
   const { setPreviewLoading, setPreviewData } = useQueryPanelStore.getState().actions;
   setPreviewLoading(true);


### PR DESCRIPTION
Fixes: client workspace variables and app variables are not resolved.
All existing apps using app variables or workspace variables (client) in query builder fails the query as empty strings are being updated to queryOptions.
Therefore, server-side resolving is not possible, and hence queries fails.

ref: #6882