### PR TITLE
Fix/query rename delay

### DIFF
--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -185,7 +185,9 @@ export function CodeHinter({
 
     if (error) {
       const err = String(error);
-      const errorMessage = err.includes('.run()') ? `${err} in ${componentName.split('::')[0]}'s field` : err;
+      const errorMessage = err.includes('.run()')
+        ? `${err} in ${componentName ? componentName.split('::')[0] + "'s" : 'fx'} field`
+        : err;
       return (
         <animated.div className={isOpen ? themeCls : null} style={{ ...slideInStyles, overflow: 'hidden' }}>
           <div ref={heightRef} className="dynamic-variable-preview bg-red-lt px-1 py-1">

--- a/frontend/src/_stores/dataQueriesStore.js
+++ b/frontend/src/_stores/dataQueriesStore.js
@@ -8,6 +8,7 @@ import { useAppVersionStore } from '@/_stores/appVersionStore';
 import { runQueries } from '@/_helpers/appUtils';
 import { v4 as uuidv4 } from 'uuid';
 import { toast } from 'react-hot-toast';
+import { isEmpty, throttle } from 'lodash';
 
 const initialState = {
   dataQueries: [],
@@ -16,13 +17,16 @@ const initialState = {
   loadingDataQueries: true,
   isDeletingQueryInProcess: false,
   /** TODO: Below two params are primarily used only for websocket invocation post update. Can be removed onece websocket logic is revamped */
-  isCreatingQueryInProcess: false,
+  // isCreatingQueryInProcess: false,
+  creatingQueryInProcessId: null,
   isUpdatingQueryInProcess: false,
+  /** When a 'Create Data Query' operation is in progress, rename/update API calls are cached in the variable. */
+  queuedActions: {},
 };
 
 export const useDataQueriesStore = create(
   zustandDevTools(
-    (set) => ({
+    (set, get) => ({
       ...initialState,
       actions: {
         // TODO: Remove editor state while changing currentState
@@ -93,14 +97,14 @@ export const useDataQueriesStore = create(
           const appId = useAppDataStore.getState().appId;
           const { options, name } = getDefaultOptions(selectedDataSource);
           const kind = selectedDataSource.kind;
-          set({ isCreatingQueryInProcess: true });
+          const tempId = uuidv4();
+          set({ creatingQueryInProcessId: tempId });
           const { actions, selectedQuery } = useQueryPanelStore.getState();
           const dataSourceId = selectedDataSource?.id !== 'null' ? selectedDataSource?.id : null;
           const pluginId = selectedDataSource.pluginId || selectedDataSource.plugin_id;
           useAppDataStore.getState().actions.setIsSaving(true);
           const { dataQueries } = useDataQueriesStore.getState();
           const currDataQueries = [...dataQueries];
-          const tempId = uuidv4();
           set(() => ({
             dataQueries: [
               {
@@ -117,25 +121,41 @@ export const useDataQueriesStore = create(
             ],
           }));
           actions.setSelectedQuery(tempId);
+          actions.setNameInputFocussed(true);
           dataqueryService
             .create(appId, appVersionId, name, kind, options, dataSourceId, pluginId)
             .then((data) => {
               set((state) => ({
-                isCreatingQueryInProcess: false,
+                creatingQueryInProcessId: null,
                 dataQueries: state.dataQueries.map((query) => {
                   if (query.id === tempId) {
-                    return { ...query, ...data, data_source_id: dataSourceId };
+                    return {
+                      ...query,
+                      // ...data,
+                      id: data.id,
+                      data_source_id: dataSourceId,
+                    };
                   }
                   return query;
                 }),
               }));
               actions.setSelectedQuery(data.id, data);
-              actions.setNameInputFocussed(true);
               if (shouldRunQuery) actions.setQueryToBeRun(data);
+
+              /** Checks if there is an API call cached. If yes execute it */
+              if (!isEmpty(get()?.queuedActions?.renameQuery)) {
+                get().actions.renameQuery(data.id, get().queuedActions.renameQuery);
+                set({ queuedActions: { ...get().queuedActions, renameQuery: undefined } });
+              }
+
+              if (!isEmpty(get()?.queuedActions?.saveData)) {
+                get().actions.saveData({ ...get().queuedActions.saveData, id: data.id });
+                set({ queuedActions: { ...get().queuedActions, saveData: undefined } });
+              }
             })
             .catch((error) => {
               set((state) => ({
-                isCreatingQueryInProcess: false,
+                creatingQueryInProcessId: null,
                 dataQueries: state.dataQueries.filter((query) => query.id !== tempId),
               }));
               actions.setSelectedQuery(null);
@@ -144,6 +164,11 @@ export const useDataQueriesStore = create(
             .finally(() => useAppDataStore.getState().actions.setIsSaving(false));
         },
         renameQuery: (id, newName) => {
+          /** If query creation in progress, skips call and pushes the update to queue */
+          if (get().creatingQueryInProcessId && get().creatingQueryInProcessId === id) {
+            set({ queuedActions: { ...get().queuedActions, renameQuery: newName } });
+            return;
+          }
           useAppDataStore.getState().actions.setIsSaving(true);
           /**
            * Seting name to store before api call for instant UI update and better UX.
@@ -196,7 +221,7 @@ export const useDataQueriesStore = create(
             .finally(() => useAppDataStore.getState().actions.setIsSaving(false));
         },
         duplicateQuery: (id, appId) => {
-          set({ isCreatingQueryInProcess: true });
+          set({ creatingQueryInProcessId: uuidv4() });
           const { actions } = useQueryPanelStore.getState();
           const { dataQueries } = useDataQueriesStore.getState();
           const queryToClone = { ...dataQueries.find((query) => query.id === id) };
@@ -222,7 +247,7 @@ export const useDataQueriesStore = create(
             )
             .then((data) => {
               set((state) => ({
-                isCreatingQueryInProcess: false,
+                creatingQueryInProcessId: null,
                 dataQueries: [{ ...data, data_source_id: queryToClone.data_source_id }, ...state.dataQueries],
               }));
               actions.setSelectedQuery(data.id, { ...data, data_source_id: queryToClone.data_source_id });
@@ -230,12 +255,17 @@ export const useDataQueriesStore = create(
             .catch((error) => {
               console.error('error', error);
               set({
-                isCreatingQueryInProcess: false,
+                creatingQueryInProcessId: null,
               });
             })
             .finally(() => useAppDataStore.getState().actions.setIsSaving(false));
         },
-        saveData: debounce((newValues) => {
+        saveData: throttle((newValues) => {
+          /** If query creation in progress, skips call and pushes the update to queue */
+          if (get().creatingQueryInProcessId && get().creatingQueryInProcessId === newValues.id) {
+            set({ queuedActions: { ...get().queuedActions, saveData: newValues } });
+            return;
+          }
           useAppDataStore.getState().actions.setIsSaving(true);
           set({ isUpdatingQueryInProcess: true });
           dataqueryService
@@ -286,5 +316,5 @@ const sortByAttribute = (data, sortBy, order) => {
 
 export const useDataQueries = () => useDataQueriesStore((state) => state.dataQueries);
 export const useDataQueriesActions = () => useDataQueriesStore((state) => state.actions);
-export const useQueryCreationLoading = () => useDataQueriesStore((state) => state.isCreatingQueryInProcess);
+export const useQueryCreationLoading = () => useDataQueriesStore((state) => !!state.creatingQueryInProcessId);
 export const useQueryUpdationLoading = () => useDataQueriesStore((state) => state.isUpdatingQueryInProcess);

--- a/frontend/src/_stores/dataQueriesStore.js
+++ b/frontend/src/_stores/dataQueriesStore.js
@@ -131,7 +131,6 @@ export const useDataQueriesStore = create(
                   if (query.id === tempId) {
                     return {
                       ...query,
-                      // ...data,
                       id: data.id,
                       data_source_id: dataSourceId,
                     };
@@ -165,7 +164,7 @@ export const useDataQueriesStore = create(
         },
         renameQuery: (id, newName) => {
           /** If query creation in progress, skips call and pushes the update to queue */
-          if (get().creatingQueryInProcessId && get().creatingQueryInProcessId === id) {
+          if (get().creatingQueryInProcessId === id) {
             set({ queuedActions: { ...get().queuedActions, renameQuery: newName } });
             return;
           }


### PR DESCRIPTION
When query is selected for creation, it does not immediately enables the rename query input. Instead it wait for the create api to finish. This given sub optimal UX in low speed. 