### PR TITLE
[docs]: fixed documentation link

### DIFF
--- a/marketplace/plugins/harperdb/README.md
+++ b/marketplace/plugins/harperdb/README.md
@@ -1,4 +1,4 @@
 
 # HarperDB
 
-Documentation on: https://docs.tooljet.com/docs/data-sources/harperdb
+Documentation on: https://docs.tooljet.com/docs/marketplace/plugins/marketplace-plugin-harperdb


### PR DESCRIPTION
Fixed documentation link in the Harper DB plugins folder in repository. #7169 