### PR TITLE
fixed dark mode inconsistency in query formation dialog box

### DIFF
--- a/frontend/src/Editor/QueryManager/constants.js
+++ b/frontend/src/Editor/QueryManager/constants.js
@@ -1,5 +1,5 @@
 export const staticDataSources = [
-  { kind: 'tooljetdb', id: 'null', name: 'Tooljet Database' },
+  { kind: 'tooljetdb', id: 'null', name: 'ToolJet Database' },
   { kind: 'restapi', id: 'null', name: 'REST API' },
   { kind: 'runjs', id: 'runjs', name: 'Run JavaScript code' },
   { kind: 'runpy', id: 'runpy', name: 'Run Python code' },
@@ -86,6 +86,6 @@ export const schemaUnavailableOptions = {
 export const defaultSources = {
   restapi: { kind: 'restapi', id: 'null', name: 'REST API' },
   runjs: { kind: 'runjs', id: 'runjs', name: 'Run JavaScript code' },
-  tooljetdb: { kind: 'tooljetdb', id: 'null', name: 'Tooljet Database' },
+  tooljetdb: { kind: 'tooljetdb', id: 'null', name: 'ToolJet Database' },
   runpy: { kind: 'runpy', id: 'runpy', name: 'Run Python code' },
 };

--- a/frontend/src/Editor/QueryManager/constants.js
+++ b/frontend/src/Editor/QueryManager/constants.js
@@ -1,5 +1,5 @@
 export const staticDataSources = [
-  { kind: 'tooljetdb', id: 'null', name: 'ToolJet Database' },
+  { kind: 'tooljetdb', id: 'null', name: 'Tooljet Database' },
   { kind: 'restapi', id: 'null', name: 'REST API' },
   { kind: 'runjs', id: 'runjs', name: 'Run JavaScript code' },
   { kind: 'runpy', id: 'runpy', name: 'Run Python code' },
@@ -86,6 +86,6 @@ export const schemaUnavailableOptions = {
 export const defaultSources = {
   restapi: { kind: 'restapi', id: 'null', name: 'REST API' },
   runjs: { kind: 'runjs', id: 'runjs', name: 'Run JavaScript code' },
-  tooljetdb: { kind: 'tooljetdb', id: 'null', name: 'ToolJet Database' },
+  tooljetdb: { kind: 'tooljetdb', id: 'null', name: 'Tooljet Database' },
   runpy: { kind: 'runpy', id: 'runpy', name: 'Run Python code' },
 };

--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -576,6 +576,7 @@ class ViewerComponent extends React.Component {
               onConfirm={(queryConfirmationData) => onQueryConfirmOrCancel(this, queryConfirmationData, true, 'view')}
               onCancel={() => onQueryConfirmOrCancel(this, queryConfirmationList[0], false, 'view')}
               queryConfirmationData={queryConfirmationList[0]}
+              darkMode={this.props.darkMode}
               key={queryConfirmationList[0]?.queryName}
             />
             <DndProvider backend={HTML5Backend}>


### PR DESCRIPTION
closed https://github.com/ToolJet/ToolJet/issues/6942

If dark mode is on and we click on eye icon  and then try to submit query it shows diaglog box with options "Cancel" and "Yes", this dialog box was not carrying dark mode.
I just passed darkMode state to Confirm Component in Viewer.tsx.