### PR TITLE
bug fixed tag column type auto generation issue

### DIFF
--- a/frontend/src/Editor/Components/Table/columns/autogenerateColumns.js
+++ b/frontend/src/Editor/Components/Table/columns/autogenerateColumns.js
@@ -29,15 +29,27 @@ export default function autogenerateColumns(
 
   // mapping the keys of first row with one level of nested elements.
   const keysOfTableData = Object.entries(firstRow).reduce((accumulator, currentValue) => {
-    if (typeof currentValue[1] === 'object') {
+    /*
+    if currentValue[1] type is particularly object, that means it has nested data, so 
+    we trygo inside the if statrment to check it's depth and support auto generation of
+    columns till one level.
+     */
+    if (Object.prototype.toString.call(currentValue[1]).slice(8, -1).toLowerCase() === 'object') {
       accumulator.push(
         ...Object.entries(currentValue[1]).reduce((acc, cv) => {
-          if (typeof cv[1] !== 'object') {
+          /*
+            to only support one level of nesting, we are checking condition, if type of cv[1] value is 
+            premitive data type or array particulary, if it satisfies any one of the condition, then we auto 
+            generate column for it. Else, if it comes out to be object,that means it has more than one level
+            of nexted data, so we do not auto generate column for the same.
+            */
+          if (Object.prototype.toString.call(cv[1]).slice(8, -1).toLowerCase() !== 'object') {
             acc.push(`${currentValue[0]}.${cv[0]}`);
           }
           return acc;
         }, [])
       );
+
       return accumulator;
     }
     accumulator.push(currentValue[0]);


### PR DESCRIPTION
Resolves, when we have array data type as a value in key-value pair to the data fed to the table. Then, auto-generating a column creates a column for each element in the array.