### PR TITLE
fix: remove toast on viewer for all queries

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -581,7 +581,6 @@ function executeActionWithDebounce(_ref, event, mode, customVariables) {
 
 export async function onEvent(_ref, eventName, options, mode = 'edit') {
   let _self = _ref;
-  console.log('Event: ', _ref, eventName, options, (mode = 'edit'));
 
   const { customVariables } = options;
 


### PR DESCRIPTION
Fixed bug that caused toast to popup on running any queries, even when toast is not enabled