### PR TITLE
Avoid box shadow on the selector  type column header, when clicked on the input checkbox in the table component

### DIFF
--- a/frontend/src/Editor/Components/Table/IndeterminateCheckbox.jsx
+++ b/frontend/src/Editor/Components/Table/IndeterminateCheckbox.jsx
@@ -20,6 +20,7 @@ const IndeterminateCheckbox = React.forwardRef(({ indeterminate, ...rest }, ref)
           width: 16,
           height: 16,
         }}
+        onMouseDown={(e) => e.preventDefault()}
       />
     </>
   );

--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -1148,7 +1148,7 @@ export function Table({
                                       column.isSorted && (column.isSortedDesc ? '' : '')
                                     } ${column.isResizing && 'resizing-column'} ${
                                       column.Header === 'Actions' && 'has-actions'
-                                    } position-relative`}
+                                    } position-relative ${column.columnType === 'selector' && 'selector-header'}`}
                                   >
                                     <div
                                       className={`${

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -492,7 +492,7 @@
         border: 1px solid var(--indigo9, #3E63DD) !important;
         background: var(--indigo2, #F8FAFF) !important;
         /* Focus rings/Indigo/light */
-        box-shadow: 0px 0px 0px 4px #C6D4F9 !important;
+        box-shadow: 0px 0px 0px 4px var(--indigo6) !important;
       }
     }
     .total-page-number{
@@ -528,9 +528,18 @@
       &:focus-within{
         outline: 0;
         background: var(--slate4, #ECEEF0) !important;
-        box-shadow: 0px 0px 0px 4px #DFE3E6 !important;
+        box-shadow: 0px 0px 0px 4px var(--slate6) !important;
         z-index: 999;
         margin: 4px 0;
+        
+      }
+      &:first-child:focus-within{
+        outline: 0;
+        border-left: 4px solid  var(--slate6);
+      }
+      &:last-child:focus-within{
+        outline: 0;
+        border-right: 4px solid  var(--slate6);
       }
       div:focus-visible{
         outline: 0 !important;
@@ -594,7 +603,10 @@
   }
 }
 .jet-data-table .has-actions{
-  padding: 0;
+  padding: 6px 12px;
+  .justify-content-start{
+    justify-content: center !important;
+  }
 }
 .jet-table.table-component{
   .isResizing{

--- a/frontend/src/_ui/AppButton/AppButton.scss
+++ b/frontend/src/_ui/AppButton/AppButton.scss
@@ -82,7 +82,7 @@
     &:active {
         background: var(--slate1);
         border: 1px solid rgba(255, 255, 255, 0.00);
-        box-shadow: 0px 0px 0px 4px #C6D4F9;
+        box-shadow: 0px 0px 0px 4px var(--indigo6);
         background: var(--indigo9);
     }
 
@@ -113,7 +113,7 @@
         background: var(--indigo3, #F0F4FF) !important;
 
         /* Focus rings/Indigo/light */
-        box-shadow: 0px 0px 0px 4px #C6D4F9;
+        box-shadow: 0px 0px 0px 4px var(--indigo6);
     }}
 
 .tj-tertiary-btn {


### PR DESCRIPTION
Resolves -
-Box shadow is not getting applied to the left side of the first header and the right side of the last header in the table, also change the box shadow color of it in dark theme

-When we click on the input checkbox in the selector type column header, at that time, its parent element's focus-within state gets activated, hence we see a box-shadow over the respective column header container. Whereas , our ideal scenario is, we need box-shadow effect only, when with key events


https://github.com/ToolJet/ToolJet/assets/37823141/4659f754-0ca6-4101-9249-afaf06ddb846

