### PR TITLE
Workspace spelling updated from Workspace to workspace #7335

### DIFF
--- a/frontend/src/ManageOrgConstants/EmptyState.jsx
+++ b/frontend/src/ManageOrgConstants/EmptyState.jsx
@@ -13,7 +13,7 @@ const EmptyState = ({ canCreateVariable, setIsManageVarDrawerOpen, isLoading }) 
             <div className="w-50 mt-2">
               <h3 data-cy="empty-state-header">No Workspace constants yet</h3>
               <p className="text-muted mt-2" data-cy="empty-state-text">
-                Use Workspace constants seamlessly in both the app builder and global data source connections across
+                Use workspace constants seamlessly in both the app builder and global data source connections across
                 ToolJet.
               </p>
               {canCreateVariable && (


### PR DESCRIPTION
Fix - Workspace Constants: The text in the middle of the page should be updated from "Use Workspace constants seamlessly in both the app builder and global data source connections across ToolJet." to "Use workspace constants seamlessly in both the app builder and global data source connections across ToolJet."