### PR TITLE
[BugFix] Fix dynamic form breaking in case "react-component-headers" form type outside of the editor

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -60,9 +60,8 @@ class EditorComponent extends React.Component {
   constructor(props) {
     super(props);
     resetAllStores();
-
     const appId = this.props.params.id;
-
+    useEditorStore.getState().actions.setIsEditorActive(true);
     const { socket } = createWebsocketConnection(appId);
 
     this.renameQueryNameId = React.createRef();
@@ -267,6 +266,7 @@ class EditorComponent extends React.Component {
     this.socket && this.socket?.close();
     this.subscription && this.subscription.unsubscribe();
     if (config.ENABLE_MULTIPLAYER_EDITING) this.props?.provider?.disconnect();
+    useEditorStore.getState().actions.setIsEditorActive(false);
   }
 
   // 1. When we receive an undoable action – we can always undo but cannot redo anymore.

--- a/frontend/src/_components/DynamicForm.jsx
+++ b/frontend/src/_components/DynamicForm.jsx
@@ -18,6 +18,8 @@ import { orgEnvironmentVariableService } from '../_services';
 import { find, isEmpty } from 'lodash';
 import { ButtonSolid } from './AppButton';
 import { useCurrentState } from '@/_stores/currentStateStore';
+import { useEditorStore } from '@/_stores/editorStore';
+import { shallow } from 'zustand/shallow';
 
 const DynamicForm = ({
   schema,
@@ -34,8 +36,15 @@ const DynamicForm = ({
 }) => {
   const [computedProps, setComputedProps] = React.useState({});
   const currentState = useCurrentState();
-  const [workspaceVariables, setWorkspaceVariables] = React.useState([]);
 
+  const { isEditorActive } = useEditorStore(
+    (state) => ({
+      isEditorActive: state?.isEditorActive,
+    }),
+    shallow
+  );
+
+  const [workspaceVariables, setWorkspaceVariables] = React.useState([]);
   // if(schema.properties)  todo add empty check
   React.useLayoutEffect(() => {
     if (!isEditMode || isEmpty(options)) {
@@ -207,7 +216,12 @@ const DynamicForm = ({
         };
 
       case 'react-component-headers': {
-        const isRenderedAsQueryEditor = currentState != null;
+        let isRenderedAsQueryEditor;
+        if (!isEditorActive) {
+          isRenderedAsQueryEditor = false;
+        } else {
+          isRenderedAsQueryEditor = currentState != null;
+        }
         return {
           getter: key,
           options: isRenderedAsQueryEditor

--- a/frontend/src/_stores/editorStore.js
+++ b/frontend/src/_stores/editorStore.js
@@ -3,6 +3,7 @@ import { create, zustandDevTools } from './utils';
 const initialState = {
   currentLayout: 'desktop',
   showComments: false,
+  isEditorActive: false,
 };
 
 export const useEditorStore = create(
@@ -13,6 +14,7 @@ export const useEditorStore = create(
         setShowComments: (showComments) => set({ showComments }),
         toggleComments: () => set({ showComments: !get().showComments }),
         toggleCurrentLayout: (currentLayout) => set({ currentLayout }),
+        setIsEditorActive: (isEditorActive) => set(() => ({ isEditorActive })),
       },
     }),
     { name: 'Editor Store' }


### PR DESCRIPTION
Steps to reproduce the issue:

1. Click on Global Datasources in the left sidebar and then click on "Add new datasource" button.
2. When the Modal is open, Select "Postgres" or "Rest API", then it will lead to complete page to go blank.