### PR TITLE
fix: update componentid inside widget details on duplication of page

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1138,6 +1138,7 @@ class EditorComponent extends React.Component {
       newPageData.components = Object.keys(newPageData.components).reduce((acc, key) => {
         const newComponentId = uuid();
         acc[newComponentId] = newPageData.components[key];
+        acc[newComponentId].id = newComponentId;
         oldToNewIdMapping[key] = newComponentId;
         return acc;
       }, {});


### PR DESCRIPTION
Fix for issue that breaks resizing of duplicated page components