### PR TITLE
Resolves table fixes from appbuilder-1.3

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -206,7 +206,7 @@ export function Table({
   const defaultColumn = React.useMemo(
     () => ({
       minWidth: 60,
-      width: 268,
+      width: 150,
     }),
     []
   );

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -412,6 +412,7 @@
     align-items: flex-start;
     .popover-body{
         color: inherit;
+        border: none;
     }
     
     .table-download-option{


### PR DESCRIPTION
Resolves 
- Avoided Horizontal scroll by default when the table component is dropped on the canvas by decreasing the width of default column to 150
- Removed extra unwanted border around the child container of download popover in the table