### PR TITLE
Fix: buildx in docker workflow

### DIFF
--- a/.github/workflows/render-preview-deploy-pro.yml
+++ b/.github/workflows/render-preview-deploy-pro.yml
@@ -268,7 +268,7 @@ jobs:
           sudo apt install postgresql-client -y
 
       - name: Wait after installing PostgreSQL
-        run: sleep 10          
+        run: sleep 25
 
       - name: Drop PostgreSQL PR database
         env:

--- a/.github/workflows/render-preview-deploy.yml
+++ b/.github/workflows/render-preview-deploy.yml
@@ -252,7 +252,7 @@ jobs:
           sudo apt install postgresql-client -y
 
       - name: Wait after installing PostgreSQL
-        run: sleep 10    
+        run: sleep 25  
 
       - name: Drop PostgreSQL PR database
         env:

--- a/.github/workflows/tooljet-docker-develop-build.yml
+++ b/.github/workflows/tooljet-docker-develop-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           mkdir -p ~/.docker/cli-plugins
-          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          curl -SL https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
           docker buildx use mybuilder
@@ -81,7 +81,7 @@ jobs:
         - name: Set up Docker Buildx
           run: |
             mkdir -p ~/.docker/cli-plugins
-            curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+            curl -SL https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
             chmod a+x ~/.docker/cli-plugins/docker-buildx
             docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
             docker buildx use mybuilder

--- a/.github/workflows/tooljet-docker-develop-build.yml
+++ b/.github/workflows/tooljet-docker-develop-build.yml
@@ -25,11 +25,20 @@ jobs:
         with:
           ref: refs/heads/develop
 
+      # Create Docker Buildx builder with platform configuration
+      - name: Set up Docker Buildx
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          docker buildx use mybuilder
+
       - name: Set DOCKER_CLI_EXPERIMENTAL
         run: echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: use mybuilder buildx
+        run: docker buildx use mybuilder
 
       - name: Docker Login
         uses: docker/login-action@v2
@@ -68,11 +77,20 @@ jobs:
           with:
             ref: refs/heads/develop
 
+        # Create Docker Buildx builder with platform configuration
+        - name: Set up Docker Buildx
+          run: |
+            mkdir -p ~/.docker/cli-plugins
+            curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+            docker buildx use mybuilder
+
         - name: Set DOCKER_CLI_EXPERIMENTAL
           run: echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
-
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v1
+          
+        - name: use mybuilder buildx
+          run: docker buildx use mybuilder
 
         - name: Docker Login
           uses: docker/login-action@v2
@@ -86,7 +104,7 @@ jobs:
             context: .
             file: docker/server.Dockerfile
             push: true
-            tags: tooljet/tooljet-ce:develop
+            tags: tooljet/tooljet-server-ce:develop
             platforms: linux/amd64
           env:
             DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tooljet-release-docker-image-build.yml
+++ b/.github/workflows/tooljet-release-docker-image-build.yml
@@ -3,6 +3,8 @@ name: Tooljet release docker images build
 on:
   release: 
     types: [published]
+    branches:
+      - main
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/tooljet-release-docker-image-build.yml
+++ b/.github/workflows/tooljet-release-docker-image-build.yml
@@ -26,11 +26,20 @@ jobs:
         with:
           ref: refs/heads/main
 
+      # Create Docker Buildx builder with platform configuration
+      - name: Set up Docker Buildx
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          docker buildx use mybuilder
+
       - name: Set DOCKER_CLI_EXPERIMENTAL
         run: echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        
+      - name: use mybuilder buildx
+        run: docker buildx use mybuilder
 
       - name: Docker Login
         uses: docker/login-action@v2
@@ -72,11 +81,20 @@ jobs:
         with:
           ref: main
 
+      # Create Docker Buildx builder with platform configuration
+      - name: Set up Docker Buildx
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          docker buildx use mybuilder
+
       - name: Set DOCKER_CLI_EXPERIMENTAL
         run: echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        
