### PR TITLE
Bug fixed - Datepicker dates are not aligned properly 

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -1370,7 +1370,7 @@ export function Table({
                           className={cx(
                             `table-text-align-${cell.column.horizontalAlignment} ${
                               wrapAction ? wrapAction : cell?.column?.Header === 'Actions' ? '' : 'wrap'
-                            }-wrapper`,
+                            }-wrapper td`,
                             {
                               'has-actions': cell.column.id === 'rightActions' || cell.column.id === 'leftActions',
                               'has-left-actions': cell.column.id === 'leftActions',

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -135,8 +135,8 @@
     overflow-x: hidden !important;
   }
 
-  td {
-    padding: 6px 12px;
+  .td {
+    // padding: 6px 12px;
     .text-container:focus-visible,
     .text-container:focus,
     .text-container:focus-within,


### PR DESCRIPTION
Resolves 
- datepicker dates are not aligned properly
- Above problem was introduced due to padding added to td element, the same padding was also making an issue for cell size regular or condensed. Due to padding, there was no significant change when toggled between condensed and regular cell sizes.
- To avoid confusion between table component td and deterpicker td element, added class `td` to the table component's td element