### PR TITLE
Fix: TreeSelect Component: Text color now adapts when switching to dark mode

### DIFF
--- a/frontend/src/Editor/Components/TreeSelect.jsx
+++ b/frontend/src/Editor/Components/TreeSelect.jsx
@@ -8,7 +8,7 @@ import { isExpectedDataType } from '@/_helpers/utils.js';
 export const TreeSelect = ({ height, properties, styles, setExposedVariable, fireEvent, darkMode, dataCy }) => {
   const { label } = properties;
   const { visibility, disabledState, checkboxColor, boxShadow } = styles;
-  const textColor = darkMode && styles.textColor === '#000' ? '#fff' : styles.textColor;
+  const textColor = darkMode ? '#fff' : '#000';
   const [checked, setChecked] = useState(checkedData);
   const [expanded, setExpanded] = useState(expandedData);
   const data = isExpectedDataType(properties.data, 'array');


### PR DESCRIPTION
Resolves issue [#7279](https://github.com/ToolJet/ToolJet/issues/7279)
![image](https://github.com/ToolJet/ToolJet/assets/32923170/9e9b2e5f-f095-4a62-b6c7-74ebdfdc8c28)
![image](https://github.com/ToolJet/ToolJet/assets/32923170/496363ea-f293-4ded-8748-09fb6b692911)
