### PR TITLE
feat: Minor UX changes on querymanager for button states

### DIFF
--- a/frontend/src/Editor/QueryManager/Components/QueryManagerHeader.jsx
+++ b/frontend/src/Editor/QueryManager/Components/QueryManagerHeader.jsx
@@ -101,10 +101,7 @@ export const QueryManagerHeader = forwardRef(({ darkMode, options, editorRef }, 
       >
         <button
           onClick={() => runQuery(editorRef, selectedQuery?.id, selectedQuery?.name)}
-          className={`border-0 default-secondary-button float-right1 ${buttonLoadingState(
-            isLoading,
-            isVersionReleased
-          )}`}
+          className={`border-0 default-secondary-button float-right1 ${buttonLoadingState(isLoading)}`}
           data-cy="query-run-button"
           disabled={isInDraft}
           {...(isInDraft && {
@@ -139,7 +136,14 @@ export const QueryManagerHeader = forwardRef(({ darkMode, options, editorRef }, 
   return (
     <div className="row header">
       <div className="col font-weight-500">
-        {selectedQuery && <NameInput onInput={executeQueryNameUpdation} value={queryName} darkMode={darkMode} />}
+        {selectedQuery && (
+          <NameInput
+            onInput={executeQueryNameUpdation}
+            value={queryName}
+            darkMode={darkMode}
+            isDiabled={isVersionReleased}
+          />
+        )}
       </div>
       <div className="query-header-buttons me-3">{renderButtons()}</div>
     </div>
@@ -164,7 +168,7 @@ const PreviewButton = ({ buttonLoadingState, onClick }) => {
   );
 };
 
-const NameInput = ({ onInput, value, darkMode }) => {
+const NameInput = ({ onInput, value, darkMode, isDiabled }) => {
   const [isFocussed, setIsFocussed] = useNameInputFocussed(false);
   const [name, setName] = useState(value);
   const isVersionReleased = useAppVersionStore((state) => state.isVersionReleased);
@@ -226,7 +230,8 @@ const NameInput = ({ onInput, value, darkMode }) => {
         ) : (
           <Button
             size="sm"
-            onClick={() => setIsFocussed(true)}
+            onClick={isDiabled ? null : () => setIsFocussed(true)}
+            disabled={isDiabled}
             className={'bg-transparent justify-content-between color-slate12 w-100 px-2 py-1 rounded font-weight-500'}
           >
             <span className="text-truncate">{name} </span>
@@ -234,7 +239,7 @@ const NameInput = ({ onInput, value, darkMode }) => {
               className={cx('breadcrum-rename-query-icon', { 'd-none': isFocussed && isVersionReleased })}
               style={{ minWidth: 14 }}
             >
-              <RenameIcon />
+              {!isDiabled && <RenameIcon />}
             </span>
           </Button>
         )}

--- a/frontend/src/Editor/QueryPanel/QueryDataPane.jsx
+++ b/frontend/src/Editor/QueryPanel/QueryDataPane.jsx
@@ -17,6 +17,8 @@ import useShowPopover from '@/_hooks/useShowPopover';
 import DataSourceSelect from '../QueryManager/Components/DataSourceSelect';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import FolderEmpty from '@/_ui/Icon/solidIcons/FolderEmpty';
+import { useAppVersionStore } from '@/_stores/appVersionStore';
+import { shallow } from 'zustand/shallow';
 
 export const QueryDataPane = ({ darkMode, fetchDataQueries, editorRef, appId, toggleQueryEditor }) => {
   const { t } = useTranslation();
@@ -204,9 +206,17 @@ const EmptyDataSource = () => (
   </div>
 );
 
-const AddDataSourceButton = ({ darkMode, disabled }) => {
+const AddDataSourceButton = ({ darkMode, disabled: _disabled }) => {
   const [showMenu, setShowMenu] = useShowPopover(false, '#query-add-ds-popover', '#query-add-ds-popover-btn');
   const selectRef = useRef();
+  const { isVersionReleased } = useAppVersionStore(
+    (state) => ({
+      isVersionReleased: state.isVersionReleased,
+      editingVersionId: state.editingVersion?.id,
+    }),
+    shallow
+  );
+  const disabled = isVersionReleased || _disabled;
 
   useEffect(() => {
     if (showMenu) {

--- a/frontend/src/Editor/QueryPanel/QueryDataPane.jsx
+++ b/frontend/src/Editor/QueryPanel/QueryDataPane.jsx
@@ -116,7 +116,7 @@ export const QueryDataPane = ({ darkMode, fetchDataQueries, editorRef, appId, to
             />
             <Tooltip id="tooltip-for-query-panel-header-btn" className="tooltip" />
           </div>
-          <AddDataSourceButton darkMode={darkMode} disabled={isEmpty(dataQueries)} />
+          <AddDataSourceButton darkMode={darkMode} />
         </div>
         <div
           className={cx('queries-header row d-flex align-items-center justify-content-between', {


### PR DESCRIPTION
Minor UI/UX fixes
1. Enable the Add data query button even when no queries are created. 
2. Run button enabled even after releasing the application.
3. Should not be able to edit the query name after releasing.
4. The "+Add" button should be disabled after releasing.