### PR TITLE
fix: invoke on-page-load events after query details loaded

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -287,8 +287,8 @@ class EditorComponent extends React.Component {
     useDataSourcesStore.getState().actions.fetchGlobalDataSources(organizationId);
   };
 
-  fetchDataQueries = (id, selectFirstQuery = false, runQueriesOnAppLoad = false) => {
-    useDataQueriesStore.getState().actions.fetchDataQueries(id, selectFirstQuery, runQueriesOnAppLoad, this);
+  fetchDataQueries = async (id, selectFirstQuery = false, runQueriesOnAppLoad = false) => {
+    await useDataQueriesStore.getState().actions.fetchDataQueries(id, selectFirstQuery, runQueriesOnAppLoad, this);
   };
 
   toggleAppMaintenance = () => {
@@ -354,17 +354,17 @@ class EditorComponent extends React.Component {
             this.setState({
               showComments: !!queryString.parse(this.props.location.search).threadId,
             });
-            for (const event of dataDefinition.pages[homePageId]?.events ?? []) {
-              await this.handleEvent(event.eventId, event);
-            }
           });
         }
       );
 
       this.fetchDataSources(data.editing_version?.id);
-      this.fetchDataQueries(data.editing_version?.id, true, true);
+      await this.fetchDataQueries(data.editing_version?.id, true, true);
       this.fetchGlobalDataSources();
       initEditorWalkThrough();
+      for (const event of dataDefinition.pages[homePageId]?.events ?? []) {
+        await this.handleEvent(event.eventId, event);
+      }
     };
 
     this.setState(

--- a/frontend/src/_stores/dataQueriesStore.js
+++ b/frontend/src/_stores/dataQueriesStore.js
@@ -19,9 +19,9 @@ export const useDataQueriesStore = create(
       ...initialState,
       actions: {
         // TODO: Remove editor state while changing currentState
-        fetchDataQueries: (appId, selectFirstQuery = false, runQueriesOnAppLoad = false, editorRef) => {
+        fetchDataQueries: async (appId, selectFirstQuery = false, runQueriesOnAppLoad = false, editorRef) => {
           set({ loadingDataQueries: true });
-          dataqueryService.getAll(appId).then((data) => {
+          await dataqueryService.getAll(appId).then((data) => {
             set({
               dataQueries: data.data_queries,
               loadingDataQueries: false,


### PR DESCRIPTION
Fixes running query on page load.

Issue - When the query is attached to the page load event, the following error message is displayed when the page is refreshed no query has been associated with the action.