### PR TITLE
refactor: updation of the text Datasource 101 to Datasources

### DIFF
--- a/frontend/src/GlobalDatasources/GlobalDataSourcesPage/index.jsx
+++ b/frontend/src/GlobalDatasources/GlobalDataSourcesPage/index.jsx
@@ -92,7 +92,7 @@ export const GlobalDataSourcesPage = ({ darkMode = false, updateSelectedDatasour
             <div className="icon-container">
               <DataSourceFolder />
             </div>
-            <div className="heading tj-text-lg mt-2">Datasource 101</div>
+            <div className="heading tj-text-lg mt-2">Datasources</div>
             <div className="sub-heading text-secondary tj-text-md mt-2">
               Connect your app with REST API, PGSQL, MongoDB, Stripe and 40+ other datasources
             </div>


### PR DESCRIPTION
I have made the change to update the text on the datasources tab from 'Datasource 101' to 'Datasources', here is how it looks:

![image](https://github.com/ToolJet/ToolJet/assets/94978425/e86b50f1-5403-4b4f-8e9a-c4888123dfd4)

closes #7028 