### PR TITLE
✅ #7227 and #7226 "Added a check and a new toster message and filePicker description change"

### DIFF
--- a/cypress-tests/cypress/e2e/editor/widget/csa.cy.js
+++ b/cypress-tests/cypress/e2e/editor/widget/csa.cy.js
@@ -148,7 +148,7 @@ describe("Editor- CSA", () => {
     cy.get(commonWidgetSelector.draggableWidget("button1")).click();
     cy.get(`${commonWidgetSelector.draggableWidget("filepicker1")} p`).should(
       "have.text",
-      "Drag and Drop some files here, or click to select files"
+      "Drag and Drop files here, or click to select files"
     );
   });
 

--- a/frontend/src/Editor/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Components/FilePicker.jsx
@@ -20,7 +20,7 @@ export const FilePicker = ({
   const currentState = useCurrentState();
   //* properties definitions
   const instructionText =
-    component.definition.properties.instructionText?.value ?? 'Drag and Drop some files here, or click to select files';
+    component.definition.properties.instructionText?.value ?? 'Drag and Drop files here, or click to select files';
   const enableDropzone = component.definition.properties.enableDropzone.value ?? true;
   const enablePicker = component.definition.properties?.enablePicker?.value ?? true;
   const maxFileCount = component.definition.properties.maxFileCount?.value ?? 2;

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -3215,7 +3215,7 @@ export const widgets = [
         showOnMobile: { value: '{{false}}' },
       },
       properties: {
-        instructionText: { value: 'Drag and Drop some files here, or click to select files' },
+        instructionText: { value: 'Drag and Drop files here, or click to select files' },
         enableDropzone: { value: '{{true}}' },
         enablePicker: { value: '{{true}}' },
         maxFileCount: { value: '{{2}}' },

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -1349,7 +1349,11 @@ export const cloneComponents = (_ref, updateAppDefinition, isCloning = true, isC
     updateAppDefinition(newDefinition);
   } else {
     navigator.clipboard.writeText(JSON.stringify(newComponentObj));
-    toast.success('Component copied succesfully');
+    if (newComponentObj.newComponents.length > 1) {
+      toast.success("Component's copied succesfully");
+    } else {
+      toast.success('Component copied succesfully');
+    }
   }
   _ref.setState({ currentSidebarTab: 2 });
 };

--- a/server/data-migrations/1653472569828-addedInstructionTextPropInFilePickerWidget.ts
+++ b/server/data-migrations/1653472569828-addedInstructionTextPropInFilePickerWidget.ts
@@ -16,7 +16,7 @@ export class addedInstructionTextPropInFilePickerWidget1653472569828 implements 
           const component = components[componentId];
           if (component.component.component === 'FilePicker') {
             component.component.definition.properties.instructionText = {
-              value: 'Drag and Drop some files here, or click to select files',
+              value: 'Drag and Drop files here, or click to select files',
             };
             components[componentId] = {
               ...component,

--- a/server/templates/gcs-file-explorer/definition.json
+++ b/server/templates/gcs-file-explorer/definition.json
@@ -1130,7 +1130,7 @@
                     },
                     "properties": {
                       "instructionText": {
-                        "value": "Drag and Drop some files here, or click to select files"
+                        "value": "Drag and Drop files here, or click to select files"
                       },
                       "enableDropzone": {
                         "value": "{{true}}"
@@ -6971,7 +6971,7 @@
                       },
                       "properties": {
                         "instructionText": {
-                          "value": "Drag and Drop some files here, or click to select files"
+                          "value": "Drag and Drop files here, or click to select files"
                         },
                         "enableDropzone": {
                           "value": "{{true}}"


### PR DESCRIPTION
✅ added this check 

if (newComponentObj.newComponents.length > 1) {
    toast.success("Component's copied succesfully");
  } else {
    toast.success('Component copied succesfully');
 }

for multiple component selection 

This is regarding this issue #7226 

--------------------------------------------------------------
✅ Changed the name of file picker to  - Drag and Drop files here, or click to select files
fix for issue #7227 