### PR TITLE
Added jsconfig.json to enable VS code to automatically do absolute imports

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+      "baseUrl": "./src",
+      "paths": {
+        "@/*": ["./*"]
+      }
+    }
+  }


### PR DESCRIPTION
Currently whenever we try to use VS code automatic imports, it imports using a file's relative path respective to the path we are doing changes in.

This PR will help in VS code intellisense in importing using absolute paths like "@/_stores".