### PR TITLE
Bugfix/tooljetdb join operations

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/Confirm.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/Confirm.jsx
@@ -31,7 +31,7 @@ function useConfirm() {
           onHide={() => handleConfirm(false)}
           centered
           size="sm"
-          contentClassName={darkMode ? 'theme-dark' : ''}
+          contentClassName={darkMode ? 'theme-dark dark-theme' : ''}
         >
           <Modal.Header>
             <Modal.Title>{heading || 'Confirm action ?'}</Modal.Title>
@@ -48,14 +48,14 @@ function useConfirm() {
                 fillRule="evenodd"
                 clipRule="evenodd"
                 d="M11.5996 11.6201C11.8599 11.3597 12.282 11.3597 12.5424 11.6201L16.071 15.1487L19.5996 11.6201C19.8599 11.3597 20.282 11.3597 20.5424 11.6201C20.8027 11.8804 20.8027 12.3025 20.5424 12.5629L17.0138 16.0915L20.5424 19.6201C20.8027 19.8804 20.8027 20.3025 20.5424 20.5629C20.282 20.8232 19.8599 20.8232 19.5996 20.5629L16.071 17.0343L12.5424 20.5629C12.282 20.8232 11.8599 20.8232 11.5996 20.5629C11.3392 20.3025 11.3392 19.8804 11.5996 19.6201L15.1282 16.0915L11.5996 12.5629C11.3392 12.3025 11.3392 11.8804 11.5996 11.6201Z"
-                fill="#11181C"
+                fill="var(--slate12)"
               />
             </svg>
           </Modal.Header>
           <Modal.Body data-cy={'tjdb-delete-confirmation-modal-message'}>{message}</Modal.Body>
           <Modal.Footer
             style={{
-              borderTop: '1px solid #e6e8e9',
+              borderTop: '1px solid var(--slate5)',
               padding: '0.875rem 1.5rem',
             }}
           >

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
@@ -127,7 +127,7 @@ const DropDownSelect = ({
           className="tdb-dropdown-btn px-1 pe-3 ps-2 gap-0 w-100 border-0 justify-content-start rounded-0 position-relative font-weight-normal"
           data-cy={`show-ds-popover-button`}
         >
-          <div className="text-truncate">
+          <div className="pe-1 text-truncate">
             {renderSelected && renderSelected(selected)}
 
             {!renderSelected && selected

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import SelectBox from './SelectBox';
+import cx from 'classnames';
 import useShowPopover from '@/_hooks/useShowPopover';
 import { Badge, OverlayTrigger, Popover } from 'react-bootstrap';
 import { ButtonSolid } from '@/_ui/AppButton/AppButton';
@@ -19,6 +20,7 @@ const DropDownSelect = ({
   value,
   renderSelected,
   emptyError,
+  shouldCenterAlignText = false,
 }) => {
   const popoverId = useRef(`dd-select-${uuidv4()}`);
   const popoverBtnId = useRef(`dd-select-btn-${uuidv4()}`);
@@ -124,10 +126,25 @@ const DropDownSelect = ({
             }
             setShowMenu((show) => !show);
           }}
-          className="tdb-dropdown-btn px-1 pe-3 ps-2 gap-0 w-100 border-0 justify-content-start rounded-0 position-relative font-weight-normal"
+          className={cx(
+            {
+              'justify-content-start': !shouldCenterAlignText,
+              'justify-content-centre': shouldCenterAlignText,
+            },
+            'tdb-dropdown-btn',
+            'gap-0',
+            'w-100',
+            'border-0',
+            'rounded-0',
+            'position-relative',
+            'font-weight-normal',
+            'px-1',
+            'pe-3',
+            'ps-2'
+          )}
           data-cy={`show-ds-popover-button`}
         >
-          <div className="pe-1 text-truncate">
+          <div className={`pe-1 text-truncate`}>
             {renderSelected && renderSelected(selected)}
 
             {!renderSelected && selected

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
@@ -170,9 +170,11 @@ const DropDownSelect = ({
 
 function MultiSelectValueBadge({ options, selected, setSelected, onChange }) {
   if (options?.length === selected?.length && selected?.length !== 0) {
+    // Filter Options without 'Select All'
+    const optionsWithoutSelectAll = options.filter((option) => option.value !== 'SELECT ALL');
     return (
       <Badge className={`me-1 dd-select-value-badge`} bg="secondary">
-        All {options?.length} selected
+        All {optionsWithoutSelectAll?.length} selected
         <span
           role="button"
           onClick={(e) => {

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
@@ -5,6 +5,7 @@ import { Badge, OverlayTrigger, Popover } from 'react-bootstrap';
 import { ButtonSolid } from '@/_ui/AppButton/AppButton';
 import CheveronDown from '@/_ui/Icon/bulkIcons/CheveronDown';
 import Remove from '@/_ui/Icon/bulkIcons/Remove';
+import { v4 as uuidv4 } from 'uuid';
 import { isEmpty } from 'lodash';
 
 const DropDownSelect = ({
@@ -19,8 +20,8 @@ const DropDownSelect = ({
   renderSelected,
   emptyError,
 }) => {
-  const popoverId = useRef(`dd-select-${generateRandomId(10)}`);
-  const popoverBtnId = useRef(`dd-select-btn-${generateRandomId(10)}`);
+  const popoverId = useRef(`dd-select-${uuidv4()}`);
+  const popoverBtnId = useRef(`dd-select-btn-${uuidv4()}`);
   const [showMenu, setShowMenu] = useShowPopover(false, `#${popoverId.current}`, `#${popoverBtnId.current}`);
   const [selected, setSelected] = useState(value);
   const selectRef = useRef();
@@ -126,38 +127,41 @@ const DropDownSelect = ({
           className="tdb-dropdown-btn px-1 pe-3 ps-2 gap-0 w-100 border-0 justify-content-start rounded-0 position-relative font-weight-normal"
           data-cy={`show-ds-popover-button`}
         >
-          {renderSelected && renderSelected(selected)}
-          {!renderSelected && selected
-            ? Array.isArray(selected)
-              ? !isOverflown && (
-                  <MultiSelectValueBadge
-                    options={options}
-                    selected={selected}
-                    setSelected={setSelected}
-                    onChange={onChange}
-                  />
-                )
-              : selected?.label
-            : ''}
-          {!renderSelected && isOverflown && !Array.isArray(selected) && (
-            <Badge className="me-1 dd-select-value-badge" bg="secondary">
-              {selected?.length} selected
-              <span
-                role="button"
-                onClick={(e) => {
-                  setSelected([]);
-                  onChange && onChange([]);
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
-              >
-                <Remove fill="var(--slate12)" />
-              </span>
-            </Badge>
-          )}
-          <span className="dd-select-control-chevron">
+          <div className="text-truncate">
+            {renderSelected && renderSelected(selected)}
+
+            {!renderSelected && selected
+              ? Array.isArray(selected)
+                ? !isOverflown && (
+                    <MultiSelectValueBadge
+                      options={options}
+                      selected={selected}
+                      setSelected={setSelected}
+                      onChange={onChange}
+                    />
+                  )
+                : selected?.label
+              : ''}
+            {!renderSelected && isOverflown && !Array.isArray(selected) && (
+              <Badge className="me-1 dd-select-value-badge" bg="secondary">
+                {selected?.length} selected
+                <span
+                  role="button"
+                  onClick={(e) => {
+                    setSelected([]);
+                    onChange && onChange([]);
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                >
+                  <Remove fill="var(--slate12)" width="12px" />
+                </span>
+              </Badge>
+            )}
+          </div>
+          <div className="dd-select-control-chevron">
             <CheveronDown />
-          </span>
+          </div>
         </ButtonSolid>
       </span>
     </OverlayTrigger>
@@ -202,18 +206,6 @@ function MultiSelectValueBadge({ options, selected, setSelected, onChange }) {
       </span>
     </Badge>
   ));
-}
-
-function generateRandomId(length) {
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let randomId = '';
-
-  for (let i = 0; i < length; i++) {
-    const randomIndex = Math.floor(Math.random() * characters.length);
-    randomId += characters.charAt(randomIndex);
-  }
-
-  return randomId;
 }
 
 export default DropDownSelect;

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
@@ -132,6 +132,7 @@ const JoinConstraint = ({ darkMode, index, onRemove, onChange, data }) => {
         </Col>
         <Col sm="1" className="p-0 border-end">
           <DropDownSelect
+            shouldCenterAlignText
             options={staticJoinOperationsList}
             darkMode={darkMode}
             onChange={(value) => onChange({ ...data, joinType: value?.value })}

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
@@ -152,14 +152,12 @@ const JoinConstraint = ({ darkMode, index, onRemove, onChange, data }) => {
             options={tableList}
             darkMode={darkMode}
             onChange={async (value) => {
-              let result = false;
+              let result = true;
               if (rightFieldTable?.length) {
                 result = await confirm(
                   'Changing the table will also delete its associated conditions. Are you sure you want to continue?',
                   'Change table?'
                 );
-              } else {
-                result = true;
               }
 
               if (result) {
@@ -231,7 +229,7 @@ const JoinConstraint = ({ darkMode, index, onRemove, onChange, data }) => {
           </ButtonSolid>
         </Col>
       </Row>
-      <ConfirmDialog confirmButtonText="Delete" darkMode={darkMode} />
+      <ConfirmDialog confirmButtonText="Continue" darkMode={darkMode} />
     </Container>
   );
 };

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
@@ -59,7 +59,7 @@ const JoinConstraint = ({ darkMode, index, onRemove, onChange, data }) => {
     });
 
   return (
-    <Container className="p-0">
+    <Container fluid className="p-0">
       <Row className={`mx-0 ${index === 0 && 'pb-2'}`}>
         <Col sm="2"></Col>
         <Col sm="4" className="text-left">
@@ -137,7 +137,13 @@ const JoinConstraint = ({ darkMode, index, onRemove, onChange, data }) => {
             onChange={(value) => onChange({ ...data, joinType: value?.value })}
             value={staticJoinOperationsList.find((val) => val.value === joinType)}
             renderSelected={(selected) =>
-              selected ? <Icon name={selected?.icon} height={20} width={20} viewBox="" /> : ''
+              selected ? (
+                <div className="w-100">
+                  <Icon name={selected?.icon} height={20} width={20} viewBox="" />
+                </div>
+              ) : (
+                ''
+              )
             }
           />
         </Col>

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSelect.jsx
@@ -3,6 +3,7 @@ import { Col, Container, Row } from 'react-bootstrap';
 import { TooljetDatabaseContext } from '@/TooljetDatabase/index';
 import DropDownSelect from './DropDownSelect';
 import { cloneDeep } from 'lodash';
+import SolidIcon from '@/_ui/Icon/SolidIcons';
 
 export default function JoinSelect({ darkMode }) {
   const { joinOptions, tableInfo, joinTableOptions, joinTableOptionsChange, findTableDetails } =
@@ -44,8 +45,27 @@ export default function JoinSelect({ darkMode }) {
 
   // When column name are same, alias has been added
   const handleChange = (columns, table) => {
-    const unchangedSelectFields = joinSelectOptions.filter((t) => t.table !== table);
-    let newSelectFields = [...unchangedSelectFields, ...columns.map((column) => ({ name: column?.value, table }))];
+    const unchangedSelectFields = [];
+    const prevSelectedFields = [];
+    joinSelectOptions.forEach((t) => {
+      if (t.table !== table) unchangedSelectFields.push(t);
+      if (t.table === table) prevSelectedFields.push(t);
+    });
+
+    // Select All & Deselect Functionality
+    const allColumnsOfTable = tableOptions[table] ?? [];
+    const columnsWithoutSelectAllOption = columns.filter((column) => column.value !== 'SELECT ALL');
+    const isSelectAllExists = columns.findIndex((column) => column.value === 'SELECT ALL') >= 0;
+
+    let newSelectFields = [...unchangedSelectFields];
+    if (
+      (!isSelectAllExists && prevSelectedFields.length !== columnsWithoutSelectAllOption.length) ||
+      (isSelectAllExists && prevSelectedFields.length === allColumnsOfTable.length)
+    )
+      columnsWithoutSelectAllOption.forEach((column) => newSelectFields.push({ name: column?.value, table }));
+    // Push all the Columns When Select All options is clicked
+    if (isSelectAllExists && allColumnsOfTable.length && prevSelectedFields.length !== allColumnsOfTable.length)
+      allColumnsOfTable.forEach((column) => newSelectFields.push({ name: column?.value, table }));
 
     newSelectFields = newSelectFields.map((field) => {
       if (newSelectFields.filter(({ name }) => name === field.name).length > 1 && !('alias' in field)) {
@@ -65,34 +85,66 @@ export default function JoinSelect({ darkMode }) {
 
   return (
     <Container fluid className="p-0">
-      {tables.map((table) => (
-        <Row key={table} className="border rounded mb-2 mx-0">
-          <Col sm="3" className="p-0 border-end">
-            <div className="tj-small-btn px-2">{findTableDetails(table)?.table_name ?? ''}</div>
-          </Col>
-          <Col sm="9" className="p-0 border-end">
-            <DropDownSelect
-              options={tableOptions[table]?.sort((a, b) => {
-                const aChecked = joinSelectOptions.some((item) => item.name === a.value && item.table === table);
-                const bChecked = joinSelectOptions.some((item) => item.name === b.value && item.table === table);
-                if (aChecked && !bChecked) {
-                  return -1;
-                }
-                if (!aChecked && bChecked) {
-                  return 1;
-                }
-                return 0;
-              })}
-              darkMode={darkMode}
-              isMulti
-              onChange={(values) => handleChange(values, table)}
-              value={joinSelectOptions
-                .filter((val) => val?.table === table)
-                .map((column) => ({ value: column?.name, label: column?.name }))}
-            />
-          </Col>
+      {tables.length ? (
+        tables.map((table) => {
+          const respectiveTableSelectedOptions = joinSelectOptions.filter((val) => val?.table === table);
+          const respectiveTableOptions = tableOptions[table] ?? [];
+          return (
+            <Row key={table} className="border rounded mb-2 mx-0">
+              <Col sm="3" className="p-0 border-end">
+                <div className="tj-small-btn px-2">{findTableDetails(table)?.table_name ?? ''}</div>
+              </Col>
+              <Col sm="9" className="p-0 border-end">
+                <DropDownSelect
+                  options={[
+                    { label: 'Select All', value: 'SELECT ALL' },
+                    ...(tableOptions[table]?.sort((a, b) => {
+                      const aChecked = joinSelectOptions.some((item) => item.name === a.value && item.table === table);
+                      const bChecked = joinSelectOptions.some((item) => item.name === b.value && item.table === table);
+                      if (aChecked && !bChecked) {
+                        return -1;
+                      }
+                      if (!aChecked && bChecked) {
+                        return 1;
+                      }
+                      return 0;
+                    }) ?? []),
+                  ]}
+                  darkMode={darkMode}
+                  isMulti
+                  onChange={(values) => handleChange(values, table)}
+                  value={[
+                    ...(respectiveTableOptions?.length === respectiveTableSelectedOptions?.length &&
+                    respectiveTableSelectedOptions?.length !== 0
+                      ? [
+                          {
+                            label: 'Select All',
+                            value: 'SELECT ALL',
+                          },
+                        ]
+                      : []),
+                    ...respectiveTableSelectedOptions.map((column) => ({ value: column?.name, label: column?.name })),
+                  ]}
+                />
+              </Col>
+            </Row>
+          );
+        })
+      ) : (
+        <Row className="mb-2 mx-0">
+          <div
+            style={{
+              gap: '4px',
+              height: '30px',
+              border: '1px dashed var(--slate-08, #C1C8CD)',
+            }}
+            className="px-4 py-2 text-center rounded-1"
+          >
+            <SolidIcon name="information" style={{ height: 14, width: 14 }} width={14} height={14} /> Tables are not
+            selected
+          </div>
         </Row>
-      ))}
+      )}
     </Container>
   );
 }

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSelect.jsx
@@ -63,7 +63,7 @@ export default function JoinSelect({ darkMode }) {
   };
 
   return (
-    <Container className="p-0">
+    <Container fluid className="p-0">
       {tables.map((table) => (
         <Row key={table} className="border rounded mb-2 mx-0">
           <Col sm="3" className="p-0 border-end">

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSelect.jsx
@@ -7,6 +7,7 @@ import { cloneDeep } from 'lodash';
 export default function JoinSelect({ darkMode }) {
   const { joinOptions, tableInfo, joinTableOptions, joinTableOptionsChange, findTableDetails } =
     useContext(TooljetDatabaseContext);
+
   const joinSelectOptions = cloneDeep(joinTableOptions['fields']) || [];
   const setJoinSelectOptions = (fields) => {
     joinTableOptionsChange('fields', fields);

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
@@ -35,7 +35,7 @@ export default function JoinSort({ darkMode }) {
   ];
 
   return (
-    <Container className="p-0">
+    <Container fluid className="p-0">
       {isEmpty(joinOrderByOptions) ? (
         <Row className="mb-2 mx-0">
           <div

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
@@ -69,46 +69,29 @@ export default function JoinSort({ darkMode }) {
           </div>
         </Row>
       ) : (
-        joinOrderByOptions.map((options, i) => (
-          <Row className="border rounded mb-2 mx-0" key={i}>
-            <Col sm="6" className="p-0 border-end">
-              <DropDownSelect
-                options={tableList}
-                darkMode={darkMode}
-                value={{
-                  value: options.columnName + '_' + options.table,
-                  label: options.columnName,
-                  table: options.table,
-                }}
-                onChange={(option) => {
-                  setJoinOrderByOptions(
-                    joinOrderByOptions.map((sortBy, index) => {
-                      if (i === index) {
-                        return {
-                          ...sortBy,
-                          columnName: option?.label,
-                          table: option.table,
-                        };
-                      }
-                      return sortBy;
-                    })
-                  );
-                }}
-              />
-            </Col>
-            <Col sm="6" className="p-0 d-flex">
-              <div className="flex-grow-1 border-end">
+        joinOrderByOptions.map((options, i) => {
+          const tableDetails = options?.table ? findTableDetails(options?.table) : '';
+          return (
+            <Row className="border rounded mb-2 mx-0" key={i}>
+              <Col sm="6" className="p-0 border-end">
                 <DropDownSelect
-                  options={sortbyConstants}
+                  options={tableList}
                   darkMode={darkMode}
-                  value={sortbyConstants.find((opt) => opt.value === options.direction)}
+                  value={{
+                    value: options.columnName + '_' + options.table,
+                    label: tableDetails?.table_name
+                      ? tableDetails?.table_name + '.' + options.columnName
+                      : options.columnName,
+                    table: options.table,
+                  }}
                   onChange={(option) => {
                     setJoinOrderByOptions(
                       joinOrderByOptions.map((sortBy, index) => {
                         if (i === index) {
                           return {
                             ...sortBy,
-                            direction: option?.value,
+                            columnName: option?.label,
+                            table: option.table,
                           };
                         }
                         return sortBy;
@@ -116,18 +99,40 @@ export default function JoinSort({ darkMode }) {
                     );
                   }}
                 />
-              </div>
-              <ButtonSolid
-                size="sm"
-                variant="ghostBlack"
-                className="px-1 rounded-0"
-                onClick={() => setJoinOrderByOptions(joinOrderByOptions.filter((opt, idx) => idx !== i))}
-              >
-                <Trash fill="var(--slate9)" style={{ height: '16px' }} />
-              </ButtonSolid>
-            </Col>
-          </Row>
-        ))
+              </Col>
+              <Col sm="6" className="p-0 d-flex">
+                <div className="flex-grow-1 border-end">
+                  <DropDownSelect
+                    options={sortbyConstants}
+                    darkMode={darkMode}
+                    value={sortbyConstants.find((opt) => opt.value === options.direction)}
+                    onChange={(option) => {
+                      setJoinOrderByOptions(
+                        joinOrderByOptions.map((sortBy, index) => {
+                          if (i === index) {
+                            return {
+                              ...sortBy,
+                              direction: option?.value,
+                            };
+                          }
+                          return sortBy;
+                        })
+                      );
+                    }}
+                  />
+                </div>
+                <ButtonSolid
+                  size="sm"
+                  variant="ghostBlack"
+                  className="px-1 rounded-0"
+                  onClick={() => setJoinOrderByOptions(joinOrderByOptions.filter((opt, idx) => idx !== i))}
+                >
+                  <Trash fill="var(--slate9)" style={{ height: '16px' }} />
+                </ButtonSolid>
+              </Col>
+            </Row>
+          );
+        })
       )}
       {/* Dynamically render below Row */}
       <Row className="mx-0">

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
@@ -78,8 +78,8 @@ export default function JoinSort({ darkMode }) {
                 }}
               />
             </Col>
-            <Col sm="5" className="p-0 border-end d-flex">
-              <div className="flex-grow-1">
+            <Col sm="6" className="p-0 d-flex">
+              <div className="flex-grow-1 border-end">
                 <DropDownSelect
                   options={sortbyConstants}
                   darkMode={darkMode}
@@ -99,12 +99,10 @@ export default function JoinSort({ darkMode }) {
                   }}
                 />
               </div>
-            </Col>
-            <Col sm="1" className="p-0">
               <ButtonSolid
                 size="sm"
                 variant="ghostBlack"
-                className="px-1 w-100 rounded-0"
+                className="px-1 rounded-0"
                 onClick={() => setJoinOrderByOptions(joinOrderByOptions.filter((opt, idx) => idx !== i))}
               >
                 <Trash fill="var(--slate9)" style={{ height: '16px' }} />

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
@@ -9,23 +9,41 @@ import { isEmpty } from 'lodash';
 import SolidIcon from '@/_ui/Icon/SolidIcons';
 
 export default function JoinSort({ darkMode }) {
-  const { tableInfo, joinOrderByOptions, setJoinOrderByOptions, findTableDetailsByName } =
+  const { tableInfo, joinOrderByOptions, setJoinOrderByOptions, joinOptions, findTableDetails } =
     useContext(TooljetDatabaseContext);
 
-  let tableList = [];
-  Object.entries(tableInfo).forEach(([key, value]) => {
-    const tableDetail = findTableDetailsByName(key);
-    if (tableDetail && tableDetail?.table_name) {
-      const tableDetails = {
-        label: tableDetail.table_name,
-        value: tableDetail.table_id,
-        options: value.map((columns) => ({
-          label: columns.Header,
-          value: columns.Header + '_' + tableDetail.table_id,
-          table: tableDetail.table_id,
-        })),
+  const tableSet = new Set();
+  (joinOptions || []).forEach((join) => {
+    const { table, conditions } = join;
+    tableSet.add(table);
+    conditions?.conditionsList?.forEach((condition) => {
+      const { leftField, rightField } = condition;
+      if (leftField?.table) {
+        tableSet.add(leftField?.table);
+      }
+      if (rightField?.table) {
+        tableSet.add(rightField?.table);
+      }
+    });
+  });
+
+  const tables = [...tableSet];
+  const tableList = [];
+
+  tables.forEach((tableId) => {
+    const tableDetails = findTableDetails(tableId);
+    if (tableDetails?.table_name && tableInfo[tableDetails.table_name]) {
+      const tableDetailsForDropDown = {
+        label: tableDetails.table_name,
+        value: tableId,
+        options:
+          tableInfo[tableDetails.table_name]?.map((columns) => ({
+            label: columns.Header,
+            value: columns.Header + '_' + tableId,
+            table: tableId,
+          })) || [],
       };
-      tableList.push(tableDetails);
+      tableList.push(tableDetailsForDropDown);
     }
   });
 

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinSort.jsx
@@ -70,7 +70,7 @@ export default function JoinSort({ darkMode }) {
         </Row>
       ) : (
         joinOrderByOptions.map((options, i) => (
-          <Row className="border rounded mb-1 mx-0" key={i}>
+          <Row className="border rounded mb-2 mx-0" key={i}>
             <Col sm="6" className="p-0 border-end">
               <DropDownSelect
                 options={tableList}

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinTable.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinTable.jsx
@@ -438,7 +438,7 @@ const RenderFilterSection = ({ darkMode }) => {
   });
 
   return (
-    <Container className="p-0">
+    <Container fluid className="p-0">
       {conditionsList.length === 0 && (
         <Row className="mb-2 mx-0">
           <div

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinTable.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinTable.jsx
@@ -42,17 +42,17 @@ const SelectTableMenu = ({ darkMode }) => {
     const cleanedJoin = [];
     const tableSet = new Set();
     (updatedJoin || []).forEach((join, i) => {
-      const { _table, conditions } = join;
+      const { conditions } = join;
       let leftTable, rightTable;
       conditions?.conditionsList?.forEach((condition) => {
-        const { leftField, rightField } = condition;
+        const { leftField = {}, rightField = {} } = condition;
         if (leftField?.table) leftTable = leftField?.table;
         if (rightField?.table) rightTable = rightField?.table;
       });
 
       if ((tableSet.has(leftTable) && !tableSet.has(rightTable)) || i === 0) {
-        tableSet.add(leftTable);
-        tableSet.add(rightTable);
+        if (leftTable) tableSet.add(leftTable);
+        if (rightTable) tableSet.add(rightTable);
         cleanedJoin.push({ ...join });
       }
     });
@@ -92,14 +92,14 @@ const SelectTableMenu = ({ darkMode }) => {
       <div className="field-container d-flex" style={{ marginBottom: '1.5rem' }}>
         <label className="form-label">From</label>
         <div className="field flex-grow-1 mt-1">
-          {joins.map((join, i) => (
+          {joins.map((join, joinIndex) => (
             <JoinConstraint
               darkMode={darkMode}
-              key={join.id}
-              index={i}
+              key={join?.id}
+              index={joinIndex}
               data={join}
-              onChange={(value) => handleJoinChange(value, i)}
-              onRemove={() => setJoins(calcUpdatedJoins(joins.filter((join, index) => index !== i)))}
+              onChange={(value) => handleJoinChange(value, joinIndex)}
+              onRemove={() => setJoins(calcUpdatedJoins(joins.filter((join, index) => index !== joinIndex)))}
             />
           ))}
           <Row className="mx-0">

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinTable.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinTable.jsx
@@ -111,7 +111,15 @@ const SelectTableMenu = ({ darkMode }) => {
                   ...joins,
                   {
                     id: new Date().getTime(),
-                    conditions: { conditionsList: [{ leftField: { table: selectedTableId } }] },
+                    conditions: {
+                      operator: 'AND',
+                      conditionsList: [
+                        {
+                          operator: '=',
+                          leftField: { table: selectedTableId },
+                        },
+                      ],
+                    },
                     joinType: 'INNER',
                   },
                 ])
@@ -204,7 +212,7 @@ const RenderFilterSection = ({ darkMode }) => {
   function addNewFilterConditionEntry() {
     let editedFilterCondition = {};
 
-    const emptyConditionTemplate = { operator: '', leftField: {}, rightField: {} };
+    const emptyConditionTemplate = { operator: '=', leftField: {}, rightField: {} };
 
     // First time populate operator & conditionList details
     if (!Object.keys(conditions).length) {
@@ -354,6 +362,7 @@ const RenderFilterSection = ({ darkMode }) => {
 
   const filterComponents = conditionsList.map((conditionDetail, index) => {
     const { operator = '', leftField = {}, rightField = {} } = conditionDetail;
+    const LeftSideTableDetails = leftField?.table ? findTableDetails(leftField?.table) : '';
     return (
       <Row className="border rounded mb-2 mx-0" key={index}>
         <Col sm="2" className="p-0 border-end">
@@ -378,7 +387,9 @@ const RenderFilterSection = ({ darkMode }) => {
               })
             }
             value={{
-              label: leftField?.columnName,
+              label: LeftSideTableDetails?.table_name
+                ? LeftSideTableDetails?.table_name + '.' + leftField?.columnName
+                : leftField?.columnName,
               value: leftField?.columnName + '-' + leftField?.table,
               table: leftField?.table,
             }}

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -236,7 +236,7 @@ const MenuList = ({ children, getStyles, innerRef, onAdd, addBtnLabel, emptyErro
   const { admin } = authenticationService.currentSessionValue;
   if (admin) {
     //offseting for height of button since react-select calculates only the size of options list
-    menuListStyles.maxHeight = 400 - 48;
+    menuListStyles.maxHeight = 225 - 48;
   }
   menuListStyles.padding = '4px';
 

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -1,4 +1,4 @@
-import React, { isValidElement, useCallback } from 'react';
+import React, { isValidElement, useCallback, useState } from 'react';
 import Select, { components } from 'react-select';
 import { isEmpty } from 'lodash';
 import { authenticationService } from '@/_services';
@@ -211,10 +211,10 @@ function DataSourceSelect({
         value={selected}
         // onKeyDown={handleKeyDown}
         onInputChange={() => {
-          const queryDsSelectMenu = document.getElementById('query-ds-select-menu');
-          if (queryDsSelectMenu && !queryDsSelectMenu?.style?.height) {
-            queryDsSelectMenu.style.height = queryDsSelectMenu.offsetHeight + 'px';
-          }
+          const _queryDsSelectMenu = document.getElementById('query-ds-select-menu');
+          // if (queryDsSelectMenu && !queryDsSelectMenu?.style?.height) {
+          //   queryDsSelectMenu.style.height = queryDsSelectMenu.offsetHeight + 'px';
+          // }
         }}
         // filterOption={(data, search) => {
         //   if (data?.data?.source) {
@@ -271,14 +271,18 @@ const DropdownIndicator = (props) => {
 };
 
 const CustomGroupHeading = (props) => {
-  const node = document.querySelector(`#${props.id}`)?.parentElement?.nextElementSibling;
-  const classes = node?.classList;
-  const hidden = classes?.contains('d-none');
+  const [isGroupListCollapsed, setIsGroupListCollapsed] = useState(false);
 
   const handleHeaderClick = (id) => {
+    const node = document.querySelector(`#${id}`)?.parentElement?.nextElementSibling;
+    const classes = node?.classList;
+    const hidden = classes?.contains('d-none');
+
     if (hidden) {
+      setIsGroupListCollapsed(false);
       node.classList.remove('d-none');
     } else {
+      setIsGroupListCollapsed(true);
       node.classList.add('d-none');
     }
   };
@@ -289,7 +293,8 @@ const CustomGroupHeading = (props) => {
       onClick={() => handleHeaderClick(props.id)}
       style={{ cursor: 'pointer' }}
     >
-      <components.GroupHeading {...props} /> <SolidIcon name={hidden ? 'cheverondown' : 'cheveronup'} height={20} />
+      <components.GroupHeading {...props} />{' '}
+      <SolidIcon name={isGroupListCollapsed ? 'cheverondown' : 'cheveronup'} height={20} />
     </div>
   );
 };

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
@@ -106,7 +106,10 @@ const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLay
       return {
         ...prevJoinOptions,
         joins: values,
-        conditions: { conditionsList: newConditionsList },
+        conditions: {
+          ...(conditions?.operator && { operator: conditions.operator }),
+          conditionsList: newConditionsList,
+        },
         order_by: newOrderBy,
         fields: updatedFields,
       };

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
@@ -402,7 +402,20 @@ const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLay
 
     setJoinTableOptions(() => {
       return {
-        joins: [{ conditions: { conditionsList: [{ leftField: { table: tableId } }] }, joinType: 'INNER' }],
+        joins: [
+          {
+            conditions: {
+              operator: 'AND',
+              conditionsList: [
+                {
+                  operator: '=',
+                  leftField: { table: tableId },
+                },
+              ],
+            },
+            joinType: 'INNER',
+          },
+        ],
         from: {
           name: tableId,
           type: 'Table',

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
@@ -407,6 +407,7 @@ const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLay
       return {
         joins: [
           {
+            id: new Date().getTime(),
             conditions: {
               operator: 'AND',
               conditionsList: [

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
@@ -7,18 +7,21 @@ import { CreateRow } from './CreateRow';
 import { UpdateRows } from './UpdateRows';
 import { DeleteRows } from './DeleteRows';
 import { toast } from 'react-hot-toast';
-import Select from '@/_ui/Select';
 import { queryManagerSelectComponentStyle } from '@/_ui/Select/styles';
 import { useMounted } from '@/_hooks/use-mount';
 import { useCurrentState } from '@/_stores/currentStateStore';
 import { JoinTable } from './JoinTable';
 import { cloneDeep, difference } from 'lodash';
+import DropDownSelect from './DropDownSelect';
+import { getPrivateRoute } from '@/_helpers/routes';
+import { useNavigate } from 'react-router-dom';
 
 const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLayout }) => {
   const computeSelectStyles = (darkMode, width) => {
     return queryManagerSelectComponentStyle(darkMode, width);
   };
   const currentState = useCurrentState();
+  const navigate = useNavigate();
   const { current_organization_id: organizationId } = authenticationService.currentSessionValue;
   const mounted = useMounted();
   const [operation, setOperation] = useState(options['operation'] || '');
@@ -391,7 +394,7 @@ const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLay
   const generateListForDropdown = (tableList) => {
     return tableList.map((tableMap) =>
       Object.fromEntries([
-        ['name', tableMap.table_name],
+        ['label', tableMap.table_name],
         ['value', tableMap.table_id],
       ])
     );
@@ -444,6 +447,14 @@ const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLay
     }
   };
 
+  const tooljetDbOperationList = [
+    { label: 'List rows', value: 'list_rows' },
+    { label: 'Create row', value: 'create_row' },
+    { label: 'Update rows', value: 'update_rows' },
+    { label: 'Delete rows', value: 'delete_rows' },
+    { label: 'Join tables', value: 'join_tables' },
+  ];
+
   const ComponentToRender = getComponent(operation);
 
   return (
@@ -452,15 +463,16 @@ const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLay
       <div className={cx({ row: !isHorizontalLayout })}>
         <div className={cx({ 'col-4': !isHorizontalLayout, 'd-flex': isHorizontalLayout })}>
           <label className={cx('form-label')}>Table name</label>
-          <div className={cx({ 'flex-grow-1': isHorizontalLayout })}>
-            <Select
+          <div className={cx({ 'flex-grow-1': isHorizontalLayout }, 'border', 'rounded')}>
+            <DropDownSelect
               options={generateListForDropdown(tables)}
-              value={selectedTableId}
-              onChange={(value) => handleTableNameSelect(value)}
-              width="100%"
-              // useMenuPortal={false}
-              useCustomStyles={true}
-              styles={computeSelectStyles(darkMode, '100%')}
+              darkMode={darkMode}
+              onChange={(value) => {
+                value?.value && handleTableNameSelect(value?.value);
+              }}
+              onAdd={() => navigate(getPrivateRoute('database'))}
+              addBtnLabel={'Add new table'}
+              value={generateListForDropdown(tables).find((val) => val?.value === selectedTableId)}
             />
           </div>
         </div>
@@ -473,21 +485,14 @@ const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLay
           className={cx({ 'col-4': !isHorizontalLayout, 'd-flex': isHorizontalLayout })}
         >
           <label className={cx('form-label')}>Operations</label>
-          <div className={cx({ 'flex-grow-1': isHorizontalLayout })}>
-            <Select
-              options={[
-                { name: 'List rows', value: 'list_rows' },
-                { name: 'Create row', value: 'create_row' },
-                { name: 'Update rows', value: 'update_rows' },
-                { name: 'Delete rows', value: 'delete_rows' },
-                { name: 'Join tables', value: 'join_tables' },
-              ]}
-              value={operation}
-              onChange={(value) => setOperation(value)}
-              width="100%"
-              // useMenuPortal={false}
-              useCustomStyles={true}
-              styles={computeSelectStyles(darkMode, '100%')}
+          <div className={cx({ 'flex-grow-1': isHorizontalLayout }, 'border', 'rounded')}>
+            <DropDownSelect
+              options={tooljetDbOperationList}
+              darkMode={darkMode}
+              onChange={(value) => {
+                value?.value && setOperation(value?.value);
+              }}
+              value={tooljetDbOperationList.find((val) => val?.value === operation)}
             />
           </div>
         </div>

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -232,7 +232,7 @@ async function joinTables(dataQuery, currentState) {
     return {
       status: 'failed',
       statusText: 'failed',
-      message: `Empty values are found in the following section - ${mandatoryFieldsButEmpty.join(',')}.`,
+      message: `Empty values are found in the following section - ${mandatoryFieldsButEmpty.join(', ')}.`,
       description: 'Mandatory fields are not empty',
       data: {},
     };

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -210,21 +210,24 @@ async function joinTables(dataQuery, currentState) {
   const resolvedOptions = resolveReferences(queryOptions, currentState);
   const { join_table = {} } = resolvedOptions;
 
+  // Empty Input is restricted
   if (Object.keys(join_table).length === 0) {
     return {
       status: 'failed',
       statusText: 'failed',
-      message: `Empty JSON is not allowed`,
+      message: `Input can't be empty`,
       description: 'Empty inputs are not allowed',
       data: {},
     };
   }
+
   const sanitizedJoinTableJson = { ...join_table };
-  // If mandatory fields are empty throw error
+  // If mandatory fields ( Select, JOin & From section ), are empty throw error
   let mandatoryFieldsButEmpty = [];
   if (!sanitizedJoinTableJson?.fields.length) mandatoryFieldsButEmpty.push('Select');
   if (sanitizedJoinTableJson?.from && !Object.keys(sanitizedJoinTableJson?.from).length)
     mandatoryFieldsButEmpty.push('From');
+  // if (join_table?.joins && !validateInputJsonHasEmptyFields(join_table?.joins)) mandatoryFieldsButEmpty.push('Joins');
   if (mandatoryFieldsButEmpty.length) {
     return {
       status: 'failed',
@@ -235,15 +238,16 @@ async function joinTables(dataQuery, currentState) {
     };
   }
 
-  // If non-mandatory fields are empty - remove the particular field
+  // If non-mandatory fields ( Filter & Sort ) are empty - remove the particular field
   if (
     sanitizedJoinTableJson?.conditions &&
-    (!Object.keys(sanitizedJoinTableJson?.conditions).length ||
-      !sanitizedJoinTableJson?.conditions?.conditionsList.length)
+    (!Object.keys(sanitizedJoinTableJson?.conditions)?.length ||
+      !sanitizedJoinTableJson?.conditions?.conditionsList?.length)
   ) {
     delete sanitizedJoinTableJson.conditions;
   }
-  if (!sanitizedJoinTableJson?.order_by.length) delete sanitizedJoinTableJson.order_by;
+  if (sanitizedJoinTableJson?.order_by && !sanitizedJoinTableJson?.order_by.length)
+    delete sanitizedJoinTableJson.order_by;
 
   return await tooljetDatabaseService.joinTables(organizationId, sanitizedJoinTableJson);
 }

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -870,6 +870,8 @@ export function previewQuery(_ref, query, calledFromQuery = false, parameters = 
 
         switch (queryStatus) {
           case 'Bad Request':
+          case 'Not Found':
+          case 'Unprocessable Entity':
           case 'failed': {
             const err = query.kind == 'tooljetdb' ? data?.error || data : _.isEmpty(data.data) ? data : data.data;
             toast.error(`${err.message}`);
@@ -976,8 +978,25 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode =
             ? data?.data?.status ?? 'ok'
             : data.status;
 
-        if (promiseStatus === 'failed' || promiseStatus === 'Bad Request') {
-          const errorData = query.kind === 'runpy' ? data.data : data;
+        if (
+          promiseStatus === 'failed' ||
+          promiseStatus === 'Bad Request' ||
+          promiseStatus === 'Not Found' ||
+          promiseStatus === 'Unprocessable Entity'
+        ) {
+          let errorData = {};
+          switch (query.kind) {
+            case 'runpy':
+              errorData = data.data;
+              break;
+            case 'tooljetdb':
+              errorData = data?.error || data;
+              break;
+            default:
+              errorData = data;
+          }
+
+          // errorData = query.kind === 'runpy' ? data.data : data;
           useCurrentStateStore.getState().actions.setErrors({
             [queryName]: {
               type: 'query',

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -990,12 +990,21 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode =
               errorData = data.data;
               break;
             case 'tooljetdb':
-              errorData = data?.error || data;
+              if (data?.error) {
+                errorData = {
+                  message: data?.error?.message || 'Something went wrong',
+                  description: data?.error?.message || 'Something went wrong',
+                  status: data?.statusText || 'Failed',
+                  data: data?.error || {},
+                };
+              } else {
+                errorData = data;
+              }
               break;
             default:
               errorData = data;
+              break;
           }
-
           // errorData = query.kind === 'runpy' ? data.data : data;
           useCurrentStateStore.getState().actions.setErrors({
             [queryName]: {


### PR DESCRIPTION
This Pr contains
BugFixes for TooljetDB Join Operations
    - **Custom Error handling** to convert - TableId to name
    - Grouped Drop Down - Chevron toggle was not working as expected 
    - While clicking **Add More** in join it was deleting new join condition
    - When we add a table in Join section and after changing it with new table, the old table was listed on Sort Section
    - First time ‘And’ operator is not added by default - Filter section.
    - **Design Review**: Select All feature in Select section
    - Empty View for Select section
    - Overflow text must be ellipses
    - **PR Review**: UUIDv4 change
    - Select All Feature
    - In the Filter Section, on Column Selecting Dropdown, the label would be like **tablename.columnname**
    - Now when trying to change condition will not show the change table confirmation when there are no conditions kept.
    -  For the filter condition, I think either there should be a placeholder or select equals by default for the operator
    - sort section on join query will have prefix table name along with column name
    - Select Drop down for Selecting table will have add new table option

As well as Design Fixes Discussed
2. For Large Screens Select, Filter and Sort Section Were Centered
3. Can the CTA be continue instead of delete? because the header is changing table so delete is seeming slightly icoherent