### PR TITLE
[Docs]: Fixes typo within `env-vars` documentation

### DIFF
--- a/docs/versioned_docs/version-2.10.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.10.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.11.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.11.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.12.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.12.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.13.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.13.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.14.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.14.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.2.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.2.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -106,7 +106,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.3.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.3.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.4.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.4.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.5.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.5.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.6.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.6.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.7.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.7.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.8.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.8.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.9.0/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.9.0/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 

--- a/docs/versioned_docs/version-2.9.4/setup/env-vars.md
+++ b/docs/versioned_docs/version-2.9.4/setup/env-vars.md
@@ -49,7 +49,7 @@ If you are using docker-compose setup, you can set PG_HOST as `postgres` which w
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable DATABASE_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 
@@ -121,7 +121,7 @@ Incase you want to trigger it manually, use the command `npm run db:create` on T
 :::
 
 :::info
-If you intent you use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
+If you intend to use the DB connection url and if the connection does not support ssl. Please use the below format using the variable TOOLJET_DB_URL.
 `postgres://username:password@hostname:port/database_name?sslmode=disable`
 :::
 


### PR DESCRIPTION
These changes fix the mis-worded copy found within the documentation, across all versions.

**Screenshot detailing the issue before changes:**
<img width="854" alt="Screenshot 2023-08-26 at 11 06 41 AM" src="https://github.com/ToolJet/ToolJet/assets/34330944/2db63cfd-4500-4ce9-a790-738b3444ce48">

**Screenshot displaying the updated version:**
<img width="854" alt="Screenshot 2023-08-26 at 1 41 24 PM" src="https://github.com/ToolJet/ToolJet/assets/34330944/dc6133c5-f0b3-49c7-8a42-501f82ddbccd">
