### PR TITLE
Removing overflow hidden to unable resizing the column header from the right side of resizer element

### DIFF
--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -55,7 +55,6 @@
     .tr{
       height: 32px; 
       .th{
-        overflow: hidden;
         .thead-editable-icon-header-text-wrapper{
           max-width: 100%;
           min-width: 70%;


### PR DESCRIPTION
Resolves - Due to overflow hidden prop, we are not able to resize the column header from the right side of its resizer element