### PR TITLE
set default bottom padding mode view to 0

### DIFF
--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -193,7 +193,7 @@ export const Container = ({
       return Math.max(max, sum);
     }, 0);
 
-    const bottomPadding = mode === 'view' ? 100 : 300;
+    const bottomPadding = mode === 'view' ? 0 : 300;
     const frameHeight = mode === 'view' ? (appDefinition.globalSettings?.hideHeader ? 0 : 45) : 85;
 
     setCanvasHeight(`max(100vh - ${frameHeight}px, ${maxHeight + bottomPadding}px)`);


### PR DESCRIPTION
I agree that the dynamic height feature is quite nice, so that when embedding the notion app it can look perfect without scroll buttons I changed the default padding bottom to 0

I've tried it in notion and it works fine for me.

**before**
<img width="1197" alt="image" src="https://github.com/ToolJet/ToolJet/assets/1139881/855a5624-0f1b-488f-b82b-78ab26262113">

**after**
<img width="1355" alt="Screenshot 2023-07-15 at 12 10 05" src="https://github.com/ToolJet/ToolJet/assets/1139881/ad823dc1-c676-42c7-a8cd-ed325059e67c">
