### PR TITLE
fix: fallback message added if componentName not passed into CodeHinter

### DIFF
--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -185,7 +185,9 @@ export function CodeHinter({
 
     if (error) {
       const err = String(error);
-      const errorMessage = err.includes('.run()') ? `${err} in ${componentName.split('::')[0]}'s field` : err;
+      const errorMessage = err.includes('.run()')
+        ? `${err} in ${componentName ? componentName.split('::')[0] + "'s" : 'fx'} field`
+        : err;
       return (
         <animated.div className={isOpen ? themeCls : null} style={{ ...slideInStyles, overflow: 'hidden' }}>
           <div ref={heightRef} className="dynamic-variable-preview bg-red-lt px-1 py-1">


### PR DESCRIPTION
CodeHinter crashes if you try to run a inside fx fields of event. This is because componentName is required for CodeHinter to show an error message which is not passed inside Event manager. Fixes #7282 .