### PR TITLE
fixes issue #7096 for toggle switches activating in the entire line

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2624,6 +2624,10 @@ body {
     position: static;
     top: 0;
   }
+
+  .form-check {
+    display: inline-block;
+  }
 }
 
 .code-hinter {


### PR DESCRIPTION
Closes #7096

Fixes the issue for toggle switch getting activated in the entire line
Fixed by providing display: inline-block to the label, this restricts the length of the parent (label) container.