### PR TITLE
Resolves table redesign bugs from appbuilder-1.3

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -942,6 +942,12 @@ export function Table({
     }
     return totalWidth;
   };
+  console.log('kavin', {
+    totalRecords,
+    'globalFilteredRows-length': globalFilteredRows.length,
+    clientSidePagination,
+    serverSidePagination,
+  });
   return (
     <div
       data-cy={`draggable-widget-${String(component.name).toLowerCase()}`}
@@ -1154,7 +1160,7 @@ export function Table({
                                       className={`${
                                         column.columnType !== 'selector' &&
                                         'd-flex justify-content-between custom-gap-12'
-                                      }`}
+                                      } ${column.columnType === 'selector' && 'd-flex justify-content-center w-100'}`}
                                       {...column.getSortByToggleProps()}
                                       {...provided.draggableProps}
                                       {...provided.dragHandleProps}
@@ -1165,9 +1171,15 @@ export function Table({
                                       }}
                                     >
                                       <div
-                                        className={`w-100 d-flex justify-content-${determineJustifyContentValue(
-                                          column?.horizontalAlignment ?? ''
-                                        )} ${column.columnType !== 'selector' && isEditable && 'custom-gap-4'}`}
+                                        className={`w-100 d-flex 
+                                          ${
+                                            column.columnType === 'selector'
+                                              ? 'justify-content-center'
+                                              : `justify-content-${determineJustifyContentValue(
+                                                  column?.horizontalAlignment ?? ''
+                                                )}`
+                                          }                                     
+                                          ${column.columnType !== 'selector' && isEditable && 'custom-gap-4'}`}
                                       >
                                         <div>
                                           {column.columnType !== 'selector' && isEditable && (
@@ -1195,10 +1207,8 @@ export function Table({
                                       </div>
                                       <div
                                         style={{
-                                          visibility:
-                                            column?.columnType !== 'selector' && column?.isSorted
-                                              ? 'visible'
-                                              : 'hidden',
+                                          display:
+                                            column?.columnType !== 'selector' && column?.isSorted ? 'block' : 'none',
                                         }}
                                       >
                                         {column?.isSortedDesc ? (

--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -942,12 +942,6 @@ export function Table({
     }
     return totalWidth;
   };
-  console.log('kavin', {
-    totalRecords,
-    'globalFilteredRows-length': globalFilteredRows.length,
-    clientSidePagination,
-    serverSidePagination,
-  });
   return (
     <div
       data-cy={`draggable-widget-${String(component.name).toLowerCase()}`}
@@ -1533,8 +1527,7 @@ export function Table({
                 ) : (
                   !loadingState && (
                     <span data-cy={`footer-number-of-records`} className="font-weight-500 text-black-000">
-                      {clientSidePagination && !serverSidePagination && `${globalFilteredRows.length} Records`}
-                      {serverSidePagination && totalRecords ? `${totalRecords} Records` : ''}
+                      {`${globalFilteredRows.length} Records`}
                     </span>
                   )
                 ))}

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -136,7 +136,7 @@ export const widgets = [
       },
       useDynamicColumn: {
         type: 'toggle',
-        displayName: 'Connect code',
+        displayName: 'Use dynamic column',
         validation: {
           schema: { type: 'boolean' },
         },

--- a/frontend/src/ToolJetUI/List/List.jsx
+++ b/frontend/src/ToolJetUI/List/List.jsx
@@ -30,20 +30,6 @@ function ListItem({
     setShowActionsMenu(false);
   };
 
-  React.useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (showActionsMenu && event.target.closest('.list-menu') === null) {
-        closeMenu();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify({ showActionsMenu })]);
-
   return (
     <div>
       <ListGroup.Item onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)} {...restProps}>
@@ -66,8 +52,9 @@ function ListItem({
             <OverlayTrigger
               trigger={'click'}
               placement={'bottom-end'}
-              rootClose={false}
+              rootClose={true}
               show={showActionsMenu}
+              onToggle={(show) => setShowActionsMenu(show)}
               overlay={
                 <Popover id="list-menu" className={darkMode && 'dark-theme'}>
                   <Popover.Body bsPrefix="list-item-popover-body" className={`list-item-popover-body`}>

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -525,7 +525,7 @@
         background: var(--slate4, #ECEEF0) !important;
         box-shadow: 0px 0px 0px 4px #DFE3E6 !important;
         z-index: 999;
-        margin: 4px;
+        margin: 4px 0;
       }
       div:focus-visible{
         outline: 0 !important;

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -340,8 +340,7 @@
     }
   }
 
-  .th,
-  .td {
+  .th{
     .resizer {
       display: inline-block;
       height: 100%;
@@ -353,6 +352,11 @@
       touch-action: none;
       width: 30px;
       cursor: ew-resize !important;
+    }
+    &:last-child{
+      .resizer{
+        transform: translateX(0%);
+      }
     }
   }
 }

--- a/frontend/src/_ui/AppButton/AppButton.jsx
+++ b/frontend/src/_ui/AppButton/AppButton.jsx
@@ -40,10 +40,10 @@ export const ButtonBase = function ButtonBase(props) {
       disabled={disabled}
       style={
         ({
-          ...customStyles,
           backgroundColor: backgroundColor && backgroundColor,
         },
-        restProps.style)
+        restProps.style,
+        customStyles)
       }
       type={isAnchor ? undefined : type || 'button'}
     >


### PR DESCRIPTION
Resolves 
- Custom styles to global buttons
- alignment of the selection checkbox in the selection column header 
- Removed unwanted addition of horizontal margin on the column headers when in focused-within state
- Removed unwanted transition translatesX to the last column header, to avoid extra space at the right end of the table, so that horizontal scroll can be set to auto
- Table columns not getting deleted from the table inspector
- Shows number records, independent of whether enable pagination is toggled on or off. Also, made the records dependent on globalFilteredRows.length all the time
- Updated back to `Use dynamic column` text from `Connect code` in the columns sections of the table inspector