+      - name: use mybuilder buildx
+        run: docker buildx use mybuilder
 
       - name: Docker Login
         uses: docker/login-action@v1
@@ -133,11 +151,20 @@ jobs:
         with:
           ref: refs/heads/main
 
+      # Create Docker Buildx builder with platform configuration
+      - name: Set up Docker Buildx
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          docker buildx use mybuilder
+
       - name: Set DOCKER_CLI_EXPERIMENTAL
         run: echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        
+      - name: use mybuilder buildx
+        run: docker buildx use mybuilder
 
       - name: Docker Login
         uses: docker/login-action@v2
@@ -179,11 +206,20 @@ jobs:
         with:
           ref: main
 
+      # Create Docker Buildx builder with platform configuration
+      - name: Set up Docker Buildx
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          docker buildx use mybuilder
+
       - name: Set DOCKER_CLI_EXPERIMENTAL
         run: echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        
+      - name: use mybuilder buildx
+        run: docker buildx use mybuilder
 
       - name: Docker Login
         uses: docker/login-action@v2
@@ -223,11 +259,20 @@ jobs:
         with:
           ref: refs/heads/main
 
+      # Create Docker Buildx builder with platform configuration
+      - name: Set up Docker Buildx
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          docker buildx use mybuilder
+
       - name: Set DOCKER_CLI_EXPERIMENTAL
         run: echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        
+      - name: use mybuilder buildx
+        run: docker buildx use mybuilder
 
       - name: Docker Login
         uses: docker/login-action@v2
@@ -268,11 +313,20 @@ jobs:
         with:
           ref: main
 
+      # Create Docker Buildx builder with platform configuration
+      - name: Set up Docker Buildx
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          docker buildx use mybuilder
+
       - name: Set DOCKER_CLI_EXPERIMENTAL
         run: echo "DOCKER_CLI_EXPERIMENTAL=enabled" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        
+      - name: use mybuilder buildx
+        run: docker buildx use mybuilder
 
       - name: Docker Login
         uses: docker/login-action@v1

--- a/.github/workflows/tooljet-release-docker-image-build.yml
+++ b/.github/workflows/tooljet-release-docker-image-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           mkdir -p ~/.docker/cli-plugins
-          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          curl -SL https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
           docker buildx use mybuilder
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           mkdir -p ~/.docker/cli-plugins
-          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          curl -SL https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
           docker buildx use mybuilder
@@ -155,7 +155,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           mkdir -p ~/.docker/cli-plugins
-          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          curl -SL https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
           docker buildx use mybuilder
@@ -210,7 +210,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           mkdir -p ~/.docker/cli-plugins
-          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          curl -SL https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
           docker buildx use mybuilder
@@ -263,7 +263,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           mkdir -p ~/.docker/cli-plugins
-          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          curl -SL https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
           docker buildx use mybuilder
@@ -317,7 +317,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           mkdir -p ~/.docker/cli-plugins
-          curl -SL https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
+          curl -SL https://github.com/docker/buildx/releases/download/v0.11.0/buildx-v0.11.0.linux-amd64 -o ~/.docker/cli-plugins/docker-buildx
           chmod a+x ~/.docker/cli-plugins/docker-buildx
           docker buildx create --name mybuilder --platform linux/arm64,linux/amd64,linux/amd64/v2,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
           docker buildx use mybuilder

--- a/.github/workflows/tooljet-release-docker-image-build.yml
+++ b/.github/workflows/tooljet-release-docker-image-build.yml
@@ -20,7 +20,7 @@ jobs:
 
   build-tooljet-ce-image:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' && contains(github.event.types, 'published') }}
+    if: "${{ github.event.release }}"
 
     steps:
       - name: Checkout code
@@ -145,7 +145,7 @@ jobs:
 
   building-tooljet-server-ce-image:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' && contains(github.event.types, 'published') }}
+    if: "${{ github.event.release }}"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Issue: 
earlier the buildx which docker marketplace provided did not have all platform. 

Fix: 
Added code to install buildx and added the platforms same as docker-desktop. 