### PR TITLE
feat: add ide-extension for i18n handling

### DIFF
--- a/.vscode/extension.json
+++ b/.vscode/extension.json
@@ -1,11 +1,12 @@
 {
-    "recommendations": [
-      "dbaeumer.vscode-eslint",
-      "CoenraadS.bracket-pair-colorizer",
-      "mgmcdermott.vscode-language-babel",
-      "formulahendry.auto-rename-tag",
-      "xabikos.javascriptsnippets",
-      "streetsidesoftware.code-spell-checker",
-      "esbenp.prettier-vscode"
-    ]
+	"recommendations": [
+		"dbaeumer.vscode-eslint",
+		"CoenraadS.bracket-pair-colorizer",
+		"mgmcdermott.vscode-language-babel",
+		"formulahendry.auto-rename-tag",
+		"xabikos.javascriptsnippets",
+		"streetsidesoftware.code-spell-checker",
+		"esbenp.prettier-vscode",
+		"inlang.vs-code-extension"
+	]
 }

--- a/frontend/assets/translations/de.json
+++ b/frontend/assets/translations/de.json
@@ -423,8 +423,16 @@
         "skip": "Überspringen"
     },
     "redirectSso": {
-        "upgradingTov1.13.0": "Aktualisieren auf v1.13.0 und höher.",
-        "fromV1.13.0": "Ab v1.13.0 haben wir volgendes eingeführt",
+        "upgradingTov1": {
+            "13": {
+                "0": "Aktualisieren auf v1.13.0 und höher."
+            }
+        },
+        "fromV1": {
+            "13": {
+                "0": "Ab v1.13.0 haben wir volgendes eingeführt"
+            }
+        },
         "multiWorkspace": "Multi-Workspace",
         "singleSignOnConfig": "Die Single Sign-On bezogenen Konfigurationen werden von den Arbeitsbereich-Variablen in die Datenbank verschoben. Bitte lesen Sie dies",
         "link": "Link",

--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -259,7 +259,7 @@
                     "enterLastName": "Enter Last Name",
                     "enterEmail": "Enter email id",
                     "enterFulltName": "Enter full name",
-                    "inviteNewUsers":"Invite new users"
+                    "inviteNewUsers": "Invite new users"
                 },
                 "manageGroups": {
                     "permissions": {
@@ -453,8 +453,16 @@
         "skip": "Skip"
     },
     "redirectSso": {
-        "upgradingTov1.13.0": "Upgrading to v1.13.0 and above.",
-        "fromV1.13.0": "From v1.13.0 we have introduced",
+        "upgradingTov1": {
+            "13": {
+                "0": "Upgrading to v1.13.0 and above."
+            }
+        },
+        "fromV1": {
+            "13": {
+                "0": "From v1.13.0 we have introduced"
+            }
+        },
         "multiWorkspace": "Multi-Workspace",
         "singleSignOnConfig": "The Single Sign-On related configurations are moved from workspace variables to database. Please refer this",
         "link": "Link",

--- a/frontend/assets/translations/es.json
+++ b/frontend/assets/translations/es.json
@@ -1,917 +1,925 @@
 {
-    "globals": {
-        "readDocumentation": "Leer la documentación",
-        "cancel": "Cancelar",
-        "save": "Guardar",
-        "back": "Atrás",
-        "edit": "Editar",
-        "search": "Buscar",
-        "update": "Actualizar",
-        "delete": "Borrar",
-        "add": "Añadir",
-        "view": "Ver",
-        "create": "Crear",
-        "enabled": "Activado",
-        "disabled": "Desactivado",
-        "yes": "Si",
-        "submit": "Enviar",
-        "select": "Seleccionar",
-        "environmentVar": "Variables de entorno",
-        "saving": "Guardando...",
-        "saveDatasource": "Guardar fuente de datos",
-        "authorize": "Autorizar",
-        "connect": "Conectar",
-        "reconnect": "Reconectar",
-        "components": "componentes",
-        "send": "Enviar",
-        "noConnection": "no se puede conectar",
-        "connectionVerifeid": "conexión verificada",
-        "left": "Izquierda",
-        "center": "Centro",
-        "right": "Derecha",
-        "justified": "Justificado",
-        "host": "Host",
-        "operation": "Operación",
-        "header": "HEADER",
-        "path": "PATH",
-        "query": "QUERY",
-        "requestBody": "REQUEST BODY"
-    },
-    "errorBoundary": "Algo salió mal. Por favor, inténtelo de nuevo.",
-    "viewer": "¡Lo sentimos!. Esta aplicación está bajo mantenimiento.",
-    "app": {
-        "updateAvailable": "Actualización disponible",
-        "newVersionReleased": "Una nueva versión de Tooljet ha sido desplegada.",
-        "readReleaseNotes": "Leer las notas del lanzamiento & actualizar.",
-        "skipVersion": "Saltar esta versión."
-    },
-    "stripe": "Por favor espere mientras cargamos la especificación de OpenAPI para Stripe",
-    "openApi": {
-        "noValidOpenApi": "Una especificación válida de OpenAPI no está disponible.",
-        "selectHost": "Seleccione un host",
-        "selectOperation": "Selecciona una operación"
-    },
-    "slack": {
-        "authorize": "Autorizar",
-        "connectToolJetToSlack": "ToolJet puede conectarse a Slack, listar usuarios, enviar mensajes, etc. Por favor seleccione los permisos apropiados.",
-        "chatWrite": "chat:escribir",
-        "listUsersAndSendMessage": "Tu aplicación de Tooljet será capaz de listar usuarios y enviar mensajes a ellos y a los canales.",
-        "connectSlack": "Conectar a Slack"
-    },
-    "googleSheets": {
-        "readOnly": "Solo lectura",
-        "enableReadAndWrite": "Si deseas que ToolJet pueda modificar tus hojas de Google Sheet, asegurate de seleccionar permisos de lectura y escritura.",
-        "readDataFromSheets": "Tus aplicaciones de ToolJet sólo pueden leer datos de tus hojas de Google Sheets.",
-        "readWrite": "Lectura y escritura",
-        "readModifySheets": "Tus aplicaciones de ToolJet pueden leer, modificar y más en tus hojas de Google Sheets.",
-        "toGoogleSheets": "a Google Sheets"
-    },
-    "profile": {
-        "profileSettings": "Preferencias de perfil"
-    },
-    "loginSignupPage": {
-        "forgotPassword": "Olvidaste la contraseña",
-        "emailAddress": "Dirección de correo electrónico",
-        "enterEmail": "Ingrese correo electrónico",
-        "resetPassword": "Restaurar contraseña",
-        "dontHaveAccount": "¿Aún no tienes una cuenta?",
-        "signIn": "Acceder",
-        "signUp": "Registrarte",
-        "createToolJetAccount": "Crear una cuenta de ToolJet",
-        "enterBusinessEmail": "Ingrese el correo electrónico de su empresa",
-        "alreadyHaveAnAccount": "¿Ya tiene una cuenta?",
-        "password": "Contraseña",
-        "showPassword": "Mostrar contraseña",
-        "loginTo": "Acceder a",
-        "yourAccount": "Su cuenta",
-        "noLoginMethodsEnabled": "No hay métodos de inicio de sesión habilitados para este espacio de trabajo",
-        "emailConfirmLink": "Compruebe su correo electrónico para ver el enlace de confirmación por favor",
-        "newPassword": "Nueva Contraseña",
-        "passwordConfirmation": "Confirmación de contraseña"
-    },
-    "editor": {
-        "preview": "Prevista",
-        "share": "Compartir",
-        "shareModal": {
-            "makeApplicationPublic": "¿Hacer aplicación pública?",
-            "shareableLink": "Obtener enlace compartible para esta aplicación",
-            "copy": "copiar",
-            "embeddableLink": "Obtener link embebible para esta aplicación",
-            "manageUsers": "Administrar usuarios"
-        },
-        "appVersionManager": {
-            "version": "Versión",
-            "currentlyReleased": "Actualmente desplegado",
-            "createVersion": "Crear versión",
-            "versionName": "Nombre de la versión",
-            "createVersionFrom": "Crear versión desde",
-            "save": "Guardar",
-            "create": "Crear versión",
-            "editVersion": "Editar versión",
-            "deleteVersion": "¿Quieres eliminar esta versión?",
-            "enterVersionName": "Introducir nombre de la versión",
-            "versionAlreadyReleased": "La versión ya fue creada anteriormente, por favor crea una nueva versión o cambia a una versión diferente para seguir realizando cambios."
-        },
-        "queries": "Consultas",
-        "inspectComponent": "Por favor seleccione un componente para inspeccionar.",
-        "release": "Desplegar",
-        "searchQueries": "Buscar consultas",
-        "createQuery": "Crear consulta",
-        "queryManager": {
-            "general": "General",
-            "advanced": "Avanzado",
-            "preview": "Prevista",
-            "Save": "Guardar",
-            "selectDatasource": "Seleccionar fuente de datos",
-            "addDatasource": "Añadir fuente de datos",
-            "dataSourceManager": {
-                "toast": {
-                    "success": {
-                        "dataSourceAdded": "Fuente de datos agregada",
-                        "dataSourceSaved": "Fuente de datos guardada"
-                    },
-                    "error": {
-                        "noEmptyDsName": "El nombre de la fuenta de datos no puede estar vacío"
-                    }
-                },
-                "suggestDataSource": "Sugerir fuente de datos",
-                "suggestAnIntegration": "Sugerir una integración",
-                "whatLookingFor": "¿Cuéntanos que estabas buscando?",
-                "noResultFound": "¿No encontraste lo que estabas buscando?",
-                "suggest": "Sugerir",
-                "addNewDataSource": "Añadir nueva fuente de datos",
-                "whiteListIP": "Por favor agrega nuestra dirección IP a la lista blanca si tu fuente de datos no es públicamente accessible.",
-                "copied": "Copiado",
-                "copy": "Copiar",
-                "saving": "Guardando",
-                "noResultsFor": "No se encontraron resultados para",
-                "noteTaken": "Gracias, ¡hemos tomado nota de esto!",
-                "goToAllDatasources": "Ir a todas las fuentes de datos",
-                "send": "Enviar"
-            },
-            "runQueryOnPageLoad": "Ejecutar consulta al cargar la página",
-            "confirmBeforeQueryRun": "¿Solicitar confirmación antes de ejecutar la consulta?",
-            "notificationOnSuccess": "¿Mostrar notificación satisfactoria?",
-            "successMessage": "Mensaje satisfactorio",
-            "queryRanSuccessfully": "La consulta fue ejecutada satisfactoriamente",
-            "notificationDuration": "Duración de la notificación (s)",
-            "events": "Eventos",
-            "transformation": {
-                "transformationToolTip": "Las transformaciones se pueden usar para transformar los resultados de las consultas. Todas las variables de la aplicación son accesibles desde los transformadores y admiten librerías JS como Lodash y Moment.",
-                "transformations": "Transformaciones"
-            }
-        },
-        "inspector": {
-            "eventManager": {
-                "event": "Evento",
-                "action": "Acción",
-                "actionOptions": "Opción de acciones",
-                "message": "Mensaje",
-                "alertType": "Tipo de alerta",
-                "url": "URL",
-                "modal": "Modal",
-                "text": "Texto",
-                "query": "Consulta",
-                "key": "Llave",
-                "value": "Valor",
-                "type": "Tipo",
-                "fileName": "Nombre del archivo",
-                "data": "Datos",
-                "table": "Tabla",
-                "pageIndex": "Índice de página",
-                "component": "Componente",
-                "addHandler": "+ Añadir manejador",
-                "addEventHandler": "+ Añadir manejador de eventos",
-                "emptyMessage": "Este {{componentName}} no tiene manejadores de eventos."
-            }
-        }
-    },
-    "header": {
-        "darkModeToggle": {
-            "activateLightMode": "Activar modo claro",
-            "activateDarkMode": "Activar modo oscuro"
-        },
-        "languageSelection": {
-            "changeLanguage": "Cambiar idioma",
-            "searchLanguage": "Buscar idioma"
-        },
-        "notificationCenter": {
-            "notifications": "Notificaciones",
-            "markAllAs": "Marcar todo como",
-            "read": "Leído",
-            "un": "un",
-            "youDontHaveany": "No tienes ningún/a",
-            "youAreCaughtUp": "¡Estás al día!",
-            "view": "Ver"
-        },
-        "organization": {
-            "loadOrganizations": "Cargar organizaciones",
-            "createWorkspace": "Crear espacio de trabajo",
-            "workspaceName": "Nombre del espacio de trabajo",
-            "editWorkspace": "Editar espacio de trabajo",
-            "menus": {
-                "addWorkspace": "Añadir espacio de trabajo",
-                "menusList": {
-                    "manageUsers": "Administrar usuarios",
-                    "manageGroups": "Administrar grupos",
-                    "manageSso": "Administrar SSO",
-                    "manageEnv": "Administrar variables de entorno"
-                },
-                "manageUsers": {
-                    "usersAndPermission": "Usuarios y Permisos",
-                    "inviteNewUser": "Invitar un nuevo usuario",
-                    "name": "NOMBRE",
-                    "email": "CORREO ELECTRÓNICO",
-                    "status": "ESTADO",
-                    "archive": "Archivar",
-                    "unarchive": "Desarchivar",
-                    "addNewUser": "Añadir un nuevo usuario",
-                    "emailAddress": "Dirección de correo electrónico",
-                    "createUser": "Crear usuario",
-                    "enterFirstName": "Ingrese su Nombre",
-                    "enterLastName": "Ingrese su Apellido",
-                    "enterEmail": "Ingrese correo electrónico"
-                },
-                "manageGroups": {
-                    "permissions": {
-                        "userGroups": "Grupos de usuarios",
-                        "createNewGroup": "Crear un nuevo grupo",
-                        "udpateGroup": "Actualizar grupo",
-                        "addNewGroup": "Añadir un nuevo grupo",
-                        "enterName": "Ingresar nombre",
-                        "createGroup": "Crear grupo",
-                        "name": "Nombre"
-                    },
-                    "permissionResources": {
-                        "userGroup": "Grupo de usuarios",
-                        "apps": "Aplicaciones",
-                        "users": "Usuarios",
-                        "permissions": "Permisos",
-                        "addAppsToGroup": "Seleccionar applicaciones para añadir al grupo.",
-                        "name": "Nombre",
-                        "addUsersToGroup": "Seleccionar usuarios para añadir al grupo.",
-                        "email": "Correo electrónico",
-                        "resource": "Recurso",
-                        "createUpdateDelete": "Crear/Actualizar/Eliminar",
-                        "folder": "Carpeta"
-                    }
-                },
-                "manageSSO": {
-                    "manageSso": "Administrar SSO",
-                    "generalSettings": {
-                        "title": "Ajustes Generales",
-                        "enableSignup": "Habilitar registro",
-                        "newAccountWillBeCreated": "Una nueva cuenta será creada para el primer inicio de sesión SSO del usuario",
-                        "allowedDomains": "Dominios permitidos",
-                        "enterDomains": "Ingresar los dominios",
-                        "supportMultiDomains": "Soporta múltiples dominios. Ingrese los nombres de dominio separados por coma. ejemplo: tooljet.com,tooljet.io,suorganizacion.com",
-                        "loginUrl": "URL de inicio de sesión",
-                        "workspaceLogin": "Use esta URL para iniciar sesión en el espacio de trabajo",
-                        "allowDefaultSso": "Permitir SSO por defecto",
-                        "ssoAuth": "Permitir a los usuarios autenticarse a través de SSO por defecto. Las configuraciones de SSO por defecto pueden ser anuladas por el SSO de nivel de espacio de trabajo."
-                    },
-                    "google": {
-                        "title": "Google",
-                        "enabled": "Activado",
-                        "disabled": "Desactivado",
-                        "clientId": "ID de cliente",
-                        "enterClientId": "Ingrese el ID de cliente",
-                        "redirectUrl": "URL de redirección"
-                    },
-                    "github": {
-                        "title": "Github",
-                        "hostName": "Nombre de host",
-                        "enterHostName": "Ingrese el nombre de host",
-                        "requiredGithub": "Requiere Github alojado en su propio servidor",
-                        "clientId": "ID de cliente",
-                        "enterClientId": "Ingrese el ID de cliente",
-                        "clientSecret": "Secreto de cliente",
-                        "enterClientSecret": "Ingrese el secreto de cliente",
-                        "encrypted": "Encriptado",
-                        "redirectUrl": "URL de redirección"
-                    },
-                    "passwordLogin": "Inicio de sesión con contraseña",
-                    "environmentVar": {
-                        "noEnvConfig": "No haz configurado ninguna variable de entorno, presiona el botón 'Añadir nueva variable' para crear una",
-                        "envWillBeDeleted": "La variable será eliminada, ¿desea continuar?",
-                        "addNewVariable": "Añadir nueva variable",
-                        "variableForm": {
-                            "addNewVariable": "Añadir nueva variable",
-                            "updatevariable": "Actualizar variable",
-                            "name": "Nombre",
-                            "value": "Valor",
-                            "enterVariableName": "Ingresar nombre de variable",
-                            "enterValue": "Ingresar valor",
-                            "type": "Tipo",
-                            "enableEncryption": "Habilitar encriptación",
-                            "addVariable": "Añadir variable"
-                        },
-                        "variableTable": {
-                            "name": "nombre",
-                            "value": "valor",
-                            "type": "tipo",
-                            "secret": "secreto"
-                        }
-                    }
-                }
-            }
-        },
-        "profileSettingPage": {
-            "profileSettings": "Configuración de Perfil",
-            "firstName": "Nombre",
-            "lastName": "Apellido",
-            "enterFirstName": "Ingrese su Nombre",
-            "enterLastName": "Ingrese su Apellido",
-            "email": "Correo electrónico",
-            "avatar": "Avatar",
-            "update": "Actualizar",
-            "profile": "Perfil",
-            "changePassword": "Cambiar contraseña",
-            "currentPassword": "Contraseña actual",
-            "newPassword": "Nueva contraseña",
-            "confirmNewPassword": "Confirmar nueva contraseña",
-            "enterCurrentPassword": "Introduzca contraseña actual",
-            "enterNewPassword": "Ingrese nueva contraseña"
-        },
-        "profile": "Perfil",
-        "logout": "Cerrar Sesión"
-    },
-    "homePage": {
-        "appCard": {
-            "changeIcon": "Cambiar ícono",
-            "addToFolder": "Añadir a la carpeta",
-            "move": "Mover",
-            "to": "hacia",
-            "selectFolder": "Seleccionar carpeta",
-            "deleteApp": "Borrar aplicación",
-            "exportApp": "Exportar aplicación",
-            "cloneApp": "Clonar aplicación",
-            "launch": "Lanzar",
-            "maintenance": "Mantenimiento",
-            "noDeployedVersion": "La aplicación no tiene una versión implementada",
-            "openInAppViewer": "Abrir en el visor de aplicaciones",
-            "removeFromFolder": "Borrar de la carpeta"
-        },
-        "blankPage": {
-            "welcomeToToolJet": "¡Bienvenido a ToolJet!",
-            "getStartedCreateNewApp": "Puedes empezar creando una nueva aplicación o creando una aplicación usando una plantilla en la biblioteca de ToolJet.",
-            "importApplication": "Importar una aplicación",
-        },
-        "foldersSection": {
-            "allApplications": "Todas las aplicaciones",
-            "folders": "Carpetas",
-            "createNewFolder": "+ Crear nueva carpeta",
-            "noFolders": "No haz creado ninguna carpeta, usa carpetas para organizar tus aplicaciones",
-            "createFolder": "Crear carpeta",
-            "updateFolder": "Actualizar carpeta",
-            "editFolder": "Editar carpeta",
-            "deleteFolder": "Borrar carpeta",
-            "folderName": "Nombre de la carpeta",
-            "wishToDeleteFolder": "¿Estás seguro de que deseas eliminar la carpeta {{folderName}}? Las aplicaciones dentro de la carpeta no se eliminarán."
-        },
-        "header": {
-            "createNewApplication": "Crear nueva aplicación",
-            "import": "Importar",
-            "chooseFromTemplate": "Elegir desde plantillas"
-        },
-        "pagination": {
-            "showing": "Mostrando",
-            "of": "de",
-            "to": "para"
-        },
-        "noApplicationFound": "No se encontraron aplicaciones",
-        "thisFolderIsEmpty": "Esta carpeta está vacía",
-        "deleteAppAndData": "La aplicación y los datos asociados se eliminarán permanentemente, ¿desea continuar?",
-        "removeAppFromFolder": "La aplicación se eliminará de esta carpeta, ¿desea continuar?",
-        "change": "Cambiar",
-        "templateCard": {
-            "use": "Usar",
-            "preview": "Prevista",
-            "leadGeneretion": "Generación de líderes",
-        },
-        "templateLibraryModal": {
-            "select": "Seleccionar plantilla",
-            "createAppfromTemplate": "Crear aplicación desde plantilla",
-        }
-    },
-    "confirmationPage": {
-        "setupAccount": "Configurar cuenta",
-        "signupWithGoogle": "Registrarse con Google",
-        "signupWithGitHub": "Registrarse con GitHub",
-        "or": "ó",
-        "firstName": "Primer nombre",
-        "lastName": "Apellido",
-        "company": "Compañía",
-        "role": "Rol",
-        "pleaseSelect": "Por favor seleccionar",
-        "password": "Contraseña",
-        "confirmPassword": "Confirmar contraseña",
-        "clickAndAgree": "Al hacer clic en el siguiente botón, acepta nuestros",
-        "termsAndConditions": "Términos y Condiciones",
-        "finishAccountSetup": "Finalizar configuración de cuenta",
-        "acceptInvite": "Aceptar invitación",
-        "accountExists": "¿Ya tienes una cuenta?",
-        "and": "y"
-    },
-    "onBoarding": {
-        "finishToolJetInstallation": "Finalizar instalación de ToolJet",
-        "organization": "Organización",
-        "name": "Nombre",
-        "email": "Email",
-        "receiveUpdatesFromToolJet": "Recibirás actualizaciones de parte del equipo de ToolJet (1-2 correos electrónicos al mes, no hacemos spam)",
-        "finishSetup": "Finalizar configuración",
-        "skip": "Saltar"
-    },
-    "redirectSso": {
-        "upgradingTov1.13.0": "Actualizando a v1.13.0 y más",
-        "fromV1.13.0": "Desde la versión 1.13.0 hemos introducido...",
-        "multiWorkspace": "Multi-Workspace",
-        "singleSignOnConfig": "La configuración relacionada con SSO se ha movido de las variables de entorno a la base de datos. Por favor, consulte este",
-        "link": "Enlace",
-        "toConfigureSSO": "para configurar SSO.",
-        "haveGoogleGithubSSo": "Si tiene configuraciones de SSO de Google o GitHub antes de la actualización y deshabilitó el Multi-Workspace, entonces las configuraciones de SSO se migrarán durante la actualización, pero debe volver a configurar la URL de redireccionamiento en el lado del proveedor de SSO. Las URL de redireccionamiento para cada SSO se indican a continuación.",
-        "isMultiWorkspaceEnabled": "Si tiene Multi-Workspace habilitado, entonces debe configurar SSO en cada espacio de trabajo. Puede hacerlo desde la página de configuración de SSO en cada espacio de trabajo.",
-        "youHaveEnabled": "Has habilitado",
-        "setupSsoWorkspace": "Por favor ingresar con su contraseña para configurar SSO en este espacio de trabajo.",
-        "manageSsoMenu": "Administrar menú de SSO.",
-        "youHaveDisabled": "Has deshabilitado",
-        "configureRedirectUrl": "Por favor configure la URL de redireccionamiento en el proveedor de SSO.",
-        "google": "Google",
-        "redirectUrl": "URL de redirección",
-        "gitHub": "GitHub"
-    },
-    "oAuth2": {
-        "pleaseWait": "Por favor espere...",
-        "authSuccess": "Autenticación satisfactoria, puede cerrar esta ventana.",
-        "authFailed": "Autenticación fallida."
-    },
-    "widgetManager": {
-        "commonlyUsed": "Comúnmente utilizado",
-        "layouts": "Diseños",
-        "forms": "Formularios",
-        "intregrations": "Integraciones",
-        "others": "Otros",
-        "noResults": "No se han encontrado resultados",
-        "tryAdjustingFilterMessage": "Intenta modificar tu búsqueda o los filtros para encontrar lo que estás buscando",
-        "clearQuery": "Limpiar búsqueda"
-    },
-    "widget": {
-        "common": {
-            "properties": "Propiedades",
-            "events": "Eventos",
-            "layout": "Diseño",
-            "styles": "Estilos",
-            "general": "General",
-            "validation": "Validación",
-            "documentation": "{{componentMeta}} documentación",
-            "widgetNameEmptyError": "El nombre del widget no puede estar vacío",
-            "componentNameExistsError": "El nombre del componente ya existe",
-            "invalidWidgetName": "Nombre de widget no válido. Debe ser único e incluir solo letras, números y guión bajo."
-        },
-        "commonProperties": {
-            "visibility": "Visibilidad",
-            "disable": "Inutilizar",
-            "borderRadius": "Radio del borde",
-            "boxShadow": "Sombra de caja",
-            "tooltip": "Información sobre herramientas",
-            "showOnDesktop": "Mostrar en el escritorio",
-            "showOnMobile": "Mostrar en el móvil",
-            "showLoadingState": "Mostrar estado de carga",
-            "backgroundColor": "Color de fondo",
-            "textColor": "Color del texto",
-            "loaderColor": "Color del cargador",
-            "defaultValue": "Valor predeterminado",
-            "placeholder": "Marcador",
-            "label": "Etiqueta",
-            "title": "Título",
-            "code": "Código",
-            "data": "Data",
-            "tableData": "Datos de la tabla",
-            "tableColumns": "Columnas de la tabla",
-            "searverSideSearch": "Búsqueda del lado del servidor",
-            "loadingState": "Estado de carga",
-            "serverSidePagination": "Paginación del lado del servidor",
-            "clientSidePagination": "Paginación del lado del cliente",
-            "serverSideSearch": "Búsqueda del lado del servidor",
-            "showSearchBox": "Mostrar cuadro de búsqueda",
-            "showDownloadButton": "Mostrar botón de descarga",
-            "showFilterButton": "Mostrar botón de filtro",
-            "showBulkUpdateActions": "Mostrar acciones de actualización masiva",
-            "bulkSelection": "Selección masiva",
-            "highlightSelectedRow": "Resaltar fila seleccionada",
-            "actionButtonRadius": "Radio del botón de acción",
-            "tableType": "Tipo de tabla",
-            "cellSize": "Tamaño de la celda",
-            "setPage": "Establecer página",
-            "page": "Página",
-            "buttonText": "Texto del botón",
-            "click": "Click",
-            "setText": "Establecer texto",
-            "text": "Texto",
-            "markerColor": "Color del marcador",
-            "showAxes": "Mostrar ejes",
-            "showGridLines": "Mostrar líneas de cuadrícula",
-            "chartType": "Tipo de gráfico",
-            "jsonDescription": "Descripción JSON",
-            "usePlotlyJsonSchema": "Usar esquema JSON de Plotly",
-            "padding": "Relleno",
-            "hideTitleBar": "Ocultar barra de título",
-            "hideCloseButton": "Ocultar botón de cierre",
-            "hideOnEscape": "Ocultar en Escape",
-            "modalSize": "Tamaño modal",
-            "open": "Abrir",
-            "close": "Cerrar",
-            "regex": "Expresión regular",
-            "minLength": "Longitud mínima",
-            "maxLength": "Longitud máxima",
-            "customValidation": "Validación personalizada",
-            "clear": "Limpiar",
-            "minimumValue": "Valor mínimo",
-            "maximumValue": "Valor máximo",
-            "format": "Formato",
-            "enableTimeSelection": "Habilitar selección de tiempo",
-            "enableDateSelection": "Habilitar selección de fecha",
-            "disabledDates": "Fechas deshabilitadas",
-            "setChecked": "Establecer marcado",
-            "status": "Estado",
-            "defaultStatus": "Estado predeterminado",
-            "checkboxColor": "Color de la casilla de verificación",
-            "optionValues": "Valores de opción",
-            "optionLabels": "Etiquetas de opción",
-            "activeColor": "Color activo",
-            "selectOption": "Seleccionar opción",
-            "option": "Opción",
-            "toggleSwitchColor": "Cambiar color de interruptor",
-            "defaultStartDate": "Fecha de inicio predeterminada",
-            "defaultEndDate": "Fecha de finalización predeterminada",
-            "textSize": "Tamaño del texto",
-            "alignText": "Alinear texto",
-            "url": "URL",
-            "alternativeText": "Texto alternativo",
-            "zoomButton": "Botón de zoom",
-            "borderType": "Tipo de borde",
-            "imageFit": "Ajuste de imagen",
-            "optionsLoadingState": "Estado de carga de opciones",
-            "selectedTextColor": "Color de texto seleccionado",
-            "select": "Seleccionar",
-            "deselectOption": "Deseleccionar opción",
-            "clearSelections": "Borrar selecciones",
-            "enableSelectAllOption": "Habilitar opción Seleccionar todo",
-            "initialLocation": "Ubicación inicial",
-            "defaultMarkers": "Marcadores predeterminados",
-            "addNewMarkers": "Agregar nuevos marcadores",
-            "searchForPlaces": "Buscar lugares",
-            "setLocation": "Establecer ubicación",
-            "latitude": "Latitud",
-            "longitude": "Longitud",
-            "numberOfStars": "Número de estrellas",
-            "defaultNoOfSelectedStars": "Número predeterminado de estrellas seleccionadas",
-            "enableHalfStar": "Habilitar media estrella",
-            "tooltips": "Información sobre herramientas",
-            "starColor": "Color de la estrella",
-            "labelColor": "Color de la etiqueta",
-            "dividerColor": "Color del divisor",
-            "clearFiles": "Borrar archivos",
-            "instructionText": "Texto de instrucción",
-            "useDropZone": "Usar zona de descarga",
-            "useFilePicker": "Usar selector de archivos",
-            "pickMultipleFiles": "Seleccionar varios archivos",
-            "maxFileCount": "Conteo máximo de archivos",
-            "acceptFileTypes": "Aceptar tipos de archivos",
-            "maxSizeLimitBytes": "Límite máximo de tamaño en bytes",
-            "minSizeLimitBytes": "Límite mínimo de tamaño en bytes",
-            "parseContent": "Analizar contenido",
-            "fileType": "Tipo de archivo",
-            "dateFormat": "Formato de fecha",
-            "defaultDate": "Fecha predeterminada",
-            "events": "Eventos",
-            "resources": "Recursos",
-            "defaultView": "Vista predeterminada",
-            "startTimeOnWeekAndDayView": "Hora de inicio en vista de semana y día",
-            "endTimeOnWeekAndDayView": "Hora de finalización en vista de semana y día",
-            "showToolbar": "Mostrar barra de herramientas",
-            "showViewSwitcher": "Mostrar conmutador de vista",
-            "highlightToday": "Resaltar hoy",
-            "showPopoverWhenEventIsClicked": "Mostrar popover cuando se hace clic en el evento",
-            "cellSizeInViewsClassifiedByResource": "Tamaño de la celda en vistas clasificadas por recurso",
-            "headerDateFormatOnWeekView": "Formato de fecha de encabezado en vista de semana",
-            "showLineNumber": "Mostrar número de línea",
-            "mode": "Modo",
-            "tabs": "Pestañas",
-            "defaultTab": "Pestaña predeterminada",
-            "hideTabs": "Ocultar pestañas",
-            "highlightColor": "Color de resaltado",
-            "tabWidth": "Ancho de pestaña",
-            "setCurrentTab": "Establecer pestaña actual",
-            "id": "Id",
-            "timerType": "Tipo de temporizador",
-            "listData": "Datos de lista",
-            "rowHeight": "Altura de fila",
-            "showBottomBorder": "Mostrar borde inferior",
-            "tags": "Etiquetas",
-            "numberOfPages": "Número de páginas",
-            "defaultPageIndex": "Índice de página predeterminado",
-            "progress": "Progreso",
-            "color": "Color",
-            "strokeWidth": "Ancho de línea",
-            "counterClockwise": "En sentido contrario a las agujas del reloj",
-            "circleRatio": "Relación de círculo",
-            "colour": "Color",
-            "size": "Tamaño",
-            "primaryValueLabel": "Etiqueta de valor primario",
-            "primaryValue": "Valor primario",
-            "hideSecondaryValue": "Ocultar valor secundario",
-            "secondaryValueLabel": "Etiqueta de valor secundario",
-            "secondaryValue": "Valor secundario",
-            "secondarySignDisplay": "Mostrar signo secundario",
-            "primaryLabelColour": "Color de etiqueta primaria",
-            "primaryTextColour": "Color de texto primario",
-            "secondaryLabelColour": "Color de etiqueta secundaria",
-            "secondaryTextColour": "Color de texto secundario",
-            "min": "Mínimo",
-            "max": "Máximo",
-            "value": "Valor",
-            "twoHandles": "Dos controladores",
-            "lineColor": "Color de línea",
-            "handleColor": "Color de controlador",
-            "trackColor": "Color de pista",
-            "timelineData": "Datos de línea de tiempo",
-            "hideDate": "Ocultar fecha",
-            "svgData": "Datos SVG",
-            "rawHtml": "HTML sin procesar",
-            "values": "Valores",
-            "labels": "Etiquetas",
-            "defaultSelected": "Seleccionado predeterminado",
-            "enableMutipleSelection": "Habilitar selección múltiple",
-            "selectedTextColour": "Color de texto seleccionado",
-            "selectedBackgroundColor": "Color de fondo seleccionado",
-            "fileUrl": "URL de archivo",
-            "scalePageToWidth": "Escalar página a ancho",
-            "showPageControls": "Mostrar controles de página",
-            "steps": "Pasos",
-            "currentStep": "Paso actual",
-            "stepsSelectable": "Pasos seleccionables",
-            "theme": "Tema",
-            "columns": "Columnas",
-            "cardData": "Datos de tarjeta",
-            "enableAddCard": "Habilitar agregar tarjeta",
-            "width": "Ancho",
-            "minWidth": "Ancho mínimo",
-            "accentColor": "Color de acento",
-            "defaultColor": "Color predeterminado",
-            "setColor": "Establecer color",
-            "structure": "Estructura",
-            "checkedValues": "Valores marcados",
-            "expandedValues": "Valores expandidos",
-        },
-        "Table": {
-            "displayName": "Tabla",
-            "description": "Tabla",
-            "columnType": "Tipo de columna",
-            "columnName": "Nombre de columna",
-            "overflow": "Desbordamiento",
-            "key": "Llave",
-            "textColor": "Color de texto",
-            "validation": "Validación",
-            "regex": "Expresión regular",
-            "minLength": "Longitud mínima",
-            "maxLength": "Longitud máxima",
-            "customRule": "Regla personalizada",
-            "values": "Valores",
-            "labels": "Etiquetas",
-            "cellBgColor": "Color de fondo de celda",
-            "dateDisplayformat": "Formato de visualización de fecha",
-            "dateParseformat": "Formato de análisis de fecha",
-            "showTime": "Mostrar hora",
-            "makeEditable": "Hacer editable",
-            "buttonText": "Texto de botón",
-            "buttonPosition": "Posición del botón",
-            "remove": "Eliminar",
-            "addButton": "+ Agregar botón",
-            "addColumn": "+ Agregar columna",
-            "noActionMessage": "Esta tabla no tiene botones de acción",
-        },
-        "Button": {
-            "displayName": "Botón",
-            "description": "Invocar acciones: consultas, alertas, etc."
-        },
-        "Chart": {
-            "displayName": "Gráfico",
-            "description": "Desplegar gráficos"
-        },
-        "Modal": {
-            "displayName": "Modal",
-            "description": "Modal invocado por eventos"
-        },
-        "TextInput": {
-            "displayName": "Entrada de texto",
-            "description": "Campo de texto para formularios"
-        },
-        "NumberInput": {
-            "displayName": "Entrada numérica",
-            "description": "Campo numérico para formularios"
-        },
-        "PasswordInput": {
-            "displayName": "Entrada de contraseña",
-            "description": "Campo de contraseña para formularios"
-        },
-        "Datepicker": {
-            "displayName": "Selector de fecha",
-            "description": "Seleccionar fecha y hora"
-        },
-        "Checkbox": {
-            "displayName": "Casilla de verificación",
-            "description": "Una sola casilla de verificación"
-        },
-        "Radio-button": {
-            "displayName": "Botón de radio",
-            "description": "Botones de tipo radio"
-        },
-        "ToggleSwitch": {
-            "displayName": "Interruptor de conmutación",
-            "description": "Interruptor de conmutación"
-        },
-        "Textarea": {
-            "displayName": "Área de texto",
-            "description": "Área de texto para formularios"
-        },
-        "DateRangePicker": {
-            "displayName": "Selector de rango de fechas",
-            "description": "Seleccione un rango de fechas"
-        },
-        "Text": {
-            "displayName": "Texto",
-            "description": "Desplegar HTML o Markdown"
-        },
-        "Image": {
-            "displayName": "Imagen",
-            "description": "Desplegar imágenes"
-        },
-        "Container": {
-            "displayName": "Contenedor",
-            "description": "Contenedor para agrupar componentes"
-        },
-        "Dropdown": {
-            "displayName": "Menú desplegable",
-            "description": "Seleccione una opción de un menú desplegable"
-        },
-        "Multiselect": {
-            "displayName": "Selección múltiple",
-            "description": "Seleccione una o más opciones de un menú desplegable"
-        },
-        "RichTextEditor": {
-            "displayName": "Editor de texto",
-            "description": "Editor de texto enriquecido"
-        },
-        "Map": {
-            "displayName": "Mapa",
-            "description": "Desplegar Google Maps"
-        },
-        "QrScanner": {
-            "displayName": "Escaner de QR",
-            "description": "Escanea QR y guarda el resultado"
-        },
-        "StarRating": {
-            "displayName": "Calificación de estrellas",
-            "description": "Calificación de estrellas"
-        },
-        "Divider": {
-            "displayName": "Divisor",
-            "description": "Separador entre componentes"
-        },
-        "FilePicker": {
-            "displayName": "Selector de archivos",
-            "description": "Selector de archivos"
-        },
-        "Calendar": {
-            "displayName": "Calendario",
-            "description": "Calendario"
-        },
-        "Iframe": {
-            "displayName": "Iframe",
-            "description": "Desplegar un Iframe"
-        },
-        "CodeEditor": {
-            "displayName": "Editor de código",
-            "description": "Editor de código"
-        },
-        "Tabs": {
-            "displayName": "Pestañas",
-            "description": "Componente de pestañas"
-        },
-        "Timer": {
-            "displayName": "Temporarizador",
-            "description": "Temporarizador"
-        },
-        "Listview": {
-            "displayName": "Lista de vistas",
-            "description": "Agrupador para múltiples componentes"
-        },
-        "Tags": {
-            "displayName": "Etiquetas",
-            "description": "Contenido puede ser mostrado como etiquetas"
-        },
-        "Pagination": {
-            "displayName": "Paginación",
-            "description": "Paginación"
-        },
-        "CircularProgressbar": {
-            "displayName": "Barra de progreso circular",
-            "description": "Mostrar el progreso usando una barra de progreso circular"
-        },
-        "Spinner": {
-            "displayName": "Spinner",
-            "description": "Spinner de carga puede ser utilizado para mostrar el progreso de una tarea"
-        },
-        "Statistics": {
-            "displayName": "Estadísticas",
-            "description": "Las estadísticas pueden ser usadas para mostrar datos numéricos"
-        },
-        "RangeSlider": {
-            "displayName": "Control deslizante de rango",
-            "description": "Puede ser utilizado para seleccionar un rango de valores"
-        },
-        "Timeline": {
-            "displayName": "Línea de tiempo",
-            "description": "Representación visual de una serie de eventos"
-        },
-        "SvgImage": {
-            "displayName": "Imagen SVG",
-            "description": "Desplegar imágenes SVG"
-        },
-        "Html": {
-            "displayName": "Visor HTML",
-            "description": "Visor HTML"
-        },
-        "VerticalDivider": {
-            "displayName": "Divisor vertical",
-            "description": "Divisor vertical, entre componentes"
-        },
-        "CustomComponent": {
-            "displayName": "Componente personalizado",
-            "description": "Añadir un componente personalizado"
-        },
-        "ButtonGroup": {
-            "displayName": "Grupo de botones",
-            "description": "Agrupar botones"
-        },
-        "PDF": {
-            "displayName": "PDF",
-            "description": "Embedir archivos PDF"
-        },
-        "Steps": {
-            "displayName": "Pasos",
-            "description": "Pasos"
-        },
-        "KanbanBoard": {
-            "displayName": "Tablero Kanban",
-            "description": "Tablero Kanban"
-        },
-        "ColorPicker": {
-            "displayName": "Selector de color",
-            "description": "Paleta de colores"
-        },
-        "TreeSelect": {
-            "displayName": "Selección de árbol",
-            "description": "Selección de valores de un árbol"
-        }
-    },
-    "leftSidebar": {
-        "Inspector": {
-            "text": "Inspector",
-            "tip": "Inspector"
-        },
-        "Sources": {
-            "text": "Fuentes",
-            "tip": "Añadir o editar fuentes de datos",
-            "dataSources": "Fuentes de datos",
-            "addDataSource": "+ añadir fuentes de datos"
-        },
-        "Debugger": {
-            "text": "Debugear",
-            "tip": "Debugear",
-            "errors": "Errores",
-            "noErrors": "No se encontraron errores",
-            "clear": "limpiar"
-        },
-        "Comments": {
-            "text": "Comentarios",
-            "tip": "Habilitar comentarios",
-            "commentBody": "No hay comentarios para desplegar",
-            "typeComment": "Escriba su comentario aquí",
-        },
-        "Settings": {
-            "text": "Ajustes",
-            "tip": "Ajustes globales",
-            "hideHeader": "Ocultar encabezado para aplicaciones desplegadas",
-            "maintenanceMode": "Modo de mantenimiento",
-            "maxWidthOfCanvas": "Ancho máximo del lienzo",
-            "maxHeightOfCanvas": "Altura máxima del lienzo",
-            "backgroundColorOfCanvas": "Color de fondo del lienzo",
-        },
-        "Back": {
-            "text": "Atrás",
-            "tip": "Atrás a la vista anterior (página principal)"
-        }
-    }
+	"globals": {
+		"readDocumentation": "Leer la documentación",
+		"cancel": "Cancelar",
+		"save": "Guardar",
+		"back": "Atrás",
+		"edit": "Editar",
+		"search": "Buscar",
+		"update": "Actualizar",
+		"delete": "Borrar",
+		"add": "Añadir",
+		"view": "Ver",
+		"create": "Crear",
+		"enabled": "Activado",
+		"disabled": "Desactivado",
+		"yes": "Si",
+		"submit": "Enviar",
+		"select": "Seleccionar",
+		"environmentVar": "Variables de entorno",
+		"saving": "Guardando...",
+		"saveDatasource": "Guardar fuente de datos",
+		"authorize": "Autorizar",
+		"connect": "Conectar",
+		"reconnect": "Reconectar",
+		"components": "componentes",
+		"send": "Enviar",
+		"noConnection": "no se puede conectar",
+		"connectionVerifeid": "conexión verificada",
+		"left": "Izquierda",
+		"center": "Centro",
+		"right": "Derecha",
+		"justified": "Justificado",
+		"host": "Host",
+		"operation": "Operación",
+		"header": "HEADER",
+		"path": "PATH",
+		"query": "QUERY",
+		"requestBody": "REQUEST BODY"
+	},
+	"errorBoundary": "Algo salió mal. Por favor, inténtelo de nuevo.",
+	"viewer": "¡Lo sentimos!. Esta aplicación está bajo mantenimiento.",
+	"app": {
+		"updateAvailable": "Actualización disponible",
+		"newVersionReleased": "Una nueva versión de Tooljet ha sido desplegada.",
+		"readReleaseNotes": "Leer las notas del lanzamiento & actualizar.",
+		"skipVersion": "Saltar esta versión."
+	},
+	"stripe": "Por favor espere mientras cargamos la especificación de OpenAPI para Stripe",
+	"openApi": {
+		"noValidOpenApi": "Una especificación válida de OpenAPI no está disponible.",
+		"selectHost": "Seleccione un host",
+		"selectOperation": "Selecciona una operación"
+	},
+	"slack": {
+		"authorize": "Autorizar",
+		"connectToolJetToSlack": "ToolJet puede conectarse a Slack, listar usuarios, enviar mensajes, etc. Por favor seleccione los permisos apropiados.",
+		"chatWrite": "chat:escribir",
+		"listUsersAndSendMessage": "Tu aplicación de Tooljet será capaz de listar usuarios y enviar mensajes a ellos y a los canales.",
+		"connectSlack": "Conectar a Slack"
+	},
+	"googleSheets": {
+		"readOnly": "Solo lectura",
+		"enableReadAndWrite": "Si deseas que ToolJet pueda modificar tus hojas de Google Sheet, asegurate de seleccionar permisos de lectura y escritura.",
+		"readDataFromSheets": "Tus aplicaciones de ToolJet sólo pueden leer datos de tus hojas de Google Sheets.",
+		"readWrite": "Lectura y escritura",
+		"readModifySheets": "Tus aplicaciones de ToolJet pueden leer, modificar y más en tus hojas de Google Sheets.",
+		"toGoogleSheets": "a Google Sheets"
+	},
+	"profile": {
+		"profileSettings": "Preferencias de perfil"
+	},
+	"loginSignupPage": {
+		"forgotPassword": "Olvidaste la contraseña",
+		"emailAddress": "Dirección de correo electrónico",
+		"enterEmail": "Ingrese correo electrónico",
+		"resetPassword": "Restaurar contraseña",
+		"dontHaveAccount": "¿Aún no tienes una cuenta?",
+		"signIn": "Acceder",
+		"signUp": "Registrarte",
+		"createToolJetAccount": "Crear una cuenta de ToolJet",
+		"enterBusinessEmail": "Ingrese el correo electrónico de su empresa",
+		"alreadyHaveAnAccount": "¿Ya tiene una cuenta?",
+		"password": "Contraseña",
+		"showPassword": "Mostrar contraseña",
+		"loginTo": "Acceder a",
+		"yourAccount": "Su cuenta",
+		"noLoginMethodsEnabled": "No hay métodos de inicio de sesión habilitados para este espacio de trabajo",
+		"emailConfirmLink": "Compruebe su correo electrónico para ver el enlace de confirmación por favor",
+		"newPassword": "Nueva Contraseña",
+		"passwordConfirmation": "Confirmación de contraseña"
+	},
+	"editor": {
+		"preview": "Prevista",
+		"share": "Compartir",
+		"shareModal": {
+			"makeApplicationPublic": "¿Hacer aplicación pública?",
+			"shareableLink": "Obtener enlace compartible para esta aplicación",
+			"copy": "copiar",
+			"embeddableLink": "Obtener link embebible para esta aplicación",
+			"manageUsers": "Administrar usuarios"
+		},
+		"appVersionManager": {
+			"version": "Versión",
+			"currentlyReleased": "Actualmente desplegado",
+			"createVersion": "Crear versión",
+			"versionName": "Nombre de la versión",
+			"createVersionFrom": "Crear versión desde",
+			"save": "Guardar",
+			"create": "Crear versión",
+			"editVersion": "Editar versión",
+			"deleteVersion": "¿Quieres eliminar esta versión?",
+			"enterVersionName": "Introducir nombre de la versión",
+			"versionAlreadyReleased": "La versión ya fue creada anteriormente, por favor crea una nueva versión o cambia a una versión diferente para seguir realizando cambios."
+		},
+		"queries": "Consultas",
+		"inspectComponent": "Por favor seleccione un componente para inspeccionar.",
+		"release": "Desplegar",
+		"searchQueries": "Buscar consultas",
+		"createQuery": "Crear consulta",
+		"queryManager": {
+			"general": "General",
+			"advanced": "Avanzado",
+			"preview": "Prevista",
+			"Save": "Guardar",
+			"selectDatasource": "Seleccionar fuente de datos",
+			"addDatasource": "Añadir fuente de datos",
+			"dataSourceManager": {
+				"toast": {
+					"success": {
+						"dataSourceAdded": "Fuente de datos agregada",
+						"dataSourceSaved": "Fuente de datos guardada"
+					},
+					"error": {
+						"noEmptyDsName": "El nombre de la fuenta de datos no puede estar vacío"
+					}
+				},
+				"suggestDataSource": "Sugerir fuente de datos",
+				"suggestAnIntegration": "Sugerir una integración",
+				"whatLookingFor": "¿Cuéntanos que estabas buscando?",
+				"noResultFound": "¿No encontraste lo que estabas buscando?",
+				"suggest": "Sugerir",
+				"addNewDataSource": "Añadir nueva fuente de datos",
+				"whiteListIP": "Por favor agrega nuestra dirección IP a la lista blanca si tu fuente de datos no es públicamente accessible.",
+				"copied": "Copiado",
+				"copy": "Copiar",
+				"saving": "Guardando",
+				"noResultsFor": "No se encontraron resultados para",
+				"noteTaken": "Gracias, ¡hemos tomado nota de esto!",
+				"goToAllDatasources": "Ir a todas las fuentes de datos",
+				"send": "Enviar"
+			},
+			"runQueryOnPageLoad": "Ejecutar consulta al cargar la página",
+			"confirmBeforeQueryRun": "¿Solicitar confirmación antes de ejecutar la consulta?",
+			"notificationOnSuccess": "¿Mostrar notificación satisfactoria?",
+			"successMessage": "Mensaje satisfactorio",
+			"queryRanSuccessfully": "La consulta fue ejecutada satisfactoriamente",
+			"notificationDuration": "Duración de la notificación (s)",
+			"events": "Eventos",
+			"transformation": {
+				"transformationToolTip": "Las transformaciones se pueden usar para transformar los resultados de las consultas. Todas las variables de la aplicación son accesibles desde los transformadores y admiten librerías JS como Lodash y Moment.",
+				"transformations": "Transformaciones"
+			}
+		},
+		"inspector": {
+			"eventManager": {
+				"event": "Evento",
+				"action": "Acción",
+				"actionOptions": "Opción de acciones",
+				"message": "Mensaje",
+				"alertType": "Tipo de alerta",
+				"url": "URL",
+				"modal": "Modal",
+				"text": "Texto",
+				"query": "Consulta",
+				"key": "Llave",
+				"value": "Valor",
+				"type": "Tipo",
+				"fileName": "Nombre del archivo",
+				"data": "Datos",
+				"table": "Tabla",
+				"pageIndex": "Índice de página",
+				"component": "Componente",
+				"addHandler": "+ Añadir manejador",
+				"addEventHandler": "+ Añadir manejador de eventos",
+				"emptyMessage": "Este {{componentName}} no tiene manejadores de eventos."
+			}
+		}
+	},
+	"header": {
+		"darkModeToggle": {
+			"activateLightMode": "Activar modo claro",
+			"activateDarkMode": "Activar modo oscuro"
+		},
+		"languageSelection": {
+			"changeLanguage": "Cambiar idioma",
+			"searchLanguage": "Buscar idioma"
+		},
+		"notificationCenter": {
+			"notifications": "Notificaciones",
+			"markAllAs": "Marcar todo como",
+			"read": "Leído",
+			"un": "un",
+			"youDontHaveany": "No tienes ningún/a",
+			"youAreCaughtUp": "¡Estás al día!",
+			"view": "Ver"
+		},
+		"organization": {
+			"loadOrganizations": "Cargar organizaciones",
+			"createWorkspace": "Crear espacio de trabajo",
+			"workspaceName": "Nombre del espacio de trabajo",
+			"editWorkspace": "Editar espacio de trabajo",
+			"menus": {
+				"addWorkspace": "Añadir espacio de trabajo",
+				"menusList": {
+					"manageUsers": "Administrar usuarios",
+					"manageGroups": "Administrar grupos",
+					"manageSso": "Administrar SSO",
+					"manageEnv": "Administrar variables de entorno"
+				},
+				"manageUsers": {
+					"usersAndPermission": "Usuarios y Permisos",
+					"inviteNewUser": "Invitar un nuevo usuario",
+					"name": "NOMBRE",
+					"email": "CORREO ELECTRÓNICO",
+					"status": "ESTADO",
+					"archive": "Archivar",
+					"unarchive": "Desarchivar",
+					"addNewUser": "Añadir un nuevo usuario",
+					"emailAddress": "Dirección de correo electrónico",
+					"createUser": "Crear usuario",
+					"enterFirstName": "Ingrese su Nombre",
+					"enterLastName": "Ingrese su Apellido",
+					"enterEmail": "Ingrese correo electrónico"
+				},
+				"manageGroups": {
+					"permissions": {
+						"userGroups": "Grupos de usuarios",
+						"createNewGroup": "Crear un nuevo grupo",
+						"udpateGroup": "Actualizar grupo",
+						"addNewGroup": "Añadir un nuevo grupo",
+						"enterName": "Ingresar nombre",
+						"createGroup": "Crear grupo",
+						"name": "Nombre"
+					},
+					"permissionResources": {
+						"userGroup": "Grupo de usuarios",
+						"apps": "Aplicaciones",
+						"users": "Usuarios",
+						"permissions": "Permisos",
+						"addAppsToGroup": "Seleccionar applicaciones para añadir al grupo.",
+						"name": "Nombre",
+						"addUsersToGroup": "Seleccionar usuarios para añadir al grupo.",
+						"email": "Correo electrónico",
+						"resource": "Recurso",
+						"createUpdateDelete": "Crear/Actualizar/Eliminar",
+						"folder": "Carpeta"
+					}
+				},
+				"manageSSO": {
+					"manageSso": "Administrar SSO",
+					"generalSettings": {
+						"title": "Ajustes Generales",
+						"enableSignup": "Habilitar registro",
+						"newAccountWillBeCreated": "Una nueva cuenta será creada para el primer inicio de sesión SSO del usuario",
+						"allowedDomains": "Dominios permitidos",
+						"enterDomains": "Ingresar los dominios",
+						"supportMultiDomains": "Soporta múltiples dominios. Ingrese los nombres de dominio separados por coma. ejemplo: tooljet.com,tooljet.io,suorganizacion.com",
+						"loginUrl": "URL de inicio de sesión",
+						"workspaceLogin": "Use esta URL para iniciar sesión en el espacio de trabajo",
+						"allowDefaultSso": "Permitir SSO por defecto",
+						"ssoAuth": "Permitir a los usuarios autenticarse a través de SSO por defecto. Las configuraciones de SSO por defecto pueden ser anuladas por el SSO de nivel de espacio de trabajo."
+					},
+					"google": {
+						"title": "Google",
+						"enabled": "Activado",
+						"disabled": "Desactivado",
+						"clientId": "ID de cliente",
+						"enterClientId": "Ingrese el ID de cliente",
+						"redirectUrl": "URL de redirección"
+					},
+					"github": {
+						"title": "Github",
+						"hostName": "Nombre de host",
+						"enterHostName": "Ingrese el nombre de host",
+						"requiredGithub": "Requiere Github alojado en su propio servidor",
+						"clientId": "ID de cliente",
+						"enterClientId": "Ingrese el ID de cliente",
+						"clientSecret": "Secreto de cliente",
+						"enterClientSecret": "Ingrese el secreto de cliente",
+						"encrypted": "Encriptado",
+						"redirectUrl": "URL de redirección"
+					},
+					"passwordLogin": "Inicio de sesión con contraseña",
+					"environmentVar": {
+						"noEnvConfig": "No haz configurado ninguna variable de entorno, presiona el botón 'Añadir nueva variable' para crear una",
+						"envWillBeDeleted": "La variable será eliminada, ¿desea continuar?",
+						"addNewVariable": "Añadir nueva variable",
+						"variableForm": {
+							"addNewVariable": "Añadir nueva variable",
+							"updatevariable": "Actualizar variable",
+							"name": "Nombre",
+							"value": "Valor",
+							"enterVariableName": "Ingresar nombre de variable",
+							"enterValue": "Ingresar valor",
+							"type": "Tipo",
+							"enableEncryption": "Habilitar encriptación",
+							"addVariable": "Añadir variable"
+						},
+						"variableTable": {
+							"name": "nombre",
+							"value": "valor",
+							"type": "tipo",
+							"secret": "secreto"
+						}
+					}
+				}
+			}
+		},
+		"profileSettingPage": {
+			"profileSettings": "Configuración de Perfil",
+			"firstName": "Nombre",
+			"lastName": "Apellido",
+			"enterFirstName": "Ingrese su Nombre",
+			"enterLastName": "Ingrese su Apellido",
+			"email": "Correo electrónico",
+			"avatar": "Avatar",
+			"update": "Actualizar",
+			"profile": "Perfil",
+			"changePassword": "Cambiar contraseña",
+			"currentPassword": "Contraseña actual",
+			"newPassword": "Nueva contraseña",
+			"confirmNewPassword": "Confirmar nueva contraseña",
+			"enterCurrentPassword": "Introduzca contraseña actual",
+			"enterNewPassword": "Ingrese nueva contraseña"
+		},
+		"profile": "Perfil",
+		"logout": "Cerrar Sesión"
+	},
+	"homePage": {
+		"appCard": {
+			"changeIcon": "Cambiar ícono",
+			"addToFolder": "Añadir a la carpeta",
+			"move": "Mover",
+			"to": "hacia",
+			"selectFolder": "Seleccionar carpeta",
+			"deleteApp": "Borrar aplicación",
+			"exportApp": "Exportar aplicación",
+			"cloneApp": "Clonar aplicación",
+			"launch": "Lanzar",
+			"maintenance": "Mantenimiento",
+			"noDeployedVersion": "La aplicación no tiene una versión implementada",
+			"openInAppViewer": "Abrir en el visor de aplicaciones",
+			"removeFromFolder": "Borrar de la carpeta"
+		},
+		"blankPage": {
+			"welcomeToToolJet": "¡Bienvenido a ToolJet!",
+			"getStartedCreateNewApp": "Puedes empezar creando una nueva aplicación o creando una aplicación usando una plantilla en la biblioteca de ToolJet.",
+			"importApplication": "Importar una aplicación"
+		},
+		"foldersSection": {
+			"allApplications": "Todas las aplicaciones",
+			"folders": "Carpetas",
+			"createNewFolder": "+ Crear nueva carpeta",
+			"noFolders": "No haz creado ninguna carpeta, usa carpetas para organizar tus aplicaciones",
+			"createFolder": "Crear carpeta",
+			"updateFolder": "Actualizar carpeta",
+			"editFolder": "Editar carpeta",
+			"deleteFolder": "Borrar carpeta",
+			"folderName": "Nombre de la carpeta",
+			"wishToDeleteFolder": "¿Estás seguro de que deseas eliminar la carpeta {{folderName}}? Las aplicaciones dentro de la carpeta no se eliminarán."
+		},
+		"header": {
+			"createNewApplication": "Crear nueva aplicación",
+			"import": "Importar",
+			"chooseFromTemplate": "Elegir desde plantillas"
+		},
+		"pagination": {
+			"showing": "Mostrando",
+			"of": "de",
+			"to": "para"
+		},
+		"noApplicationFound": "No se encontraron aplicaciones",
+		"thisFolderIsEmpty": "Esta carpeta está vacía",
+		"deleteAppAndData": "La aplicación y los datos asociados se eliminarán permanentemente, ¿desea continuar?",
+		"removeAppFromFolder": "La aplicación se eliminará de esta carpeta, ¿desea continuar?",
+		"change": "Cambiar",
+		"templateCard": {
+			"use": "Usar",
+			"preview": "Prevista",
+			"leadGeneretion": "Generación de líderes"
+		},
+		"templateLibraryModal": {
+			"select": "Seleccionar plantilla",
+			"createAppfromTemplate": "Crear aplicación desde plantilla"
+		}
+	},
+	"confirmationPage": {
+		"setupAccount": "Configurar cuenta",
+		"signupWithGoogle": "Registrarse con Google",
+		"signupWithGitHub": "Registrarse con GitHub",
+		"or": "ó",
+		"firstName": "Primer nombre",
+		"lastName": "Apellido",
+		"company": "Compañía",
+		"role": "Rol",
+		"pleaseSelect": "Por favor seleccionar",
+		"password": "Contraseña",
+		"confirmPassword": "Confirmar contraseña",
+		"clickAndAgree": "Al hacer clic en el siguiente botón, acepta nuestros",
+		"termsAndConditions": "Términos y Condiciones",
+		"finishAccountSetup": "Finalizar configuración de cuenta",
+		"acceptInvite": "Aceptar invitación",
+		"accountExists": "¿Ya tienes una cuenta?",
+		"and": "y"
+	},
+	"onBoarding": {
+		"finishToolJetInstallation": "Finalizar instalación de ToolJet",
+		"organization": "Organización",
+		"name": "Nombre",
+		"email": "Email",
+		"receiveUpdatesFromToolJet": "Recibirás actualizaciones de parte del equipo de ToolJet (1-2 correos electrónicos al mes, no hacemos spam)",
+		"finishSetup": "Finalizar configuración",
+		"skip": "Saltar"
+	},
+	"redirectSso": {
+		"upgradingTov1": {
+			"13": {
+				"0": "Actualizando a v1.13.0 y más"
+			}
+		},
+		"fromV1": {
+			"13": {
+				"0": "Desde la versión 1.13.0 hemos introducido..."
+			}
+		},
+		"multiWorkspace": "Multi-Workspace",
+		"singleSignOnConfig": "La configuración relacionada con SSO se ha movido de las variables de entorno a la base de datos. Por favor, consulte este",
+		"link": "Enlace",
+		"toConfigureSSO": "para configurar SSO.",
+		"haveGoogleGithubSSo": "Si tiene configuraciones de SSO de Google o GitHub antes de la actualización y deshabilitó el Multi-Workspace, entonces las configuraciones de SSO se migrarán durante la actualización, pero debe volver a configurar la URL de redireccionamiento en el lado del proveedor de SSO. Las URL de redireccionamiento para cada SSO se indican a continuación.",
+		"isMultiWorkspaceEnabled": "Si tiene Multi-Workspace habilitado, entonces debe configurar SSO en cada espacio de trabajo. Puede hacerlo desde la página de configuración de SSO en cada espacio de trabajo.",
+		"youHaveEnabled": "Has habilitado",
+		"setupSsoWorkspace": "Por favor ingresar con su contraseña para configurar SSO en este espacio de trabajo.",
+		"manageSsoMenu": "Administrar menú de SSO.",
+		"youHaveDisabled": "Has deshabilitado",
+		"configureRedirectUrl": "Por favor configure la URL de redireccionamiento en el proveedor de SSO.",
+		"google": "Google",
+		"redirectUrl": "URL de redirección",
+		"gitHub": "GitHub"
+	},
+	"oAuth2": {
+		"pleaseWait": "Por favor espere...",
+		"authSuccess": "Autenticación satisfactoria, puede cerrar esta ventana.",
+		"authFailed": "Autenticación fallida."
+	},
+	"widgetManager": {
+		"commonlyUsed": "Comúnmente utilizado",
+		"layouts": "Diseños",
+		"forms": "Formularios",
+		"intregrations": "Integraciones",
+		"others": "Otros",
+		"noResults": "No se han encontrado resultados",
+		"tryAdjustingFilterMessage": "Intenta modificar tu búsqueda o los filtros para encontrar lo que estás buscando",
+		"clearQuery": "Limpiar búsqueda"
+	},
+	"widget": {
+		"common": {
+			"properties": "Propiedades",
+			"events": "Eventos",
+			"layout": "Diseño",
+			"styles": "Estilos",
+			"general": "General",
+			"validation": "Validación",
+			"documentation": "{{componentMeta}} documentación",
+			"widgetNameEmptyError": "El nombre del widget no puede estar vacío",
+			"componentNameExistsError": "El nombre del componente ya existe",
+			"invalidWidgetName": "Nombre de widget no válido. Debe ser único e incluir solo letras, números y guión bajo."
+		},
+		"commonProperties": {
+			"visibility": "Visibilidad",
+			"disable": "Inutilizar",
+			"borderRadius": "Radio del borde",
+			"boxShadow": "Sombra de caja",
+			"tooltip": "Información sobre herramientas",
+			"showOnDesktop": "Mostrar en el escritorio",
+			"showOnMobile": "Mostrar en el móvil",
+			"showLoadingState": "Mostrar estado de carga",
+			"backgroundColor": "Color de fondo",
+			"textColor": "Color del texto",
+			"loaderColor": "Color del cargador",
+			"defaultValue": "Valor predeterminado",
+			"placeholder": "Marcador",
+			"label": "Etiqueta",
+			"title": "Título",
+			"code": "Código",
+			"data": "Data",
+			"tableData": "Datos de la tabla",
+			"tableColumns": "Columnas de la tabla",
+			"searverSideSearch": "Búsqueda del lado del servidor",
+			"loadingState": "Estado de carga",
+			"serverSidePagination": "Paginación del lado del servidor",
+			"clientSidePagination": "Paginación del lado del cliente",
+			"serverSideSearch": "Búsqueda del lado del servidor",
+			"showSearchBox": "Mostrar cuadro de búsqueda",
+			"showDownloadButton": "Mostrar botón de descarga",
+			"showFilterButton": "Mostrar botón de filtro",
+			"showBulkUpdateActions": "Mostrar acciones de actualización masiva",
+			"bulkSelection": "Selección masiva",
+			"highlightSelectedRow": "Resaltar fila seleccionada",
+			"actionButtonRadius": "Radio del botón de acción",
+			"tableType": "Tipo de tabla",
+			"cellSize": "Tamaño de la celda",
+			"setPage": "Establecer página",
+			"page": "Página",
+			"buttonText": "Texto del botón",
+			"click": "Click",
+			"setText": "Establecer texto",
+			"text": "Texto",
+			"markerColor": "Color del marcador",
+			"showAxes": "Mostrar ejes",
+			"showGridLines": "Mostrar líneas de cuadrícula",
+			"chartType": "Tipo de gráfico",
+			"jsonDescription": "Descripción JSON",
+			"usePlotlyJsonSchema": "Usar esquema JSON de Plotly",
+			"padding": "Relleno",
+			"hideTitleBar": "Ocultar barra de título",
+			"hideCloseButton": "Ocultar botón de cierre",
+			"hideOnEscape": "Ocultar en Escape",
+			"modalSize": "Tamaño modal",
+			"open": "Abrir",
+			"close": "Cerrar",
+			"regex": "Expresión regular",
+			"minLength": "Longitud mínima",
+			"maxLength": "Longitud máxima",
+			"customValidation": "Validación personalizada",
+			"clear": "Limpiar",
+			"minimumValue": "Valor mínimo",
+			"maximumValue": "Valor máximo",
+			"format": "Formato",
+			"enableTimeSelection": "Habilitar selección de tiempo",
+			"enableDateSelection": "Habilitar selección de fecha",
+			"disabledDates": "Fechas deshabilitadas",
+			"setChecked": "Establecer marcado",
+			"status": "Estado",
+			"defaultStatus": "Estado predeterminado",
+			"checkboxColor": "Color de la casilla de verificación",
+			"optionValues": "Valores de opción",
+			"optionLabels": "Etiquetas de opción",
+			"activeColor": "Color activo",
+			"selectOption": "Seleccionar opción",
+			"option": "Opción",
+			"toggleSwitchColor": "Cambiar color de interruptor",
+			"defaultStartDate": "Fecha de inicio predeterminada",
+			"defaultEndDate": "Fecha de finalización predeterminada",
+			"textSize": "Tamaño del texto",
+			"alignText": "Alinear texto",
+			"url": "URL",
+			"alternativeText": "Texto alternativo",
+			"zoomButton": "Botón de zoom",
+			"borderType": "Tipo de borde",
+			"imageFit": "Ajuste de imagen",
+			"optionsLoadingState": "Estado de carga de opciones",
+			"selectedTextColor": "Color de texto seleccionado",
+			"select": "Seleccionar",
+			"deselectOption": "Deseleccionar opción",
+			"clearSelections": "Borrar selecciones",
+			"enableSelectAllOption": "Habilitar opción Seleccionar todo",
+			"initialLocation": "Ubicación inicial",
+			"defaultMarkers": "Marcadores predeterminados",
+			"addNewMarkers": "Agregar nuevos marcadores",
+			"searchForPlaces": "Buscar lugares",
+			"setLocation": "Establecer ubicación",
+			"latitude": "Latitud",
+			"longitude": "Longitud",
+			"numberOfStars": "Número de estrellas",
+			"defaultNoOfSelectedStars": "Número predeterminado de estrellas seleccionadas",
+			"enableHalfStar": "Habilitar media estrella",
+			"tooltips": "Información sobre herramientas",
+			"starColor": "Color de la estrella",
+			"labelColor": "Color de la etiqueta",
+			"dividerColor": "Color del divisor",
+			"clearFiles": "Borrar archivos",
+			"instructionText": "Texto de instrucción",
+			"useDropZone": "Usar zona de descarga",
+			"useFilePicker": "Usar selector de archivos",
+			"pickMultipleFiles": "Seleccionar varios archivos",
+			"maxFileCount": "Conteo máximo de archivos",
+			"acceptFileTypes": "Aceptar tipos de archivos",
+			"maxSizeLimitBytes": "Límite máximo de tamaño en bytes",
+			"minSizeLimitBytes": "Límite mínimo de tamaño en bytes",
+			"parseContent": "Analizar contenido",
+			"fileType": "Tipo de archivo",
+			"dateFormat": "Formato de fecha",
+			"defaultDate": "Fecha predeterminada",
+			"events": "Eventos",
+			"resources": "Recursos",
+			"defaultView": "Vista predeterminada",
+			"startTimeOnWeekAndDayView": "Hora de inicio en vista de semana y día",
+			"endTimeOnWeekAndDayView": "Hora de finalización en vista de semana y día",
+			"showToolbar": "Mostrar barra de herramientas",
+			"showViewSwitcher": "Mostrar conmutador de vista",
+			"highlightToday": "Resaltar hoy",
+			"showPopoverWhenEventIsClicked": "Mostrar popover cuando se hace clic en el evento",
+			"cellSizeInViewsClassifiedByResource": "Tamaño de la celda en vistas clasificadas por recurso",
+			"headerDateFormatOnWeekView": "Formato de fecha de encabezado en vista de semana",
+			"showLineNumber": "Mostrar número de línea",
+			"mode": "Modo",
+			"tabs": "Pestañas",
+			"defaultTab": "Pestaña predeterminada",
+			"hideTabs": "Ocultar pestañas",
+			"highlightColor": "Color de resaltado",
+			"tabWidth": "Ancho de pestaña",
+			"setCurrentTab": "Establecer pestaña actual",
+			"id": "Id",
+			"timerType": "Tipo de temporizador",
+			"listData": "Datos de lista",
+			"rowHeight": "Altura de fila",
+			"showBottomBorder": "Mostrar borde inferior",
+			"tags": "Etiquetas",
+			"numberOfPages": "Número de páginas",
+			"defaultPageIndex": "Índice de página predeterminado",
+			"progress": "Progreso",
+			"color": "Color",
+			"strokeWidth": "Ancho de línea",
+			"counterClockwise": "En sentido contrario a las agujas del reloj",
+			"circleRatio": "Relación de círculo",
+			"colour": "Color",
+			"size": "Tamaño",
+			"primaryValueLabel": "Etiqueta de valor primario",
+			"primaryValue": "Valor primario",
+			"hideSecondaryValue": "Ocultar valor secundario",
+			"secondaryValueLabel": "Etiqueta de valor secundario",
+			"secondaryValue": "Valor secundario",
+			"secondarySignDisplay": "Mostrar signo secundario",
+			"primaryLabelColour": "Color de etiqueta primaria",
+			"primaryTextColour": "Color de texto primario",
+			"secondaryLabelColour": "Color de etiqueta secundaria",
+			"secondaryTextColour": "Color de texto secundario",
+			"min": "Mínimo",
+			"max": "Máximo",
+			"value": "Valor",
+			"twoHandles": "Dos controladores",
+			"lineColor": "Color de línea",
+			"handleColor": "Color de controlador",
+			"trackColor": "Color de pista",
+			"timelineData": "Datos de línea de tiempo",
+			"hideDate": "Ocultar fecha",
+			"svgData": "Datos SVG",
+			"rawHtml": "HTML sin procesar",
+			"values": "Valores",
+			"labels": "Etiquetas",
+			"defaultSelected": "Seleccionado predeterminado",
+			"enableMutipleSelection": "Habilitar selección múltiple",
+			"selectedTextColour": "Color de texto seleccionado",
+			"selectedBackgroundColor": "Color de fondo seleccionado",
+			"fileUrl": "URL de archivo",
+			"scalePageToWidth": "Escalar página a ancho",
+			"showPageControls": "Mostrar controles de página",
+			"steps": "Pasos",
+			"currentStep": "Paso actual",
+			"stepsSelectable": "Pasos seleccionables",
+			"theme": "Tema",
+			"columns": "Columnas",
+			"cardData": "Datos de tarjeta",
+			"enableAddCard": "Habilitar agregar tarjeta",
+			"width": "Ancho",
+			"minWidth": "Ancho mínimo",
+			"accentColor": "Color de acento",
+			"defaultColor": "Color predeterminado",
+			"setColor": "Establecer color",
+			"structure": "Estructura",
+			"checkedValues": "Valores marcados",
+			"expandedValues": "Valores expandidos"
+		},
+		"Table": {
+			"displayName": "Tabla",
+			"description": "Tabla",
+			"columnType": "Tipo de columna",
+			"columnName": "Nombre de columna",
+			"overflow": "Desbordamiento",
+			"key": "Llave",
+			"textColor": "Color de texto",
+			"validation": "Validación",
+			"regex": "Expresión regular",
+			"minLength": "Longitud mínima",
+			"maxLength": "Longitud máxima",
+			"customRule": "Regla personalizada",
+			"values": "Valores",
+			"labels": "Etiquetas",
+			"cellBgColor": "Color de fondo de celda",
+			"dateDisplayformat": "Formato de visualización de fecha",
+			"dateParseformat": "Formato de análisis de fecha",
+			"showTime": "Mostrar hora",
+			"makeEditable": "Hacer editable",
+			"buttonText": "Texto de botón",
+			"buttonPosition": "Posición del botón",
+			"remove": "Eliminar",
+			"addButton": "+ Agregar botón",
+			"addColumn": "+ Agregar columna",
+			"noActionMessage": "Esta tabla no tiene botones de acción"
+		},
+		"Button": {
+			"displayName": "Botón",
+			"description": "Invocar acciones: consultas, alertas, etc."
+		},
+		"Chart": {
+			"displayName": "Gráfico",
+			"description": "Desplegar gráficos"
+		},
+		"Modal": {
+			"displayName": "Modal",
+			"description": "Modal invocado por eventos"
+		},
+		"TextInput": {
+			"displayName": "Entrada de texto",
+			"description": "Campo de texto para formularios"
+		},
+		"NumberInput": {
+			"displayName": "Entrada numérica",
+			"description": "Campo numérico para formularios"
+		},
+		"PasswordInput": {
+			"displayName": "Entrada de contraseña",
+			"description": "Campo de contraseña para formularios"
+		},
+		"Datepicker": {
+			"displayName": "Selector de fecha",
+			"description": "Seleccionar fecha y hora"
+		},
+		"Checkbox": {
+			"displayName": "Casilla de verificación",
+			"description": "Una sola casilla de verificación"
+		},
+		"Radio-button": {
+			"displayName": "Botón de radio",
+			"description": "Botones de tipo radio"
+		},
+		"ToggleSwitch": {
+			"displayName": "Interruptor de conmutación",
+			"description": "Interruptor de conmutación"
+		},
+		"Textarea": {
+			"displayName": "Área de texto",
+			"description": "Área de texto para formularios"
+		},
+		"DateRangePicker": {
+			"displayName": "Selector de rango de fechas",
+			"description": "Seleccione un rango de fechas"
+		},
+		"Text": {
+			"displayName": "Texto",
+			"description": "Desplegar HTML o Markdown"
+		},
+		"Image": {
+			"displayName": "Imagen",
+			"description": "Desplegar imágenes"
+		},
+		"Container": {
+			"displayName": "Contenedor",
+			"description": "Contenedor para agrupar componentes"
+		},
+		"Dropdown": {
+			"displayName": "Menú desplegable",
+			"description": "Seleccione una opción de un menú desplegable"
+		},
+		"Multiselect": {
+			"displayName": "Selección múltiple",
+			"description": "Seleccione una o más opciones de un menú desplegable"
+		},
+		"RichTextEditor": {
+			"displayName": "Editor de texto",
+			"description": "Editor de texto enriquecido"
+		},
+		"Map": {
+			"displayName": "Mapa",
+			"description": "Desplegar Google Maps"
+		},
+		"QrScanner": {
+			"displayName": "Escaner de QR",
+			"description": "Escanea QR y guarda el resultado"
+		},
+		"StarRating": {
+			"displayName": "Calificación de estrellas",
+			"description": "Calificación de estrellas"
+		},
+		"Divider": {
+			"displayName": "Divisor",
+			"description": "Separador entre componentes"
+		},
+		"FilePicker": {
+			"displayName": "Selector de archivos",
+			"description": "Selector de archivos"
+		},
+		"Calendar": {
+			"displayName": "Calendario",
+			"description": "Calendario"
+		},
+		"Iframe": {
+			"displayName": "Iframe",
+			"description": "Desplegar un Iframe"
+		},
+		"CodeEditor": {
+			"displayName": "Editor de código",
+			"description": "Editor de código"
+		},
+		"Tabs": {
+			"displayName": "Pestañas",
+			"description": "Componente de pestañas"
+		},
+		"Timer": {
+			"displayName": "Temporarizador",
+			"description": "Temporarizador"
+		},
+		"Listview": {
+			"displayName": "Lista de vistas",
+			"description": "Agrupador para múltiples componentes"
+		},
+		"Tags": {
+			"displayName": "Etiquetas",
+			"description": "Contenido puede ser mostrado como etiquetas"
+		},
+		"Pagination": {
+			"displayName": "Paginación",
+			"description": "Paginación"
+		},
+		"CircularProgressbar": {
+			"displayName": "Barra de progreso circular",
+			"description": "Mostrar el progreso usando una barra de progreso circular"
+		},
+		"Spinner": {
+			"displayName": "Spinner",
+			"description": "Spinner de carga puede ser utilizado para mostrar el progreso de una tarea"
+		},
+		"Statistics": {
+			"displayName": "Estadísticas",
+			"description": "Las estadísticas pueden ser usadas para mostrar datos numéricos"
+		},
+		"RangeSlider": {
+			"displayName": "Control deslizante de rango",
+			"description": "Puede ser utilizado para seleccionar un rango de valores"
+		},
+		"Timeline": {
+			"displayName": "Línea de tiempo",
+			"description": "Representación visual de una serie de eventos"
+		},
+		"SvgImage": {
+			"displayName": "Imagen SVG",
+			"description": "Desplegar imágenes SVG"
+		},
+		"Html": {
+			"displayName": "Visor HTML",
+			"description": "Visor HTML"
+		},
+		"VerticalDivider": {
+			"displayName": "Divisor vertical",
+			"description": "Divisor vertical, entre componentes"
+		},
+		"CustomComponent": {
+			"displayName": "Componente personalizado",
+			"description": "Añadir un componente personalizado"
+		},
+		"ButtonGroup": {
+			"displayName": "Grupo de botones",
+			"description": "Agrupar botones"
+		},
+		"PDF": {
+			"displayName": "PDF",
+			"description": "Embedir archivos PDF"
+		},
+		"Steps": {
+			"displayName": "Pasos",
+			"description": "Pasos"
+		},
+		"KanbanBoard": {
+			"displayName": "Tablero Kanban",
+			"description": "Tablero Kanban"
+		},
+		"ColorPicker": {
+			"displayName": "Selector de color",
+			"description": "Paleta de colores"
+		},
+		"TreeSelect": {
+			"displayName": "Selección de árbol",
+			"description": "Selección de valores de un árbol"
+		}
+	},
+	"leftSidebar": {
+		"Inspector": {
+			"text": "Inspector",
+			"tip": "Inspector"
+		},
+		"Sources": {
+			"text": "Fuentes",
+			"tip": "Añadir o editar fuentes de datos",
+			"dataSources": "Fuentes de datos",
+			"addDataSource": "+ añadir fuentes de datos"
+		},
+		"Debugger": {
+			"text": "Debugear",
+			"tip": "Debugear",
+			"errors": "Errores",
+			"noErrors": "No se encontraron errores",
+			"clear": "limpiar"
+		},
+		"Comments": {
+			"text": "Comentarios",
+			"tip": "Habilitar comentarios",
+			"commentBody": "No hay comentarios para desplegar",
+			"typeComment": "Escriba su comentario aquí"
+		},
+		"Settings": {
+			"text": "Ajustes",
+			"tip": "Ajustes globales",
+			"hideHeader": "Ocultar encabezado para aplicaciones desplegadas",
+			"maintenanceMode": "Modo de mantenimiento",
+			"maxWidthOfCanvas": "Ancho máximo del lienzo",
+			"maxHeightOfCanvas": "Altura máxima del lienzo",
+			"backgroundColorOfCanvas": "Color de fondo del lienzo"
+		},
+		"Back": {
+			"text": "Atrás",
+			"tip": "Atrás a la vista anterior (página principal)"
+		}
+	}
 }

--- a/frontend/assets/translations/fr.json
+++ b/frontend/assets/translations/fr.json
@@ -423,8 +423,16 @@
     "skip": "Passer"
   },
   "redirectSso": {
-    "upgradingTov1.13.0": "Mise à niveau vers V1.13.0 et supérieur.",
-    "fromV1.13.0": "De V1.13.0, nous avons introduit",
+    "upgradingTov1": {
+      "13": {
+        "0": "Mise à niveau vers V1.13.0 et supérieur."
+      }
+    },
+    "fromV1": {
+      "13": {
+        "0": "De V1.13.0, nous avons introduit"
+      }
+    },
     "multiWorkspace": "Espace multi-travaux",
     "singleSignOnConfig": "Les configurations liées à la connexion unique sont déplacées des variables d'environnement vers la base de données. Veuillez référer ceci",
     "link": "Lien",
@@ -909,8 +917,7 @@
       "maxHeightOfCanvas": "Hauteur maximale de la toile",
       "backgroundColorOfCanvas": "Couleur d'arrière-plan de la toile"
     },
-    "Back": 
-    {
+    "Back": {
       "text": "Retour",
       "tip": "De retour à la maison"
     }

--- a/frontend/assets/translations/id.json
+++ b/frontend/assets/translations/id.json
@@ -1,169 +1,168 @@
 {
-    "globals":{
-        "readDocumentation":"Baca dokumentasi",
-        "cancel":"Batal",
-        "save":"Simpan",
-        "back":"Kembali",
-        "edit":"Sunting",
-        "search":"Cari",
-        "update":"Memperbarui",
-        "delete":"Hapus",
-        "add":"Tambah",
-        "view":"Lihat",
-        "create":"Buat",
-        "enabled":"Diaktifkan",
-        "disabled":"Nonaktifkan",
-        "yes":"Iya",
-        "submit":"Kirim",
-        "select":"Pilih",
-        "environmentVar":"Environment Variables",
-        "saving":"Menyimpan...",
-        "saveDatasource":"Simpan sumber data",
-        "authorize":"Mengizinkan",
-        "connect":"Menghubung",
-        "reconnect":"Hubungkan kembali",
-        "components":"komponen",
-        "send":"Kirim",
-        "noConnection":"tidak dapat tersambung",
-        "connectionVerified":"koneksi diverifikasi",
-        "left":"Kiri",
-        "center":"Tengah",
-        "right":"Kanan",
-        "justified":"Rata Kiri Kanan",
-        "host":"Host",
-        "operation":"Operasi",
-        "header":"HEADER",
-        "path":"PATH",
-        "query":"QUERY",
-        "requestBody":"REQUEST BODY"
+    "globals": {
+        "readDocumentation": "Baca dokumentasi",
+        "cancel": "Batal",
+        "save": "Simpan",
+        "back": "Kembali",
+        "edit": "Sunting",
+        "search": "Cari",
+        "update": "Memperbarui",
+        "delete": "Hapus",
+        "add": "Tambah",
+        "view": "Lihat",
+        "create": "Buat",
+        "enabled": "Diaktifkan",
+        "disabled": "Nonaktifkan",
+        "yes": "Iya",
+        "submit": "Kirim",
+        "select": "Pilih",
+        "environmentVar": "Environment Variables",
+        "saving": "Menyimpan...",
+        "saveDatasource": "Simpan sumber data",
+        "authorize": "Mengizinkan",
+        "connect": "Menghubung",
+        "reconnect": "Hubungkan kembali",
+        "components": "komponen",
+        "send": "Kirim",
+        "noConnection": "tidak dapat tersambung",
+        "connectionVerified": "koneksi diverifikasi",
+        "left": "Kiri",
+        "center": "Tengah",
+        "right": "Kanan",
+        "justified": "Rata Kiri Kanan",
+        "host": "Host",
+        "operation": "Operasi",
+        "header": "HEADER",
+        "path": "PATH",
+        "query": "QUERY",
+        "requestBody": "REQUEST BODY"
     },
-    "errorBoundary":"Ada yang salah.",
-    "viewer":"Maaf! Aplikasi ini sedang dalam pemeliharaan",
-    "app":{
-        "updateAvailable":"Pembaruan tersedia",
-        "newVersionReleased":"Versi baru ToolJet telah dirilis.",
-        "readReleaseNotes":"Baca catatan rilis & pembaruan",
-        "skipVersion":"Lewati versi ini"
+    "errorBoundary": "Ada yang salah.",
+    "viewer": "Maaf! Aplikasi ini sedang dalam pemeliharaan",
+    "app": {
+        "updateAvailable": "Pembaruan tersedia",
+        "newVersionReleased": "Versi baru ToolJet telah dirilis.",
+        "readReleaseNotes": "Baca catatan rilis & pembaruan",
+        "skipVersion": "Lewati versi ini"
     },
-    "stripe":"Harap tunggu sementara kami memuat spesifikasi OpenAPI untuk Stripe.",
-    "openApi":{
-        "noValidOpenApi":"Spesifikasi OpenAPI yang valid tidak tersedia!",
-        "selectHost":"Pilih host",
-        "selectOperation":"Pilih operasi"
+    "stripe": "Harap tunggu sementara kami memuat spesifikasi OpenAPI untuk Stripe.",
+    "openApi": {
+        "noValidOpenApi": "Spesifikasi OpenAPI yang valid tidak tersedia!",
+        "selectHost": "Pilih host",
+        "selectOperation": "Pilih operasi"
     },
-    "slack":{
-        "authorize":"Mengizinkan",
-        "connectToolJetToSlack":"ToolJet dapat terhubung ke Slack dan membuat daftar pengguna, mengirim pesan, dll. Pilih cakupan izin yang sesuai.",
-        "chatWrite":"chat:write",
-        "listUsersAndSendMessage":"Aplikasi ToolJet Anda akan dapat membuat daftar pengguna dan mengirim pesan ke pengguna & saluran.",
-        "connectSlack":"Hubungkan ke Slack"
+    "slack": {
+        "authorize": "Mengizinkan",
+        "connectToolJetToSlack": "ToolJet dapat terhubung ke Slack dan membuat daftar pengguna, mengirim pesan, dll. Pilih cakupan izin yang sesuai.",
+        "chatWrite": "chat:write",
+        "listUsersAndSendMessage": "Aplikasi ToolJet Anda akan dapat membuat daftar pengguna dan mengirim pesan ke pengguna & saluran.",
+        "connectSlack": "Hubungkan ke Slack"
     },
-    "googleSheets":{
-        "readOnly":"Read only",
-        "enableReadAndWrite":"Jika Anda ingin aplikasi ToolJet Anda mengubah Google Spreadsheet Anda, pastikan untuk memilih akses baca dan tulis",
-        "readDataFromSheets":"Aplikasi ToolJet Anda hanya dapat membaca data dari Google Spreadsheet",
-        "readWrite":"Baca dan tulis",
-        "readModifySheets":"Aplikasi ToolJet Anda dapat membaca data dari sheet, memodifikasi sheet, dan banyak lagi.",
-        "toGoogleSheets":"ke Google Sheets"
-
+    "googleSheets": {
+        "readOnly": "Read only",
+        "enableReadAndWrite": "Jika Anda ingin aplikasi ToolJet Anda mengubah Google Spreadsheet Anda, pastikan untuk memilih akses baca dan tulis",
+        "readDataFromSheets": "Aplikasi ToolJet Anda hanya dapat membaca data dari Google Spreadsheet",
+        "readWrite": "Baca dan tulis",
+        "readModifySheets": "Aplikasi ToolJet Anda dapat membaca data dari sheet, memodifikasi sheet, dan banyak lagi.",
+        "toGoogleSheets": "ke Google Sheets"
     },
     "profile": {
-      "profileSettings": "Pengaturan Profil"
+        "profileSettings": "Pengaturan Profil"
     },
-    "loginSignupPage":{
-        "forgotPassword":"Lupa kata sandi",
-        "emailAddress":"Alamat email",
-        "enterEmail":"Masukan email",
-        "resetPassword":"Setel ulang kata sandi",
-        "dontHaveAccount":"Belum punya akun?",
-        "signIn":"Masuk",
-        "signUp":"Daftar",
-        "createToolJetAccount":"Buat akun ToolJet",
-        "enterBusinessEmail":"Masukkan email bisnis Anda",
-        "alreadyHaveAnAccount":"Sudah memiliki akun?",
-        "password":"Kata sandi",
-        "showPassword":"tampilkan kata sandi",
-        "loginTo":"Masuk ke",
-        "yourAccount":"akun Anda",
-        "noLoginMethodsEnabled":"Tidak ada metode login yang diaktifkan untuk workspace ini",
-        "emailConfirmLink":"Silakan periksa email Anda untuk tautan konfirmasi",
-        "newPassword":"Kata sandi baru",
-        "passwordConfirmation":"Konfirmasi kata sandi"
+    "loginSignupPage": {
+        "forgotPassword": "Lupa kata sandi",
+        "emailAddress": "Alamat email",
+        "enterEmail": "Masukan email",
+        "resetPassword": "Setel ulang kata sandi",
+        "dontHaveAccount": "Belum punya akun?",
+        "signIn": "Masuk",
+        "signUp": "Daftar",
+        "createToolJetAccount": "Buat akun ToolJet",
+        "enterBusinessEmail": "Masukkan email bisnis Anda",
+        "alreadyHaveAnAccount": "Sudah memiliki akun?",
+        "password": "Kata sandi",
+        "showPassword": "tampilkan kata sandi",
+        "loginTo": "Masuk ke",
+        "yourAccount": "akun Anda",
+        "noLoginMethodsEnabled": "Tidak ada metode login yang diaktifkan untuk workspace ini",
+        "emailConfirmLink": "Silakan periksa email Anda untuk tautan konfirmasi",
+        "newPassword": "Kata sandi baru",
+        "passwordConfirmation": "Konfirmasi kata sandi"
     },
     "editor": {
         "preview": "Pratinjau",
-        "share":"Bagikan",
+        "share": "Bagikan",
         "shareModal": {
-            "makeApplicationPublic":"Jadikan aplikasi publik?",
-            "shareableLink":"Dapatkan tautan yang dapat dibagikan untuk aplikasi ini",
-            "copy":"salin",
-            "embeddableLink":"Dapatkan tautan yang dapat disematkan untuk aplikasi ini",
-            "manageUsers":"Kelola Pengguna"
+            "makeApplicationPublic": "Jadikan aplikasi publik?",
+            "shareableLink": "Dapatkan tautan yang dapat dibagikan untuk aplikasi ini",
+            "copy": "salin",
+            "embeddableLink": "Dapatkan tautan yang dapat disematkan untuk aplikasi ini",
+            "manageUsers": "Kelola Pengguna"
         },
-        "appVersionManager":{
-            "version":"Versi",
-            "currentlyReleased":"Saat ini Dirilis",
-            "createVersion":"Buat Versi",
-            "versionName":"Nama Versi",
-            "createVersionFrom":"Buat versi dari",
-            "save":"Simpan",
-            "create":"Buat Versi",
+        "appVersionManager": {
+            "version": "Versi",
+            "currentlyReleased": "Saat ini Dirilis",
+            "createVersion": "Buat Versi",
+            "versionName": "Nama Versi",
+            "createVersionFrom": "Buat versi dari",
+            "save": "Simpan",
+            "create": "Buat Versi",
             "editVersion": "Sunting Versi",
-            "deleteVersion":"Apakah Anda benar-benar ingin menghapus versi ini ({{version}})?",
-            "enterVersionName":"Masukkan nama versi",
-            "versionAlreadyReleased":"Versi sudah dirilis. Silakan buat versi baru atau beralih ke versi lain untuk terus membuat perubahan."
+            "deleteVersion": "Apakah Anda benar-benar ingin menghapus versi ini ({{version}})?",
+            "enterVersionName": "Masukkan nama versi",
+            "versionAlreadyReleased": "Versi sudah dirilis. Silakan buat versi baru atau beralih ke versi lain untuk terus membuat perubahan."
         },
-        "queries":"Queries",
-        "inspectComponent":"Silakan pilih komponen untuk diperiksa",
-        "release":"Rilis",
-        "searchQueries":"Cari queries",
-        "createQuery":"Buat query",
-        "queryManager":{
-            "general":"Umum",
-            "advanced":"Lanjutan",
-            "preview":"Pratinjau",
-            "Save":"Simpan",
-            "selectDatasource":"Pilih Sumber Data",
-            "addDatasource":"Tambahkan sumber data",
-            "dataSourceManager":{
-                "toast":{
+        "queries": "Queries",
+        "inspectComponent": "Silakan pilih komponen untuk diperiksa",
+        "release": "Rilis",
+        "searchQueries": "Cari queries",
+        "createQuery": "Buat query",
+        "queryManager": {
+            "general": "Umum",
+            "advanced": "Lanjutan",
+            "preview": "Pratinjau",
+            "Save": "Simpan",
+            "selectDatasource": "Pilih Sumber Data",
+            "addDatasource": "Tambahkan sumber data",
+            "dataSourceManager": {
+                "toast": {
                     "success": {
                         "dataSourceAdded": "Sumber Data Ditambahkan",
                         "dataSourceSaved": "Sumber Data Disimpan"
                     },
-                    "error" :{
-                       "noEmptyDsName" :"Nama sumber data wajib diisi"
+                    "error": {
+                        "noEmptyDsName": "Nama sumber data wajib diisi"
                     }
                 },
-                "suggestDataSource":"Sarankan Sumber Data",
-                "suggestAnIntegration":"Sarankan integrasi",
-                "whatLookingFor":"Beritahu kami apa yang Anda cari?",
-                "noResultFound":"Tidak melihat apa yang Anda cari?",
-                "suggest":"Menyarankan",
-                "addNewDataSource":"Tambahkan sumber data baru",
-                "whiteListIP":"Harap daftar putih alamat IP kami jika sumber data tidak dapat diakses secara publik",
-                "copied":"Disalin",
-                "copy":"Salin",
-                "saving":"Menyimpan",
-                "noResultsFor":"Tidak ada hasil untuk",
-                "noteTaken":"Terima kasih, kami telah mencatatnya!",
-                "goToAllDatasources":"Buka semua Sumber Data",
-                "send":"Kirim"
+                "suggestDataSource": "Sarankan Sumber Data",
+                "suggestAnIntegration": "Sarankan integrasi",
+                "whatLookingFor": "Beritahu kami apa yang Anda cari?",
+                "noResultFound": "Tidak melihat apa yang Anda cari?",
+                "suggest": "Menyarankan",
+                "addNewDataSource": "Tambahkan sumber data baru",
+                "whiteListIP": "Harap daftar putih alamat IP kami jika sumber data tidak dapat diakses secara publik",
+                "copied": "Disalin",
+                "copy": "Salin",
+                "saving": "Menyimpan",
+                "noResultsFor": "Tidak ada hasil untuk",
+                "noteTaken": "Terima kasih, kami telah mencatatnya!",
+                "goToAllDatasources": "Buka semua Sumber Data",
+                "send": "Kirim"
             },
-            "runQueryOnPageLoad":"Jalankan kueri ini saat memuat halaman?",
-            "confirmBeforeQueryRun":"Minta konfirmasi sebelum menjalankan kueri?",
-            "notificationOnSuccess":"Tampilkan pemberitahuan jika berhasil?",
-            "successMessage":"Pesan Sukses",
-            "queryRanSuccessfully":"Kueri berhasil dijalankan",
-            "notificationDuration":"Durasi notifikasi",
-            "events":"Peristiwa",
-            "transformation":{
-                "transformationToolTip":"Transformasi dapat digunakan untuk mengubah hasil kueri. Semua variabel aplikasi dapat diakses dari transformer dan mendukung pustaka JS seperti Lodash & Moment.",
-                "transformations":"Transformasi"
+            "runQueryOnPageLoad": "Jalankan kueri ini saat memuat halaman?",
+            "confirmBeforeQueryRun": "Minta konfirmasi sebelum menjalankan kueri?",
+            "notificationOnSuccess": "Tampilkan pemberitahuan jika berhasil?",
+            "successMessage": "Pesan Sukses",
+            "queryRanSuccessfully": "Kueri berhasil dijalankan",
+            "notificationDuration": "Durasi notifikasi",
+            "events": "Peristiwa",
+            "transformation": {
+                "transformationToolTip": "Transformasi dapat digunakan untuk mengubah hasil kueri. Semua variabel aplikasi dapat diakses dari transformer dan mendukung pustaka JS seperti Lodash & Moment.",
+                "transformations": "Transformasi"
             }
         },
-        "inspector":{
-            "eventManager":{
+        "inspector": {
+            "eventManager": {
                 "event": "Peristiwa",
                 "action": "Tindakan",
                 "actionOptions": "Opsi Tindakan",
@@ -187,137 +186,137 @@
             }
         }
     },
-    "header":{
-        "darkModeToggle":{
-           "activateLightMode" :"Aktifkan mode terang",
-           "activateDarkMode":"Aktifkan mode gelap"
+    "header": {
+        "darkModeToggle": {
+            "activateLightMode": "Aktifkan mode terang",
+            "activateDarkMode": "Aktifkan mode gelap"
         },
-        "languageSelection":{
-           "changeLanguage":"Ganti bahasa",
-           "searchLanguage":"Cari bahasa"
+        "languageSelection": {
+            "changeLanguage": "Ganti bahasa",
+            "searchLanguage": "Cari bahasa"
         },
-        "notificationCenter":{
-            "notifications":"Notifikasi",
-            "markAllAs":"Tandai semua sebagai",
-            "read":"dibaca",
-            "un":"belum",
-            "youDontHaveany":"Anda tidak punya",
-            "youAreCaughtUp":"Sudah dilihat!",
-            "view":"Lihat"
+        "notificationCenter": {
+            "notifications": "Notifikasi",
+            "markAllAs": "Tandai semua sebagai",
+            "read": "dibaca",
+            "un": "belum",
+            "youDontHaveany": "Anda tidak punya",
+            "youAreCaughtUp": "Sudah dilihat!",
+            "view": "Lihat"
         },
-        "organization":{
-            "loadOrganizations":"Muat Organisasi",
-            "createWorkspace":"Buat ruang kerja",
-            "workspaceName":"nama ruang kerja",
-            "editWorkspace":"Sunting ruang kerja",
+        "organization": {
+            "loadOrganizations": "Muat Organisasi",
+            "createWorkspace": "Buat ruang kerja",
+            "workspaceName": "nama ruang kerja",
+            "editWorkspace": "Sunting ruang kerja",
             "menus": {
-                "addWorkspace":"Tambahkan ruang kerja",
-                "menusList":{
-                    "manageUsers":"Kelola Pengguna",
-                    "manageGroups":"Kelola Grup",
-                    "manageSso":"Kelola SSO",
-                    "manageEnv":"Kelola Environment Variables"
+                "addWorkspace": "Tambahkan ruang kerja",
+                "menusList": {
+                    "manageUsers": "Kelola Pengguna",
+                    "manageGroups": "Kelola Grup",
+                    "manageSso": "Kelola SSO",
+                    "manageEnv": "Kelola Environment Variables"
                 },
-                "manageUsers":{
-                    "usersAndPermission":"Pengguna & Izin",
-                    "inviteNewUser":"Undang pengguna baru",
-                    "name":"NAMA",
-                    "email":"EMAIL",
-                    "status":"STATUS",
-                    "archive":"Arsip",
-                    "unarchive":"Batalkan pengarsipan",
-                    "addNewUser":"Tambahkan pengguna baru",
-                    "emailAddress":"Alamat email",
-                    "createUser":"Buat pengguna",
-                    "enterFirstName":"Masukkan Nama Depan",
-                    "enterLastName":"Masukkan Nama Belakang",
-                    "enterEmail":"Masukan email"
+                "manageUsers": {
+                    "usersAndPermission": "Pengguna & Izin",
+                    "inviteNewUser": "Undang pengguna baru",
+                    "name": "NAMA",
+                    "email": "EMAIL",
+                    "status": "STATUS",
+                    "archive": "Arsip",
+                    "unarchive": "Batalkan pengarsipan",
+                    "addNewUser": "Tambahkan pengguna baru",
+                    "emailAddress": "Alamat email",
+                    "createUser": "Buat pengguna",
+                    "enterFirstName": "Masukkan Nama Depan",
+                    "enterLastName": "Masukkan Nama Belakang",
+                    "enterEmail": "Masukan email"
                 },
-                "manageGroups":{
-                    "permissions":{
-                        "userGroups":"Grup Pengguna",
-                        "createNewGroup":"Buat grup baru",
-                        "updateGroup":"Perbarui grup",
-                        "addNewGroup":"Tambahkan grup baru",
-                        "enterName":"Masukkan nama",
-                        "createGroup":"Membuat grup",
-                        "name":"Nama"
+                "manageGroups": {
+                    "permissions": {
+                        "userGroups": "Grup Pengguna",
+                        "createNewGroup": "Buat grup baru",
+                        "updateGroup": "Perbarui grup",
+                        "addNewGroup": "Tambahkan grup baru",
+                        "enterName": "Masukkan nama",
+                        "createGroup": "Membuat grup",
+                        "name": "Nama"
                     },
-                    "permissionResources":{
-                        "userGroup":"Grup pengguna",
-                        "apps":"Aplikasi",
-                        "users":"Pengguna",
-                        "permissions":"Izin",
-                        "addAppsToGroup":"Pilih aplikasi untuk ditambahkan ke grup",
-                        "name":"nama",
-                        "addUsersToGroup":"Pilih pengguna untuk ditambahkan ke grup",
-                        "email":"email",
-                        "resource":"sumber",
-                        "createUpdateDelete":"Buat/Perbarui/Hapus",
-                        "folder":"Folder"
+                    "permissionResources": {
+                        "userGroup": "Grup pengguna",
+                        "apps": "Aplikasi",
+                        "users": "Pengguna",
+                        "permissions": "Izin",
+                        "addAppsToGroup": "Pilih aplikasi untuk ditambahkan ke grup",
+                        "name": "nama",
+                        "addUsersToGroup": "Pilih pengguna untuk ditambahkan ke grup",
+                        "email": "email",
+                        "resource": "sumber",
+                        "createUpdateDelete": "Buat/Perbarui/Hapus",
+                        "folder": "Folder"
                     }
                 },
-                "manageSSO":{
-                    "manageSso":"Kelola SSO",
-                    "generalSettings":{
-                        "title":"Pengaturan Umum",
-                        "enableSignup":"Aktifkan Pendaftaran",
-                        "newAccountWillBeCreated":"Akun baru akan dibuat untuk pengguna pertama kali masuk SSO",
-                        "allowedDomains":"Domain yang diizinkan",
-                        "enterDomains":"Masukkan Domain",
-                        "supportMultiDomains":"Mendukung banyak domain. Masukkan nama domain yang dipisahkan dengan koma. contoh: tooljet.com,tooljet.io,organisasianda.com",
-                        "loginUrl":"Login URL",
-                        "workspaceLogin":"Gunakan URL ini untuk masuk langsung ke ruang kerja ini",
-                        "allowDefaultSso":"Izinkan SSO default",
-                        "ssoAuth":"Izinkan pengguna untuk mengautentikasi melalui SSO default. Konfigurasi SSO default dapat diganti oleh SSO tingkat ruang kerja."
+                "manageSSO": {
+                    "manageSso": "Kelola SSO",
+                    "generalSettings": {
+                        "title": "Pengaturan Umum",
+                        "enableSignup": "Aktifkan Pendaftaran",
+                        "newAccountWillBeCreated": "Akun baru akan dibuat untuk pengguna pertama kali masuk SSO",
+                        "allowedDomains": "Domain yang diizinkan",
+                        "enterDomains": "Masukkan Domain",
+                        "supportMultiDomains": "Mendukung banyak domain. Masukkan nama domain yang dipisahkan dengan koma. contoh: tooljet.com,tooljet.io,organisasianda.com",
+                        "loginUrl": "Login URL",
+                        "workspaceLogin": "Gunakan URL ini untuk masuk langsung ke ruang kerja ini",
+                        "allowDefaultSso": "Izinkan SSO default",
+                        "ssoAuth": "Izinkan pengguna untuk mengautentikasi melalui SSO default. Konfigurasi SSO default dapat diganti oleh SSO tingkat ruang kerja."
                     },
-                    "google":{
-                        "title":"Google",
-                        "enabled":"Diaktifkan",
-                        "disabled":"Nonaktifkan",
-                        "clientId":"ID Klien",
-                        "enterClientId":"Masukkan ID Klien",
-                        "redirectUrl":"URL pengalihan"
+                    "google": {
+                        "title": "Google",
+                        "enabled": "Diaktifkan",
+                        "disabled": "Nonaktifkan",
+                        "clientId": "ID Klien",
+                        "enterClientId": "Masukkan ID Klien",
+                        "redirectUrl": "URL pengalihan"
                     },
-                    "github":{
-                        "title":"GitHub",
-                        "hostName":"Nama Host",
-                        "enterHostName":"Masukan Nama Host",
-                        "requiredGithub":"Dibutuhkan Jika menggunakan GitHub self-hosted",
-                        "clientId":"ID Klien",
-                        "enterClientId":"Masukkan ID Klien",
-                        "clientSecret":"Rahasia Klien",
-                        "enterClientSecret":"Masukkan Rahasia Klien",
-                        "encrypted":"Terenkripsi",
-                        "redirectUrl":"URL pengalihan"
+                    "github": {
+                        "title": "GitHub",
+                        "hostName": "Nama Host",
+                        "enterHostName": "Masukan Nama Host",
+                        "requiredGithub": "Dibutuhkan Jika menggunakan GitHub self-hosted",
+                        "clientId": "ID Klien",
+                        "enterClientId": "Masukkan ID Klien",
+                        "clientSecret": "Rahasia Klien",
+                        "enterClientSecret": "Masukkan Rahasia Klien",
+                        "encrypted": "Terenkripsi",
+                        "redirectUrl": "URL pengalihan"
                     },
-                    "passwordLogin":"Masuk Kata Sandi",
-                    "environmentVar" : {
-                        "noEnvConfig":"Anda belum mengonfigurasi environment variabel apa pun, tekan tombol 'Tambahkan variabel baru' untuk membuatnya",
-                        "envWillBeDeleted":"Variabel akan dihapus, apakah Anda ingin melanjutkan?",
-                        "addNewVariable":"Tambahkan variabel baru",
-                        "variableForm":{
-                            "addNewVariable":"Tambahkan variabel baru",
-                            "updatevariable":"Perbarui variabel",
-                            "name":"Nama",
-                            "value":"Nilai",
-                            "enterVariableName":"Masukkan Nama Variabel",
-                            "enterValue":"Masukkan Nilai",
-                            "type":"Tipe",
-                            "enableEncryption":"Aktifkan enkripsi",
-                            "addVariable":"Tambahkan variabel"
+                    "passwordLogin": "Masuk Kata Sandi",
+                    "environmentVar": {
+                        "noEnvConfig": "Anda belum mengonfigurasi environment variabel apa pun, tekan tombol 'Tambahkan variabel baru' untuk membuatnya",
+                        "envWillBeDeleted": "Variabel akan dihapus, apakah Anda ingin melanjutkan?",
+                        "addNewVariable": "Tambahkan variabel baru",
+                        "variableForm": {
+                            "addNewVariable": "Tambahkan variabel baru",
+                            "updatevariable": "Perbarui variabel",
+                            "name": "Nama",
+                            "value": "Nilai",
+                            "enterVariableName": "Masukkan Nama Variabel",
+                            "enterValue": "Masukkan Nilai",
+                            "type": "Tipe",
+                            "enableEncryption": "Aktifkan enkripsi",
+                            "addVariable": "Tambahkan variabel"
                         },
-                        "variableTable":{
-                            "name":"nama",
-                            "value":"nilai",
-                            "type":"tipe",
-                            "secret":"rahasia"
+                        "variableTable": {
+                            "name": "nama",
+                            "value": "nilai",
+                            "type": "tipe",
+                            "secret": "rahasia"
                         }
                     }
                 }
             }
         },
-        "profileSettingPage":{
+        "profileSettingPage": {
             "profileSettings": "Pengaturan Profil",
             "firstName": "Nama depan",
             "lastName": "nama belakang",
@@ -339,46 +338,46 @@
     },
     "homePage": {
         "appCard": {
-          "changeIcon": "Ubah Ikon",
-          "addToFolder": "Tambahkan ke folder",
-          "move": "Bergerak",
-          "to": "ke",
-          "selectFolder": "Pilih folder",
-          "deleteApp": "Hapus Aplikasi",
-          "exportApp": "Aplikasi Ekspor",
-          "cloneApp": "Aplikasi klon",
-          "launch": "Meluncurkan",
-          "maintenance": "Pemeliharaan",
-          "noDeployedVersion": "Aplikasi tidak memiliki versi yang digunakan",
-          "openInAppViewer": "Buka di App Viewer",
-          "removeFromFolder": "Hapus dari folder"
+            "changeIcon": "Ubah Ikon",
+            "addToFolder": "Tambahkan ke folder",
+            "move": "Bergerak",
+            "to": "ke",
+            "selectFolder": "Pilih folder",
+            "deleteApp": "Hapus Aplikasi",
+            "exportApp": "Aplikasi Ekspor",
+            "cloneApp": "Aplikasi klon",
+            "launch": "Meluncurkan",
+            "maintenance": "Pemeliharaan",
+            "noDeployedVersion": "Aplikasi tidak memiliki versi yang digunakan",
+            "openInAppViewer": "Buka di App Viewer",
+            "removeFromFolder": "Hapus dari folder"
         },
         "blankPage": {
-          "welcomeToToolJet": "Selamat datang di ToolJet!",
-          "getStartedCreateNewApp": "Anda dapat memulai dengan membuat aplikasi baru atau dengan membuat aplikasi menggunakan templat di pustaka ToolJet.",
-          "importApplication": "Impor aplikasi"
+            "welcomeToToolJet": "Selamat datang di ToolJet!",
+            "getStartedCreateNewApp": "Anda dapat memulai dengan membuat aplikasi baru atau dengan membuat aplikasi menggunakan templat di pustaka ToolJet.",
+            "importApplication": "Impor aplikasi"
         },
         "foldersSection": {
-          "allApplications": "Semua aplikasi",
-          "folders": "Folder",
-          "createNewFolder": "+ Buat folder baru",
-          "noFolders": "Anda belum membuat folder apa pun. Gunakan folder untuk mengatur aplikasi Anda",
-          "createFolder": "Membuat folder",
-          "updateFolder": "Perbarui folder",
-          "editFolder": "Edit folder",
-          "deleteFolder": "Hapus folder",
-          "folderName": "Nama folder",
-          "wishToDeleteFolder": "Apakah Anda yakin ingin menghapus foldernya {{folderName}}? Aplikasi di dalam folder tidak akan dihapus."
+            "allApplications": "Semua aplikasi",
+            "folders": "Folder",
+            "createNewFolder": "+ Buat folder baru",
+            "noFolders": "Anda belum membuat folder apa pun. Gunakan folder untuk mengatur aplikasi Anda",
+            "createFolder": "Membuat folder",
+            "updateFolder": "Perbarui folder",
+            "editFolder": "Edit folder",
+            "deleteFolder": "Hapus folder",
+            "folderName": "Nama folder",
+            "wishToDeleteFolder": "Apakah Anda yakin ingin menghapus foldernya {{folderName}}? Aplikasi di dalam folder tidak akan dihapus."
         },
         "header": {
-          "createNewApplication": "Buat Aplikasi Baru",
-          "import": "Impor",
-          "chooseFromTemplate": "Pilih dari template"
+            "createNewApplication": "Buat Aplikasi Baru",
+            "import": "Impor",
+            "chooseFromTemplate": "Pilih dari template"
         },
         "pagination": {
-          "showing": "Menunjukkan",
-          "of": "dari",
-          "to": "ke"
+            "showing": "Menunjukkan",
+            "of": "dari",
+            "to": "ke"
         },
         "noApplicationFound": "Tidak ada aplikasi yang ditemukan",
         "thisFolderIsEmpty": "Folder ini kosong",
@@ -386,16 +385,16 @@
         "removeAppFromFolder": "Aplikasi ini akan dihapus dari folder ini, apakah Anda ingin melanjutkan?",
         "change": "Mengubah",
         "templateCard": {
-          "use": "Menggunakan",
-          "preview": "Pratinjau",
-          "leadGeneretion": "Generasi timbal"
+            "use": "Menggunakan",
+            "preview": "Pratinjau",
+            "leadGeneretion": "Generasi timbal"
         },
         "templateLibraryModal": {
-          "select": "Pilih template",
-          "createAppfromTemplate": "Buat Aplikasi Dari Template"
+            "select": "Pilih template",
+            "createAppfromTemplate": "Buat Aplikasi Dari Template"
         }
-      },
-      "confirmationPage": {
+    },
+    "confirmationPage": {
         "setupAccount": "Siapkan Akun Anda",
         "signupWithGoogle": "Daftar dengan Google",
         "signupWithGitHub": "Daftar dengan GitHub",
@@ -413,8 +412,8 @@
         "acceptInvite": "terima undangan",
         "accountExists": "Sudah memiliki akun?",
         "and": "dan"
-      },
-      "onBoarding": {
+    },
+    "onBoarding": {
         "finishToolJetInstallation": "Selesaikan instalasi ToolJet",
         "organization": "Organisasi",
         "name": "Nama",
@@ -422,10 +421,18 @@
         "receiveUpdatesFromToolJet": "Anda akan menerima pembaruan dari tim ToolJet (1-2 email setiap bulan, kami tidak spam)",
         "finishSetup": "Selesaikan pengaturan",
         "skip": "Melewati"
-      },
-      "redirectSso": {
-        "upgradingTov1.13.0": "Meningkatkan ke v1.13.0 dan di atas.",
-        "fromV1.13.0": "Dari v1.13.0 yang telah kami perkenalkan",
+    },
+    "redirectSso": {
+        "upgradingTov1": {
+            "13": {
+                "0": "Meningkatkan ke v1.13.0 dan di atas."
+            }
+        },
+        "fromV1": {
+            "13": {
+                "0": "Dari v1.13.0 yang telah kami perkenalkan"
+            }
+        },
         "multiWorkspace": "Multi-Workspace",
         "singleSignOnConfig": "Konfigurasi terkait masuk tunggal dipindahkan dari variabel lingkungan ke database. Silakan merujuk ini",
         "link": "Tautan",
@@ -440,13 +447,13 @@
         "google": "Google",
         "redirectUrl": "Redirect URL:",
         "gitHub": "GitHub"
-      },
-      "oAuth2": {
+    },
+    "oAuth2": {
         "pleaseWait": "Mohon tunggu...",
         "authSuccess": "Auth berhasil, Anda dapat menutup tab ini sekarang.",
         "authFailed": "Auth gagal"
-      },
-      "widgetManager": {
+    },
+    "widgetManager": {
         "commonlyUsed": "biasanya digunakan",
         "layouts": "tata letak",
         "forms": "formulir",
@@ -455,464 +462,464 @@
         "noResults": "Tidak ada hasil yang ditemukan",
         "tryAdjustingFilterMessage": "Coba sesuaikan pencarian atau filter Anda untuk menemukan apa yang Anda cari.",
         "clearQuery": "kueri yang jelas"
-      },
-      "widget": {
+    },
+    "widget": {
         "common": {
-          "properties": "Properti",
-          "events": "Acara",
-          "layout": "Tata letak",
-          "styles": "Gaya",
-          "general": "Umum",
-          "validation": "Validasi",
-          "documentation": "{{componentMeta}} dokumentasi",
-          "widgetNameEmptyError": "Nama widget tidak bisa kosong",
-          "componentNameExistsError": "Nama komponen sudah ada",
-          "invalidWidgetName": "Nama widget tidak valid. Harus unik dan hanya menyertakan huruf, angka, dan garis bawah."
+            "properties": "Properti",
+            "events": "Acara",
+            "layout": "Tata letak",
+            "styles": "Gaya",
+            "general": "Umum",
+            "validation": "Validasi",
+            "documentation": "{{componentMeta}} dokumentasi",
+            "widgetNameEmptyError": "Nama widget tidak bisa kosong",
+            "componentNameExistsError": "Nama komponen sudah ada",
+            "invalidWidgetName": "Nama widget tidak valid. Harus unik dan hanya menyertakan huruf, angka, dan garis bawah."
         },
         "commonProperties": {
-          "visibility": "Visibilitas",
-          "disable": "Nonaktifkan",
-          "borderRadius": "Radius perbatasan",
-          "boxShadow": "Bayangan kotak",
-          "tooltip": "Tooltip",
-          "showOnDesktop": "Tampilkan di desktop",
-          "showOnMobile": "Tampilkan di ponsel",
-          "showLoadingState": "Tampilkan status pemuatan",
-          "backgroundColor": "Warna latar belakang",
-          "textColor": "Warna teks",
-          "loaderColor": "Warna Loader",
-          "defaultValue": "Nilai default",
-          "placeholder": "Placeholder",
-          "label": "Label",
-          "title": "Judul",
-          "code": "Kode",
-          "data": "Data",
-          "tableData": "Data tabel",
-          "tableColumns": "Kolom tabel",
-          "searverSideSearch": "Pencarian sisi server",
-          "loadingState": "Status pemuatan",
-          "serverSidePagination": "Pagination sisi server",
-          "clientSidePagination": "Pagination sisi klien",
-          "serverSideSearch": "Pencarian sisi server",
-          "showSearchBox": "Tampilkan kotak pencarian",
-          "showDownloadButton": "Tampilkan tombol unduh",
-          "showFilterButton": "Tampilkan tombol filter",
-          "showBulkUpdateActions": "Tampilkan tombol pembaruan",
-          "bulkSelection": "Seleksi curah",
-          "highlightSelectedRow": "Sorot baris yang dipilih",
-          "actionButtonRadius": "Radius tombol aksi",
-          "tableType": "Jenis tabel",
-          "cellSize": "Ukuran sel",
-          "setPage": "Setel halaman",
-          "page": "Halaman",
-          "buttonText": "Teks Tombol",
-          "click": "Klik",
-          "setText": "Atur teks",
-          "text": "Teks",
-          "markerColor": "Warna penanda",
-          "showAxes": "Tampilkan kapak",
-          "showGridLines": "Tampilkan garis kisi",
-          "chartType": "Jenis grafik",
-          "jsonDescription": "Deskripsi json",
-          "usePlotlyJsonSchema": "Gunakan Skema JSON Plotly",
-          "padding": "Lapisan",
-          "hideTitleBar": "Sembunyikan judul bar",
-          "hideCloseButton": "Sembunyikan tombol Tutup",
-          "hideOnEscape": "Bersembunyi saat melarikan diri",
-          "modalSize": "Ukuran modal",
-          "open": "Membuka",
-          "close": "Menutup",
-          "regex": "Regex",
-          "minLength": "Panjang min",
-          "maxLength": "panjang maksimal",
-          "customValidation": "Validasi khusus",
-          "clear": "Jernih",
-          "minimumValue": "Nilai minimum",
-          "maximumValue": "Nilai maksimum",
-          "format": "Format",
-          "enableTimeSelection": "Mengaktifkan pemilihan waktu?",
-          "enableDateSelection": "Mengaktifkan pemilihan tanggal?",
-          "disabledDates": "Tanggal dinonaktifkan",
-          "setChecked": "Atur diperiksa",
-          "status": "status",
-          "defaultStatus": "Status default",
-          "checkboxColor": "Warna kotak centang",
-          "optionValues": "Nilai Opsi",
-          "optionLabels": "Label Opsi",
-          "activeColor": "Warna aktif",
-          "selectOption": "Pilih opsi",
-          "option": "Pilihan",
-          "toggleSwitchColor": "Sakelar warna sakelar",
-          "defaultStartDate": "Tanggal mulai default",
-          "defaultEndDate": "Tanggal akhir default",
-          "textSize": "Ukuran teks",
-          "alignText": "Sejajarkan teks",
-          "url": "Url",
-          "alternativeText": "Teks alternatif",
-          "zoomButton": "Tombol zoom",
-          "borderType": "Tipe perbatasan",
-          "imageFit": "Fit Image",
-          "optionsLoadingState": "Status pemuatan opsi",
-          "selectedTextColor": "Warna teks yang dipilih",
-          "select": "Pilih",
-          "deselectOption": "Opsi Batalkan Pilih",
-          "clearSelections": "Pilihan Hapus",
-          "enableSelectAllOption": "Aktifkan Pilih Semua Opsi",
-          "initialLocation": "Lokasi awal",
-          "defaultMarkers": "Penanda default",
-          "addNewMarkers": "Tambahkan penanda baru",
-          "searchForPlaces": "Cari tempat",
-          "setLocation": "Setel lokasi",
-          "latitude": "Garis Lintang",
-          "longitude": "Garis bujur",
-          "numberOfStars": "Jumlah bintang",
-          "defaultNoOfSelectedStars": "Default Tidak ada bintang yang dipilih",
-          "enableHalfStar": "Aktifkan Half Star",
-          "tooltips": "Tooltips",
-          "starColor": "Warna bintang",
-          "labelColor": "Warna label",
-          "dividerColor": "Warna pembagi",
-          "clearFiles": "Hapus file",
-          "instructionText": "Teks instruksi",
-          "useDropZone": "Gunakan zona drop",
-          "useFilePicker": "Gunakan pemetik file",
-          "pickMultipleFiles": "Pilih banyak file",
-          "maxFileCount": "Jumlah file maks",
-          "acceptFileTypes": "Menerima jenis file",
-          "maxSizeLimitBytes": "Batas ukuran maksimal (byte)",
-          "minSizeLimitBytes": "Batas ukuran min (byte)",
-          "parseContent": "Konten parse",
-          "fileType": "Jenis file",
-          "dateFormat": "Format tanggal",
-          "defaultDate": "Tanggal default",
-          "events": "Acara",
-          "resources": "Sumber daya",
-          "defaultView": "Tampilan default",
-          "startTimeOnWeekAndDayView": "Mulailah Waktu pada Tampilan Minggu dan Hari",
-          "endTimeOnWeekAndDayView": "Akhir waktu pada tampilan minggu dan hari",
-          "showToolbar": "Tampilkan toolbar",
-          "showViewSwitcher": "Tampilkan tampilan switcher",
-          "highlightToday": "Sorot hari ini",
-          "showPopoverWhenEventIsClicked": "Tampilkan Popover saat acara diklik",
-          "cellSizeInViewsClassifiedByResource": "Ukuran sel dalam tampilan yang diklasifikasikan berdasarkan sumber daya",
-          "headerDateFormatOnWeekView": "Format tanggal header pada tampilan minggu",
-          "showLineNumber": "Tampilkan nomor baris",
-          "mode": "Mode",
-          "tabs": "Tab",
-          "defaultTab": "Tab default",
-          "hideTabs": "Sembunyikan tab",
-          "highlightColor": "Warna Sorotan",
-          "tabWidth": "Lebar tab",
-          "setCurrentTab": "Atur tab saat ini",
-          "id": "Indo",
-          "timerType": "Jenis pengatur waktu",
-          "listData": "Daftar data",
-          "rowHeight": "Tinggi baris",
-          "showBottomBorder": "Tunjukkan perbatasan bawah",
-          "tags": "Tag",
-          "numberOfPages": "Jumlah halaman",
-          "defaultPageIndex": "Indeks halaman default",
-          "progress": "Kemajuan",
-          "color": "Warna",
-          "strokeWidth": "Lebar stroke",
-          "counterClockwise": "Counter searah jarum jam",
-          "circleRatio": "Rasio lingkaran",
-          "colour": "Warna",
-          "size": "Ukuran",
-          "primaryValueLabel": "Label Nilai Utama",
-          "primaryValue": "Nilai utama",
-          "hideSecondaryValue": "Sembunyikan nilai sekunder",
-          "secondaryValueLabel": "Label Nilai Sekunder",
-          "secondaryValue": "Nilai sekunder",
-          "secondarySignDisplay": "Tampilan tanda sekunder",
-          "primaryLabelColour": "Warna label primer",
-          "primaryTextColour": "Warna teks primer",
-          "secondaryLabelColour": "Warna label sekunder",
-          "secondaryTextColour": "Warna teks sekunder",
-          "min": "Min",
-          "max": "Max",
-          "value": "Nilai",
-          "twoHandles": "Dua pegangan",
-          "lineColor": "Warna garis",
-          "handleColor": "Menangani warna",
-          "trackColor": "Warna trek",
-          "timelineData": "Data Timeline",
-          "hideDate": "Tanggal Sembunyikan",
-          "svgData": "Data SVG",
-          "rawHtml": "HTML mentah",
-          "values": "nilai",
-          "labels": "Label",
-          "defaultSelected": "Default dipilih",
-          "enableMutipleSelection": "Aktifkan pemilihan Mutiple",
-          "selectedTextColour": "Warna teks yang dipilih",
-          "selectedBackgroundColor": "Warna latar belakang yang dipilih",
-          "fileUrl": "URL file",
-          "scalePageToWidth": "Skala halaman hingga lebar",
-          "showPageControls": "Tampilkan kontrol halaman",
-          "steps": "Langkah",
-          "currentStep": "Langkah saat ini",
-          "stepsSelectable": "Langkah -langkah yang dapat dipilih",
-          "theme": "Tema",
-          "columns": "Kolom",
-          "cardData": "Data kartu",
-          "enableAddCard": "Aktifkan Tambah Kartu",
-          "width": "Lebar",
-          "minWidth": "Lebar menit",
-          "accentColor": "Aksen warna",
-          "defaultColor": "Warna default",
-          "setColor": "Atur warna",
-          "structure": "Struktur",
-          "checkedValues": "Nilai -nilai yang diperiksa",
-          "expandedValues": "Nilai yang diperluas"
+            "visibility": "Visibilitas",
+            "disable": "Nonaktifkan",
+            "borderRadius": "Radius perbatasan",
+            "boxShadow": "Bayangan kotak",
+            "tooltip": "Tooltip",
+            "showOnDesktop": "Tampilkan di desktop",
+            "showOnMobile": "Tampilkan di ponsel",
+            "showLoadingState": "Tampilkan status pemuatan",
+            "backgroundColor": "Warna latar belakang",
+            "textColor": "Warna teks",
+            "loaderColor": "Warna Loader",
+            "defaultValue": "Nilai default",
+            "placeholder": "Placeholder",
+            "label": "Label",
+            "title": "Judul",
+            "code": "Kode",
+            "data": "Data",
+            "tableData": "Data tabel",
+            "tableColumns": "Kolom tabel",
+            "searverSideSearch": "Pencarian sisi server",
+            "loadingState": "Status pemuatan",
+            "serverSidePagination": "Pagination sisi server",
+            "clientSidePagination": "Pagination sisi klien",
+            "serverSideSearch": "Pencarian sisi server",
+            "showSearchBox": "Tampilkan kotak pencarian",
+            "showDownloadButton": "Tampilkan tombol unduh",
+            "showFilterButton": "Tampilkan tombol filter",
+            "showBulkUpdateActions": "Tampilkan tombol pembaruan",
+            "bulkSelection": "Seleksi curah",
+            "highlightSelectedRow": "Sorot baris yang dipilih",
+            "actionButtonRadius": "Radius tombol aksi",
+            "tableType": "Jenis tabel",
+            "cellSize": "Ukuran sel",
+            "setPage": "Setel halaman",
+            "page": "Halaman",
+            "buttonText": "Teks Tombol",
+            "click": "Klik",
+            "setText": "Atur teks",
+            "text": "Teks",
+            "markerColor": "Warna penanda",
+            "showAxes": "Tampilkan kapak",
+            "showGridLines": "Tampilkan garis kisi",
+            "chartType": "Jenis grafik",
+            "jsonDescription": "Deskripsi json",
+            "usePlotlyJsonSchema": "Gunakan Skema JSON Plotly",
+            "padding": "Lapisan",
+            "hideTitleBar": "Sembunyikan judul bar",
+            "hideCloseButton": "Sembunyikan tombol Tutup",
+            "hideOnEscape": "Bersembunyi saat melarikan diri",
+            "modalSize": "Ukuran modal",
+            "open": "Membuka",
+            "close": "Menutup",
+            "regex": "Regex",
+            "minLength": "Panjang min",
+            "maxLength": "panjang maksimal",
+            "customValidation": "Validasi khusus",
+            "clear": "Jernih",
+            "minimumValue": "Nilai minimum",
+            "maximumValue": "Nilai maksimum",
+            "format": "Format",
+            "enableTimeSelection": "Mengaktifkan pemilihan waktu?",
+            "enableDateSelection": "Mengaktifkan pemilihan tanggal?",
+            "disabledDates": "Tanggal dinonaktifkan",
+            "setChecked": "Atur diperiksa",
+            "status": "status",
+            "defaultStatus": "Status default",
+            "checkboxColor": "Warna kotak centang",
+            "optionValues": "Nilai Opsi",
+            "optionLabels": "Label Opsi",
+            "activeColor": "Warna aktif",
+            "selectOption": "Pilih opsi",
+            "option": "Pilihan",
+            "toggleSwitchColor": "Sakelar warna sakelar",
+            "defaultStartDate": "Tanggal mulai default",
+            "defaultEndDate": "Tanggal akhir default",
+            "textSize": "Ukuran teks",
+            "alignText": "Sejajarkan teks",
+            "url": "Url",
+            "alternativeText": "Teks alternatif",
+            "zoomButton": "Tombol zoom",
+            "borderType": "Tipe perbatasan",
+            "imageFit": "Fit Image",
+            "optionsLoadingState": "Status pemuatan opsi",
+            "selectedTextColor": "Warna teks yang dipilih",
+            "select": "Pilih",
+            "deselectOption": "Opsi Batalkan Pilih",
+            "clearSelections": "Pilihan Hapus",
+            "enableSelectAllOption": "Aktifkan Pilih Semua Opsi",
+            "initialLocation": "Lokasi awal",
+            "defaultMarkers": "Penanda default",
+            "addNewMarkers": "Tambahkan penanda baru",
+            "searchForPlaces": "Cari tempat",
+            "setLocation": "Setel lokasi",
+            "latitude": "Garis Lintang",
+            "longitude": "Garis bujur",
+            "numberOfStars": "Jumlah bintang",
+            "defaultNoOfSelectedStars": "Default Tidak ada bintang yang dipilih",
+            "enableHalfStar": "Aktifkan Half Star",
+            "tooltips": "Tooltips",
+            "starColor": "Warna bintang",
+            "labelColor": "Warna label",
+            "dividerColor": "Warna pembagi",
+            "clearFiles": "Hapus file",
+            "instructionText": "Teks instruksi",
+            "useDropZone": "Gunakan zona drop",
+            "useFilePicker": "Gunakan pemetik file",
+            "pickMultipleFiles": "Pilih banyak file",
+            "maxFileCount": "Jumlah file maks",
+            "acceptFileTypes": "Menerima jenis file",
+            "maxSizeLimitBytes": "Batas ukuran maksimal (byte)",
+            "minSizeLimitBytes": "Batas ukuran min (byte)",
+            "parseContent": "Konten parse",
+            "fileType": "Jenis file",
+            "dateFormat": "Format tanggal",
+            "defaultDate": "Tanggal default",
+            "events": "Acara",
+            "resources": "Sumber daya",
+            "defaultView": "Tampilan default",
+            "startTimeOnWeekAndDayView": "Mulailah Waktu pada Tampilan Minggu dan Hari",
+            "endTimeOnWeekAndDayView": "Akhir waktu pada tampilan minggu dan hari",
+            "showToolbar": "Tampilkan toolbar",
+            "showViewSwitcher": "Tampilkan tampilan switcher",
+            "highlightToday": "Sorot hari ini",
+            "showPopoverWhenEventIsClicked": "Tampilkan Popover saat acara diklik",
+            "cellSizeInViewsClassifiedByResource": "Ukuran sel dalam tampilan yang diklasifikasikan berdasarkan sumber daya",
+            "headerDateFormatOnWeekView": "Format tanggal header pada tampilan minggu",
+            "showLineNumber": "Tampilkan nomor baris",
+            "mode": "Mode",
+            "tabs": "Tab",
+            "defaultTab": "Tab default",
+            "hideTabs": "Sembunyikan tab",
+            "highlightColor": "Warna Sorotan",
+            "tabWidth": "Lebar tab",
+            "setCurrentTab": "Atur tab saat ini",
+            "id": "Indo",
+            "timerType": "Jenis pengatur waktu",
+            "listData": "Daftar data",
+            "rowHeight": "Tinggi baris",
+            "showBottomBorder": "Tunjukkan perbatasan bawah",
+            "tags": "Tag",
+            "numberOfPages": "Jumlah halaman",
+            "defaultPageIndex": "Indeks halaman default",
+            "progress": "Kemajuan",
+            "color": "Warna",
+            "strokeWidth": "Lebar stroke",
+            "counterClockwise": "Counter searah jarum jam",
+            "circleRatio": "Rasio lingkaran",
+            "colour": "Warna",
+            "size": "Ukuran",
+            "primaryValueLabel": "Label Nilai Utama",
+            "primaryValue": "Nilai utama",
+            "hideSecondaryValue": "Sembunyikan nilai sekunder",
+            "secondaryValueLabel": "Label Nilai Sekunder",
+            "secondaryValue": "Nilai sekunder",
+            "secondarySignDisplay": "Tampilan tanda sekunder",
+            "primaryLabelColour": "Warna label primer",
+            "primaryTextColour": "Warna teks primer",
+            "secondaryLabelColour": "Warna label sekunder",
+            "secondaryTextColour": "Warna teks sekunder",
+            "min": "Min",
+            "max": "Max",
+            "value": "Nilai",
+            "twoHandles": "Dua pegangan",
+            "lineColor": "Warna garis",
+            "handleColor": "Menangani warna",
+            "trackColor": "Warna trek",
+            "timelineData": "Data Timeline",
+            "hideDate": "Tanggal Sembunyikan",
+            "svgData": "Data SVG",
+            "rawHtml": "HTML mentah",
+            "values": "nilai",
+            "labels": "Label",
+            "defaultSelected": "Default dipilih",
+            "enableMutipleSelection": "Aktifkan pemilihan Mutiple",
+            "selectedTextColour": "Warna teks yang dipilih",
+            "selectedBackgroundColor": "Warna latar belakang yang dipilih",
+            "fileUrl": "URL file",
+            "scalePageToWidth": "Skala halaman hingga lebar",
+            "showPageControls": "Tampilkan kontrol halaman",
+            "steps": "Langkah",
+            "currentStep": "Langkah saat ini",
+            "stepsSelectable": "Langkah -langkah yang dapat dipilih",
+            "theme": "Tema",
+            "columns": "Kolom",
+            "cardData": "Data kartu",
+            "enableAddCard": "Aktifkan Tambah Kartu",
+            "width": "Lebar",
+            "minWidth": "Lebar menit",
+            "accentColor": "Aksen warna",
+            "defaultColor": "Warna default",
+            "setColor": "Atur warna",
+            "structure": "Struktur",
+            "checkedValues": "Nilai -nilai yang diperiksa",
+            "expandedValues": "Nilai yang diperluas"
         },
         "Table": {
-          "displayName": "Tabel",
-          "description": "Tampilkan data tabel paginated",
-          "columnType": "Jenis kolom",
-          "columnName": "Nama kolom",
-          "overflow": "Meluap",
-          "key": "kunci",
-          "textColor": "Warna teks",
-          "validation": "Validasi",
-          "regex": "Regex",
-          "minLength": "Panjang min",
-          "maxLength": "panjang maksimal",
-          "customRule": "Aturan khusus",
-          "values": "Nilai",
-          "labels": "Label",
-          "cellBgColor": "Warna latar belakang sel",
-          "dateDisplayformat": "Format tampilan tanggal",
-          "dateParseformat": "Format parse tanggal",
-          "showTime": "waktu pertunjukan",
-          "makeEditable": "membuat edit",
-          "buttonText": "Teks Tombol",
-          "buttonPosition": "Posisi tombol",
-          "remove": "Menghapus",
-          "addButton": "+ Tambahkan tombol",
-          "addColumn": "+ Tambahkan kolom",
-          "noActionMessage": "Tabel ini tidak memiliki tombol tindakan apa pun"
+            "displayName": "Tabel",
+            "description": "Tampilkan data tabel paginated",
+            "columnType": "Jenis kolom",
+            "columnName": "Nama kolom",
+            "overflow": "Meluap",
+            "key": "kunci",
+            "textColor": "Warna teks",
+            "validation": "Validasi",
+            "regex": "Regex",
+            "minLength": "Panjang min",
+            "maxLength": "panjang maksimal",
+            "customRule": "Aturan khusus",
+            "values": "Nilai",
+            "labels": "Label",
+            "cellBgColor": "Warna latar belakang sel",
+            "dateDisplayformat": "Format tampilan tanggal",
+            "dateParseformat": "Format parse tanggal",
+            "showTime": "waktu pertunjukan",
+            "makeEditable": "membuat edit",
+            "buttonText": "Teks Tombol",
+            "buttonPosition": "Posisi tombol",
+            "remove": "Menghapus",
+            "addButton": "+ Tambahkan tombol",
+            "addColumn": "+ Tambahkan kolom",
+            "noActionMessage": "Tabel ini tidak memiliki tombol tindakan apa pun"
         },
         "Button": {
-          "displayName": "Tombol",
-          "description": "Tindakan pemicu: kueri, peringatan dll"
+            "displayName": "Tombol",
+            "description": "Tindakan pemicu: kueri, peringatan dll"
         },
         "Chart": {
-          "displayName": "Bagan",
-          "description": "Tampilan grafik"
+            "displayName": "Bagan",
+            "description": "Tampilan grafik"
         },
         "Modal": {
-          "displayName": "Modal",
-          "description": "Modal dipicu oleh peristiwa"
+            "displayName": "Modal",
+            "description": "Modal dipicu oleh peristiwa"
         },
         "TextInput": {
-          "displayName": "Input teks",
-          "description": "Bidang teks untuk formulir"
+            "displayName": "Input teks",
+            "description": "Bidang teks untuk formulir"
         },
         "NumberInput": {
-          "displayName": "Input angka",
-          "description": "Bidang Nomor untuk Formulir"
+            "displayName": "Input angka",
+            "description": "Bidang Nomor untuk Formulir"
         },
         "PasswordInput": {
-          "displayName": "Input kata sandi",
-          "description": "Bidang input kata sandi untuk formulir"
+            "displayName": "Input kata sandi",
+            "description": "Bidang input kata sandi untuk formulir"
         },
         "Datepicker": {
-          "displayName": "Pemetik tanggal",
-          "description": "Pilih tanggal dan waktu"
+            "displayName": "Pemetik tanggal",
+            "description": "Pilih tanggal dan waktu"
         },
         "Checkbox": {
-          "displayName": "Kotak centang",
-          "description": "Kotak centang tunggal"
+            "displayName": "Kotak centang",
+            "description": "Kotak centang tunggal"
         },
         "Radio-button": {
-          "displayName": "Tombol radio",
-          "description": "Tombol radio"
+            "displayName": "Tombol radio",
+            "description": "Tombol radio"
         },
         "ToggleSwitch": {
-          "displayName": "Sakelar Beralih",
-          "description": "Sakelar Beralih"
+            "displayName": "Sakelar Beralih",
+            "description": "Sakelar Beralih"
         },
         "Textarea": {
-          "displayName": "Area teks",
-          "description": "Bidang bentuk area teks"
+            "displayName": "Area teks",
+            "description": "Bidang bentuk area teks"
         },
         "DateRangePicker": {
-          "displayName": "Range Picker",
-          "description": "Pilih rentang tanggal"
+            "displayName": "Range Picker",
+            "description": "Pilih rentang tanggal"
         },
         "Text": {
-          "displayName": "Teks",
-          "description": "Tampilkan Markdown atau HTML"
+            "displayName": "Teks",
+            "description": "Tampilkan Markdown atau HTML"
         },
         "Image": {
-          "displayName": "Gambar",
-          "description": "Menampilkan gambar"
+            "displayName": "Gambar",
+            "description": "Menampilkan gambar"
         },
         "Container": {
-          "displayName": "Wadah",
-          "description": "Pembungkus untuk beberapa komponen"
+            "displayName": "Wadah",
+            "description": "Pembungkus untuk beberapa komponen"
         },
         "Dropdown": {
-          "displayName": "Dropdown",
-          "description": "Pilih satu nilai dari opsi"
+            "displayName": "Dropdown",
+            "description": "Pilih satu nilai dari opsi"
         },
         "Multiselect": {
-          "displayName": "Multiselect",
-          "description": "Pilih beberapa nilai dari opsi"
+            "displayName": "Multiselect",
+            "description": "Pilih beberapa nilai dari opsi"
         },
         "RichTextEditor": {
-          "displayName": "Editor Teks",
-          "description": "Editor Teks Kaya"
+            "displayName": "Editor Teks",
+            "description": "Editor Teks Kaya"
         },
         "Map": {
-          "displayName": "Peta",
-          "description": "Tampilkan Google Maps"
+            "displayName": "Peta",
+            "description": "Tampilkan Google Maps"
         },
         "QrScanner": {
-          "displayName": "Pemindai QR",
-          "description": "Pindai kode QR dan tahan datanya"
+            "displayName": "Pemindai QR",
+            "description": "Pindai kode QR dan tahan datanya"
         },
         "StarRating": {
-          "displayName": "Peringkat",
-          "description": "Peringkat bintang"
+            "displayName": "Peringkat",
+            "description": "Peringkat bintang"
         },
         "Divider": {
-          "displayName": "Pembagi",
-          "description": "Pemisah antar komponen"
+            "displayName": "Pembagi",
+            "description": "Pemisah antar komponen"
         },
         "FilePicker": {
-          "displayName": "Pemilih file",
-          "description": "Pemilih file"
+            "displayName": "Pemilih file",
+            "description": "Pemilih file"
         },
         "Calendar": {
-          "displayName": "Kalender",
-          "description": "Kalender"
+            "displayName": "Kalender",
+            "description": "Kalender"
         },
         "Iframe": {
-          "displayName": "Iframe",
-          "description": "Tampilkan iframe"
+            "displayName": "Iframe",
+            "description": "Tampilkan iframe"
         },
         "CodeEditor": {
-          "displayName": "Editor Kode",
-          "description": "Editor Kode"
+            "displayName": "Editor Kode",
+            "description": "Editor Kode"
         },
         "Tabs": {
-          "displayName": "Tab",
-          "description": "Komponen tab"
+            "displayName": "Tab",
+            "description": "Komponen tab"
         },
         "Timer": {
-          "displayName": "Timer",
-          "description": "timer"
+            "displayName": "Timer",
+            "description": "timer"
         },
         "Listview": {
-          "displayName": "Tampilan Daftar",
-          "description": "Pembungkus untuk beberapa komponen"
+            "displayName": "Tampilan Daftar",
+            "description": "Pembungkus untuk beberapa komponen"
         },
         "Tags": {
-          "displayName": "Tag",
-          "description": "Konten dapat ditampilkan sebagai tag"
+            "displayName": "Tag",
+            "description": "Konten dapat ditampilkan sebagai tag"
         },
         "Pagination": {
-          "displayName": "Pagination",
-          "description": "Pagination"
+            "displayName": "Pagination",
+            "description": "Pagination"
         },
         "CircularProgressbar": {
-          "displayName": "Circular Progressbar",
-          "description": "Tunjukkan Kemajuan Menggunakan Progressbar Circular"
+            "displayName": "Circular Progressbar",
+            "description": "Tunjukkan Kemajuan Menggunakan Progressbar Circular"
         },
         "Spinner": {
-          "displayName": "Pemintal",
-          "description": "Spinner dapat digunakan untuk menampilkan status pemuatan"
+            "displayName": "Pemintal",
+            "description": "Spinner dapat digunakan untuk menampilkan status pemuatan"
         },
         "Statistics": {
-          "displayName": "Statistik",
-          "description": "Statistik dapat digunakan untuk menampilkan informasi statistik yang berbeda"
+            "displayName": "Statistik",
+            "description": "Statistik dapat digunakan untuk menampilkan informasi statistik yang berbeda"
         },
         "RangeSlider": {
-          "displayName": "Range Slider",
-          "description": "Dapat digunakan untuk menampilkan slider dengan jangkauan"
+            "displayName": "Range Slider",
+            "description": "Dapat digunakan untuk menampilkan slider dengan jangkauan"
         },
         "Timeline": {
-          "displayName": "Linimasa",
-          "description": "Representasi visual dari urutan peristiwa"
+            "displayName": "Linimasa",
+            "description": "Representasi visual dari urutan peristiwa"
         },
         "SvgImage": {
-          "displayName": "Gambar SVG",
-          "description": "Gambar SVG"
+            "displayName": "Gambar SVG",
+            "description": "Gambar SVG"
         },
         "Html": {
-          "displayName": "Penampil html",
-          "description": "Penampil html"
+            "displayName": "Penampil html",
+            "description": "Penampil html"
         },
         "VerticalDivider": {
-          "displayName": "Pembagi vertikal",
-          "description": "Pemisah vertikal antar komponen"
+            "displayName": "Pembagi vertikal",
+            "description": "Pemisah vertikal antar komponen"
         },
         "CustomComponent": {
-          "displayName": "Komponen khusus",
-          "description": "Tambahkan Komponen React Kustom Anda"
+            "displayName": "Komponen khusus",
+            "description": "Tambahkan Komponen React Kustom Anda"
         },
         "ButtonGroup": {
-          "displayName": "Grup tombol",
-          "description": "Buttongroup"
+            "displayName": "Grup tombol",
+            "description": "Buttongroup"
         },
         "PDF": {
-          "displayName": "Pdf",
-          "description": "Embed file PDF"
+            "displayName": "Pdf",
+            "description": "Embed file PDF"
         },
         "Steps": {
-          "displayName": "Langkah",
-          "description": "Langkah"
+            "displayName": "Langkah",
+            "description": "Langkah"
         },
         "KanbanBoard": {
-          "displayName": "Dewan Kanban",
-          "description": "Dewan Kanban"
+            "displayName": "Dewan Kanban",
+            "description": "Dewan Kanban"
         },
         "ColorPicker": {
-          "displayName": "Pemilih warna",
-          "description": "Palet Picker Warna"
+            "displayName": "Pemilih warna",
+            "description": "Palet Picker Warna"
         },
         "TreeSelect": {
-          "displayName": "Pilihan Pohon",
-          "description": "Pilih nilai dari tampilan pohon"
+            "displayName": "Pilihan Pohon",
+            "description": "Pilih nilai dari tampilan pohon"
         }
-      },
-      "leftSidebar": {
+    },
+    "leftSidebar": {
         "Inspector": {
-          "text": "Pemeriksa",
-          "tip": "Pemeriksa"
+            "text": "Pemeriksa",
+            "tip": "Pemeriksa"
         },
         "Sources": {
-          "text": "Sumber",
-          "tip": "Tambahkan atau Edit DataSources",
-          "dataSources": "Sumber data",
-          "addDataSource": "+ Tambahkan Sumber Data"
+            "text": "Sumber",
+            "tip": "Tambahkan atau Edit DataSources",
+            "dataSources": "Sumber data",
+            "addDataSource": "+ Tambahkan Sumber Data"
         },
         "Debugger": {
-          "text": "Debugger",
-          "tip": "Debugger",
-          "errors": "Kesalahan",
-          "noErrors": "Tidak ada kesalahan yang ditemukan",
-          "clear": "bersihkan"
+            "text": "Debugger",
+            "tip": "Debugger",
+            "errors": "Kesalahan",
+            "noErrors": "Tidak ada kesalahan yang ditemukan",
+            "clear": "bersihkan"
         },
         "Comments": {
-          "text": "Komentar",
-          "tip": "alihkan komentar",
-          "commentBody": "Tidak ada komentar untuk ditampilkan",
-          "typeComment": "tulis komentarmu di sini"
+            "text": "Komentar",
+            "tip": "alihkan komentar",
+            "commentBody": "Tidak ada komentar untuk ditampilkan",
+            "typeComment": "tulis komentarmu di sini"
         },
         "Settings": {
-          "text": "Pengaturan",
-          "tip": "Pengaturan global",
-          "hideHeader": "Sembunyikan header untuk aplikasi yang diluncurkan",
-          "maintenanceMode": "Mode pemeliharaan",
-          "maxWidthOfCanvas": "Lebar Maksimum Kanvas",
-          "maxHeightOfCanvas": "Tinggi kanvas maksimal",
-          "backgroundColorOfCanvas": "Warna latar belakang kanvas"
+            "text": "Pengaturan",
+            "tip": "Pengaturan global",
+            "hideHeader": "Sembunyikan header untuk aplikasi yang diluncurkan",
+            "maintenanceMode": "Mode pemeliharaan",
+            "maxWidthOfCanvas": "Lebar Maksimum Kanvas",
+            "maxHeightOfCanvas": "Tinggi kanvas maksimal",
+            "backgroundColorOfCanvas": "Warna latar belakang kanvas"
         },
         "Back": {
-          "text": "Kembali",
-          "tip": "Kembali ke Beranda"
+            "text": "Kembali",
+            "tip": "Kembali ke Beranda"
         }
-      }
+    }
 }

--- a/frontend/assets/translations/it.json
+++ b/frontend/assets/translations/it.json
@@ -1,916 +1,924 @@
 {
-"globals":{
-        "readDocumentation":"Leggi documentazione",
-        "cancel":"Annulla",
-        "save":"Salva",
-        "back":"Indietro",
-        "edit":"Modifica",
-        "search":"Cerca",
-        "update":"Aggiorna",
-        "delete":"Cancella",
-        "add":"Aggiungi",
-        "view":"Esplora",
-        "create":"Crea",
-        "enabled":"Abilitato",
-        "disabled":"Disabilitato",
-        "yes":"Sì",
-        "submit":"Conferma",
-        "select":"Selezione",
-        "environmentVar":"Variabili globali",
-        "saving":"Salvataggio in corso...",
-        "saveDatasource":"Salva dati",
-        "authorize":"Autoizza",
-        "connect":"Connetti",
-        "reconnect":"Riconnetti",
-        "components":"Componenti",
-        "send":"Invia",
-        "noConnection":"Impossibile connettersi",
-        "connectionVerifeid":"Connessione verificata",
-        "left":"Sinistra",
-        "center":"Centro",
-        "right":"Destra",
-        "justified":"Giustifica",
-        "host":"Host",
-        "operation":"Operazione",
-        "header":"TESTATA",
-        "path":"PERCORSO",
-        "query":"RICHIESTA",
-        "requestBody":"CORPO DELLA RICHIESTA"
+  "globals": {
+    "readDocumentation": "Leggi documentazione",
+    "cancel": "Annulla",
+    "save": "Salva",
+    "back": "Indietro",
+    "edit": "Modifica",
+    "search": "Cerca",
+    "update": "Aggiorna",
+    "delete": "Cancella",
+    "add": "Aggiungi",
+    "view": "Esplora",
+    "create": "Crea",
+    "enabled": "Abilitato",
+    "disabled": "Disabilitato",
+    "yes": "Sì",
+    "submit": "Conferma",
+    "select": "Selezione",
+    "environmentVar": "Variabili globali",
+    "saving": "Salvataggio in corso...",
+    "saveDatasource": "Salva dati",
+    "authorize": "Autoizza",
+    "connect": "Connetti",
+    "reconnect": "Riconnetti",
+    "components": "Componenti",
+    "send": "Invia",
+    "noConnection": "Impossibile connettersi",
+    "connectionVerifeid": "Connessione verificata",
+    "left": "Sinistra",
+    "center": "Centro",
+    "right": "Destra",
+    "justified": "Giustifica",
+    "host": "Host",
+    "operation": "Operazione",
+    "header": "TESTATA",
+    "path": "PERCORSO",
+    "query": "RICHIESTA",
+    "requestBody": "CORPO DELLA RICHIESTA"
+  },
+  "errorBoundary": "Qualcosa è andato storto.",
+  "viewer": "Spiacente! L'app è al momento in fase di manutenzione.",
+  "app": {
+    "updateAvailable": "Aggiornamento disponibilee",
+    "newVersionReleased": "È disponibile una nuova versione di ToolJet.",
+    "readReleaseNotes": "Leggi le note di rilascio e gli aggiornamenti",
+    "skipVersion": "Salta questa versione"
+  },
+  "stripe": "Per favore attendi durante il caricamento delle specifiche per Stripe di OpenAPI.",
+  "openApi": {
+    "noValidOpenApi": "OpenAPI Spec valida non disponibile!.",
+    "selectHost": "Selezione un host",
+    "selectOperation": "Seleziona un'operazione"
+  },
+  "slack": {
+    "authorize": "Autorizza",
+    "connectToolJetToSlack": "ToolJet può connettersi a Slack ed elencare gli utenti, inviare messaggi, ecc. Selezionare i permessi desiderati.",
+    "chatWrite": "chat:scrivi",
+    "listUsersAndSendMessage": "L'applicazione ToolJet sarà in grado di elencare gli utenti e di inviare messaggi agli utenti e al canale.",
+    "connectSlack": "Connetti a Slack"
+  },
+  "googleSheets": {
+    "readOnly": "Sola Lettura",
+    "enableReadAndWrite": "Se volete che le vostre applicazioni ToolJet modifichino i vostri fogli di lavoro su Google Sheets, assicuratevi di selezionare gli accessi di lettura e scrittura.",
+    "readDataFromSheets": "Le applicazioni ToolJet possono leggere i dati solo dal foglio di lavoro Google Sheets",
+    "readWrite": "Lettura e Scrittura",
+    "readModifySheets": "Le applicazioni ToolJet possono leggere i dati dai fogli di lavoro, modificarli e molto altro ancora.",
+    "toGoogleSheets": "vai a Google Sheets"
+  },
+  "profile": {
+    "profileSettings": "Impostazioni Profilo"
+  },
+  "loginSignupPage": {
+    "forgotPassword": "Password dimenticata",
+    "emailAddress": "Indirizzo email",
+    "enterEmail": "Inserisci email",
+    "resetPassword": "Reimposta la Password",
+    "dontHaveAccount": "Non disponi ancora di un account?",
+    "signIn": "Accedi",
+    "signUp": "Registrati",
+    "createToolJetAccount": "Crea un acocunt ToolJet",
+    "enterBusinessEmail": "Inserisci la tua email di lavoro",
+    "alreadyHaveAnAccount": "Hai già un account?",
+    "password": "Password",
+    "showPassword": "mostra password",
+    "loginTo": "Accedi al",
+    "yourAccount": "tuo account",
+    "noLoginMethodsEnabled": "Nessun metodo di accesso attivato per questo spazio di lavoro",
+    "emailConfirmLink": "Si prega di controllare la propria email per il link di conferma",
+    "newPassword": "Nuova Password",
+    "passwordConfirmation": "Conferma Password"
+  },
+  "editor": {
+    "preview": "Anteprimaw",
+    "share": "Condividi",
+    "shareModal": {
+      "makeApplicationPublic": "Rendere pullica l'applicazione?",
+      "shareableLink": "Ottieni un link condivisibile per questa applicazione",
+      "copy": "copia",
+      "embeddableLink": "Ottieni un link integrabile per questa applicazione",
+      "manageUsers": "Gestisci Utenti"
     },
-    "errorBoundary": "Qualcosa è andato storto.",
-    "viewer": "Spiacente! L'app è al momento in fase di manutenzione.",
-    "app": {
-        "updateAvailable": "Aggiornamento disponibilee",
-        "newVersionReleased": "È disponibile una nuova versione di ToolJet.",
-        "readReleaseNotes": "Leggi le note di rilascio e gli aggiornamenti",
-        "skipVersion": "Salta questa versione"
+    "appVersionManager": {
+      "version": "Versione",
+      "currentlyReleased": "Attualmente Rilasciate",
+      "createVersion": "Crea Versione",
+      "versionName": "Nome Versione",
+      "createVersionFrom": "Crea versione da",
+      "save": "Salva",
+      "create": "Crea Versione",
+      "editVersion": "Modifica Versione",
+      "deleteVersion": "Vuoi veramente eliminare questa versione ({{version}})?",
+      "enterVersionName": "Inserisci nome versione",
+      "versionAlreadyReleased": "Versione già rilasciata. Per favore crea una nuova versione o passa ad una diversa versione per effettuare ulteriori modifiche."
     },
-    "stripe": "Per favore attendi durante il caricamento delle specifiche per Stripe di OpenAPI.",
-    "openApi": {
-        "noValidOpenApi": "OpenAPI Spec valida non disponibile!.",
-        "selectHost": "Selezione un host",
-        "selectOperation": "Seleziona un'operazione"
-    },
-    "slack": {
-        "authorize": "Autorizza",
-        "connectToolJetToSlack": "ToolJet può connettersi a Slack ed elencare gli utenti, inviare messaggi, ecc. Selezionare i permessi desiderati.",
-        "chatWrite": "chat:scrivi",
-        "listUsersAndSendMessage": "L'applicazione ToolJet sarà in grado di elencare gli utenti e di inviare messaggi agli utenti e al canale.",
-        "connectSlack": "Connetti a Slack"
-    },
-    "googleSheets": {
-        "readOnly": "Sola Lettura",
-        "enableReadAndWrite": "Se volete che le vostre applicazioni ToolJet modifichino i vostri fogli di lavoro su Google Sheets, assicuratevi di selezionare gli accessi di lettura e scrittura.",
-        "readDataFromSheets": "Le applicazioni ToolJet possono leggere i dati solo dal foglio di lavoro Google Sheets",
-        "readWrite": "Lettura e Scrittura",
-        "readModifySheets": "Le applicazioni ToolJet possono leggere i dati dai fogli di lavoro, modificarli e molto altro ancora.",
-        "toGoogleSheets": "vai a Google Sheets"
-    },
-    "profile": {
-        "profileSettings": "Impostazioni Profilo"
-    },
-    "loginSignupPage": {
-        "forgotPassword": "Password dimenticata",
-        "emailAddress": "Indirizzo email",
-        "enterEmail": "Inserisci email",
-        "resetPassword": "Reimposta la Password",
-        "dontHaveAccount": "Non disponi ancora di un account?",
-        "signIn": "Accedi",
-        "signUp": "Registrati",
-        "createToolJetAccount": "Crea un acocunt ToolJet",
-        "enterBusinessEmail": "Inserisci la tua email di lavoro",
-        "alreadyHaveAnAccount": "Hai già un account?",
-        "password": "Password",
-        "showPassword": "mostra password",
-        "loginTo": "Accedi al",
-        "yourAccount": "tuo account",
-        "noLoginMethodsEnabled": "Nessun metodo di accesso attivato per questo spazio di lavoro",
-        "emailConfirmLink": "Si prega di controllare la propria email per il link di conferma",
-        "newPassword": "Nuova Password",
-        "passwordConfirmation": "Conferma Password"
-    },
-    "editor": {
-        "preview": "Anteprimaw",
-        "share": "Condividi",
-        "shareModal": {
-            "makeApplicationPublic": "Rendere pullica l'applicazione?",
-            "shareableLink": "Ottieni un link condivisibile per questa applicazione",
-            "copy": "copia",
-            "embeddableLink": "Ottieni un link integrabile per questa applicazione",
-            "manageUsers": "Gestisci Utenti"
+    "queries": "Queries",
+    "inspectComponent": "Seleziona un elemento da ispezionare",
+    "release": "Rilascia",
+    "searchQueries": "Cerca queries",
+    "createQuery": "Crea query",
+    "queryManager": {
+      "general": "Generale",
+      "advanced": "Avanzato",
+      "preview": "Anteprima",
+      "Save": "Salva",
+      "selectDatasource": "Seleziona Sorgente Dati",
+      "addDatasource": "Aggiungi Sorgente Dati",
+      "dataSourceManager": {
+        "toast": {
+          "success": {
+            "dataSourceAdded": "Sorgente Dati Aggiunta",
+            "dataSourceSaved": "Sorgente Dati Salvata"
+          },
+          "error": {
+            "noEmptyDsName": "Il nome della fonte di dati non deve essere vuoto."
+          }
         },
-        "appVersionManager": {
-            "version": "Versione",
-            "currentlyReleased": "Attualmente Rilasciate",
-            "createVersion": "Crea Versione",
-            "versionName": "Nome Versione",
-            "createVersionFrom": "Crea versione da",
-            "save": "Salva",
-            "create": "Crea Versione",
-            "editVersion": "Modifica Versione",
-            "deleteVersion": "Vuoi veramente eliminare questa versione ({{version}})?",
-            "enterVersionName": "Inserisci nome versione",
-            "versionAlreadyReleased": "Versione già rilasciata. Per favore crea una nuova versione o passa ad una diversa versione per effettuare ulteriori modifiche."
+        "suggestDataSource": "Suggerisci Sorgente Dati",
+        "suggestAnIntegration": "Suggerisci un'integrazione",
+        "whatLookingFor": "Che cosa stai cercando?",
+        "noResultFound": "Non vedi quello che stavi cercando?",
+        "suggest": "Suggerisci",
+        "addNewDataSource": "Aggiungi una nuova Sorgente Dati",
+        "whiteListIP": "Se la fonte dei dati non è accessibile al pubblico, si prega di aggiungere il nostro indirizzo IP nella white-list.",
+        "copied": "Copiato",
+        "copy": "Copia",
+        "saving": "Salva",
+        "noResultsFor": "Nessun risultato per",
+        "noteTaken": "Grazie, ne abbiamo preso nota!",
+        "goToAllDatasources": "Vai a tutte le Sorgenti Dati",
+        "send": "Invia"
+      },
+      "runQueryOnPageLoad": "Eseguire questa query al caricamento della pagina?",
+      "confirmBeforeQueryRun": "Chiedere conferma prima di eseguire la query?",
+      "notificationOnSuccess": "Mostrare una notifica in caso di successo?",
+      "successMessage": "Messaggio di successo",
+      "queryRanSuccessfully": "Query eseguita con successo",
+      "notificationDuration": "Durata Notifiche (s)",
+      "events": "Eventi",
+      "transformation": {
+        "transformationToolTip": "Le trasformazioni possono essere utilizzate per trasformare i risultati delle query. Tutte le variabili dell'applicazione sono accessibili dai trasformatori e supportano librerie JS come Lodash e Moment.",
+        "transformations": "Trasformazioni"
+      }
+    },
+    "inspector": {
+      "eventManager": {
+        "event": "Evento",
+        "action": "Azione",
+        "actionOptions": "Opzioni Azione",
+        "message": "Messaggio",
+        "alertType": "Tipo di Avviso",
+        "url": "URL",
+        "modal": "Modale",
+        "text": "Testo",
+        "query": "Query",
+        "key": "Chiave",
+        "value": "Valore",
+        "type": "Tipo",
+        "fileName": "Nome File",
+        "data": "Dati",
+        "table": "Tabella",
+        "pageIndex": "Indice delle Pagine",
+        "component": "Componente",
+        "addHandler": "+ Aggiungi handler",
+        "addEventHandler": "+ Aggiungi handler eventi",
+        "emptyMessage": "Questo {{componentName}} non ha handler eventi"
+      }
+    }
+  },
+  "header": {
+    "darkModeToggle": {
+      "activateLightMode": "Attiva tema chiaro",
+      "activateDarkMode": "Attiva tema scuro"
+    },
+    "languageSelection": {
+      "changeLanguage": "Cambia lingua",
+      "searchLanguage": "Cerca lingua"
+    },
+    "notificationCenter": {
+      "notifications": "Notifiche",
+      "markAllAs": "Contrassegna tutto come",
+      "read": "letto",
+      "un": "un",
+      "youDontHaveany": "Non hai alcun",
+      "youAreCaughtUp": "Sei al corrente!",
+      "view": "Visualizza"
+    },
+    "organization": {
+      "loadOrganizations": "Carica Organizzazioni",
+      "createWorkspace": "Crea spazio di lavoro",
+      "workspaceName": "nome dello spazio di lavoro",
+      "editWorkspace": "Modifica spazio di lavoro",
+      "menus": {
+        "addWorkspace": "Aggiungi spazio di lavoro",
+        "menusList": {
+          "manageUsers": "Gestisci Utenti",
+          "manageGroups": "Gestisci Gruppi",
+          "manageSso": "Gestisci SSO",
+          "manageEnv": "Gestisci Variabili d'Ambiente"
         },
-        "queries": "Queries",
-        "inspectComponent": "Seleziona un elemento da ispezionare",
-        "release": "Rilascia",
-        "searchQueries": "Cerca queries",
-        "createQuery": "Crea query",
-        "queryManager": {
-            "general": "Generale",
-            "advanced": "Avanzato",
-            "preview": "Anteprima",
-            "Save": "Salva",
-            "selectDatasource": "Seleziona Sorgente Dati",
-            "addDatasource": "Aggiungi Sorgente Dati",
-            "dataSourceManager": {
-                "toast": {
-                    "success": {
-                        "dataSourceAdded": "Sorgente Dati Aggiunta",
-                        "dataSourceSaved": "Sorgente Dati Salvata"
-                    },
-                    "error": {
-                        "noEmptyDsName": "Il nome della fonte di dati non deve essere vuoto."
-                    }
-                },
-                "suggestDataSource": "Suggerisci Sorgente Dati",
-                "suggestAnIntegration": "Suggerisci un'integrazione",
-                "whatLookingFor": "Che cosa stai cercando?",
-                "noResultFound": "Non vedi quello che stavi cercando?",
-                "suggest": "Suggerisci",
-                "addNewDataSource": "Aggiungi una nuova Sorgente Dati",
-                "whiteListIP": "Se la fonte dei dati non è accessibile al pubblico, si prega di aggiungere il nostro indirizzo IP nella white-list.",
-                "copied": "Copiato",
-                "copy": "Copia",
-                "saving": "Salva",
-                "noResultsFor": "Nessun risultato per",
-                "noteTaken": "Grazie, ne abbiamo preso nota!",
-                "goToAllDatasources": "Vai a tutte le Sorgenti Dati",
-                "send": "Invia"
+        "manageUsers": {
+          "usersAndPermission": "Utenti & Permessi",
+          "inviteNewUser": "Invita nuovi utenti",
+          "name": "NOME",
+          "email": "EMAIL",
+          "status": "STATO",
+          "archive": "Archivio",
+          "unarchive": "Disarchivia",
+          "addNewUser": "Aggiungi nuovo utente",
+          "emailAddress": "Indirizzo email",
+          "createUser": "Crea Utente",
+          "enterFirstName": "Inserisci Nome",
+          "enterLastName": "Inserisci Cognome",
+          "enterEmail": "Inserisci email"
+        },
+        "manageGroups": {
+          "permissions": {
+            "userGroups": "Gruppi dell'Utente",
+            "createNewGroup": "Crea nuovo gruppo",
+            "updateGroup": "Aggiorna gruppo",
+            "addNewGroup": "Aggiungi nuovo gruppo",
+            "enterName": "Inserisci Nome",
+            "createGroup": "Crea Gruppo",
+            "name": "Nome"
+          },
+          "permissionResources": {
+            "userGroup": "Gruppo Utente",
+            "apps": "Apps",
+            "users": "Utente",
+            "permissions": "Permessi",
+            "addAppsToGroup": "Seleziona app da aggiungere al gruppo",
+            "name": "nome",
+            "addUsersToGroup": "Seleziona utenti da aggiungere al gruppo",
+            "email": "email",
+            "resource": "resorsa",
+            "createUpdateDelete": "Crea/Aggiorna/Elimina",
+            "folder": "Cartella"
+          }
+        },
+        "manageSSO": {
+          "manageSso": "Gestisci SSO",
+          "generalSettings": {
+            "title": "Impostazioni Generali",
+            "enableSignup": "Attiva Registrazione",
+            "newAccountWillBeCreated": "Verrà creato un nuovo account per il primo accesso SSO dell'utente.",
+            "allowedDomains": "Domini consentiti",
+            "enterDomains": "Inserisci domini",
+            "supportMultiDomains": "Supporta moltepici domini. Inserire i nomi di dominio separati da una virgola. Esempio: tooljet.com,tooljet.io,yourorganization.com",
+            "loginUrl": "URL di accesso",
+            "workspaceLogin": "Utilizza questo URL per accedere direttamente a questo spazio di lavoro",
+            "allowDefaultSso": "Consenti SSO predefinitoO",
+            "ssoAuth": "Consentire agli utenti di autenticarsi tramite SSO predefinito. Le configurazioni SSO predefinite possono essere sovrascritte da SSO degli spazio di lavoro."
+          },
+          "google": {
+            "title": "Google",
+            "enabled": "Attivo",
+            "disabled": "Disabilitato",
+            "clientId": "Id Cliente",
+            "enterClientId": "Inserisci Id Cliente",
+            "redirectUrl": "URL di reindirizzamento"
+          },
+          "github": {
+            "title": "GitHub",
+            "hostName": "Nome Host",
+            "enterHostName": "Inserisci Nome dell'Host",
+            "requiredGithub": "Richiesto se GitHub è self-hosted",
+            "clientId": "Id Cliente",
+            "enterClientId": "Inserisci Id Cliente",
+            "clientSecret": "Segreto Cliente",
+            "enterClientSecret": "Inserisci Segreto del Cliente",
+            "encrypted": "Criptato",
+            "redirectUrl": "URL di reindirizzamento"
+          },
+          "passwordLogin": "Password di Accesso",
+          "environmentVar": {
+            "noEnvConfig": "Se non sono state configurate variabili d'ambiente, premere il pulsante 'Aggiungi nuova variabile' per crearne una",
+            "envWillBeDeleted": "La variabile verrà cancellata, vuoi continuare?",
+            "addNewVariable": "Aggiungi nuova variabile",
+            "variableForm": {
+              "addNewVariable": "Aggiungi nuova variabile",
+              "updatevariable": "Aggiorna variabile",
+              "name": "Nome",
+              "value": "Valore",
+              "enterVariableName": "Inserisci Nome Variabile",
+              "enterValue": "Inserisci Valore",
+              "type": "Tipo",
+              "enableEncryption": "Abilita cifratura",
+              "addVariable": "Aggiungi variabile"
             },
-            "runQueryOnPageLoad": "Eseguire questa query al caricamento della pagina?",
-            "confirmBeforeQueryRun": "Chiedere conferma prima di eseguire la query?",
-            "notificationOnSuccess": "Mostrare una notifica in caso di successo?",
-            "successMessage": "Messaggio di successo",
-            "queryRanSuccessfully": "Query eseguita con successo",
-            "notificationDuration": "Durata Notifiche (s)",
-            "events": "Eventi",
-            "transformation": {
-                "transformationToolTip": "Le trasformazioni possono essere utilizzate per trasformare i risultati delle query. Tutte le variabili dell'applicazione sono accessibili dai trasformatori e supportano librerie JS come Lodash e Moment.",
-                "transformations": "Trasformazioni"
+            "variableTable": {
+              "name": "nome",
+              "value": "valore",
+              "type": "tipo",
+              "secret": "segreto"
             }
-        },
-        "inspector": {
-            "eventManager": {
-                "event": "Evento",
-                "action": "Azione",
-                "actionOptions": "Opzioni Azione",
-                "message": "Messaggio",
-                "alertType": "Tipo di Avviso",
-                "url": "URL",
-                "modal": "Modale",
-                "text": "Testo",
-                "query": "Query",
-                "key": "Chiave",
-                "value": "Valore",
-                "type": "Tipo",
-                "fileName": "Nome File",
-                "data": "Dati",
-                "table": "Tabella",
-                "pageIndex": "Indice delle Pagine",
-                "component": "Componente",
-                "addHandler": "+ Aggiungi handler",
-                "addEventHandler": "+ Aggiungi handler eventi",
-                "emptyMessage": "Questo {{componentName}} non ha handler eventi"
-            }
+          }
         }
+      }
+    },
+    "profileSettingPage": {
+      "profileSettings": "Impostazioni Profilo",
+      "firstName": "Nome",
+      "lastName": "Cognome",
+      "enterFirstName": "Inserisci Nome",
+      "enterLastName": "Inserisci Cognome",
+      "email": "Email",
+      "avatar": "Avatar",
+      "update": "Aggiorna",
+      "profile": "Profilo",
+      "changePassword": "Modifica password",
+      "currentPassword": "Password corrente",
+      "newPassword": "Nuova password",
+      "confirmNewPassword": "Conferma nuova password",
+      "enterCurrentPassword": "Inserisci password corrente",
+      "enterNewPassword": "Inserisci nuova password"
+    },
+    "profile": "Profilo",
+    "logout": "Esci"
+  },
+  "homePage": {
+    "appCard": {
+      "changeIcon": "Modifica l'Icona",
+      "addToFolder": "Aggiungi ad una cartella",
+      "move": "Sposta",
+      "to": "in",
+      "selectFolder": "Seleziona Cartella",
+      "deleteApp": "Elimina l'app",
+      "exportApp": "Esporta l'app",
+      "cloneApp": "Crea una copia dell'app",
+      "launch": "Avvia",
+      "maintenance": "Manutenzione",
+      "noDeployedVersion": "L'App non ha una versione distribuita",
+      "openInAppViewer": "Apri nell'app viewer",
+      "removeFromFolder": "Rimuovi dalla cartella"
+    },
+    "blankPage": {
+      "welcomeToToolJet": "Benvenuti su ToolJet!",
+      "getStartedCreateNewApp": "Inizia creando una nuova applicazione o creando un'applicazione utilizzando un modello della ToolJet Library.",
+      "importApplication": "Importa un'applicazione"
+    },
+    "foldersSection": {
+      "allApplications": "Tutte le applicazioni",
+      "folders": "Cartelle",
+      "createNewFolder": "+ Crea nuova cartellar",
+      "noFolders": "Non è stata creata alcuna cartella. Usa le cartelle per organizzare le app",
+      "createFolder": "Crea cartella",
+      "updateFolder": "Aggiorna cartella",
+      "editFolder": "Modifica cartella",
+      "deleteFolder": "Elimina cartella",
+      "folderName": "Nome cartella",
+      "wishToDeleteFolder": "Vuoi veramente eliminare la cartella {{folderName}}? Le applicazioni all'interno della cartella non verranno eliminate."
     },
     "header": {
-        "darkModeToggle": {
-            "activateLightMode": "Attiva tema chiaro",
-            "activateDarkMode": "Attiva tema scuro"
-        },
-        "languageSelection": {
-            "changeLanguage": "Cambia lingua",
-            "searchLanguage": "Cerca lingua"
-        },
-        "notificationCenter": {
-            "notifications": "Notifiche",
-            "markAllAs": "Contrassegna tutto come",
-            "read": "letto",
-            "un": "un",
-            "youDontHaveany": "Non hai alcun",
-            "youAreCaughtUp": "Sei al corrente!",
-            "view": "Visualizza"
-        },
-        "organization": {
-            "loadOrganizations": "Carica Organizzazioni",
-            "createWorkspace": "Crea spazio di lavoro",
-            "workspaceName": "nome dello spazio di lavoro",
-            "editWorkspace": "Modifica spazio di lavoro",
-            "menus": {
-                "addWorkspace": "Aggiungi spazio di lavoro",
-                "menusList": {
-                    "manageUsers": "Gestisci Utenti",
-                    "manageGroups": "Gestisci Gruppi",
-                    "manageSso": "Gestisci SSO",
-                    "manageEnv": "Gestisci Variabili d'Ambiente"
-                },
-                "manageUsers": {
-                    "usersAndPermission": "Utenti & Permessi",
-                    "inviteNewUser": "Invita nuovi utenti",
-                    "name": "NOME",
-                    "email": "EMAIL",
-                    "status": "STATO",
-                    "archive": "Archivio",
-                    "unarchive": "Disarchivia",
-                    "addNewUser": "Aggiungi nuovo utente",
-                    "emailAddress": "Indirizzo email",
-                    "createUser": "Crea Utente",
-                    "enterFirstName": "Inserisci Nome",
-                    "enterLastName": "Inserisci Cognome",
-                    "enterEmail": "Inserisci email"
-                },
-                "manageGroups": {
-                    "permissions": {
-                        "userGroups": "Gruppi dell'Utente",
-                        "createNewGroup": "Crea nuovo gruppo",
-                        "updateGroup": "Aggiorna gruppo",
-                        "addNewGroup": "Aggiungi nuovo gruppo",
-                        "enterName": "Inserisci Nome",
-                        "createGroup": "Crea Gruppo",
-                        "name": "Nome"
-                    },
-                    "permissionResources": {
-                        "userGroup": "Gruppo Utente",
-                        "apps": "Apps",
-                        "users": "Utente",
-                        "permissions": "Permessi",
-                        "addAppsToGroup": "Seleziona app da aggiungere al gruppo",
-                        "name": "nome",
-                        "addUsersToGroup": "Seleziona utenti da aggiungere al gruppo",
-                        "email": "email",
-                        "resource": "resorsa",
-                        "createUpdateDelete": "Crea/Aggiorna/Elimina",
-                        "folder": "Cartella"
-                    }
-                },
-                "manageSSO": {
-                    "manageSso": "Gestisci SSO",
-                    "generalSettings": {
-                        "title": "Impostazioni Generali",
-                        "enableSignup": "Attiva Registrazione",
-                        "newAccountWillBeCreated": "Verrà creato un nuovo account per il primo accesso SSO dell'utente.",
-                        "allowedDomains": "Domini consentiti",
-                        "enterDomains": "Inserisci domini",
-                        "supportMultiDomains": "Supporta moltepici domini. Inserire i nomi di dominio separati da una virgola. Esempio: tooljet.com,tooljet.io,yourorganization.com",
-                        "loginUrl": "URL di accesso",
-                        "workspaceLogin": "Utilizza questo URL per accedere direttamente a questo spazio di lavoro",
-                        "allowDefaultSso": "Consenti SSO predefinitoO",
-                        "ssoAuth": "Consentire agli utenti di autenticarsi tramite SSO predefinito. Le configurazioni SSO predefinite possono essere sovrascritte da SSO degli spazio di lavoro."
-                    },
-                    "google": {
-                        "title": "Google",
-                        "enabled": "Attivo",
-                        "disabled": "Disabilitato",
-                        "clientId": "Id Cliente",
-                        "enterClientId": "Inserisci Id Cliente",
-                        "redirectUrl": "URL di reindirizzamento"
-                    },
-                    "github": {
-                        "title": "GitHub",
-                        "hostName": "Nome Host",
-                        "enterHostName": "Inserisci Nome dell'Host",
-                        "requiredGithub": "Richiesto se GitHub è self-hosted",
-                        "clientId": "Id Cliente",
-                        "enterClientId": "Inserisci Id Cliente",
-                        "clientSecret": "Segreto Cliente",
-                        "enterClientSecret": "Inserisci Segreto del Cliente",
-                        "encrypted": "Criptato",
-                        "redirectUrl": "URL di reindirizzamento"
-                    },
-                    "passwordLogin": "Password di Accesso",
-                    "environmentVar": {
-                        "noEnvConfig": "Se non sono state configurate variabili d'ambiente, premere il pulsante 'Aggiungi nuova variabile' per crearne una",
-                        "envWillBeDeleted": "La variabile verrà cancellata, vuoi continuare?",
-                        "addNewVariable": "Aggiungi nuova variabile",
-                        "variableForm": {
-                            "addNewVariable": "Aggiungi nuova variabile",
-                            "updatevariable": "Aggiorna variabile",
-                            "name": "Nome",
-                            "value": "Valore",
-                            "enterVariableName": "Inserisci Nome Variabile",
-                            "enterValue": "Inserisci Valore",
-                            "type": "Tipo",
-                            "enableEncryption": "Abilita cifratura",
-                            "addVariable": "Aggiungi variabile"
-                        },
-                        "variableTable": {
-                            "name": "nome",
-                            "value": "valore",
-                            "type": "tipo",
-                            "secret": "segreto"
-                        }
-                    }
-                }
-            }
-        },
-        "profileSettingPage": {
-            "profileSettings": "Impostazioni Profilo",
-            "firstName": "Nome",
-            "lastName": "Cognome",
-            "enterFirstName": "Inserisci Nome",
-            "enterLastName": "Inserisci Cognome",
-            "email": "Email",
-            "avatar": "Avatar",
-            "update": "Aggiorna",
-            "profile": "Profilo",
-            "changePassword": "Modifica password",
-            "currentPassword": "Password corrente",
-            "newPassword": "Nuova password",
-            "confirmNewPassword": "Conferma nuova password",
-            "enterCurrentPassword": "Inserisci password corrente",
-            "enterNewPassword": "Inserisci nuova password"
-        },
-        "profile": "Profilo",
-        "logout": "Esci"
+      "createNewApplication": "Crea una nuova applicazione",
+      "import": "Importa",
+      "chooseFromTemplate": "Scegli un modello"
     },
-    "homePage": {
-        "appCard": {
-            "changeIcon": "Modifica l'Icona",
-            "addToFolder": "Aggiungi ad una cartella",
-            "move": "Sposta",
-            "to": "in",
-            "selectFolder": "Seleziona Cartella",
-            "deleteApp": "Elimina l'app",
-            "exportApp": "Esporta l'app",
-            "cloneApp": "Crea una copia dell'app",
-            "launch": "Avvia",
-            "maintenance": "Manutenzione",
-            "noDeployedVersion": "L'App non ha una versione distribuita",
-            "openInAppViewer": "Apri nell'app viewer",
-            "removeFromFolder": "Rimuovi dalla cartella"
-        },
-        "blankPage": {
-            "welcomeToToolJet": "Benvenuti su ToolJet!",
-            "getStartedCreateNewApp": "Inizia creando una nuova applicazione o creando un'applicazione utilizzando un modello della ToolJet Library.",
-            "importApplication": "Importa un'applicazione"
-        },
-        "foldersSection": {
-            "allApplications": "Tutte le applicazioni",
-            "folders": "Cartelle",
-            "createNewFolder": "+ Crea nuova cartellar",
-            "noFolders": "Non è stata creata alcuna cartella. Usa le cartelle per organizzare le app",
-            "createFolder": "Crea cartella",
-            "updateFolder": "Aggiorna cartella",
-            "editFolder": "Modifica cartella",
-            "deleteFolder": "Elimina cartella",
-            "folderName": "Nome cartella",
-            "wishToDeleteFolder": "Vuoi veramente eliminare la cartella {{folderName}}? Le applicazioni all'interno della cartella non verranno eliminate."
-        },
-        "header": {
-            "createNewApplication": "Crea una nuova applicazione",
-            "import": "Importa",
-            "chooseFromTemplate": "Scegli un modello"
-        },
-        "pagination": {
-            "showing": "Mostra",
-            "of": "di",
-            "to": "a"
-        },
-        "noApplicationFound": "Nessuna Applicazione trovata",
-        "thisFolderIsEmpty": "Questa cartella è vuota",
-        "deleteAppAndData": "L'app e i dati ad essa associati saranno eliminati in modo permanente, vuoi continuare?",
-        "removeAppFromFolder": "L'applicazione verrà rimossa da questa cartella, vuoi continuare?",
-        "change": "Modifica",
-        "templateCard": {
-            "use": "Usa",
-            "preview": "Anteprima",
-            "leadGeneration": "Generazione Lead"
-        },
-        "templateLibraryModal": {
-            "select": "Seleziona modello",
-            "createAppfromTemplate": "Usa un modello per creare l'applicazione"
-        }
+    "pagination": {
+      "showing": "Mostra",
+      "of": "di",
+      "to": "a"
     },
-    "confirmationPage": {
-        "setupAccount": "Configura il tuo account",
-        "signupWithGoogle": "Accedi con Google",
-        "signupWithGitHub": "Accedi con GitHub",
-        "or": "O",
-        "firstName": "Nome",
-        "lastName": "Cognome",
-        "company": "Azienda",
-        "role": "Ruolo",
-        "pleaseSelect": "Seleziona",
-        "password": "Password",
-        "confirmPassword": "Conferma Password",
-        "clickAndAgree": "Cliccando il pulsante sottostante, si accettano",
-        "termsAndConditions": "Termini e Condizioni",
-        "finishAccountSetup": "Termina configurazione account",
-        "acceptInvite": "accetta l'invito",
-        "accountExists": "Hai già un account?",
-        "and": "e"
+    "noApplicationFound": "Nessuna Applicazione trovata",
+    "thisFolderIsEmpty": "Questa cartella è vuota",
+    "deleteAppAndData": "L'app e i dati ad essa associati saranno eliminati in modo permanente, vuoi continuare?",
+    "removeAppFromFolder": "L'applicazione verrà rimossa da questa cartella, vuoi continuare?",
+    "change": "Modifica",
+    "templateCard": {
+      "use": "Usa",
+      "preview": "Anteprima",
+      "leadGeneration": "Generazione Lead"
     },
-    "onBoarding": {
-        "finishToolJetInstallation": "Completa l'installazione di ToolJet",
-        "organization": "Organizzazione",
-        "name": "Nome",
-        "email": "Email",
-        "receiveUpdatesFromToolJet": "Riceverete aggiornamenti dal team di ToolJet (1-2 email al mese, non facciamo spam).",
-        "finishSetup": "Completa la configurazione",
-        "skip": "Salta"
-    },
-    "redirectSso": {
-        "upgradingTov1.13.0": "Aggiornamento alla versione v1.13.0 e a versioni successive.",
-        "fromV1.13.0": "Dalla v1.13.0 abbiamo introdotto",
-        "multiWorkspace": "Multi-Workspace",
-        "singleSignOnConfig": "Le impostazioni relative al Single Sign-On sono state spostate dalle variabili d'ambiente al database. Fare riferimento a questo",
-        "link": "Link",
-        "toConfigureSSO": "per configurare SSO.",
-        "haveGoogleGithubSSo": "Se sono preseneti impostazioni SSO di Google o GitHub prima dell'aggiornamento e Multi-Workspace è disabilitato, le configurazioni SSO saranno migrate durante l'aggiornamento, ma è necessario riconfigurare l'URL di reindirizzamento sul lato del provider SSO. Gli URL di reindirizzamento per ogni SSO sono indicati di seguito.",
-        "isMultiWorkspaceEnabled": "Se Multi-Workspace è abilitato, le configurazioni SSO non verranno migrate durante l'aggiornamento, quindi è necessario riconfigurare l'SSO nel rispettivo spazio di lavoro.",
-        "youHaveEnabled": "Hai Attivato",
-        "setupSsoWorkspace": "Effettua il login con la password e imposta l'SSO  utilizzando lo spazio di lavoro.",
-        "manageSsoMenu": "Gestisci il menu SSO.",
-        "youHaveDisabled": "Hai Disattivato",
-        "configureRedirectUrl": "Configurare l'URL di reindirizzamento tramite il provider SSO.",
-        "google": "Google",
-        "redirectUrl": "URL di reindirizzamento:",
-        "gitHub": "GitHub"
-    },
-    "oAuth2": {
-        "pleaseWait": "Per favore attendi...",
-        "authSuccess": "Autenticazione riuscita con successo, puoi chiudere questa pagina.",
-        "authFailed": "Autenticazione fallita"
-    },
-    "widgetManager": {
-        "commonlyUsed": "comunemente usati",
-        "layouts": "layout",
-        "forms": "forms",
-        "integrations": "integrazioni",
-        "others": "altri",
-        "noResults": "Nessun risultato trovato",
-        "tryAdjustingFilterMessage": "Prova a modificare la ricerca o il filtro per trovare quello che cerchi.",
-        "clearQuery": "Cancella la query"
-    },
-    "widget": {
-        "common": {
-            "properties": "Proprietà",
-            "events": "Eventi",
-            "layout": "Layout",
-            "styles": "Stili",
-            "general": "Generale",
-            "validation": "Validazione",
-            "documentation": "{{componentMeta}} documentazione",
-            "widgetNameEmptyError": "Il nome del Widget non può essere lasciato vuoto",
-            "componentNameExistsError": "Nome del componente già esistente",
-            "invalidWidgetName": "Nome del widget non valido. Deve essere unico e includere solo lettere, numeri e trattini bassi."
-        },
-        "commonProperties": {
-            "visibility": "Visibilità",
-            "disable": "Disattiva",
-            "borderRadius": "Raggio del bordo",
-            "boxShadow": "Ombra del box",
-            "tooltip": "Tooltip",
-            "showOnDesktop": "Mostra nel desktop",
-            "showOnMobile": "Mostra su dispositivo mobile",
-            "showLoadingState": "Mostra stato di caricamento",
-            "backgroundColor": "Colore sfondo",
-            "textColor": "Colore testo",
-            "loaderColor": "Colore loader",
-            "defaultValue": "Valore predefinito",
-            "placeholder": "Placeholder",
-            "label": "etichetta",
-            "title": "Titolo",
-            "code": "Codice",
-            "data": "Dati",
-            "tableData": "Tabella dati",
-            "tableColumns": "Colonne tabella",
-            "loadingState": "Stato di Caricamento",
-            "serverSidePagination": "Paginazione sul lato server",
-            "clientSidePagination": "Paginazione sul lato del Client",
-            "serverSideSearch": "Ricerca sul lato server",
-            "showSearchBox": "Mostra casella di ricerca",
-            "showDownloadButton": "Mostra il pulsante di download",
-            "showFilterButton": "Mostra il pulsante filtro",
-            "showBulkUpdateActions": "Mostra le azioni di aggiornamento in blocco",
-            "bulkSelection": "Seleziona blocco",
-            "highlightSelectedRow": "Evidenzia riga selezionata",
-            "actionButtonRadius": "Raggio del Pulsante di Azione",
-            "tableType": "Tipo di Tabella",
-            "cellSize": "Grandezza cella",
-            "setPage": "Imposta pagina",
-            "page": "Pagina",
-            "buttonText": "Testo Pulsante",
-            "click": "Premi",
-            "setText": "Imposta il testo",
-            "text": "Testo",
-            "markerColor": "Colore del Pennarello",
-            "showAxes": "Mostra assi",
-            "showGridLines": "Mostra linee di griglia",
-            "chartType": "Tipo di grafico",
-            "jsonDescription": "Descrizione Json",
-            "usePlotlyJsonSchema": "Usa schema Plotly JSON",
-            "padding": "Padding",
-            "hideTitleBar": "Nascondi barra del titolo",
-            "hideCloseButton": "Nascondi il pulsante di chiusura",
-            "hideOnEscape": "Nascondi in chiusura",
-            "modalSize": "Dimensione del modale",
-            "open": "Apri",
-            "close": "Chiudi",
-            "regex": "Regex",
-            "minLength": "Lunghezza min",
-            "maxLength": "Lunghezza max",
-            "customValidation": "Validazione personalizzata",
-            "clear": "Svuota",
-            "minimumValue": "Valore minimo",
-            "maximumValue": "Valore massimo",
-            "format": "Formato",
-            "enableTimeSelection": "Attivare la selezione dell'orario?",
-            "enableDateSelection": "Attivare la selezione della data?",
-            "disabledDates": "Disattiva date",
-            "setChecked": "Impostazione controllata",
-            "status": "stato",
-            "defaultStatus": "Stato Predefinito",
-            "checkboxColor": "Colore casella",
-            "optionValues": "Valori di opzione",
-            "optionLabels": "Etichette delle opzioni",
-            "activeColor": "Colore Attivo",
-            "selectOption": "Seleziona opzione",
-            "option": "Opzione",
-            "toggleSwitchColor": "Colore interruttore",
-            "defaultStartDate": "Data di inizio predefinita",
-            "defaultEndDate": "Data finale predefinita",
-            "textSize": "Dimensione testo",
-            "alignText": "Allinea il testo",
-            "url": "URL",
-            "alternativeText": "Testo alternativo",
-            "zoomButton": "Pulsante di ingrandimento",
-            "borderType": "Tipo di bordo",
-            "imageFit": "Adatta immagine",
-            "optionsLoadingState": "Stato di caricamento delle opzioni",
-            "selectedTextColor": "Colore Testo Selezionato",
-            "select": "Seleziona",
-            "deselectOption": "Deseleziona opzione",
-            "clearSelections": "Svuota selezione",
-            "enableSelectAllOption": "Abilita l'opzione Seleziona tutto",
-            "initialLocation": "Posizione Iniziale",
-            "defaultMarkers": "Marker predefiniti",
-            "addNewMarkers": "Aggiungi marker",
-            "searchForPlaces": "Cerca posizione",
-            "setLocation": "Seleziona la Posizione",
-            "latitude": "Latitudine",
-            "longitude": "Longitudine",
-            "numberOfStars": "Numero di stelle",
-            "defaultNoOfSelectedStars": "Numero predefinito di stelle selezionate",
-            "enableHalfStar": "Abilita la mezza stella",
-            "tooltips": "Tooltips",
-            "starColor": "Colore Stella",
-            "labelColor": "Colore Etichetta",
-            "dividerColor": "Colore Divisore",
-            "clearFiles": "Svuota i File",
-            "instructionText": "Testo di Istruzione",
-            "useDropZone": "Utilizzare zona drop",
-            "useFilePicker": "Usa il selezionatore di File",
-            "pickMultipleFiles": "Seleziona molteplici file",
-            "maxFileCount": "Numero massimo di file",
-            "acceptFileTypes": "Accetta tipi di file",
-            "maxSizeLimitBytes": "Limite di dimensione massima(Bytes)",
-            "minSizeLimitBytes": "Limite di dimensione minima(Bytes)",
-            "parseContent": "Effettua il parsing del contenuto",
-            "fileType": "Tipo di file",
-            "dateFormat": "Formato data",
-            "defaultDate": "Data predefinita",
-            "events": "Eventi",
-            "resources": "Risorse",
-            "defaultView": "Visuale predefinita",
-            "startTimeOnWeekAndDayView": "Ora di inizio nella visuale settimana e giorno",
-            "endTimeOnWeekAndDayView": "Ora di fine nella visuale settimana e giorno",
-            "showToolbar": "Mostra barra strumenti",
-            "showViewSwitcher": "Mostra il selettore di visuale",
-            "highlightToday": "Evidenzia oggi",
-            "showPopoverWhenEventIsClicked": "Mostra il pop-over quando si fa clic sull'evento",
-            "cellSizeInViewsClassifiedByResource": "Dimensioni delle celle nelle visuali classificate per risorse",
-            "headerDateFormatOnWeekView": "Formato della data dell'intestazione nella visuale settimana",
-            "showLineNumber": "Mostra numero riga",
-            "mode": "Modalità",
-            "tabs": "Schede",
-            "defaultTab": "Scheda Predefinita",
-            "hideTabs": "Nascondi Schede",
-            "highlightColor": "Colore di evidenziazione",
-            "tabWidth": "Larghezza scheda",
-            "setCurrentTab": "Imposta scheda corrente",
-            "id": "Id",
-            "timerType": "Tipo di timer",
-            "listData": "Elenca i dati",
-            "rowHeight": "Altezza riga",
-            "showBottomBorder": "Mostra bordo inferiore",
-            "tags": "Etichette",
-            "numberOfPages": "Numero di pagine",
-            "defaultPageIndex": "Indice pagine predefinito",
-            "progress": "Progresso",
-            "color": "Colore",
-            "strokeWidth": "Larghezza del trattoh",
-            "counterClockwise": "Senso Antiorario",
-            "circleRatio": "Rapporto del Cerchio",
-            "colour": "Colore",
-            "size": "Dimensione",
-            "primaryValueLabel": "Etichetta valore primario",
-            "primaryValue": "Valore primario",
-            "hideSecondaryValue": "Nascondi valore secondario",
-            "secondaryValueLabel": "Etichetta valore secondario",
-            "secondaryValue": "Valore secondario",
-            "secondarySignDisplay": "Visualizza segno secondario",
-            "primaryLabelColour": "Colore dell'Etichetta Primaria",
-            "primaryTextColour": "Colore Testo Primario",
-            "secondaryLabelColour": "Colore dell'Etichetta Secondaria",
-            "secondaryTextColour": "Colore Secondario del Testo",
-            "min": "Min",
-            "max": "Max",
-            "value": "Valore",
-            "twoHandles": "Due handle",
-            "lineColor": "Colore linea",
-            "handleColor": "Colore Handle",
-            "trackColor": "Traccia Colore",
-            "timelineData": "Dati Cronologia",
-            "hideDate": "Nascondi la Data",
-            "svgData": "Dati Svg",
-            "rawHtml": "Raw HTML",
-            "values": "valori",
-            "labels": "Etichette",
-            "defaultSelected": "Selezioni predefinite",
-            "enableMultipleSelection": "Attiva selezione multipla",
-            "selectedTextColour": "Seleziona colore testo",
-            "selectedBackgroundColor": "Seleziona colore sfondo",
-            "fileUrl": "URL del File",
-            "scalePageToWidth": "Ridimensiona la pagina alla larghezza",
-            "showPageControls": "Mostra controlli pagina",
-            "steps": "Fasi",
-            "currentStep": "Fase corrente",
-            "stepsSelectable": "Fasi selezionabili",
-            "theme": "Tema",
-            "columns": "Colonne",
-            "cardData": "Dati Scheda",
-            "enableAddCard": "Attiva Aggiungi Scheda",
-            "width": "Larghezza",
-            "minWidth": "Larghezza Minima",
-            "accentColor": "Colore d'Accento",
-            "defaultColor": "Colore Predefinito",
-            "setColor": "Imposta Colore",
-            "structure": "Struttura",
-            "checkedValues": "Valori Controllati",
-            "expandedValues": "Espandi Valori"
-        },
-        "Table": {
-            "displayName": "Tabella",
-            "description": "Visualizzazione di dati tabellari paginati",
-            "columnType": "Tipo di Colonna",
-            "columnName": "Nome colonna",
-            "overflow": "Overflow",
-            "key": "chiave",
-            "textColor": "Colore testo",
-            "validation": "Validazione",
-            "regex": "Regex",
-            "minLength": "Lunghezza minima",
-            "maxLength": "Lunghezza massima",
-            "customRule": "Regola personalizzata",
-            "values": "Valori",
-            "labels": "Etichette",
-            "cellBgColor": "Colore Sfondo Cella",
-            "dateDisplayformat": "Formato di Visualizzazione della Data",
-            "dateParseformat": "Formato parsing della data",
-            "showTime": "mostra l'ora",
-            "makeEditable": "rendi modificabile",
-            "buttonText": "Testo Pulsante",
-            "buttonPosition": "Posizione Pulsante",
-            "remove": "Rimuovi",
-            "addButton": "+ Aggiungi pulsante",
-            "addColumn": "+ Aggiungi colonna",
-            "noActionMessage": "Questa tabella non ha pulsanti di azione"
-        },
-        "Button": {
-            "displayName": "Pulsanti",
-            "description": "Azioni di attivazione: query, avvisi, ecc."
-        },
-        "Chart": {
-            "displayName": "Grafici",
-            "description": "Visualizza grafici"
-        },
-        "Modal": {
-            "displayName": "Modale",
-            "description": "Modale attivata da eventi"
-        },
-        "TextInput": {
-            "displayName": "Input di Testo",
-            "description": "Campo di testo per moduli"
-        },
-        "NumberInput": {
-            "displayName": "Input Numerico",
-            "description": "Campo numerico per moduli"
-        },
-        "PasswordInput": {
-            "displayName": "Input Password",
-            "description": "Campo di immissione della password per moduli"
-        },
-        "Datepicker": {
-            "displayName": "Selezionatore Data",
-            "description": "Seleziona data e ora"
-        },
-        "Checkbox": {
-            "displayName": "Checkbox",
-            "description": "Singola casella di controllo"
-        },
-        "Radio-button": {
-            "displayName": "Pulsante Radio",
-            "description": "Pulsanti Radio"
-        },
-        "ToggleSwitch": {
-            "displayName": "Toggle Switch",
-            "description": "Toggle Switch"
-        },
-        "Textarea": {
-            "displayName": "Area di Testo",
-            "description": "Campo di testo per moduli"
-        },
-        "DateRangePicker": {
-            "displayName": "Selezionatore Range",
-            "description": "Seleziona un range di dati"
-        },
-        "Text": {
-            "displayName": "Testo",
-            "description": "Visualizza markdown o HTML"
-        },
-        "Image": {
-            "displayName": "Immagine",
-            "description": "Visualizza un'immagine"
-        },
-        "Container": {
-            "displayName": "Contenitore",
-            "description": "Wrapper per molteplici componenti"
-        },
-        "Dropdown": {
-            "displayName": "Dropdown",
-            "description": "Seleziona un valore dalle opzioni"
-        },
-        "Multiselect": {
-            "displayName": "Multiselezione",
-            "description": "Seleziona diversi valori dalle opzioni"
-        },
-        "RichTextEditor": {
-            "displayName": "Editor di testo",
-            "description": "Editor di testo versatile"
-        },
-        "Map": {
-            "displayName": "Mappa",
-            "description": "Visualizza su Google Maps"
-        },
-        "QrScanner": {
-            "displayName": "Scanner codici QR",
-            "description": "Scansione dei codici QR e conservazione dei dati rilevati"
-        },
-        "StarRating": {
-            "displayName": "Valutazione",
-            "description": "Valutazione a stelle"
-        },
-        "Divider": {
-            "displayName": "Divisore",
-            "description": "Divisore tra componenti"
-        },
-        "FilePicker": {
-            "displayName": "Selezionatore File",
-            "description": "Selezionatore File"
-        },
-        "Calendar": {
-            "displayName": "Agenda",
-            "description": "Agenda"
-        },
-        "Iframe": {
-            "displayName": "Iframe",
-            "description": "Visualizza un Iframe"
-        },
-        "CodeEditor": {
-            "displayName": "Editor di Codice",
-            "description": "Editor di Codice"
-        },
-        "Tabs": {
-            "displayName": "Schede",
-            "description": "Componente Schede"
-        },
-        "Timer": {
-            "displayName": "Timer",
-            "description": "timer"
-        },
-        "Listview": {
-            "displayName": "Vista elenco",
-            "description": "Wrapper per più componenti"
-        },
-        "Tags": {
-            "displayName": "Tag",
-            "description": "I contenuti possono essere mostrati come Tag"
-        },
-        "Pagination": {
-            "displayName": "Paginazione",
-            "description": "Paginazione "
-        },
-        "CircularProgressbar": {
-            "displayName": "Barra di Progresso Circolare",
-            "description": "Mostrare l'avanzamento utilizzando una barra di progresso circolare"
-        },
-        "Spinner": {
-            "displayName": "Spinner",
-            "description": "Lo Spinner può essere utilizzato per mostrare lo stato del caricamento"
-        },
-        "Statistics": {
-            "displayName": "Statistiche",
-            "description": "Le statistiche possono essere utilizzate per visualizzare diverse informazioni statistiche"
-        },
-        "RangeSlider": {
-            "displayName": "Range Slider",
-            "description": "Può essere utilizzato per mostrare il range di un cursore"
-        },
-        "Timeline": {
-            "displayName": "Cronologia",
-            "description": "Rappresentazione visiva di una sequenza di eventi"
-        },
-        "SvgImage": {
-            "displayName": "Immagine Svg",
-            "description": "Immagine Svg"
-        },
-        "Html": {
-            "displayName": "Visualizzatore HTML",
-            "description": "Visualizzatore HTML"
-        },
-        "VerticalDivider": {
-            "displayName": "Divisore Verticale",
-            "description": "Divisore Verticale tra componenti"
-        },
-        "CustomComponent": {
-            "displayName": "Componente personalizzata",
-            "description": "Aggiungi la tua componente react personalizzata"
-        },
-        "ButtonGroup": {
-            "displayName": "Gruppo Pulsante",
-            "description": "GruppoPulsante"
-        },
-        "PDF": {
-            "displayName": "PDF",
-            "description": "Integra un file PDF"
-        },
-        "Steps": {
-            "displayName": "Fasi",
-            "description": "Fasi"
-        },
-        "KanbanBoard": {
-            "displayName": "Kanban Board",
-            "description": "Kanban Board"
-        },
-        "ColorPicker": {
-            "displayName": "Picker di colori",
-            "description": "Palette di selezione dei colori"
-        },
-        "TreeSelect": {
-            "displayName": "Selezione ad albero",
-            "description": "Seleziona i valori da una vista ad albero"
-        }
-    },
-    "leftSidebar": {
-        "Inspector": {
-            "text": "Ispettore",
-            "tip": "Ispettore"
-        },
-        "Sources": {
-            "text": "Sorgenti Dati",
-            "tip": "Aggiungi o modifica le sorgenti dati",
-            "dataSources": "Sorgenti dati",
-            "addDataSource": "+ aggiungi una sorgente dati"
-        },
-        "Debugger": {
-            "text": "Debugger",
-            "tip": "Debugger",
-            "errors": "Errori",
-            "noErrors": "Nessun errore trovato",
-            "clear": "svuota"
-        },
-        "Comments": {
-            "text": "Commenti",
-            "tip": "attiva/disattiva commenti",
-            "commentBody": "Non ci sono commenti da mostrare",
-            "typeComment": "Inserisci il tuo commento qui"
-        },
-        "Settings": {
-            "text": "Impostazioni",
-            "tip": "Impostazioni globali",
-            "hideHeader": "Nascondi l'intestazione delle app avviate",
-            "maintenanceMode": "Modalità di manutenzione",
-            "maxWidthOfCanvas": "Larghezza massima della tela",
-            "maxHeightOfCanvas": "Altezza massima della tela",
-            "backgroundColorOfCanvas": "Colore di sfondo della tela"
-        },
-        "Back": {
-            "text": "Indietro",
-            "tip": "Torna alla Home"
-        }
+    "templateLibraryModal": {
+      "select": "Seleziona modello",
+      "createAppfromTemplate": "Usa un modello per creare l'applicazione"
     }
+  },
+  "confirmationPage": {
+    "setupAccount": "Configura il tuo account",
+    "signupWithGoogle": "Accedi con Google",
+    "signupWithGitHub": "Accedi con GitHub",
+    "or": "O",
+    "firstName": "Nome",
+    "lastName": "Cognome",
+    "company": "Azienda",
+    "role": "Ruolo",
+    "pleaseSelect": "Seleziona",
+    "password": "Password",
+    "confirmPassword": "Conferma Password",
+    "clickAndAgree": "Cliccando il pulsante sottostante, si accettano",
+    "termsAndConditions": "Termini e Condizioni",
+    "finishAccountSetup": "Termina configurazione account",
+    "acceptInvite": "accetta l'invito",
+    "accountExists": "Hai già un account?",
+    "and": "e"
+  },
+  "onBoarding": {
+    "finishToolJetInstallation": "Completa l'installazione di ToolJet",
+    "organization": "Organizzazione",
+    "name": "Nome",
+    "email": "Email",
+    "receiveUpdatesFromToolJet": "Riceverete aggiornamenti dal team di ToolJet (1-2 email al mese, non facciamo spam).",
+    "finishSetup": "Completa la configurazione",
+    "skip": "Salta"
+  },
+  "redirectSso": {
+    "upgradingTov1": {
+      "13": {
+        "0": "Aggiornamento alla versione v1.13.0 e a versioni successive."
+      }
+    },
+    "fromV1": {
+      "13": {
+        "0": "Dalla v1.13.0 abbiamo introdotto"
+      }
+    },
+    "multiWorkspace": "Multi-Workspace",
+    "singleSignOnConfig": "Le impostazioni relative al Single Sign-On sono state spostate dalle variabili d'ambiente al database. Fare riferimento a questo",
+    "link": "Link",
+    "toConfigureSSO": "per configurare SSO.",
+    "haveGoogleGithubSSo": "Se sono preseneti impostazioni SSO di Google o GitHub prima dell'aggiornamento e Multi-Workspace è disabilitato, le configurazioni SSO saranno migrate durante l'aggiornamento, ma è necessario riconfigurare l'URL di reindirizzamento sul lato del provider SSO. Gli URL di reindirizzamento per ogni SSO sono indicati di seguito.",
+    "isMultiWorkspaceEnabled": "Se Multi-Workspace è abilitato, le configurazioni SSO non verranno migrate durante l'aggiornamento, quindi è necessario riconfigurare l'SSO nel rispettivo spazio di lavoro.",
+    "youHaveEnabled": "Hai Attivato",
+    "setupSsoWorkspace": "Effettua il login con la password e imposta l'SSO  utilizzando lo spazio di lavoro.",
+    "manageSsoMenu": "Gestisci il menu SSO.",
+    "youHaveDisabled": "Hai Disattivato",
+    "configureRedirectUrl": "Configurare l'URL di reindirizzamento tramite il provider SSO.",
+    "google": "Google",
+    "redirectUrl": "URL di reindirizzamento:",
+    "gitHub": "GitHub"
+  },
+  "oAuth2": {
+    "pleaseWait": "Per favore attendi...",
+    "authSuccess": "Autenticazione riuscita con successo, puoi chiudere questa pagina.",
+    "authFailed": "Autenticazione fallita"
+  },
+  "widgetManager": {
+    "commonlyUsed": "comunemente usati",
+    "layouts": "layout",
+    "forms": "forms",
+    "integrations": "integrazioni",
+    "others": "altri",
+    "noResults": "Nessun risultato trovato",
+    "tryAdjustingFilterMessage": "Prova a modificare la ricerca o il filtro per trovare quello che cerchi.",
+    "clearQuery": "Cancella la query"
+  },
+  "widget": {
+    "common": {
+      "properties": "Proprietà",
+      "events": "Eventi",
+      "layout": "Layout",
+      "styles": "Stili",
+      "general": "Generale",
+      "validation": "Validazione",
+      "documentation": "{{componentMeta}} documentazione",
+      "widgetNameEmptyError": "Il nome del Widget non può essere lasciato vuoto",
+      "componentNameExistsError": "Nome del componente già esistente",
+      "invalidWidgetName": "Nome del widget non valido. Deve essere unico e includere solo lettere, numeri e trattini bassi."
+    },
+    "commonProperties": {
+      "visibility": "Visibilità",
+      "disable": "Disattiva",
+      "borderRadius": "Raggio del bordo",
+      "boxShadow": "Ombra del box",
+      "tooltip": "Tooltip",
+      "showOnDesktop": "Mostra nel desktop",
+      "showOnMobile": "Mostra su dispositivo mobile",
+      "showLoadingState": "Mostra stato di caricamento",
+      "backgroundColor": "Colore sfondo",
+      "textColor": "Colore testo",
+      "loaderColor": "Colore loader",
+      "defaultValue": "Valore predefinito",
+      "placeholder": "Placeholder",
+      "label": "etichetta",
+      "title": "Titolo",
+      "code": "Codice",
+      "data": "Dati",
+      "tableData": "Tabella dati",
+      "tableColumns": "Colonne tabella",
+      "loadingState": "Stato di Caricamento",
+      "serverSidePagination": "Paginazione sul lato server",
+      "clientSidePagination": "Paginazione sul lato del Client",
+      "serverSideSearch": "Ricerca sul lato server",
+      "showSearchBox": "Mostra casella di ricerca",
+      "showDownloadButton": "Mostra il pulsante di download",
+      "showFilterButton": "Mostra il pulsante filtro",
+      "showBulkUpdateActions": "Mostra le azioni di aggiornamento in blocco",
+      "bulkSelection": "Seleziona blocco",
+      "highlightSelectedRow": "Evidenzia riga selezionata",
+      "actionButtonRadius": "Raggio del Pulsante di Azione",
+      "tableType": "Tipo di Tabella",
+      "cellSize": "Grandezza cella",
+      "setPage": "Imposta pagina",
+      "page": "Pagina",
+      "buttonText": "Testo Pulsante",
+      "click": "Premi",
+      "setText": "Imposta il testo",
+      "text": "Testo",
+      "markerColor": "Colore del Pennarello",
+      "showAxes": "Mostra assi",
+      "showGridLines": "Mostra linee di griglia",
+      "chartType": "Tipo di grafico",
+      "jsonDescription": "Descrizione Json",
+      "usePlotlyJsonSchema": "Usa schema Plotly JSON",
+      "padding": "Padding",
+      "hideTitleBar": "Nascondi barra del titolo",
+      "hideCloseButton": "Nascondi il pulsante di chiusura",
+      "hideOnEscape": "Nascondi in chiusura",
+      "modalSize": "Dimensione del modale",
+      "open": "Apri",
+      "close": "Chiudi",
+      "regex": "Regex",
+      "minLength": "Lunghezza min",
+      "maxLength": "Lunghezza max",
+      "customValidation": "Validazione personalizzata",
+      "clear": "Svuota",
+      "minimumValue": "Valore minimo",
+      "maximumValue": "Valore massimo",
+      "format": "Formato",
+      "enableTimeSelection": "Attivare la selezione dell'orario?",
+      "enableDateSelection": "Attivare la selezione della data?",
+      "disabledDates": "Disattiva date",
+      "setChecked": "Impostazione controllata",
+      "status": "stato",
+      "defaultStatus": "Stato Predefinito",
+      "checkboxColor": "Colore casella",
+      "optionValues": "Valori di opzione",
+      "optionLabels": "Etichette delle opzioni",
+      "activeColor": "Colore Attivo",
+      "selectOption": "Seleziona opzione",
+      "option": "Opzione",
+      "toggleSwitchColor": "Colore interruttore",
+      "defaultStartDate": "Data di inizio predefinita",
+      "defaultEndDate": "Data finale predefinita",
+      "textSize": "Dimensione testo",
+      "alignText": "Allinea il testo",
+      "url": "URL",
+      "alternativeText": "Testo alternativo",
+      "zoomButton": "Pulsante di ingrandimento",
+      "borderType": "Tipo di bordo",
+      "imageFit": "Adatta immagine",
+      "optionsLoadingState": "Stato di caricamento delle opzioni",
+      "selectedTextColor": "Colore Testo Selezionato",
+      "select": "Seleziona",
+      "deselectOption": "Deseleziona opzione",
+      "clearSelections": "Svuota selezione",
+      "enableSelectAllOption": "Abilita l'opzione Seleziona tutto",
+      "initialLocation": "Posizione Iniziale",
+      "defaultMarkers": "Marker predefiniti",
+      "addNewMarkers": "Aggiungi marker",
+      "searchForPlaces": "Cerca posizione",
+      "setLocation": "Seleziona la Posizione",
+      "latitude": "Latitudine",
+      "longitude": "Longitudine",
+      "numberOfStars": "Numero di stelle",
+      "defaultNoOfSelectedStars": "Numero predefinito di stelle selezionate",
+      "enableHalfStar": "Abilita la mezza stella",
+      "tooltips": "Tooltips",
+      "starColor": "Colore Stella",
+      "labelColor": "Colore Etichetta",
+      "dividerColor": "Colore Divisore",
+      "clearFiles": "Svuota i File",
+      "instructionText": "Testo di Istruzione",
+      "useDropZone": "Utilizzare zona drop",
+      "useFilePicker": "Usa il selezionatore di File",
+      "pickMultipleFiles": "Seleziona molteplici file",
+      "maxFileCount": "Numero massimo di file",
+      "acceptFileTypes": "Accetta tipi di file",
+      "maxSizeLimitBytes": "Limite di dimensione massima(Bytes)",
+      "minSizeLimitBytes": "Limite di dimensione minima(Bytes)",
+      "parseContent": "Effettua il parsing del contenuto",
+      "fileType": "Tipo di file",
+      "dateFormat": "Formato data",
+      "defaultDate": "Data predefinita",
+      "events": "Eventi",
+      "resources": "Risorse",
+      "defaultView": "Visuale predefinita",
+      "startTimeOnWeekAndDayView": "Ora di inizio nella visuale settimana e giorno",
+      "endTimeOnWeekAndDayView": "Ora di fine nella visuale settimana e giorno",
+      "showToolbar": "Mostra barra strumenti",
+      "showViewSwitcher": "Mostra il selettore di visuale",
+      "highlightToday": "Evidenzia oggi",
+      "showPopoverWhenEventIsClicked": "Mostra il pop-over quando si fa clic sull'evento",
+      "cellSizeInViewsClassifiedByResource": "Dimensioni delle celle nelle visuali classificate per risorse",
+      "headerDateFormatOnWeekView": "Formato della data dell'intestazione nella visuale settimana",
+      "showLineNumber": "Mostra numero riga",
+      "mode": "Modalità",
+      "tabs": "Schede",
+      "defaultTab": "Scheda Predefinita",
+      "hideTabs": "Nascondi Schede",
+      "highlightColor": "Colore di evidenziazione",
+      "tabWidth": "Larghezza scheda",
+      "setCurrentTab": "Imposta scheda corrente",
+      "id": "Id",
+      "timerType": "Tipo di timer",
+      "listData": "Elenca i dati",
+      "rowHeight": "Altezza riga",
+      "showBottomBorder": "Mostra bordo inferiore",
+      "tags": "Etichette",
+      "numberOfPages": "Numero di pagine",
+      "defaultPageIndex": "Indice pagine predefinito",
+      "progress": "Progresso",
+      "color": "Colore",
+      "strokeWidth": "Larghezza del trattoh",
+      "counterClockwise": "Senso Antiorario",
+      "circleRatio": "Rapporto del Cerchio",
+      "colour": "Colore",
+      "size": "Dimensione",
+      "primaryValueLabel": "Etichetta valore primario",
+      "primaryValue": "Valore primario",
+      "hideSecondaryValue": "Nascondi valore secondario",
+      "secondaryValueLabel": "Etichetta valore secondario",
+      "secondaryValue": "Valore secondario",
+      "secondarySignDisplay": "Visualizza segno secondario",
+      "primaryLabelColour": "Colore dell'Etichetta Primaria",
+      "primaryTextColour": "Colore Testo Primario",
+      "secondaryLabelColour": "Colore dell'Etichetta Secondaria",
+      "secondaryTextColour": "Colore Secondario del Testo",
+      "min": "Min",
+      "max": "Max",
+      "value": "Valore",
+      "twoHandles": "Due handle",
+      "lineColor": "Colore linea",
+      "handleColor": "Colore Handle",
+      "trackColor": "Traccia Colore",
+      "timelineData": "Dati Cronologia",
+      "hideDate": "Nascondi la Data",
+      "svgData": "Dati Svg",
+      "rawHtml": "Raw HTML",
+      "values": "valori",
+      "labels": "Etichette",
+      "defaultSelected": "Selezioni predefinite",
+      "enableMultipleSelection": "Attiva selezione multipla",
+      "selectedTextColour": "Seleziona colore testo",
+      "selectedBackgroundColor": "Seleziona colore sfondo",
+      "fileUrl": "URL del File",
+      "scalePageToWidth": "Ridimensiona la pagina alla larghezza",
+      "showPageControls": "Mostra controlli pagina",
+      "steps": "Fasi",
+      "currentStep": "Fase corrente",
+      "stepsSelectable": "Fasi selezionabili",
+      "theme": "Tema",
+      "columns": "Colonne",
+      "cardData": "Dati Scheda",
+      "enableAddCard": "Attiva Aggiungi Scheda",
+      "width": "Larghezza",
+      "minWidth": "Larghezza Minima",
+      "accentColor": "Colore d'Accento",
+      "defaultColor": "Colore Predefinito",
+      "setColor": "Imposta Colore",
+      "structure": "Struttura",
+      "checkedValues": "Valori Controllati",
+      "expandedValues": "Espandi Valori"
+    },
+    "Table": {
+      "displayName": "Tabella",
+      "description": "Visualizzazione di dati tabellari paginati",
+      "columnType": "Tipo di Colonna",
+      "columnName": "Nome colonna",
+      "overflow": "Overflow",
+      "key": "chiave",
+      "textColor": "Colore testo",
+      "validation": "Validazione",
+      "regex": "Regex",
+      "minLength": "Lunghezza minima",
+      "maxLength": "Lunghezza massima",
+      "customRule": "Regola personalizzata",
+      "values": "Valori",
+      "labels": "Etichette",
+      "cellBgColor": "Colore Sfondo Cella",
+      "dateDisplayformat": "Formato di Visualizzazione della Data",
+      "dateParseformat": "Formato parsing della data",
+      "showTime": "mostra l'ora",
+      "makeEditable": "rendi modificabile",
+      "buttonText": "Testo Pulsante",
+      "buttonPosition": "Posizione Pulsante",
+      "remove": "Rimuovi",
+      "addButton": "+ Aggiungi pulsante",
+      "addColumn": "+ Aggiungi colonna",
+      "noActionMessage": "Questa tabella non ha pulsanti di azione"
+    },
+    "Button": {
+      "displayName": "Pulsanti",
+      "description": "Azioni di attivazione: query, avvisi, ecc."
+    },
+    "Chart": {
+      "displayName": "Grafici",
+      "description": "Visualizza grafici"
+    },
+    "Modal": {
+      "displayName": "Modale",
+      "description": "Modale attivata da eventi"
+    },
+    "TextInput": {
+      "displayName": "Input di Testo",
+      "description": "Campo di testo per moduli"
+    },
+    "NumberInput": {
+      "displayName": "Input Numerico",
+      "description": "Campo numerico per moduli"
+    },
+    "PasswordInput": {
+      "displayName": "Input Password",
+      "description": "Campo di immissione della password per moduli"
+    },
+    "Datepicker": {
+      "displayName": "Selezionatore Data",
+      "description": "Seleziona data e ora"
+    },
+    "Checkbox": {
+      "displayName": "Checkbox",
+      "description": "Singola casella di controllo"
+    },
+    "Radio-button": {
+      "displayName": "Pulsante Radio",
+      "description": "Pulsanti Radio"
+    },
+    "ToggleSwitch": {
+      "displayName": "Toggle Switch",
+      "description": "Toggle Switch"
+    },
+    "Textarea": {
+      "displayName": "Area di Testo",
+      "description": "Campo di testo per moduli"
+    },
+    "DateRangePicker": {
+      "displayName": "Selezionatore Range",
+      "description": "Seleziona un range di dati"
+    },
+    "Text": {
+      "displayName": "Testo",
+      "description": "Visualizza markdown o HTML"
+    },
+    "Image": {
+      "displayName": "Immagine",
+      "description": "Visualizza un'immagine"
+    },
+    "Container": {
+      "displayName": "Contenitore",
+      "description": "Wrapper per molteplici componenti"
+    },
+    "Dropdown": {
+      "displayName": "Dropdown",
+      "description": "Seleziona un valore dalle opzioni"
+    },
+    "Multiselect": {
+      "displayName": "Multiselezione",
+      "description": "Seleziona diversi valori dalle opzioni"
+    },
+    "RichTextEditor": {
+      "displayName": "Editor di testo",
+      "description": "Editor di testo versatile"
+    },
+    "Map": {
+      "displayName": "Mappa",
+      "description": "Visualizza su Google Maps"
+    },
+    "QrScanner": {
+      "displayName": "Scanner codici QR",
+      "description": "Scansione dei codici QR e conservazione dei dati rilevati"
+    },
+    "StarRating": {
+      "displayName": "Valutazione",
+      "description": "Valutazione a stelle"
+    },
+    "Divider": {
+      "displayName": "Divisore",
+      "description": "Divisore tra componenti"
+    },
+    "FilePicker": {
+      "displayName": "Selezionatore File",
+      "description": "Selezionatore File"
+    },
+    "Calendar": {
+      "displayName": "Agenda",
+      "description": "Agenda"
+    },
+    "Iframe": {
+      "displayName": "Iframe",
+      "description": "Visualizza un Iframe"
+    },
+    "CodeEditor": {
+      "displayName": "Editor di Codice",
+      "description": "Editor di Codice"
+    },
+    "Tabs": {
+      "displayName": "Schede",
+      "description": "Componente Schede"
+    },
+    "Timer": {
+      "displayName": "Timer",
+      "description": "timer"
+    },
+    "Listview": {
+      "displayName": "Vista elenco",
+      "description": "Wrapper per più componenti"
+    },
+    "Tags": {
+      "displayName": "Tag",
+      "description": "I contenuti possono essere mostrati come Tag"
+    },
+    "Pagination": {
+      "displayName": "Paginazione",
+      "description": "Paginazione "
+    },
+    "CircularProgressbar": {
+      "displayName": "Barra di Progresso Circolare",
+      "description": "Mostrare l'avanzamento utilizzando una barra di progresso circolare"
+    },
+    "Spinner": {
+      "displayName": "Spinner",
+      "description": "Lo Spinner può essere utilizzato per mostrare lo stato del caricamento"
+    },
+    "Statistics": {
+      "displayName": "Statistiche",
+      "description": "Le statistiche possono essere utilizzate per visualizzare diverse informazioni statistiche"
+    },
+    "RangeSlider": {
+      "displayName": "Range Slider",
+      "description": "Può essere utilizzato per mostrare il range di un cursore"
+    },
+    "Timeline": {
+      "displayName": "Cronologia",
+      "description": "Rappresentazione visiva di una sequenza di eventi"
+    },
+    "SvgImage": {
+      "displayName": "Immagine Svg",
+      "description": "Immagine Svg"
+    },
+    "Html": {
+      "displayName": "Visualizzatore HTML",
+      "description": "Visualizzatore HTML"
+    },
+    "VerticalDivider": {
+      "displayName": "Divisore Verticale",
+      "description": "Divisore Verticale tra componenti"
+    },
+    "CustomComponent": {
+      "displayName": "Componente personalizzata",
+      "description": "Aggiungi la tua componente react personalizzata"
+    },
+    "ButtonGroup": {
+      "displayName": "Gruppo Pulsante",
+      "description": "GruppoPulsante"
+    },
+    "PDF": {
+      "displayName": "PDF",
+      "description": "Integra un file PDF"
+    },
+    "Steps": {
+      "displayName": "Fasi",
+      "description": "Fasi"
+    },
+    "KanbanBoard": {
+      "displayName": "Kanban Board",
+      "description": "Kanban Board"
+    },
+    "ColorPicker": {
+      "displayName": "Picker di colori",
+      "description": "Palette di selezione dei colori"
+    },
+    "TreeSelect": {
+      "displayName": "Selezione ad albero",
+      "description": "Seleziona i valori da una vista ad albero"
+    }
+  },
+  "leftSidebar": {
+    "Inspector": {
+      "text": "Ispettore",
+      "tip": "Ispettore"
+    },
+    "Sources": {
+      "text": "Sorgenti Dati",
+      "tip": "Aggiungi o modifica le sorgenti dati",
+      "dataSources": "Sorgenti dati",
+      "addDataSource": "+ aggiungi una sorgente dati"
+    },
+    "Debugger": {
+      "text": "Debugger",
+      "tip": "Debugger",
+      "errors": "Errori",
+      "noErrors": "Nessun errore trovato",
+      "clear": "svuota"
+    },
+    "Comments": {
+      "text": "Commenti",
+      "tip": "attiva/disattiva commenti",
+      "commentBody": "Non ci sono commenti da mostrare",
+      "typeComment": "Inserisci il tuo commento qui"
+    },
+    "Settings": {
+      "text": "Impostazioni",
+      "tip": "Impostazioni globali",
+      "hideHeader": "Nascondi l'intestazione delle app avviate",
+      "maintenanceMode": "Modalità di manutenzione",
+      "maxWidthOfCanvas": "Larghezza massima della tela",
+      "maxHeightOfCanvas": "Altezza massima della tela",
+      "backgroundColorOfCanvas": "Colore di sfondo della tela"
+    },
+    "Back": {
+      "text": "Indietro",
+      "tip": "Torna alla Home"
+    }
+  }
 }

--- a/frontend/assets/translations/ru.json
+++ b/frontend/assets/translations/ru.json
@@ -1,169 +1,168 @@
 {
-  "globals":{
-    "readDocumentation":"Прочесть документацию",
-    "cancel":"Отмена",
-    "save":"Сохранить",
-    "back":"Назад",
-    "edit":"Редактировать",
-    "search":"Поиск",
-    "update":"Обновить",
-    "delete":"Удалить",
-    "add":"Добавить",
-    "view":"Просмотр",
-    "create":"Создать",
-    "enabled":"Включен",
-    "disabled":"Отключен",
-    "yes":"Да",
-    "submit":"Отправить",
-    "select":"Выбор",
-    "environmentVar":"Переменные среды",
-    "saving":"Сохранение...",
-    "saveDatasource":"Сохранить источник данных",
-    "authorize":"Авторизоваться",
-    "connect":"Подключиться",
-    "reconnect":"Переподключиться",
-    "components":"компоненты",
-    "send":"Отправить",
-    "noConnection":"не удалось подключиться",
-    "connectionVerifeid":"соединение установлено",
-    "left":"Влево",
-    "center":"Центр",
-    "right":"Вправо",
-    "justified":"Выровнено",
-    "host":"Хост",
-    "operation":"Операция",
-    "header":"ЗАГОЛОВОК",
-    "path":"ПУТЬ",
-    "query":"ЗАПРОС",
-    "requestBody":"ТЕЛО ЗАПРОСА"
+  "globals": {
+    "readDocumentation": "Прочесть документацию",
+    "cancel": "Отмена",
+    "save": "Сохранить",
+    "back": "Назад",
+    "edit": "Редактировать",
+    "search": "Поиск",
+    "update": "Обновить",
+    "delete": "Удалить",
+    "add": "Добавить",
+    "view": "Просмотр",
+    "create": "Создать",
+    "enabled": "Включен",
+    "disabled": "Отключен",
+    "yes": "Да",
+    "submit": "Отправить",
+    "select": "Выбор",
+    "environmentVar": "Переменные среды",
+    "saving": "Сохранение...",
+    "saveDatasource": "Сохранить источник данных",
+    "authorize": "Авторизоваться",
+    "connect": "Подключиться",
+    "reconnect": "Переподключиться",
+    "components": "компоненты",
+    "send": "Отправить",
+    "noConnection": "не удалось подключиться",
+    "connectionVerifeid": "соединение установлено",
+    "left": "Влево",
+    "center": "Центр",
+    "right": "Вправо",
+    "justified": "Выровнено",
+    "host": "Хост",
+    "operation": "Операция",
+    "header": "ЗАГОЛОВОК",
+    "path": "ПУТЬ",
+    "query": "ЗАПРОС",
+    "requestBody": "ТЕЛО ЗАПРОСА"
   },
-  "errorBoundary":"Что-то пошло не так.",
-  "viewer":"Извините! Это приложение находится на тех.обслуживании",
-  "app":{
-    "updateAvailable":"Доступно обновление",
-    "newVersionReleased":"Новая версия Tooljet была выпущена",
-    "readReleaseNotes":"Прочитать, что нового было добавлено",
-    "skipVersion":"Пропустить эту версию"
+  "errorBoundary": "Что-то пошло не так.",
+  "viewer": "Извините! Это приложение находится на тех.обслуживании",
+  "app": {
+    "updateAvailable": "Доступно обновление",
+    "newVersionReleased": "Новая версия Tooljet была выпущена",
+    "readReleaseNotes": "Прочитать, что нового было добавлено",
+    "skipVersion": "Пропустить эту версию"
   },
-  "stripe":"Пожалуйста, подождите пока мы загрузим OpenAPI для Stripe.",
-  "openApi":{
-    "noValidOpenApi":"Подходящая спецификация OpenAPI сейчас недоступна!.",
-    "selectHost":"Выберите хоста",
-    "selectOperation":"Выберите операцию"
+  "stripe": "Пожалуйста, подождите пока мы загрузим OpenAPI для Stripe.",
+  "openApi": {
+    "noValidOpenApi": "Подходящая спецификация OpenAPI сейчас недоступна!.",
+    "selectHost": "Выберите хоста",
+    "selectOperation": "Выберите операцию"
   },
-  "slack":{
-    "authorize":"Авторизоваться",
-    "connectToolJetToSlack":"ToolJet может подключиться к Slack и получить список пользователей, отправлять сообщения, и др. Пожалуйста, настройте подходящие права доступа.",
-    "chatWrite":"chat:написать",
-    "listUsersAndSendMessage":"Ваше приложение ToolJet сможет получить список пользователей, а также отправлять сообщения пользователям и в чаты.",
-    "connectSlack":"Подключиться к Slack"
+  "slack": {
+    "authorize": "Авторизоваться",
+    "connectToolJetToSlack": "ToolJet может подключиться к Slack и получить список пользователей, отправлять сообщения, и др. Пожалуйста, настройте подходящие права доступа.",
+    "chatWrite": "chat:написать",
+    "listUsersAndSendMessage": "Ваше приложение ToolJet сможет получить список пользователей, а также отправлять сообщения пользователям и в чаты.",
+    "connectSlack": "Подключиться к Slack"
   },
-  "googleSheets":{
-    "readOnly":"Только чтение",
-    "enableReadAndWrite":"Если вы хотите, чтобы приложения ToolJet могли изменять ваши Google-таблицы, удостоверьтесь, что были даны права на чтение и запись",
-    "readDataFromSheets":"Ваши ToolJet приложения могут только читать данные из Google-таблиц",
-    "readWrite":"Чтение и запись",
-    "readModifySheets":"Ваши ToolJet приложения могут только читать данные из Google-таблиц, изменять их, и др",
-    "toGoogleSheets":"к Google-таблицам"
-
+  "googleSheets": {
+    "readOnly": "Только чтение",
+    "enableReadAndWrite": "Если вы хотите, чтобы приложения ToolJet могли изменять ваши Google-таблицы, удостоверьтесь, что были даны права на чтение и запись",
+    "readDataFromSheets": "Ваши ToolJet приложения могут только читать данные из Google-таблиц",
+    "readWrite": "Чтение и запись",
+    "readModifySheets": "Ваши ToolJet приложения могут только читать данные из Google-таблиц, изменять их, и др",
+    "toGoogleSheets": "к Google-таблицам"
   },
   "profile": {
     "profileSettings": "Настройки профиля"
   },
-  "loginSignupPage":{
-    "forgotPassword":"Забыли пароль",
-    "emailAddress":"Почтовый адрес",
-    "enterEmail":"Введите адрес электронной почты",
-    "resetPassword":"Сбросить пароль",
-    "dontHaveAccount":"У вас еще нет аккаунта??",
-    "signIn":"Войти",
-    "signUp":"Зарегистрироваться",
-    "createToolJetAccount":"Создать аккаунт ToolJet",
-    "enterBusinessEmail":"Введите свою бизнес почту",
-    "alreadyHaveAnAccount":"У вас уже есть аккаунт?",
-    "password":"Пароль",
-    "showPassword":"Показать пароль",
-    "loginTo":"Залогиниться в",
-    "yourAccount":"ваш аккаунт",
-    "noLoginMethodsEnabled":"Не найдено методов логина для этого рабочего пространства",
-    "emailConfirmLink":"Пожалуйста, поищите письмо с подтверждением на вашей электронной почте",
-    "newPassword":"Новый Пароль",
-    "passwordConfirmation":"Подтверждение Пароля"
+  "loginSignupPage": {
+    "forgotPassword": "Забыли пароль",
+    "emailAddress": "Почтовый адрес",
+    "enterEmail": "Введите адрес электронной почты",
+    "resetPassword": "Сбросить пароль",
+    "dontHaveAccount": "У вас еще нет аккаунта??",
+    "signIn": "Войти",
+    "signUp": "Зарегистрироваться",
+    "createToolJetAccount": "Создать аккаунт ToolJet",
+    "enterBusinessEmail": "Введите свою бизнес почту",
+    "alreadyHaveAnAccount": "У вас уже есть аккаунт?",
+    "password": "Пароль",
+    "showPassword": "Показать пароль",
+    "loginTo": "Залогиниться в",
+    "yourAccount": "ваш аккаунт",
+    "noLoginMethodsEnabled": "Не найдено методов логина для этого рабочего пространства",
+    "emailConfirmLink": "Пожалуйста, поищите письмо с подтверждением на вашей электронной почте",
+    "newPassword": "Новый Пароль",
+    "passwordConfirmation": "Подтверждение Пароля"
   },
   "editor": {
     "preview": "Предпросмотр",
-    "share":"Поделиться",
+    "share": "Поделиться",
     "shareModal": {
-      "makeApplicationPublic":"Сделать приложение общедоступным ?",
-      "shareableLink":"Получить ссылку, которой можно поделиться этим приложением",
-      "copy":"копировать",
-      "embeddableLink":"Получить встроенную ссылку для этого приложения",
-      "manageUsers":"Управлять пользователями"
+      "makeApplicationPublic": "Сделать приложение общедоступным ?",
+      "shareableLink": "Получить ссылку, которой можно поделиться этим приложением",
+      "copy": "копировать",
+      "embeddableLink": "Получить встроенную ссылку для этого приложения",
+      "manageUsers": "Управлять пользователями"
     },
-    "appVersionManager":{
-      "version":"Версия",
-      "currentlyReleased":"Текущая выпущенная",
-      "createVersion":"Создать Версию",
-      "versionName":"Имя версии",
-      "createVersionFrom":"Создать версию из",
-      "save":"Сохранить",
-      "create":"Создать версию",
+    "appVersionManager": {
+      "version": "Версия",
+      "currentlyReleased": "Текущая выпущенная",
+      "createVersion": "Создать Версию",
+      "versionName": "Имя версии",
+      "createVersionFrom": "Создать версию из",
+      "save": "Сохранить",
+      "create": "Создать версию",
       "editVersion": "Редактировать версию",
-      "deleteVersion":"Вы действительно хотите удалить эту версию ({{version}})?",
-      "enterVersionName":"Введите имя версии",
-      "versionAlreadyReleased":"Версия уже выпущена. Пожалуйста, создайте новую версию или переключитесь на другую, чтобы продолжить работу."
+      "deleteVersion": "Вы действительно хотите удалить эту версию ({{version}})?",
+      "enterVersionName": "Введите имя версии",
+      "versionAlreadyReleased": "Версия уже выпущена. Пожалуйста, создайте новую версию или переключитесь на другую, чтобы продолжить работу."
     },
-    "queries":"Запросы",
-    "inspectComponent":"Пожалуйста, выберите компонент для инспекции",
-    "release":"Релиз",
-    "searchQueries":"Поисковые запросы",
-    "createQuery":"Создать запрос",
-    "queryManager":{
-      "general":"Общие",
-      "advanced":"Продвинутые",
-      "preview":"Предпросмотр",
-      "Save":"Сохранить",
-      "selectDatasource":"Выбрать источник данных",
-      "addDatasource":"Добавить источник данных",
-      "dataSourceManager":{
-        "toast":{
+    "queries": "Запросы",
+    "inspectComponent": "Пожалуйста, выберите компонент для инспекции",
+    "release": "Релиз",
+    "searchQueries": "Поисковые запросы",
+    "createQuery": "Создать запрос",
+    "queryManager": {
+      "general": "Общие",
+      "advanced": "Продвинутые",
+      "preview": "Предпросмотр",
+      "Save": "Сохранить",
+      "selectDatasource": "Выбрать источник данных",
+      "addDatasource": "Добавить источник данных",
+      "dataSourceManager": {
+        "toast": {
           "success": {
             "dataSourceAdded": "Источник данных добавлен",
             "dataSourceSaved": "Источник данных сохранен"
           },
-          "error" :{
-            "noEmptyDsName" :"Имя источника не может быть пустым"
+          "error": {
+            "noEmptyDsName": "Имя источника не может быть пустым"
           }
         },
-        "suggestDataSource":"Предложить источник данных",
-        "suggestAnIntegration":"Предложить интеграцию",
-        "whatLookingFor":"Расскажите нам, что вы ищете?",
-        "noResultFound":"Не нашли то, что искали?",
-        "suggest":"Предложить",
-        "addNewDataSource":"Добавить новый источник данных",
-        "whiteListIP":"Пожалуйста, добавьте наш  IP адрес в белый список, если источник данных не в открытом доступе.",
-        "copied":"Скопировано",
-        "copy":"Копировать",
-        "saving":"Сохранение",
-        "noResultsFor":"Нет результато для",
-        "noteTaken":"Спасибо, мы уведомлены об этом!",
-        "goToAllDatasources":"Ко всем источникам данных",
-        "send":"Отправлено"
+        "suggestDataSource": "Предложить источник данных",
+        "suggestAnIntegration": "Предложить интеграцию",
+        "whatLookingFor": "Расскажите нам, что вы ищете?",
+        "noResultFound": "Не нашли то, что искали?",
+        "suggest": "Предложить",
+        "addNewDataSource": "Добавить новый источник данных",
+        "whiteListIP": "Пожалуйста, добавьте наш  IP адрес в белый список, если источник данных не в открытом доступе.",
+        "copied": "Скопировано",
+        "copy": "Копировать",
+        "saving": "Сохранение",
+        "noResultsFor": "Нет результато для",
+        "noteTaken": "Спасибо, мы уведомлены об этом!",
+        "goToAllDatasources": "Ко всем источникам данных",
+        "send": "Отправлено"
       },
-      "runQueryOnPageLoad":"Запускать этот запрос при загрузке страницы?",
-      "confirmBeforeQueryRun":"Требовать подтверждение перед запуском запроса?",
-      "notificationOnSuccess":"Показывать уведомление при успехе?",
-      "successMessage":"Успех",
-      "queryRanSuccessfully":"Запрос был успешно запущен",
-      "notificationDuration":"Длина сообщения (сек)",
-      "events":"События",
-      "transformation":{
-        "transformationToolTip":"Трансформации могут быть использованы для преобразования результатов запросов. Все переменные доступны для преобразователей и поддерживают JS-библиотеки, такие как Lodash и Moment",
-        "transformations":"Трансформации"
+      "runQueryOnPageLoad": "Запускать этот запрос при загрузке страницы?",
+      "confirmBeforeQueryRun": "Требовать подтверждение перед запуском запроса?",
+      "notificationOnSuccess": "Показывать уведомление при успехе?",
+      "successMessage": "Успех",
+      "queryRanSuccessfully": "Запрос был успешно запущен",
+      "notificationDuration": "Длина сообщения (сек)",
+      "events": "События",
+      "transformation": {
+        "transformationToolTip": "Трансформации могут быть использованы для преобразования результатов запросов. Все переменные доступны для преобразователей и поддерживают JS-библиотеки, такие как Lodash и Moment",
+        "transformations": "Трансформации"
       }
     },
-    "inspector":{
-      "eventManager":{
+    "inspector": {
+      "eventManager": {
         "event": "Событие",
         "action": "Действие",
         "actionOptions": "Опции действия",
@@ -187,279 +186,285 @@
       }
     }
   },
-  "header":{
-    "darkModeToggle":{
-      "activateLightMode" :"Включить светлый режим",
-      "activateDarkMode":"Включить темный режим"
+  "header": {
+    "darkModeToggle": {
+      "activateLightMode": "Включить светлый режим",
+      "activateDarkMode": "Включить темный режим"
     },
-    "languageSelection":{
-      "changeLanguage":"Изменить язык",
-      "searchLanguage":"Выбрать язык"
+    "languageSelection": {
+      "changeLanguage": "Изменить язык",
+      "searchLanguage": "Выбрать язык"
     },
-    "notificationCenter":{
-      "notifications":"Уведомления",
-      "markAllAs":"Отметить все как",
-      "read":"прочитано",
-      "un":"не",
-      "youDontHaveany":"У вас нет ни одного",
-      "youAreCaughtUp":"Вы просмотрели все уведомления!",
-      "view":"Просмотр"
+    "notificationCenter": {
+      "notifications": "Уведомления",
+      "markAllAs": "Отметить все как",
+      "read": "прочитано",
+      "un": "не",
+      "youDontHaveany": "У вас нет ни одного",
+      "youAreCaughtUp": "Вы просмотрели все уведомления!",
+      "view": "Просмотр"
     },
-    "organization":{
-      "loadOrganizations":"Загрузить организации",
-      "createWorkspace":"Создать рабочее пространство",
-      "workspaceName":"имя пространства",
-      "editWorkspace":"редактировать пространство",
+    "organization": {
+      "loadOrganizations": "Загрузить организации",
+      "createWorkspace": "Создать рабочее пространство",
+      "workspaceName": "имя пространства",
+      "editWorkspace": "редактировать пространство",
       "menus": {
-        "addWorkspace":"Добавить рабочее пространство",
-        "menusList":{
-          "manageUsers":"Управлять пользователями",
-          "manageGroups":"Управлять группами",
-          "manageSso":"Управлять SSO",
-          "manageEnv":"Управлять переменными среды"
+        "addWorkspace": "Добавить рабочее пространство",
+        "menusList": {
+          "manageUsers": "Управлять пользователями",
+          "manageGroups": "Управлять группами",
+          "manageSso": "Управлять SSO",
+          "manageEnv": "Управлять переменными среды"
         },
-        "manageUsers":{
-          "usersAndPermission":"Пользователи и разрешения",
-          "inviteNewUser":"Пригласить нового пользователя",
-          "name":"ИМЯ",
-          "email":"ПОЧТА",
-          "status":"СТАТУС",
-          "archive":"Архивировать",
-          "unarchive":"Разархивировать",
-          "addNewUser":"Добавить нового пользователя",
-          "emailAddress":"Адрес электронной почты",
-          "createUser":"Создать пользователя",
-          "enterFirstName":"Введите Имя",
-          "enterLastName":"Введитя Фамилию",
-          "enterEmail":"Введите Почту"
+        "manageUsers": {
+          "usersAndPermission": "Пользователи и разрешения",
+          "inviteNewUser": "Пригласить нового пользователя",
+          "name": "ИМЯ",
+          "email": "ПОЧТА",
+          "status": "СТАТУС",
+          "archive": "Архивировать",
+          "unarchive": "Разархивировать",
+          "addNewUser": "Добавить нового пользователя",
+          "emailAddress": "Адрес электронной почты",
+          "createUser": "Создать пользователя",
+          "enterFirstName": "Введите Имя",
+          "enterLastName": "Введитя Фамилию",
+          "enterEmail": "Введите Почту"
         },
-        "manageGroups":{
-          "permissions":{
-            "userGroups":"Группы пользователей",
-            "createNewGroup":"Создать новую группу",
-            "udpateGroup":"Обновить группу",
-            "addNewGroup":"Добавить новую группу",
-            "enterName":"Введите имя",
-            "createGroup":"Создать группу",
-            "name":"Имя"
+        "manageGroups": {
+          "permissions": {
+            "userGroups": "Группы пользователей",
+            "createNewGroup": "Создать новую группу",
+            "udpateGroup": "Обновить группу",
+            "addNewGroup": "Добавить новую группу",
+            "enterName": "Введите имя",
+            "createGroup": "Создать группу",
+            "name": "Имя"
           },
-          "permissionResources":{
-            "userGroup":"Группа пользователей",
-            "apps":"Приложения",
-            "users":"Пользователь",
-            "permissions":"Разрешение",
-            "addAppsToGroup":"Выберите приложения для добавления в группу",
-            "name":"имя",
-            "addUsersToGroup":"Выберите пользователей для добавления в группу",
-            "email":"электронная почта",
-            "resource":"ресурс",
-            "createUpdateDelete":"Создать/Обновить/Удалить",
-            "folder":"Папка"
+          "permissionResources": {
+            "userGroup": "Группа пользователей",
+            "apps": "Приложения",
+            "users": "Пользователь",
+            "permissions": "Разрешение",
+            "addAppsToGroup": "Выберите приложения для добавления в группу",
+            "name": "имя",
+            "addUsersToGroup": "Выберите пользователей для добавления в группу",
+            "email": "электронная почта",
+            "resource": "ресурс",
+            "createUpdateDelete": "Создать/Обновить/Удалить",
+            "folder": "Папка"
           }
         },
-        "manageSSO":{
-          "manageSso":"Управлять SSO",
-          "generalSettings":{
-            "title":"Основные настройки",
-            "enableSignup":"Включить вход",
-            "newAccountWillBeCreated":"Новый аккаунт будет создан для первого логина пользователя через SSO",
-            "allowedDomains":"Разрешенные домены",
-            "enterDomains":"Домены входа",
-            "supportMultiDomains":"Поддержка множества доменов. Введите доменные имена, разделенные запятой. Например: tooljet.com,tooljet.io,yourorganization.com",
-            "loginUrl":"Ссылка на логин",
-            "workspaceLogin":"Используйте эту чтобы напрямую залогиниться в рабочую область",
-            "allowDefaultSso":"Разрешить стандартный SSO",
-            "ssoAuth":"Разрешить пользователям вход через стандартный SSO. Стандартная конфигурация SSO будут перезаписана."
+        "manageSSO": {
+          "manageSso": "Управлять SSO",
+          "generalSettings": {
+            "title": "Основные настройки",
+            "enableSignup": "Включить вход",
+            "newAccountWillBeCreated": "Новый аккаунт будет создан для первого логина пользователя через SSO",
+            "allowedDomains": "Разрешенные домены",
+            "enterDomains": "Домены входа",
+            "supportMultiDomains": "Поддержка множества доменов. Введите доменные имена, разделенные запятой. Например: tooljet.com,tooljet.io,yourorganization.com",
+            "loginUrl": "Ссылка на логин",
+            "workspaceLogin": "Используйте эту чтобы напрямую залогиниться в рабочую область",
+            "allowDefaultSso": "Разрешить стандартный SSO",
+            "ssoAuth": "Разрешить пользователям вход через стандартный SSO. Стандартная конфигурация SSO будут перезаписана."
           },
-          "google":{
-            "title":"Google",
-            "enabled":"Включен",
-            "disabled":"Выключен",
-            "clientId":"Id клиента",
-            "enterClientId":"Ввести Id клиента",
-            "redirectUrl":"Редирект ссылка"
+          "google": {
+            "title": "Google",
+            "enabled": "Включен",
+            "disabled": "Выключен",
+            "clientId": "Id клиента",
+            "enterClientId": "Ввести Id клиента",
+            "redirectUrl": "Редирект ссылка"
           },
-          "github":{
-            "title":"Github",
-            "hostName":"Имя хоста",
-            "enterHostName":"Введите имя хоста",
-            "requiredGithub":"Обязателен, если GitHub хоститься самостоятельно",
-            "clientId":"Id клиента",
-            "enterClientId":"Ввести Id клиента",
-            "clientSecret":"Secret клиента",
-            "enterClientSecret":"Введите Secret клиента",
-            "encrypted":"Зашифровано",
-            "redirectUrl":"Редирект ссылка"
+          "github": {
+            "title": "Github",
+            "hostName": "Имя хоста",
+            "enterHostName": "Введите имя хоста",
+            "requiredGithub": "Обязателен, если GitHub хоститься самостоятельно",
+            "clientId": "Id клиента",
+            "enterClientId": "Ввести Id клиента",
+            "clientSecret": "Secret клиента",
+            "enterClientSecret": "Введите Secret клиента",
+            "encrypted": "Зашифровано",
+            "redirectUrl": "Редирект ссылка"
           },
-          "passwordLogin":"Пароль логин",
-          "environmentVar" : {
-            "noEnvConfig":"Вы не настроили ни одной переменной среды, нажмите кнопку 'Добавить новую переменную' чтобы создать",
-            "envWillBeDeleted":"Переменная будет удалена, вы хотите продолжить?",
-            "addNewVariable":"Добавить новую переменную",
-            "variableForm":{
-              "addNewVariable":"Добавить новую переменную",
-              "updatevariable":"Обновить переменную",
-              "name":"Имя",
-              "value":"Значение",
-              "enterVariableName":"Введите значение переменной",
-              "enterValue":"Введите значение",
-              "type":"Тип",
-              "enableEncryption":"Включить шифрование",
-              "addVariable":"Добавить переменную"
+          "passwordLogin": "Пароль логин",
+          "environmentVar": {
+            "noEnvConfig": "Вы не настроили ни одной переменной среды, нажмите кнопку 'Добавить новую переменную' чтобы создать",
+            "envWillBeDeleted": "Переменная будет удалена, вы хотите продолжить?",
+            "addNewVariable": "Добавить новую переменную",
+            "variableForm": {
+              "addNewVariable": "Добавить новую переменную",
+              "updatevariable": "Обновить переменную",
+              "name": "Имя",
+              "value": "Значение",
+              "enterVariableName": "Введите значение переменной",
+              "enterValue": "Введите значение",
+              "type": "Тип",
+              "enableEncryption": "Включить шифрование",
+              "addVariable": "Добавить переменную"
             },
-            "variableTable":{
-              "name":"Имя",
-              "value":"значение",
-              "type":"тип",
-              "secret":"secret"
+            "variableTable": {
+              "name": "Имя",
+              "value": "значение",
+              "type": "тип",
+              "secret": "secret"
             }
           }
         }
       }
     },
-    "profileSettingPage":{
-      "profileSettings":"Настройки профиля",
-      "firstName":"Имя",
-      "lastName":"Фамилия",
-      "enterFirstName":"Ввести имя",
-      "enterLastName":"Ввести фамилию",
-      "email":"Электронная почта",
-      "avatar":"Аватар",
-      "update":"Обновить",
-      "profile":"Профиль",
-      "changePassword":"Сменить пароль",
-      "currentPassword":"Текущий пароль",
-      "newPassword":"Новый пароль",
-      "confirmNewPassword":"Подтвердить новый пароль",
-      "enterCurrentPassword":"Ввести текущий пароль",
-      "enterNewPassword":"Ввести новый пароль"
+    "profileSettingPage": {
+      "profileSettings": "Настройки профиля",
+      "firstName": "Имя",
+      "lastName": "Фамилия",
+      "enterFirstName": "Ввести имя",
+      "enterLastName": "Ввести фамилию",
+      "email": "Электронная почта",
+      "avatar": "Аватар",
+      "update": "Обновить",
+      "profile": "Профиль",
+      "changePassword": "Сменить пароль",
+      "currentPassword": "Текущий пароль",
+      "newPassword": "Новый пароль",
+      "confirmNewPassword": "Подтвердить новый пароль",
+      "enterCurrentPassword": "Ввести текущий пароль",
+      "enterNewPassword": "Ввести новый пароль"
     },
-    "profile":"Профиль",
-    "logout":"Разлогиниться"
+    "profile": "Профиль",
+    "logout": "Разлогиниться"
   },
-  "homePage":{
-    "appCard":{
-      "changeIcon":"Изменить иконку",
-      "addToFolder":"Добавить в папку",
-      "move":"Переместить",
-      "to":"в",
-      "selectFolder":"Выбрать папку",
-      "deleteApp":"Удалить приложение",
-      "exportApp":"Экспортировать приложение",
-      "cloneApp":"Клонировать приложение",
-      "launch":"Запустить",
-      "maintenance":"Тех.обслуживание",
-      "noDeployedVersion":"Приложение не имеет задеплоенной версии",
-      "openInAppViewer":"Открыть просмотрщик приложений",
-      "removeFromFolder":"Удалить из папки"
+  "homePage": {
+    "appCard": {
+      "changeIcon": "Изменить иконку",
+      "addToFolder": "Добавить в папку",
+      "move": "Переместить",
+      "to": "в",
+      "selectFolder": "Выбрать папку",
+      "deleteApp": "Удалить приложение",
+      "exportApp": "Экспортировать приложение",
+      "cloneApp": "Клонировать приложение",
+      "launch": "Запустить",
+      "maintenance": "Тех.обслуживание",
+      "noDeployedVersion": "Приложение не имеет задеплоенной версии",
+      "openInAppViewer": "Открыть просмотрщик приложений",
+      "removeFromFolder": "Удалить из папки"
     },
-    "blankPage":{
-      "welcomeToToolJet":"Добро пожаловать в ToolJet!",
-      "getStartedCreateNewApp":"Вы можете начать создание нового приложения или создание нового приложения используя шаблон из библиотеки ToolJet",
-      "importApplication":"Импортировать приложение"
+    "blankPage": {
+      "welcomeToToolJet": "Добро пожаловать в ToolJet!",
+      "getStartedCreateNewApp": "Вы можете начать создание нового приложения или создание нового приложения используя шаблон из библиотеки ToolJet",
+      "importApplication": "Импортировать приложение"
     },
-    "foldersSection":{
-      "allApplications":"Все приложения",
-      "folders":"Папки",
-      "createNewFolder":"+ Создать новую папку",
-      "noFolders":"Вы не создали ни одной папки.",
-      "createFolder":"Создать папку",
-      "updateFolder":"Обновить папку",
-      "editFolder":"Редактировать папку",
-      "deleteFolder":"Удалить папку",
-      "folderName":"Имя папки",
-      "wishToDeleteFolder":"Вы уверены, что хотите удалить папку {{folderName}}? Приложения в папке не будут удалены."
-
+    "foldersSection": {
+      "allApplications": "Все приложения",
+      "folders": "Папки",
+      "createNewFolder": "+ Создать новую папку",
+      "noFolders": "Вы не создали ни одной папки.",
+      "createFolder": "Создать папку",
+      "updateFolder": "Обновить папку",
+      "editFolder": "Редактировать папку",
+      "deleteFolder": "Удалить папку",
+      "folderName": "Имя папки",
+      "wishToDeleteFolder": "Вы уверены, что хотите удалить папку {{folderName}}? Приложения в папке не будут удалены."
     },
-    "header":{
-      "createNewApplication":"Создать новое приложение",
-      "import":"Импорт",
-      "chooseFromTemplate":"Выбрать из шаблона"
+    "header": {
+      "createNewApplication": "Создать новое приложение",
+      "import": "Импорт",
+      "chooseFromTemplate": "Выбрать из шаблона"
     },
-    "pagination":{
-      "showing":"Показывается",
-      "of":"от",
-      "to":"до"
+    "pagination": {
+      "showing": "Показывается",
+      "of": "от",
+      "to": "до"
     },
-    "noApplicationFound":"Приложения не найдены",
-    "thisFolderIsEmpty":"Эта папка пуста",
-    "deleteAppAndData":"Приложение и связанные с ним данные будут удалены, вы хотите продолжить?",
-    "removeAppFromFolder":"Приложение будет удалине из папки, вы хотите продолжить?",
-    "change":"Изменить",
-    "templateCard":{
-      "use":"Использовать",
-      "preview":"Предпросмотр",
-      "leadGeneretion":"Лидогенерация"
+    "noApplicationFound": "Приложения не найдены",
+    "thisFolderIsEmpty": "Эта папка пуста",
+    "deleteAppAndData": "Приложение и связанные с ним данные будут удалены, вы хотите продолжить?",
+    "removeAppFromFolder": "Приложение будет удалине из папки, вы хотите продолжить?",
+    "change": "Изменить",
+    "templateCard": {
+      "use": "Использовать",
+      "preview": "Предпросмотр",
+      "leadGeneretion": "Лидогенерация"
     },
-    "templateLibraryModal":{
-      "select":"Выбрать шаблон",
-      "createAppfromTemplate":"Создать приложение из шаблона"
+    "templateLibraryModal": {
+      "select": "Выбрать шаблон",
+      "createAppfromTemplate": "Создать приложение из шаблона"
     }
   },
-  "confirmationPage":{
-    "setupAccount":"Настройте свою учетную запись",
-    "signupWithGoogle":"Залогиниться через Google",
-    "signupWithGitHub":"Залогиниться через GitHub",
-    "or":"ИЛИ",
-    "firstName":"Имя",
-    "lastName":"Фамилия",
-    "company":"Компания",
-    "role":"Роль",
-    "pleaseSelect":"Пожалуйста выберите",
-    "password":"Пароль",
-    "confirmPassword":"Подтвердите пароль",
-    "clickAndAgree":"Нажав на кнопку ниже, вы соглашаетесь с нашими",
-    "termsAndConditions":"Условиями и положениями",
-    "finishAccountSetup":"Закончить настройку учетной записи",
-    "acceptInvite":"принять инвайт",
-    "accountExists":"У вас уже есть учетная запись?",
-    "and":"и"
-
+  "confirmationPage": {
+    "setupAccount": "Настройте свою учетную запись",
+    "signupWithGoogle": "Залогиниться через Google",
+    "signupWithGitHub": "Залогиниться через GitHub",
+    "or": "ИЛИ",
+    "firstName": "Имя",
+    "lastName": "Фамилия",
+    "company": "Компания",
+    "role": "Роль",
+    "pleaseSelect": "Пожалуйста выберите",
+    "password": "Пароль",
+    "confirmPassword": "Подтвердите пароль",
+    "clickAndAgree": "Нажав на кнопку ниже, вы соглашаетесь с нашими",
+    "termsAndConditions": "Условиями и положениями",
+    "finishAccountSetup": "Закончить настройку учетной записи",
+    "acceptInvite": "принять инвайт",
+    "accountExists": "У вас уже есть учетная запись?",
+    "and": "и"
   },
-  "onBoarding":{
-    "finishToolJetInstallation":"Закончить установку ToolJet",
-    "organization":"Организация",
-    "name":"Имя",
-    "email":"Электронная почта",
-    "receiveUpdatesFromToolJet":"Вы будете получать обновления от команды ToolJet ( 1-2 письма каждый месяц, мы не спамим )",
-    "finishSetup":"Закончить настройку",
-    "skip":"Пропустить"
+  "onBoarding": {
+    "finishToolJetInstallation": "Закончить установку ToolJet",
+    "organization": "Организация",
+    "name": "Имя",
+    "email": "Электронная почта",
+    "receiveUpdatesFromToolJet": "Вы будете получать обновления от команды ToolJet ( 1-2 письма каждый месяц, мы не спамим )",
+    "finishSetup": "Закончить настройку",
+    "skip": "Пропустить"
   },
-  "redirectSso":{
-    "upgradingTov1.13.0":"Обновление до версии v1.13.0 и выше.",
-    "fromV1.13.0":"С v1.13.0 мы представили",
-    "multiWorkspace":"Мульти-рабочее пространство",
-    "singleSignOnConfig":"Конфигурации, связанные с SSO были перенесены переменных среды в базу данных. Пожалуйста, учтите это",
-    "link":"Ссылка",
-    "toConfigureSSO":"чтобы настроить SSO.",
-    "haveGoogleGithubSSo":"Если у вас есть конфигурации SSO от Google или GitHub до обновления и мульти-рабочие пространства были отключены значит SSO конфигурации будут мигрированы во время обновления, но, вам нужно перенастроить ссылку перенаправления на стороне SSO провайдера. Ссылки перенаправления для каждого SSO даны ниже.",
-    "isMultiWorkspaceEnabled":"Если вы включили Мульти-рабочие пространства, тогда конфигурации SSO не будут мигрированы во время обновления и вам нужно перенастроить SSO в соответствующем провайдере.",
-    "youHaveEnabled":"Вы включили",
-    "setupSsoWorkspace":"Пожалуйста, залогиньтесь с вашим паролем и вы сможете настроить SSO в пространстве",
-    "manageSsoMenu":"Управление меню SSO.",
-    "youHaveDisabled":"Вы отключили",
-    "configureRedirectUrl":"Пожалуйста, настройте ссылку перенаправления на стороне SSO провайдера.",
-    "google":"Google",
-    "redirectUrl":"Ссылка перенаправления:",
-    "gitHub":"GitHub"
+  "redirectSso": {
+    "upgradingTov1": {
+      "13": {
+        "0": "Обновление до версии v1.13.0 и выше."
+      }
+    },
+    "fromV1": {
+      "13": {
+        "0": "С v1.13.0 мы представили"
+      }
+    },
+    "multiWorkspace": "Мульти-рабочее пространство",
+    "singleSignOnConfig": "Конфигурации, связанные с SSO были перенесены переменных среды в базу данных. Пожалуйста, учтите это",
+    "link": "Ссылка",
+    "toConfigureSSO": "чтобы настроить SSO.",
+    "haveGoogleGithubSSo": "Если у вас есть конфигурации SSO от Google или GitHub до обновления и мульти-рабочие пространства были отключены значит SSO конфигурации будут мигрированы во время обновления, но, вам нужно перенастроить ссылку перенаправления на стороне SSO провайдера. Ссылки перенаправления для каждого SSO даны ниже.",
+    "isMultiWorkspaceEnabled": "Если вы включили Мульти-рабочие пространства, тогда конфигурации SSO не будут мигрированы во время обновления и вам нужно перенастроить SSO в соответствующем провайдере.",
+    "youHaveEnabled": "Вы включили",
+    "setupSsoWorkspace": "Пожалуйста, залогиньтесь с вашим паролем и вы сможете настроить SSO в пространстве",
+    "manageSsoMenu": "Управление меню SSO.",
+    "youHaveDisabled": "Вы отключили",
+    "configureRedirectUrl": "Пожалуйста, настройте ссылку перенаправления на стороне SSO провайдера.",
+    "google": "Google",
+    "redirectUrl": "Ссылка перенаправления:",
+    "gitHub": "GitHub"
   },
   "oAuth2": {
-    "pleaseWait":"Пожалуйста подождите...",
-    "authSuccess":"Аутентификация успешна, вы можете закрыть эту вкладку.",
-    "authFailed":"Аутентификация провалена"
+    "pleaseWait": "Пожалуйста подождите...",
+    "authSuccess": "Аутентификация успешна, вы можете закрыть эту вкладку.",
+    "authFailed": "Аутентификация провалена"
   },
   "widgetManager": {
     "commonlyUsed": "обычно используется",
-    "layouts" : "слои",
-    "forms" : "формы",
-    "intregrations" : "интеграции",
-    "others":"другие",
+    "layouts": "слои",
+    "forms": "формы",
+    "intregrations": "интеграции",
+    "others": "другие",
     "noResults": "Не найдено результатов",
     "tryAdjustingFilterMessage": "Попробуйте изменить свой поисковой запрос или фильтр чтобы найти то, что вы ищете.",
     "clearQuery": "очистить запрос"
   },
-  "widget":{
-    "common":{
+  "widget": {
+    "common": {
       "properties": "Свойства",
       "events": "События",
       "layout": "Слой",
@@ -702,220 +707,219 @@
       "displayName": "Диаграмма",
       "description": "Отображает диаграммы"
     },
-    "Modal" : {
+    "Modal": {
       "displayName": "Модальное окно",
       "description": "Модальное окно, которое вызывается событиями"
     },
-    "TextInput" : {
+    "TextInput": {
       "displayName": "Ввода текста",
       "description": "Ввод текста в формах"
     },
-    "NumberInput" :{
+    "NumberInput": {
       "displayName": "Ввод цифр",
       "description": "Цифровое поле для форм"
     },
-    "PasswordInput":{
+    "PasswordInput": {
       "displayName": "Ввод пароля",
       "description": "Ввод пароля для форм"
     },
-    "Datepicker" :{
+    "Datepicker": {
       "displayName": "Выбор даты",
       "description": "Выбор даты и времени"
     },
-    "Checkbox":{
+    "Checkbox": {
       "displayName": "Чекбокс",
       "description": "Обычный чекбокс"
     },
-    "Radio-button":{
+    "Radio-button": {
       "displayName": "Радио баттоны",
       "description": "Радио баттоны"
     },
-    "ToggleSwitch":{
+    "ToggleSwitch": {
       "displayName": "Переключатель",
       "description": "Переключатель"
     },
-    "Textarea":{
+    "Textarea": {
       "displayName": "Текстовое поле",
       "description": "Текстовое поле в форме"
     },
-    "DateRangePicker":{
+    "DateRangePicker": {
       "displayName": "Выбор диапазона",
       "description": "Выберите диапазон дат"
     },
-    "Text":{
+    "Text": {
       "displayName": "Текст",
       "description": "Отображать HTML или разметку"
     },
-    "Image":{
+    "Image": {
       "displayName": "Изображение",
       "description": "Отображает изображeние"
     },
-    "Container":{
+    "Container": {
       "displayName": "Контейнер",
       "description": "Обертка для множества компонентов"
     },
-    "Dropdown":{
+    "Dropdown": {
       "displayName": "Выпадающий список",
       "description": "Выбрать одно значение из списка опций"
     },
-    "Multiselect":{
+    "Multiselect": {
       "displayName": "Мультивыбор",
       "description": "Выбирает несколько значений из списка опций"
     },
-    "RichTextEditor":{
+    "RichTextEditor": {
       "displayName": "Редактор текста",
       "description": "Полноценный текстовый редактор"
     },
-    "Map":{
+    "Map": {
       "displayName": "Карта",
       "description": "Отображает Google карты"
     },
-    "QrScanner":{
+    "QrScanner": {
       "displayName": "QR сканер",
       "description": "Сканирует QR коды и хранит данные"
     },
-    "StarRating":{
+    "StarRating": {
       "displayName": "Рейтинг",
       "description": "Рейтинг через звездочки"
     },
-    "Divider":{
+    "Divider": {
       "displayName": "Разделитель",
       "description": "Разделитель между компонентами"
     },
-    "FilePicker":{
+    "FilePicker": {
       "displayName": "Средство выбора файлов",
       "description": "Средство выбора файлов"
     },
-    "Calendar":{
+    "Calendar": {
       "displayName": "Календарь",
       "description": "Календарь"
     },
-    "Iframe":{
+    "Iframe": {
       "displayName": "Iframe",
       "description": "отображать как Iframe"
     },
-    "CodeEditor":{
+    "CodeEditor": {
       "displayName": "Редактор кода",
       "description": "Редактор кода"
     },
-    "Tabs":{
+    "Tabs": {
       "displayName": "Вкладки",
       "description": "Компонент вкладок"
     },
-    "Timer":{
+    "Timer": {
       "displayName": "Таймер",
       "description": "таймер"
     },
-    "Listview":{
+    "Listview": {
       "displayName": "Список",
       "description": "Может использоваться для разных компонентов"
     },
-    "Tags":{
+    "Tags": {
       "displayName": "Теги",
       "description": "Контент может быть показан как теги"
     },
-    "Pagination":{
+    "Pagination": {
       "displayName": "Пагинация",
       "description": "Пагинация "
     },
-    "CircularProgressbar":{
+    "CircularProgressbar": {
       "displayName": "Круговой индикатор прогресса",
       "description": "Показывает прогресс благодаря круговому прогрессбару"
     },
-    "Spinner":{
+    "Spinner": {
       "displayName": "Спиннер",
       "description": "Можно использовать для отображения состояния загрузки"
     },
-    "Statistics":{
+    "Statistics": {
       "displayName": "Статистика",
       "description": "Может быть использована для отображения разной статистической информации"
     },
-    "RangeSlider":{
+    "RangeSlider": {
       "displayName": "Ползунок диапазона",
       "description": "Можно использовать для отображения диапазона"
     },
-    "Timeline":{
+    "Timeline": {
       "displayName": "Временная линия",
       "description": "Визуальное отображение последовательности событий"
     },
-    "SvgImage":{
+    "SvgImage": {
       "displayName": "Svg изображение",
       "description": "Svg изображение"
     },
-    "Html":{
+    "Html": {
       "displayName": "HTML просмотрщик",
       "description": "HTML просмотрщик"
     },
-    "VerticalDivider":{
+    "VerticalDivider": {
       "displayName": "Вертикальный разделитель",
       "description": "Вертикальный разделитель между компонентами"
     },
-    "CustomComponent":{
+    "CustomComponent": {
       "displayName": "Пользовательский элемент",
       "description": "Добавьте свой собственный react компонент"
     },
-    "ButtonGroup":{
+    "ButtonGroup": {
       "displayName": "Группа кнопок",
       "description": "ButtonGroup"
     },
-    "PDF":{
+    "PDF": {
       "displayName": "PDF",
       "description": "Встроенный PDF файл"
     },
-    "Steps":{
+    "Steps": {
       "displayName": "Шаги",
       "description": "Шаги"
     },
-    "KanbanBoard":{
+    "KanbanBoard": {
       "displayName": "Канбан доска",
       "description": "Канбан доска "
     },
-    "ColorPicker":{
+    "ColorPicker": {
       "displayName": "Выбор цвета",
       "description": "Выбор цвета из палитры"
     },
-    "TreeSelect":{
+    "TreeSelect": {
       "displayName": "Выбор дерева",
       "description": "Выберите значения из режима дерева"
     }
   },
-  "leftSidebar":{
-    "Inspector":{
-      "text":"Инспектор",
-      "tip" : "Инспектор"
+  "leftSidebar": {
+    "Inspector": {
+      "text": "Инспектор",
+      "tip": "Инспектор"
     },
-    "Sources" :{
-      "text":"Источники",
-      "tip" : "Добавить или редактировать источники данных",
-      "dataSources":"Источники данных",
-      "addDataSource":"+ добавить источник данных"
+    "Sources": {
+      "text": "Источники",
+      "tip": "Добавить или редактировать источники данных",
+      "dataSources": "Источники данных",
+      "addDataSource": "+ добавить источник данных"
     },
-    "Debugger":{
-      "text":"Отладчик",
-      "tip" : "Отладчик",
-      "errors":"Ошибки",
-      "noErrors":"Ошибок нет",
-      "clear":"очистить"
+    "Debugger": {
+      "text": "Отладчик",
+      "tip": "Отладчик",
+      "errors": "Ошибки",
+      "noErrors": "Ошибок нет",
+      "clear": "очистить"
     },
-    "Comments":{
-      "text":"Комментарии",
-      "tip" : "Включить комментарии",
-      "commentBody":"Нет комментариев для отображения",
-      "typeComment":"Оставьте свой комментарий тут"
+    "Comments": {
+      "text": "Комментарии",
+      "tip": "Включить комментарии",
+      "commentBody": "Нет комментариев для отображения",
+      "typeComment": "Оставьте свой комментарий тут"
     },
-    "Settings":{
-      "text":"Настройки",
-      "tip" : "Главные настройки",
+    "Settings": {
+      "text": "Настройки",
+      "tip": "Главные настройки",
       "hideHeader": "Спрятать заголовок для запущенных приложений",
-      "maintenanceMode":"Режим тех.обслуживания",
-      "maxWidthOfCanvas":"Максимальная ширина поверхности",
-      "maxHeightOfCanvas" :"Максимальная высота поверхности",
-      "backgroundColorOfCanvas":"Задний фон поверхности"
-
+      "maintenanceMode": "Режим тех.обслуживания",
+      "maxWidthOfCanvas": "Максимальная ширина поверхности",
+      "maxHeightOfCanvas": "Максимальная высота поверхности",
+      "backgroundColorOfCanvas": "Задний фон поверхности"
     },
-    "Back":{
-      "text":"Назад",
-      "tip" : "Домой"
+    "Back": {
+      "text": "Назад",
+      "tip": "Домой"
     }
   }
 }

--- a/frontend/assets/translations/uk.json
+++ b/frontend/assets/translations/uk.json
@@ -1,168 +1,168 @@
 {
-  "globals":{
-    "readDocumentation":"Прочитать документацію",
-    "cancel":"Відміна",
-    "save":"Зберегти",
-    "back":"Назад",
-    "edit":"Редактувати",
-    "search":"Пошук",
-    "update":"Оновити",
-    "delete":"Видалити",
-    "add":"Додати",
-    "view":"Перегляд",
-    "create":"Створити",
-    "enabled":"Увімкнено",
-    "disabled":"Вимкнено",
-    "yes":"Так",
-    "submit":"Відіслати",
-    "select":"Вибір",
-    "environmentVar":"Змінні середовища",
-    "saving":"Збереження...",
-    "saveDatasource":"Зберегти джерело даних",
-    "authorize":"Авторизуватися",
-    "connect":"Під'єднатися",
-    "reconnect":"Перепідключитися",
-    "components":"компоненти",
-    "send":"Відправити",
-    "noConnection":"Не вдалося під'єднатися",
-    "connectionVerifeid":"з'єднання встановлено",
-    "left":"Ліворуч",
-    "center":"Центр",
-    "right":"Праворуч",
-    "justified":"Вирівняно",
-    "host":"Хост",
-    "operation":"Операція",
-    "header":"ЗАГОЛОВОК",
-    "path":"ШЛЯХ",
-    "query":"ЗАПИТ",
-    "requestBody":"ТІЛО ЗАПИТУ"
+  "globals": {
+    "readDocumentation": "Прочитать документацію",
+    "cancel": "Відміна",
+    "save": "Зберегти",
+    "back": "Назад",
+    "edit": "Редактувати",
+    "search": "Пошук",
+    "update": "Оновити",
+    "delete": "Видалити",
+    "add": "Додати",
+    "view": "Перегляд",
+    "create": "Створити",
+    "enabled": "Увімкнено",
+    "disabled": "Вимкнено",
+    "yes": "Так",
+    "submit": "Відіслати",
+    "select": "Вибір",
+    "environmentVar": "Змінні середовища",
+    "saving": "Збереження...",
+    "saveDatasource": "Зберегти джерело даних",
+    "authorize": "Авторизуватися",
+    "connect": "Під'єднатися",
+    "reconnect": "Перепідключитися",
+    "components": "компоненти",
+    "send": "Відправити",
+    "noConnection": "Не вдалося під'єднатися",
+    "connectionVerifeid": "з'єднання встановлено",
+    "left": "Ліворуч",
+    "center": "Центр",
+    "right": "Праворуч",
+    "justified": "Вирівняно",
+    "host": "Хост",
+    "operation": "Операція",
+    "header": "ЗАГОЛОВОК",
+    "path": "ШЛЯХ",
+    "query": "ЗАПИТ",
+    "requestBody": "ТІЛО ЗАПИТУ"
   },
-  "errorBoundary":"Щось пішло не так.",
-  "viewer":"Вибачте! Цей додаток наразі на тех.обслуговуванні",
-  "app":{
-    "updateAvailable":"Доступне оновлення",
-    "newVersionReleased":"Нова версія Tooljet була випущена",
-    "readReleaseNotes":"Прочитать, що нового було додано",
-    "skipVersion":"Пропустити цю версію"
+  "errorBoundary": "Щось пішло не так.",
+  "viewer": "Вибачте! Цей додаток наразі на тех.обслуговуванні",
+  "app": {
+    "updateAvailable": "Доступне оновлення",
+    "newVersionReleased": "Нова версія Tooljet була випущена",
+    "readReleaseNotes": "Прочитать, що нового було додано",
+    "skipVersion": "Пропустити цю версію"
   },
-  "stripe":"Будь ласка, почекайте пока ми завантажимо OpenAPI для Stripe.",
-  "openApi":{
-    "noValidOpenApi":"Відповідна специфікація OpenAPI зараз недоступна!.",
-    "selectHost":"Оберіть хоста",
-    "selectOperation":"Оберіть операцію"
+  "stripe": "Будь ласка, почекайте пока ми завантажимо OpenAPI для Stripe.",
+  "openApi": {
+    "noValidOpenApi": "Відповідна специфікація OpenAPI зараз недоступна!.",
+    "selectHost": "Оберіть хоста",
+    "selectOperation": "Оберіть операцію"
   },
-  "slack":{
-    "authorize":"Авторизуватися",
-    "connectToolJetToSlack":"ToolJet може підключитися до Slack і отримати список користувачів, надсилати повідомлення та ін. Будь ласка, налаштуйте відповідні права доступу",
-    "chatWrite":"chat:написати",
-    "listUsersAndSendMessage":"Ваша програма ToolJet зможе отримати список користувачів, а також надсилати повідомлення користувачам і в чати.",
-    "connectSlack":"Підключитися до Slack"
+  "slack": {
+    "authorize": "Авторизуватися",
+    "connectToolJetToSlack": "ToolJet може підключитися до Slack і отримати список користувачів, надсилати повідомлення та ін. Будь ласка, налаштуйте відповідні права доступу",
+    "chatWrite": "chat:написати",
+    "listUsersAndSendMessage": "Ваша програма ToolJet зможе отримати список користувачів, а також надсилати повідомлення користувачам і в чати.",
+    "connectSlack": "Підключитися до Slack"
   },
-  "googleSheets":{
-    "readOnly":"Тільки читання",
-    "enableReadAndWrite":"Якщо ви хочете, щоб програми ToolJet могли змінювати ваші Google-таблиці, переконайтеся, що були надані права на читання та запис",
-    "readDataFromSheets":"Ваші ToolJet програми можуть тільки читати дані з Google-таблиць",
-    "readWrite":"Читання та запис",
-    "readModifySheets":"Ваші ToolJet програми можуть тільки читати дані з Google-таблиць, змінювати їх, та ін",
-    "toGoogleSheets":"до Google-таблиць"
+  "googleSheets": {
+    "readOnly": "Тільки читання",
+    "enableReadAndWrite": "Якщо ви хочете, щоб програми ToolJet могли змінювати ваші Google-таблиці, переконайтеся, що були надані права на читання та запис",
+    "readDataFromSheets": "Ваші ToolJet програми можуть тільки читати дані з Google-таблиць",
+    "readWrite": "Читання та запис",
+    "readModifySheets": "Ваші ToolJet програми можуть тільки читати дані з Google-таблиць, змінювати їх, та ін",
+    "toGoogleSheets": "до Google-таблиць"
   },
   "profile": {
     "profileSettings": "Налаштувння профілю"
   },
-  "loginSignupPage":{
-    "forgotPassword":"Забули пароль",
-    "emailAddress":"Поштова адреса",
-    "enterEmail":"Введіть адресу електронної пошти",
-    "resetPassword":"Скинути пароль",
-    "dontHaveAccount":"У вас ще немає облікового запису??",
-    "signIn":"Увійти",
-    "signUp":"Зареєструватися",
-    "createToolJetAccount":"Створити обліковий запис ToolJet",
-    "enterBusinessEmail":"Введіть свою бізнес пошту",
-    "alreadyHaveAnAccount":"У вас вже є обліковий запис?",
-    "password":"Пароль",
-    "showPassword":"Показати пароль",
-    "loginTo":"Залогінитися в",
-    "yourAccount":"ваш аккаунт",
-    "noLoginMethodsEnabled":"Не знайдено методів логіну для цього робочого простору",
-    "emailConfirmLink":"Будь ласка, пошукайте листа з підтвердженням на вашій електронній пошті",
-    "newPassword":"Новий Пароль",
-    "passwordConfirmation":"Підтвердження Пароля"
+  "loginSignupPage": {
+    "forgotPassword": "Забули пароль",
+    "emailAddress": "Поштова адреса",
+    "enterEmail": "Введіть адресу електронної пошти",
+    "resetPassword": "Скинути пароль",
+    "dontHaveAccount": "У вас ще немає облікового запису??",
+    "signIn": "Увійти",
+    "signUp": "Зареєструватися",
+    "createToolJetAccount": "Створити обліковий запис ToolJet",
+    "enterBusinessEmail": "Введіть свою бізнес пошту",
+    "alreadyHaveAnAccount": "У вас вже є обліковий запис?",
+    "password": "Пароль",
+    "showPassword": "Показати пароль",
+    "loginTo": "Залогінитися в",
+    "yourAccount": "ваш аккаунт",
+    "noLoginMethodsEnabled": "Не знайдено методів логіну для цього робочого простору",
+    "emailConfirmLink": "Будь ласка, пошукайте листа з підтвердженням на вашій електронній пошті",
+    "newPassword": "Новий Пароль",
+    "passwordConfirmation": "Підтвердження Пароля"
   },
   "editor": {
     "preview": "Предперегляд",
-    "share":"Поділитися",
+    "share": "Поділитися",
     "shareModal": {
-      "makeApplicationPublic":"Зробити програму загальнодоступною?",
-      "shareableLink":"Отримати посилання, яким можна поділитися цією програмою",
-      "copy":"копіювати",
-      "embeddableLink":"Отримати вбудоване посилання для цієї програми",
-      "manageUsers":"Керувати користувачами"
+      "makeApplicationPublic": "Зробити програму загальнодоступною?",
+      "shareableLink": "Отримати посилання, яким можна поділитися цією програмою",
+      "copy": "копіювати",
+      "embeddableLink": "Отримати вбудоване посилання для цієї програми",
+      "manageUsers": "Керувати користувачами"
     },
-    "appVersionManager":{
-      "version":"Версія",
-      "currentlyReleased":"Поточна випущена",
-      "createVersion":"Створити Версію",
-      "versionName":"Ім'я версії",
-      "createVersionFrom":"Створити версію з",
-      "save":"Зберегти",
-      "create":"Створити версію",
+    "appVersionManager": {
+      "version": "Версія",
+      "currentlyReleased": "Поточна випущена",
+      "createVersion": "Створити Версію",
+      "versionName": "Ім'я версії",
+      "createVersionFrom": "Створити версію з",
+      "save": "Зберегти",
+      "create": "Створити версію",
       "editVersion": "Редагувати версію",
-      "deleteVersion":"Ви дійсно хочете видалити цю версію?",
-      "enterVersionName":"Введіть ім'я версії",
-      "versionAlreadyReleased":"Версія вже випущена. Будь ласка, створіть нову версію або перейдіть на іншу, щоб продовжити роботу."
+      "deleteVersion": "Ви дійсно хочете видалити цю версію?",
+      "enterVersionName": "Введіть ім'я версії",
+      "versionAlreadyReleased": "Версія вже випущена. Будь ласка, створіть нову версію або перейдіть на іншу, щоб продовжити роботу."
     },
     "queries": "Запити",
-    "inspectComponent":"Будь ласка, оберіть компонент для інспекції",
+    "inspectComponent": "Будь ласка, оберіть компонент для інспекції",
     "release": "Реліз",
-    "searchQueries":"Пошукові запити",
-    "createQuery":"Створити запит",
-    "queryManager":{
-      "general":"Загальні",
-      "advanced":"Додаткові",
-      "preview":"Перегляд",
-      "Save":"Зберегти",
-      "selectDatasource":"Вибрати джерело даних",
-      "addDatasource":"Додати джерело даних",
-      "dataSourceManager":{
-        "toast":{
+    "searchQueries": "Пошукові запити",
+    "createQuery": "Створити запит",
+    "queryManager": {
+      "general": "Загальні",
+      "advanced": "Додаткові",
+      "preview": "Перегляд",
+      "Save": "Зберегти",
+      "selectDatasource": "Вибрати джерело даних",
+      "addDatasource": "Додати джерело даних",
+      "dataSourceManager": {
+        "toast": {
           "success": {
             "dataSourceAdded": "Джерело даних додано",
             "dataSourceSaved": "Джерело даних збережено"
           },
-          "error" :{
-            "noEmptyDsName" :"Ім'я джерела не може бути порожнім"
+          "error": {
+            "noEmptyDsName": "Ім'я джерела не може бути порожнім"
           }
         },
-        "suggestDataSource":"Запропонувати джерело даних",
-        "suggestAntegration":"Запропонувати інтеграцію",
-        "whatLookingFor":"Розкажіть нам, що ви шукаєте?",
-        "noResultFound":"Не знайшли те, що шукали?",
-        "suggest":"Запропонувати",
-        "addNewDataSource":"Додати нове джерело даних",
-        "whiteListIP":"Будь ласка, додайте нашу IP адресу в білий список, якщо джерело даних не у відкритому доступі.",
-        "copied":"Скопійовано",
-        "copy":"Копіювати",
+        "suggestDataSource": "Запропонувати джерело даних",
+        "suggestAntegration": "Запропонувати інтеграцію",
+        "whatLookingFor": "Розкажіть нам, що ви шукаєте?",
+        "noResultFound": "Не знайшли те, що шукали?",
+        "suggest": "Запропонувати",
+        "addNewDataSource": "Додати нове джерело даних",
+        "whiteListIP": "Будь ласка, додайте нашу IP адресу в білий список, якщо джерело даних не у відкритому доступі.",
+        "copied": "Скопійовано",
+        "copy": "Копіювати",
         "saving": "Збереження",
-        "noResultsFor":"Немає результату",
-        "noteTaken":"Дякую, ми повідомлені про це!",
-        "goToAllDatasources":"До всіх джерел даних",
-        "send":"Відправлено"
+        "noResultsFor": "Немає результату",
+        "noteTaken": "Дякую, ми повідомлені про це!",
+        "goToAllDatasources": "До всіх джерел даних",
+        "send": "Відправлено"
       },
-      "runQueryOnPageLoad":"Запускати цей запит під час завантаження сторінки?",
-      "confirmBeforeQueryRun":"Вимагати підтвердження перед запуском запиту?",
-      "notificationOnSuccess":"Показувати повідомлення при успіху?",
-      "successMessage":"Успіх",
-      "queryRanSuccessfully":"Запит був успішно запущений",
-      "notificationDuration":"Довжина повідомлення (сек)",
-      "events":"Події",
-      "transformation":{
-        "transformationToolTip":"Трансформації можуть бути використані для перетворення результатів запитів. Всі змінні доступні для перетворювачів і підтримують JS-бібліотеки, такі як Lodash та Moment",
-        "transformations":"Трансформації"
+      "runQueryOnPageLoad": "Запускати цей запит під час завантаження сторінки?",
+      "confirmBeforeQueryRun": "Вимагати підтвердження перед запуском запиту?",
+      "notificationOnSuccess": "Показувати повідомлення при успіху?",
+      "successMessage": "Успіх",
+      "queryRanSuccessfully": "Запит був успішно запущений",
+      "notificationDuration": "Довжина повідомлення (сек)",
+      "events": "Події",
+      "transformation": {
+        "transformationToolTip": "Трансформації можуть бути використані для перетворення результатів запитів. Всі змінні доступні для перетворювачів і підтримують JS-бібліотеки, такі як Lodash та Moment",
+        "transformations": "Трансформації"
       }
     },
-    "inspector":{
-      "eventManager":{
+    "inspector": {
+      "eventManager": {
         "event": "Подія",
         "action": "Дія",
         "actionOptions": "Опції дії",
@@ -186,277 +186,285 @@
       }
     }
   },
-  "header":{
-    "darkModeToggle":{
-      "activateLightMode" :"Увімкнути світлий режим",
-      "activateDarkMode":"Увімкнути темний режим"
+  "header": {
+    "darkModeToggle": {
+      "activateLightMode": "Увімкнути світлий режим",
+      "activateDarkMode": "Увімкнути темний режим"
     },
-    "languageSelection":{
-      "changeLanguage":"Змінити мову",
-      "searchLanguage":"Вибрати мову"
+    "languageSelection": {
+      "changeLanguage": "Змінити мову",
+      "searchLanguage": "Вибрати мову"
     },
-    "notificationCenter":{
-      "notifications":"Повідомлення",
-      "markAllAs":"Відзначити все як",
-      "read":"прочитано",
-      "un":"не",
-      "youDontHaveany":"У вас немає жодного",
-      "youAreCaughtUp":"Ви переглянули всі повідомлення!",
-      "view":"Перегляд"
+    "notificationCenter": {
+      "notifications": "Повідомлення",
+      "markAllAs": "Відзначити все як",
+      "read": "прочитано",
+      "un": "не",
+      "youDontHaveany": "У вас немає жодного",
+      "youAreCaughtUp": "Ви переглянули всі повідомлення!",
+      "view": "Перегляд"
     },
-    "organization":{
-      "loadOrganizations":"Завантажити організації",
-      "createWorkspace":"Створити робочий простір",
-      "workspaceName":"ім'я простору",
-      "editWorkspace":"редагувати простір",
+    "organization": {
+      "loadOrganizations": "Завантажити організації",
+      "createWorkspace": "Створити робочий простір",
+      "workspaceName": "ім'я простору",
+      "editWorkspace": "редагувати простір",
       "menus": {
-        "addWorkspace":"Додати робочий простір",
-        "menusList":{
-          "manageUsers":"Керувати користувачами",
-          "manageGroups":"Керувати групами",
-          "manageSso":"Керувати SSO",
-          "manageEnv":"Керувати змінними середовища"
+        "addWorkspace": "Додати робочий простір",
+        "menusList": {
+          "manageUsers": "Керувати користувачами",
+          "manageGroups": "Керувати групами",
+          "manageSso": "Керувати SSO",
+          "manageEnv": "Керувати змінними середовища"
         },
-        "manageUsers":{
-          "usersAndPermission":"Користувачі та дозволи",
-          "inviteNewUser":"Запросити нового користувача",
-          "name":"ІМ'Я",
-          "email":"ПОШТА",
+        "manageUsers": {
+          "usersAndPermission": "Користувачі та дозволи",
+          "inviteNewUser": "Запросити нового користувача",
+          "name": "ІМ'Я",
+          "email": "ПОШТА",
           "status": "СТАТУС",
-          "archive":"Архівувати",
-          "unarchive":"Розархівувати",
-          "addNewUser":"Додати нового користувача",
-          "emailAddress":"Адреса електронної пошти",
-          "createUser":"Створити користувача",
-          "enterFirstName":"Введіть Ім'я",
-          "enterLastName":"Введіть Прізвище",
-          "enterEmail":"Введіть Пошту"
+          "archive": "Архівувати",
+          "unarchive": "Розархівувати",
+          "addNewUser": "Додати нового користувача",
+          "emailAddress": "Адреса електронної пошти",
+          "createUser": "Створити користувача",
+          "enterFirstName": "Введіть Ім'я",
+          "enterLastName": "Введіть Прізвище",
+          "enterEmail": "Введіть Пошту"
         },
-        "manageGroups":{
-          "permissions":{
-            "userGroups":"Групи користувачів",
-            "createNewGroup":"Створити нову групу",
-            "updateGroup":"Оновити групу",
-            "addNewGroup":"Додати нову групу",
-            "enterName":"Введіть ім'я",
-            "createGroup":"Створити групу",
-            "name":"Ім'я"
+        "manageGroups": {
+          "permissions": {
+            "userGroups": "Групи користувачів",
+            "createNewGroup": "Створити нову групу",
+            "updateGroup": "Оновити групу",
+            "addNewGroup": "Додати нову групу",
+            "enterName": "Введіть ім'я",
+            "createGroup": "Створити групу",
+            "name": "Ім'я"
           },
-          "permissionResources":{
-            "userGroup":"Група користувачів",
-            "apps":"Додатки",
-            "users":"Користувач",
-            "permissions":"Дозвол",
-            "addAppsToGroup":"Виберіть програми для додавання до групи",
-            "name":"ім'я",
-            "addUsersToGroup":"Виберіть користувачів для додавання до групи",
-            "email":"електронна пошта",
-            "resource":"ресурс",
-            "createUpdateDelete":"Створити/Оновити/Видалити",
-            "folder":"Папка"
+          "permissionResources": {
+            "userGroup": "Група користувачів",
+            "apps": "Додатки",
+            "users": "Користувач",
+            "permissions": "Дозвол",
+            "addAppsToGroup": "Виберіть програми для додавання до групи",
+            "name": "ім'я",
+            "addUsersToGroup": "Виберіть користувачів для додавання до групи",
+            "email": "електронна пошта",
+            "resource": "ресурс",
+            "createUpdateDelete": "Створити/Оновити/Видалити",
+            "folder": "Папка"
           }
         },
-        "manageSSO":{
-          "manageSso":"Керувати SSO",
-          "generalSettings":{
-            "title":"Основні налаштування",
-            "enableSignup":"Увімкнути вхід",
-            "newAccountWillBeCreated":"Новий обліковий запис буде створено для першого логіна користувача через SSO",
-            "allowedDomains":"Дозволені домени",
-            "enterDomains":"Домени входу",
-            "supportMultiDomains":"Підтримка безлічі доменів. Введіть доменні імена, розділені комою. Наприклад: tooljet.com,tooljet.io,yourorganization.com",
-            "loginUrl":"Посилання на логін",
-            "workspaceLogin":"Використовуйте це, щоб безпосередньо залогінитися в робочу область",
-            "allowDefaultSso":"Дозволити стандартний SSO",
-            "ssoAuth":"Дозволити користувачам вхід через стандартний SSO. Стандартну конфігурацію SSO буде перезаписано."
+        "manageSSO": {
+          "manageSso": "Керувати SSO",
+          "generalSettings": {
+            "title": "Основні налаштування",
+            "enableSignup": "Увімкнути вхід",
+            "newAccountWillBeCreated": "Новий обліковий запис буде створено для першого логіна користувача через SSO",
+            "allowedDomains": "Дозволені домени",
+            "enterDomains": "Домени входу",
+            "supportMultiDomains": "Підтримка безлічі доменів. Введіть доменні імена, розділені комою. Наприклад: tooljet.com,tooljet.io,yourorganization.com",
+            "loginUrl": "Посилання на логін",
+            "workspaceLogin": "Використовуйте це, щоб безпосередньо залогінитися в робочу область",
+            "allowDefaultSso": "Дозволити стандартний SSO",
+            "ssoAuth": "Дозволити користувачам вхід через стандартний SSO. Стандартну конфігурацію SSO буде перезаписано."
           },
-          "google":{
-            "title":"Google",
-            "enabled":"Увімкнено",
-            "disabled":"Вимкнено",
-            "clientId":"Id клієнта",
-            "enterClientId":"Ввести Id клієнта",
-            "redirectUrl":"Редирект посилання"
+          "google": {
+            "title": "Google",
+            "enabled": "Увімкнено",
+            "disabled": "Вимкнено",
+            "clientId": "Id клієнта",
+            "enterClientId": "Ввести Id клієнта",
+            "redirectUrl": "Редирект посилання"
           },
-          "github":{
-            "title":"Github",
-            "hostName":"Ім'я хоста",
-            "enterHostName":"Введіть ім'я хоста",
-            "requiredGithub":"Обов'язковий, якщо GitHub хоститься самостійно",
-            "clientId":"Id клієнта",
-            "enterClientId":"Ввести Id клієнта",
-            "clientSecret":"Secret клієнта",
-            "enterClientSecret":"Введіть Secret клієнта",
-            "encrypted":"Зашифровано",
-            "redirectUrl":"Редирект посилання"
+          "github": {
+            "title": "Github",
+            "hostName": "Ім'я хоста",
+            "enterHostName": "Введіть ім'я хоста",
+            "requiredGithub": "Обов'язковий, якщо GitHub хоститься самостійно",
+            "clientId": "Id клієнта",
+            "enterClientId": "Ввести Id клієнта",
+            "clientSecret": "Secret клієнта",
+            "enterClientSecret": "Введіть Secret клієнта",
+            "encrypted": "Зашифровано",
+            "redirectUrl": "Редирект посилання"
           },
-          "passwordLogin":"Пароль логин",
-          "environmentVar" : {
-            "noEnvConfig":"Ви не налаштували жодного змінного середовища, натисніть кнопку 'Додати нову змінну' щоб створити",
-            "envWillBeDeleted":"Змінна буде видалена, ви хочете продовжити?",
-            "addNewVariable":"Додати нову змінну",
-            "variableForm":{
-              "addNewVariable":"Додати нову змінну",
-              "updatevariable":"Оновити змінну",
-              "name":"Ім'я",
-              "value":"Значення",
-              "enterVariableName":"Введіть значення змінної",
-              "enterValue":"Введіть значення",
-              "type":"Тип",
-              "enableEncryption":"Увімкнути шифрування",
-              "addVariable":"Додати змінну"
+          "passwordLogin": "Пароль логин",
+          "environmentVar": {
+            "noEnvConfig": "Ви не налаштували жодного змінного середовища, натисніть кнопку 'Додати нову змінну' щоб створити",
+            "envWillBeDeleted": "Змінна буде видалена, ви хочете продовжити?",
+            "addNewVariable": "Додати нову змінну",
+            "variableForm": {
+              "addNewVariable": "Додати нову змінну",
+              "updatevariable": "Оновити змінну",
+              "name": "Ім'я",
+              "value": "Значення",
+              "enterVariableName": "Введіть значення змінної",
+              "enterValue": "Введіть значення",
+              "type": "Тип",
+              "enableEncryption": "Увімкнути шифрування",
+              "addVariable": "Додати змінну"
             },
-            "variableTable":{
-              "name":"Ім'я",
-              "value":"значення",
-              "type":"тип",
-              "secret":"secret"
+            "variableTable": {
+              "name": "Ім'я",
+              "value": "значення",
+              "type": "тип",
+              "secret": "secret"
             }
           }
         }
       }
     },
-    "profileSettingPage":{
-      "profileSettings":"Налаштування профілю",
-      "firstName":"Ім'я",
-      "lastName":"Прізвище",
-      "enterFirstName":"Ввести ім'я",
-      "enterLastName":"Ввести прізвище",
-      "email":"Електронна пошта",
-      "avatar":"Аватар",
-      "update":"Оновити",
-      "profile":"Профіль",
-      "changePassword":"Змінити пароль",
-      "currentPassword":"Поточний пароль",
-      "newPassword":"Новий пароль",
-      "confirmNewPassword":"Підтвердити новий пароль",
-      "enterCurrentPassword":"Ввести поточний пароль",
-      "enterNewPassword":"Ввести новий пароль"
+    "profileSettingPage": {
+      "profileSettings": "Налаштування профілю",
+      "firstName": "Ім'я",
+      "lastName": "Прізвище",
+      "enterFirstName": "Ввести ім'я",
+      "enterLastName": "Ввести прізвище",
+      "email": "Електронна пошта",
+      "avatar": "Аватар",
+      "update": "Оновити",
+      "profile": "Профіль",
+      "changePassword": "Змінити пароль",
+      "currentPassword": "Поточний пароль",
+      "newPassword": "Новий пароль",
+      "confirmNewPassword": "Підтвердити новий пароль",
+      "enterCurrentPassword": "Ввести поточний пароль",
+      "enterNewPassword": "Ввести новий пароль"
     },
-    "profile":"Профіль",
-    "logout":"Розлогитися"
+    "profile": "Профіль",
+    "logout": "Розлогитися"
   },
-  "homePage":{
-    "appCard":{
-      "changeIcon":"Змінити іконку",
-      "addToFolder":"Додати до папки",
-      "move":"Перемістити",
-      "to":"в",
-      "selectFolder":"Вибрати папку",
-      "deleteApp":"Видалити програму",
-      "exportApp":"Експортувати програму",
-      "cloneApp":"Клонувати програму",
+  "homePage": {
+    "appCard": {
+      "changeIcon": "Змінити іконку",
+      "addToFolder": "Додати до папки",
+      "move": "Перемістити",
+      "to": "в",
+      "selectFolder": "Вибрати папку",
+      "deleteApp": "Видалити програму",
+      "exportApp": "Експортувати програму",
+      "cloneApp": "Клонувати програму",
       "launch": "Запустити",
-      "maintenance":"Тех.обслуговування",
-      "noDeployedVersion":"Додаток не має задеплоєної версії",
-      "openInAppViewer":"Відкрити переглядач додатків",
-      "removeFromFolder":"Видалити з папки"
+      "maintenance": "Тех.обслуговування",
+      "noDeployedVersion": "Додаток не має задеплоєної версії",
+      "openInAppViewer": "Відкрити переглядач додатків",
+      "removeFromFolder": "Видалити з папки"
     },
-    "blankPage":{
-      "welcomeToToolJet":"Ласкаво просимо до ToolJet!",
-      "getStartedCreateNewApp":"Ви можете почати створення нової програми або створення нової програми, використовуючи шаблон з бібліотеки ToolJet",
-      "importApplication":"Імпортувати програму"
+    "blankPage": {
+      "welcomeToToolJet": "Ласкаво просимо до ToolJet!",
+      "getStartedCreateNewApp": "Ви можете почати створення нової програми або створення нової програми, використовуючи шаблон з бібліотеки ToolJet",
+      "importApplication": "Імпортувати програму"
     },
-    "foldersSection":{
-      "allApplications":"Всі програми",
-      "folders":"Папки",
-      "createNewFolder":"+ Створити нову папку",
-      "noFolders":"Ви не створили жодної папки.",
-      "createFolder":"Створити папку",
-      "updateFolder":"Оновити папку",
-      "editFolder":"Редагувати папку",
-      "deleteFolder":"Видалити папку",
-      "folderName":"Ім'я папки",
-      "wishToDeleteFolder":"Ви впевнені, що хочете видалити папку {{folderName}}? Програми не будуть видалені."
+    "foldersSection": {
+      "allApplications": "Всі програми",
+      "folders": "Папки",
+      "createNewFolder": "+ Створити нову папку",
+      "noFolders": "Ви не створили жодної папки.",
+      "createFolder": "Створити папку",
+      "updateFolder": "Оновити папку",
+      "editFolder": "Редагувати папку",
+      "deleteFolder": "Видалити папку",
+      "folderName": "Ім'я папки",
+      "wishToDeleteFolder": "Ви впевнені, що хочете видалити папку {{folderName}}? Програми не будуть видалені."
     },
-    "header":{
-      "createNewApplication":"Створити новий додаток",
-      "import":"Імпорт",
-      "chooseFromTemplate":"Вибрати із шаблону"
+    "header": {
+      "createNewApplication": "Створити новий додаток",
+      "import": "Імпорт",
+      "chooseFromTemplate": "Вибрати із шаблону"
     },
-    "pagination":{
-      "showing":"Показується",
-      "of":"від",
-      "to":"до"
+    "pagination": {
+      "showing": "Показується",
+      "of": "від",
+      "to": "до"
     },
-    "noApplicationFound":"Програми не знайдені",
-    "thisFolderIsEmpty":"Ця папка порожня",
-    "deleteAppAndData":"Додаток та пов'язані з ним дані будуть видалені, ви хочете продовжити?",
-    "removeAppFromFolder":"Додаток буде видалений з папки, ви хочете продовжити?",
-    "change":"Змінити",
-    "templateCard":{
-      "use":"Використати",
-      "preview":"Перегляд",
-      "leadGeneretion":"Лідогенерація"
+    "noApplicationFound": "Програми не знайдені",
+    "thisFolderIsEmpty": "Ця папка порожня",
+    "deleteAppAndData": "Додаток та пов'язані з ним дані будуть видалені, ви хочете продовжити?",
+    "removeAppFromFolder": "Додаток буде видалений з папки, ви хочете продовжити?",
+    "change": "Змінити",
+    "templateCard": {
+      "use": "Використати",
+      "preview": "Перегляд",
+      "leadGeneretion": "Лідогенерація"
     },
-    "templateLibraryModal":{
-      "select":"Вибрати шаблон",
-      "createAppfromTemplate":"Створити програму з шаблону"
+    "templateLibraryModal": {
+      "select": "Вибрати шаблон",
+      "createAppfromTemplate": "Створити програму з шаблону"
     }
   },
-  "confirmationPage":{
-    "setupAccount":"Налаштуйте свій обліковий запис",
-    "signupWithGoogle":"Залогуватися через Google",
-    "signupWithGitHub":"Залогуватися через GitHub",
-    "or":"АБО",
-    "firstName":"Ім'я",
-    "lastName":"Прізвище",
-    "company":"Компанія",
+  "confirmationPage": {
+    "setupAccount": "Налаштуйте свій обліковий запис",
+    "signupWithGoogle": "Залогуватися через Google",
+    "signupWithGitHub": "Залогуватися через GitHub",
+    "or": "АБО",
+    "firstName": "Ім'я",
+    "lastName": "Прізвище",
+    "company": "Компанія",
     "Role": "Роль",
-    "pleaseSelect":"Будь ласка, виберіть",
-    "password":"Пароль",
-    "confirmPassword":"Підтвердіть пароль",
-    "clickAndAgree":"Натиснувши на кнопку нижче, ви погоджуєтесь з нашими",
-    "termsAndConditions":"Умовами та положеннями",
-    "finishAccountSetup":"Закінчити налаштування облікового запису",
-    "acceptInvite":"прийняти інвайт",
-    "accountExists":"У вас вже є обліковий запис?",
-    "and":"і"
+    "pleaseSelect": "Будь ласка, виберіть",
+    "password": "Пароль",
+    "confirmPassword": "Підтвердіть пароль",
+    "clickAndAgree": "Натиснувши на кнопку нижче, ви погоджуєтесь з нашими",
+    "termsAndConditions": "Умовами та положеннями",
+    "finishAccountSetup": "Закінчити налаштування облікового запису",
+    "acceptInvite": "прийняти інвайт",
+    "accountExists": "У вас вже є обліковий запис?",
+    "and": "і"
   },
-  "onBoarding":{
-    "finishToolJetInstallation":"Закінчити встановлення ToolJet",
+  "onBoarding": {
+    "finishToolJetInstallation": "Закінчити встановлення ToolJet",
     "organization": "Організація",
-    "name":"Ім'я",
-    "email":"Електронна пошта",
-    "receiveUpdatesFromToolJet":"Ви отримуватимете оновлення від команди ToolJet ( 1-2 листи щомісяця, ми не спамимо )",
-    "finishSetup":"Закінчити налаштування",
-    "skip":"Пропустити"
+    "name": "Ім'я",
+    "email": "Електронна пошта",
+    "receiveUpdatesFromToolJet": "Ви отримуватимете оновлення від команди ToolJet ( 1-2 листи щомісяця, ми не спамимо )",
+    "finishSetup": "Закінчити налаштування",
+    "skip": "Пропустити"
   },
-  "redirectSso":{
-    "upgradingTov1.13.0":"Оновлення до версії v1.13.0 та вище.",
-    "fromV1.13.0":"З v1.13.0 ми представили",
-    "multiWorkspace":"Мульти-робочий простір",
-    "singleSignOnConfig":"Конфігурації, пов'язані з SSO були перенесені змінних середовища в базу даних. Будь ласка, врахуйте це",
-    "link":"Посилання",
-    "toConfigureSSO":"щоб налаштувати SSO.",
-    "haveGoogleGithubSSo":"Якщо у вас є конфігурації SSO від Google або GitHub до оновлення та мульти-робочі простори були відключені значить SSO конфігурації будуть мігровані під час оновлення, але, вам потрібно переналаштувати посилання перенаправлення на стороні SSO провайдера. Посилання перенаправлення дано нижче.",
-    "isMultiWorkspaceEnabled":"Якщо ви увімкнули Мульти-робочі простори, тоді конфігурації SSO не будуть мігровані під час оновлення і вам потрібно переналаштувати SSO у відповідному провайдері.",
-    "youHaveEnabled":"Ви увімкнули",
-    "setupSsoWorkspace":"Будь ласка, залогіньтесь з вашим паролем і ви зможете налаштувати SSO у просторі",
-    "manageSsoMenu":"Керування меню SSO.",
-    "youHaveDisabled":"Ви відключили",
-    "configureRedirectUrl":"Будь ласка, налаштуйте посилання перенаправлення на стороні SSO-провайдера.",
-    "google":"Google",
-    "redirectUrl":"Посилання перенаправлення:",
-    "gitHub":"GitHub"
+  "redirectSso": {
+    "upgradingTov1": {
+      "13": {
+        "0": "Оновлення до версії v1.13.0 та вище."
+      }
+    },
+    "fromV1": {
+      "13": {
+        "0": "З v1.13.0 ми представили"
+      }
+    },
+    "multiWorkspace": "Мульти-робочий простір",
+    "singleSignOnConfig": "Конфігурації, пов'язані з SSO були перенесені змінних середовища в базу даних. Будь ласка, врахуйте це",
+    "link": "Посилання",
+    "toConfigureSSO": "щоб налаштувати SSO.",
+    "haveGoogleGithubSSo": "Якщо у вас є конфігурації SSO від Google або GitHub до оновлення та мульти-робочі простори були відключені значить SSO конфігурації будуть мігровані під час оновлення, але, вам потрібно переналаштувати посилання перенаправлення на стороні SSO провайдера. Посилання перенаправлення дано нижче.",
+    "isMultiWorkspaceEnabled": "Якщо ви увімкнули Мульти-робочі простори, тоді конфігурації SSO не будуть мігровані під час оновлення і вам потрібно переналаштувати SSO у відповідному провайдері.",
+    "youHaveEnabled": "Ви увімкнули",
+    "setupSsoWorkspace": "Будь ласка, залогіньтесь з вашим паролем і ви зможете налаштувати SSO у просторі",
+    "manageSsoMenu": "Керування меню SSO.",
+    "youHaveDisabled": "Ви відключили",
+    "configureRedirectUrl": "Будь ласка, налаштуйте посилання перенаправлення на стороні SSO-провайдера.",
+    "google": "Google",
+    "redirectUrl": "Посилання перенаправлення:",
+    "gitHub": "GitHub"
   },
   "oAuth2": {
-    "pleaseWait":"Будь ласка зачекайте...",
-    "authSuccess":"Успішна автентифікація, ви можете закрити цю вкладку.",
-    "authFailed":"Аутентифікація провалена"
+    "pleaseWait": "Будь ласка зачекайте...",
+    "authSuccess": "Успішна автентифікація, ви можете закрити цю вкладку.",
+    "authFailed": "Аутентифікація провалена"
   },
   "widgetManager": {
     "commonlyUsed": "зазвичай використовується",
-    "layouts" : "шари",
-    "форми" : "форми",
-    "intregrations" : "інтеграції",
-    "others":"інші",
+    "layouts": "шари",
+    "форми": "форми",
+    "intregrations": "інтеграції",
+    "others": "інші",
     "noResults": "Не знайдено результатів",
     "tryAdjustingFilterMessage": "Спробуйте змінити пошуковий запит або фільтр, щоб знайти те, що ви шукаєте.",
     "clearQuery": "очистити запит"
   },
-  "widget":{
-    "common":{
+  "widget": {
+    "common": {
       "properties": "Властивості",
       "events": "Події",
       "layout": "Шар",
@@ -698,23 +706,23 @@
       "displayName": "Діаграма",
       "description": "Відображає діаграми"
     },
-    "Modal" : {
+    "Modal": {
       "displayName": "Модальне вікно",
       "description": "Модальне вікно, яке викликається подіями"
     },
-    "TextInput" : {
+    "TextInput": {
       "displayName": "Введення тексту",
       "description": "Введення тексту у формах"
     },
-    "NumberInput" :{
+    "NumberInput": {
       "displayName": "Введення цифр",
       "description": "Цифрове поле для форм"
     },
-    "PasswordInput":{
+    "PasswordInput": {
       "displayName": "Введення пароля",
       "description": "Введення пароля для форм"
     },
-    "Datepicker" :{
+    "Datepicker": {
       "displayName": "Вибір дати",
       "description": "Вибір дати та часу"
     },
@@ -722,7 +730,7 @@
       "displayName": "Чекбокс",
       "description": "Звичайний чекбокс"
     },
-    "Radio-button":{
+    "Radio-button": {
       "displayName": "Радіо батони",
       "description": "Радіо батони"
     },
@@ -730,31 +738,31 @@
       "displayName": "Перемикач",
       "description": "Перемикач"
     },
-    "Textarea":{
+    "Textarea": {
       "displayName": "Текстове поле",
       "description": "Текстове поле у формі"
     },
-    "DateRangePicker":{
+    "DateRangePicker": {
       "displayName": "Вибір діапазону",
       "description": "Виберіть діапазон дат"
     },
-    "Text":{
+    "Text": {
       "displayName": "Текст",
       "description": "Відображати HTML або розмітку"
     },
-    "Image":{
+    "Image": {
       "displayName": "Зображення",
       "description": "Відображає зображення"
     },
-    "Container":{
+    "Container": {
       "displayName": "Контейнер",
       "description": "Обгортка для безлічі компонентів"
     },
-    "Dropdown":{
+    "Dropdown": {
       "displayName": "Випадаючий список",
       "description": "Вибрати одне значення зі списку опцій"
     },
-    "Multiselect":{
+    "Multiselect": {
       "displayName": "Мультивибір",
       "description": "Вибирає декілька значень зі списку опцій"
     },
@@ -766,11 +774,11 @@
       "displayName": "Карта",
       "description": "Відображає Google карти"
     },
-    "QrScanner":{
+    "QrScanner": {
       "displayName": "QR сканер",
       "description": "Сканує QR коди та зберігає дані"
     },
-    "StarRating":{
+    "StarRating": {
       "displayName": "Рейтинг",
       "description": "Рейтинг через зірочки"
     },
@@ -778,7 +786,7 @@
       "displayName": "Розділювач",
       "description": "Розділювач між компонентами"
     },
-    "FilePicker":{
+    "FilePicker": {
       "displayName": "Засіб вибору файлів",
       "description": "Засіб вибору файлів"
     },
@@ -786,7 +794,7 @@
       "displayName": "Календар",
       "description": "Календар"
     },
-    "Iframe":{
+    "Iframe": {
       "displayName": "Iframe",
       "description": "відображати як Iframe"
     },
@@ -794,11 +802,11 @@
       "displayName": "Редактор коду",
       "description": "Редактор коду"
     },
-    "Tabs":{
+    "Tabs": {
       "displayName": "Вкладки",
       "description": "Компонент вкладок"
     },
-    "Timer":{
+    "Timer": {
       "displayName": "Таймер",
       "description": "таймер"
     },
@@ -810,11 +818,11 @@
       "displayName": "Теги",
       "description": "Контент може бути показаний як теги"
     },
-    "Pagination":{
+    "Pagination": {
       "displayName": "Пагінація",
       "description": "Пагінація"
     },
-    "CircularProgressbar":{
+    "CircularProgressbar": {
       "displayName": "Круговий індикатор прогресу",
       "description": "Показує прогрес завдяки круговому прогресу"
     },
@@ -822,7 +830,7 @@
       "displayName": "Спінер",
       "description": "Можна використовувати для відображення стану завантаження"
     },
-    "Statistics":{
+    "Statistics": {
       "displayName": "Статистика",
       "description": "Може бути використана для відображення різної статистичної інформації"
     },
@@ -838,23 +846,23 @@
       "displayName": "Svg зображення",
       "description": "Svg зображення"
     },
-    "Html":{
+    "Html": {
       "displayName": "HTML переглядач",
       "description": "HTML переглядач"
     },
-    "VerticalDivider":{
+    "VerticalDivider": {
       "displayName": "Вертикальний роздільник",
       "description": "Вертикальний роздільник між компонентами"
     },
-    "CustomComponent":{
+    "CustomComponent": {
       "displayName": "Елемент користувача",
       "description": "Додайте свій власний react компонент"
     },
-    "ButtonGroup":{
+    "ButtonGroup": {
       "displayName": "Група кнопок",
       "description": "ButtonGroup"
     },
-    "PDF":{
+    "PDF": {
       "displayName": "PDF",
       "description": "Вбудований PDF файл"
     },
@@ -870,48 +878,47 @@
       "displayName": "Вибір кольору",
       "description": "Вибір кольору з палітри"
     },
-    "TreeSelect":{
+    "TreeSelect": {
       "displayName": "Вибір дерева",
       "description": "Виберіть значення з режиму дерева"
     }
   },
-  "leftSidebar":{
-    "Inspector":{
-      "text":"Інспектор",
-      "tip" : "Інспектор"
+  "leftSidebar": {
+    "Inspector": {
+      "text": "Інспектор",
+      "tip": "Інспектор"
     },
-    "Sources" :{
-      "text":"Джерела",
-      "tip" : "Додати або редагувати джерела даних",
-      "dataSources":"Джерела даних",
-      "addDataSource":"+ додати джерело даних"
+    "Sources": {
+      "text": "Джерела",
+      "tip": "Додати або редагувати джерела даних",
+      "dataSources": "Джерела даних",
+      "addDataSource": "+ додати джерело даних"
     },
-    "Debugger":{
-      "text":"Відладчик",
-      "tip" : "Відладчик",
-      "errors":"Помилки",
-      "noErrors":"Нема помилок",
-      "clear":"очистити"
+    "Debugger": {
+      "text": "Відладчик",
+      "tip": "Відладчик",
+      "errors": "Помилки",
+      "noErrors": "Нема помилок",
+      "clear": "очистити"
     },
-    "Comments":{
-      "text":"Коментарі",
-      "tip" : "Увімкнути комментарі",
-      "commentBody":"Немає коментарів для відображення",
-      "typeComment":"Залиште свій комментар тут"
+    "Comments": {
+      "text": "Коментарі",
+      "tip": "Увімкнути комментарі",
+      "commentBody": "Немає коментарів для відображення",
+      "typeComment": "Залиште свій комментар тут"
     },
-    "Settings":{
-      "text":"Налаштування",
-      "tip" : "Головні налаштування",
+    "Settings": {
+      "text": "Налаштування",
+      "tip": "Головні налаштування",
       "hideHeader": "Спрятать заголовок для запущенных приложений",
-      "maintenanceMode":"Режим тех.обслуживания",
-      "maxWidthOfCanvas":"Максимальная ширина поверхности",
-      "maxHeightOfCanvas" :"Максимальная высота поверхности",
-      "backgroundColorOfCanvas":"Задній фон поверхні"
-
+      "maintenanceMode": "Режим тех.обслуживания",
+      "maxWidthOfCanvas": "Максимальная ширина поверхности",
+      "maxHeightOfCanvas": "Максимальная высота поверхности",
+      "backgroundColorOfCanvas": "Задній фон поверхні"
     },
-    "Back":{
-      "text":"Назад",
-      "tip" :"Додому"
+    "Back": {
+      "text": "Назад",
+      "tip": "Додому"
     }
   }
 }

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,23 @@
+/**
+ * @type { import("@inlang/core/config").DefineConfig }
+ */
+export async function defineConfig(env) {
+	const { default: jsonPlugin } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@3/dist/index.js",
+	)
+
+	const { default: standardLintRules } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-standard-lint-rules@3/dist/index.js",
+	)
+
+	return {
+		referenceLanguage: "en",
+		plugins: [
+			jsonPlugin({
+				pathPattern: "frontend/assets/translations/{language}.json",
+				ignore: ["languages.json"],
+			}),
+			standardLintRules(),
+		],
+	}
+}


### PR DESCRIPTION
> Let me know if I need to change something to merge this PR

I added the inlang [IDE extension](https://inlang.com/documentation/apps/ide-extension) to ToolJet. That should make the life of devs easier while developing (extracting and inline annotations). 

## What did I add?
- `inlang.config.js` to configure where language translations are
- Cleaned `.json` files to valid json (There are a few extra commas and weird spacings.) The keys with dots were nested to maintain a consistently nested structure. (Access stays the same)
- Added extension to recommendations so everybody can use it 

## How to use it?

### Extract Messages (translations)
Extract Messages (translations) via the Inlang: Extract Message code action.

![Extract Messages](https://cdn.jsdelivr.net/gh/inlang/inlang/assets/ide-extension/extract.gif)

### Inline annotations
You can see translations directly in your code. No back-and-forth looking into the translation files themselves. (code example from ToolJet)

![Bildschirmfoto 2023-07-04 um 3 48 52 PM](https://github.com/ToolJet/ToolJet/assets/58360188/167ab54e-a7bc-4111-8dbc-c131ac9c85c6)

Ootb [editor](https://inlang.com/documentation/apps/web-editor) & [CLI](https://inlang.com/documentation/apps/inlang-cli) if needed.