### PR TITLE
fix: appending base URL query params on redirect

### DIFF
--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -521,7 +521,9 @@ class ViewerComponent extends React.Component {
       const startingPageHandle = this.props?.params?.pageHandle;
       const homePageHandle = this.state.appDefinition?.pages?.[this.state.appDefinition?.homePageId]?.handle;
       if (!startingPageHandle && homePageHandle) {
-        return <Navigate to={homePageHandle} replace />;
+        return (
+          <Navigate to={`${homePageHandle}${this.props.params.pageHandle ? '' : window.location.search}`} replace />
+        );
       }
       if (this.state.app?.is_maintenance_on) {
         return (


### PR DESCRIPTION
Fix for appending query params added in the base url to the home page url. Since these query params where not retained on redirection, when a user base url of an app with query params, the redirection to home page will not have these params. The changes done will retain the query params in the redirection from base URL to home page url