### PR TITLE
[DO-NOT-MERGE] Refactor resolve references to take object as a argument

### DIFF
--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -151,7 +151,13 @@ export function CodeHinter({
   useEffect(() => {
     if (JSON.stringify(currentValue) !== JSON.stringify(prevCurrentValue)) {
       const customResolvables = getCustomResolvables();
-      const [preview, error] = resolveReferences(currentValue, realState, null, customResolvables, true, true);
+      const [preview, error] = resolveReferences({
+        object: currentValue,
+        customObjects: customResolvables,
+        withError: true,
+        forPreviewBox: true,
+        currentState: realState,
+      });
       setPrevCurrentValue(currentValue);
 
       if (error) {
@@ -362,7 +368,7 @@ export function CodeHinter({
             </div>
             {!codeShow && (
               <ElementToRender
-                value={resolveReferences(initialValue, realState)}
+                value={resolveReferences({ object: initialValue, currentState: realState })}
                 onChange={(value) => {
                   if (value !== currentValue) {
                     onChange(value);

--- a/frontend/src/Editor/Components/Map/Map.jsx
+++ b/frontend/src/Editor/Components/Map/Map.jsx
@@ -27,10 +27,10 @@ export const Map = function Map({
   const { t } = useTranslation();
 
   const addNewMarkersProp = component.definition.properties.addNewMarkers;
-  const canAddNewMarkers = addNewMarkersProp ? resolveReferences(addNewMarkersProp.value, currentState) : false;
+  const canAddNewMarkers = addNewMarkersProp ? resolveReferences({ object: addNewMarkersProp.value }) : false;
 
   const canSearchProp = component.definition.properties.canSearch;
-  const canSearch = canSearchProp ? resolveReferences(canSearchProp.value, currentState) : false;
+  const canSearch = canSearchProp ? resolveReferences({ object: canSearchProp.value }) : false;
   const widgetVisibility = component.definition.styles?.visibility?.value ?? true;
   const disabledState = component.definition.styles?.disabledState?.value ?? false;
 
@@ -40,14 +40,14 @@ export const Map = function Map({
   let parsedWidgetVisibility = widgetVisibility;
 
   try {
-    parsedWidgetVisibility = resolveReferences(parsedWidgetVisibility, currentState, []);
+    parsedWidgetVisibility = resolveReferences({ object: parsedWidgetVisibility });
   } catch (err) {
     console.log(err);
   }
 
   const [gmap, setGmap] = useState(null);
   const [autoComplete, setAutoComplete] = useState(null);
-  const [mapCenter, setMapCenter] = useState(resolveReferences(center, currentState));
+  const [mapCenter, setMapCenter] = useState(resolveReferences({ object: center }));
   const [markers, setMarkers] = useState(defaultMarkers);
 
   const containerStyle = {
@@ -97,7 +97,7 @@ export const Map = function Map({
   }
 
   useEffect(() => {
-    const resolvedCenter = resolveReferences(center, currentState);
+    const resolvedCenter = resolveReferences({ object: center });
     setMapCenter(resolvedCenter);
     onComponentOptionsChanged(component, [['center', addMapUrlToJson(resolvedCenter)]]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -128,7 +128,7 @@ export const Map = function Map({
 
   useEffect(() => {
     setExposedVariable('setLocation', async function (lat, lng) {
-      if (lat && lng) setMapCenter(resolveReferences({ lat, lng }, currentState));
+      if (lat && lng) setMapCenter(resolveReferences({ object: { lat, lng } }));
     });
   }, [setMapCenter]);
 

--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -370,11 +370,14 @@ export function Table({
   let tableData = [],
     dynamicColumn = [];
 
-  const useDynamicColumn = resolveReferences(component.definition.properties?.useDynamicColumn?.value, currentState);
+  const useDynamicColumn = resolveReferences({
+    object: component.definition.properties?.useDynamicColumn?.value,
+    currentState,
+  });
   if (currentState) {
-    tableData = resolveReferences(component.definition.properties.data.value, currentState, []);
+    tableData = resolveReferences({ object: component.definition.properties.data.value, currentState });
     dynamicColumn = useDynamicColumn
-      ? resolveReferences(component.definition.properties?.columnData?.value, currentState, []) ?? []
+      ? resolveReferences({ object: component.definition.properties?.columnData?.value, currentState }) ?? []
       : [];
     if (!Array.isArray(tableData)) tableData = [];
   }
@@ -404,7 +407,7 @@ export function Table({
   columnData = useMemo(
     () =>
       columnData.filter((column) => {
-        if (resolveReferences(column.columnVisibility, currentState)) {
+        if (resolveReferences({ object: column.columnVisibility, currentState })) {
           return column;
         }
       }),
@@ -1139,7 +1142,10 @@ export function Table({
                                     },
                                   };
                                 }
-                                const isEditable = resolveReferences(column?.isEditable ?? false, currentState);
+                                const isEditable = resolveReferences({
+                                  object: column?.isEditable ?? false,
+                                  currentState,
+                                });
                                 return (
                                   <th
                                     key={index}
@@ -1334,31 +1340,42 @@ export function Table({
                       const rowChangeSet = changeSet ? changeSet[cell.row.index] : null;
                       const cellValue = rowChangeSet ? rowChangeSet[cell.column.name] || cell.value : cell.value;
                       const rowData = tableData[cell.row.index];
-                      const cellBackgroundColor = resolveReferences(
-                        cell.column?.cellBackgroundColor,
+                      const cellBackgroundColor = resolveReferences({
+                        object: cell.column?.cellBackgroundColor,
                         currentState,
-                        '',
-                        {
+                        customObjects: {
                           cellValue,
                           rowData,
-                        }
-                      );
-                      const cellTextColor = resolveReferences(cell.column?.textColor, currentState, '', {
-                        cellValue,
-                        rowData,
+                        },
+                      });
+                      const cellTextColor = resolveReferences({
+                        object: cell.column?.textColor,
+                        currentState,
+                        customObjects: {
+                          cellValue,
+                          rowData,
+                        },
                       });
                       const actionButtonsArray = actions.map((action) => {
                         return {
                           ...action,
-                          isDisabled: resolveReferences(action?.disableActionButton ?? false, currentState, '', {
-                            cellValue,
-                            rowData,
+                          isDisabled: resolveReferences({
+                            object: action?.disableActionButton ?? false,
+                            currentState,
+                            customObjects: {
+                              cellValue,
+                              rowData,
+                            },
                           }),
                         };
                       });
-                      const isEditable = resolveReferences(cell.column?.isEditable ?? false, currentState, '', {
-                        cellValue,
-                        rowData,
+                      const isEditable = resolveReferences({
+                        object: cell.column?.isEditable ?? false,
+                        currentState,
+                        customObjects: {
+                          cellValue,
+                          rowData,
+                        },
                       });
                       const horizontalAlignment = cell.column?.horizontalAlignment;
                       return (

--- a/frontend/src/Editor/Components/Table/columns/index.jsx
+++ b/frontend/src/Editor/Components/Table/columns/index.jsx
@@ -41,8 +41,8 @@ export default function generateColumnsData({
       columnType === 'image'
     ) {
       columnOptions.selectOptions = [];
-      const values = resolveReferences(column.values, currentState, []);
-      const labels = resolveReferences(column.labels, currentState, []);
+      const values = resolveReferences({ object: column.values, currentState });
+      const labels = resolveReferences({ object: column.labels, currentState });
 
       if (Array.isArray(labels) && Array.isArray(values)) {
         columnOptions.selectOptions = labels.map((label, index) => {
@@ -75,7 +75,7 @@ export default function generateColumnsData({
     const width = columnSize || defaultColumn.width;
     return {
       id: column.id,
-      Header: resolveReferences(column.name, currentState) ?? '',
+      Header: resolveReferences({ object: column.name, currentState }) ?? '',
       accessor: column.key || column.name,
       filter: customFilter,
       width: width,
@@ -115,7 +115,11 @@ export default function generateColumnsData({
           case 'string':
           case undefined:
           case 'default': {
-            const textColor = resolveReferences(column.textColor, currentState, '', { cellValue, rowData });
+            const textColor = resolveReferences({
+              object: column.textColor,
+              currentState,
+              customObjects: { cellValue, rowData },
+            });
 
             const cellStyles = {
               color: textColor ?? '',
@@ -194,7 +198,11 @@ export default function generateColumnsData({
             );
           }
           case 'number': {
-            const textColor = resolveReferences(column.textColor, currentState, '', { cellValue, rowData });
+            const textColor = resolveReferences({
+              object: column.textColor,
+              currentState,
+              customObjects: { cellValue, rowData },
+            });
 
             const cellStyles = {
               color: textColor ?? '',
@@ -457,7 +465,7 @@ export default function generateColumnsData({
             );
           }
           case 'link': {
-            const linkTarget = resolveReferences(column?.linkTarget ?? '_blank', currentState);
+            const linkTarget = resolveReferences({ object: column?.linkTarget ?? '_blank', currentState });
             return (
               <div className="h-100 d-flex align-items-center">
                 <Link cellValue={cellValue} linkTarget={linkTarget} />

--- a/frontend/src/Editor/Components/Tabs.jsx
+++ b/frontend/src/Editor/Components/Tabs.jsx
@@ -23,7 +23,7 @@ export const Tabs = function Tabs({
   const disabledState = component.definition.styles?.disabledState?.value ?? false;
   const defaultTab = component.definition.properties.defaultTab.value;
   // config for tabs. Includes title
-  const tabs = isExpectedDataType(resolveReferences(component.definition.properties.tabs.value, currentState), 'array');
+  const tabs = isExpectedDataType(resolveReferences({ object: component.definition.properties.tabs.value }), 'array');
   let parsedTabs = tabs;
   parsedTabs = resolveWidgetFieldValue(parsedTabs, currentState);
   const hideTabs = component.definition.properties?.hideTabs?.value ?? false;
@@ -56,7 +56,7 @@ export const Tabs = function Tabs({
   let parsedWidgetVisibility = widgetVisibility;
 
   try {
-    parsedWidgetVisibility = resolveReferences(parsedWidgetVisibility, currentState, []);
+    parsedWidgetVisibility = resolveReferences({ object: parsedWidgetVisibility });
   } catch (err) {
     console.log(err);
   }

--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -615,7 +615,7 @@ export const Container = ({
         const canShowInCurrentLayout =
           box.component.definition.others[currentLayout === 'mobile' ? 'showOnMobile' : 'showOnDesktop'].value;
         const addDefaultChildren = box.withDefaultChildren;
-        if (!box.parent && resolveReferences(canShowInCurrentLayout, currentState)) {
+        if (!box.parent && resolveReferences({ object: canShowInCurrentLayout })) {
           return (
             <DraggableBox
               className={showComments && 'pointer-events-none'}

--- a/frontend/src/Editor/Header/GlobalSettings.jsx
+++ b/frontend/src/Editor/Header/GlobalSettings.jsx
@@ -52,9 +52,12 @@ export const GlobalSettings = ({
 
   useEffect(() => {
     backgroundFxQuery &&
-      globalSettingsChanged('canvasBackgroundColor', resolveReferences(backgroundFxQuery, realState));
+      globalSettingsChanged(
+        'canvasBackgroundColor',
+        resolveReferences({ object: backgroundFxQuery, currentState: realState })
+      );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(resolveReferences(backgroundFxQuery, realState))]);
+  }, [JSON.stringify(resolveReferences({ object: backgroundFxQuery, currentState: realState }))]);
 
   const outerStyles = {
     width: '142px',

--- a/frontend/src/Editor/Inspector/Components/Chart.jsx
+++ b/frontend/src/Editor/Inspector/Components/Chart.jsx
@@ -61,10 +61,10 @@ class Chart extends React.Component {
 
     const jsonDescription = this.state.component.component.definition.properties.jsonDescription;
 
-    const plotFromJson = resolveReferences(
-      this.state.component.component.definition.properties.plotFromJson?.value,
-      currentState
-    );
+    const plotFromJson = resolveReferences({
+      object: this.state.component.component.definition.properties.plotFromJson?.value,
+      currentState,
+    });
 
     const chartType = this.state.component.component.definition.properties.type.value;
 

--- a/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
+++ b/frontend/src/Editor/Inspector/Components/DefaultComponent.jsx
@@ -68,7 +68,9 @@ export const baseComponentProperties = (
     Layout: [],
   };
   if (component.component.component === 'Listview') {
-    if (!resolveReferences(component.component.definition.properties?.enablePagination?.value, currentState)) {
+    if (
+      !resolveReferences({ object: component.component.definition.properties?.enablePagination?.value, currentState })
+    ) {
       properties = properties.filter((property) => property !== 'rowsPerPage');
     }
   }

--- a/frontend/src/Editor/Inspector/Components/FilePicker.jsx
+++ b/frontend/src/Editor/Inspector/Components/FilePicker.jsx
@@ -20,10 +20,10 @@ export const FilePicker = ({ componentMeta, darkMode, ...restProps }) => {
     return renderElement(component, componentMeta, paramUpdated, dataQueries, param, paramType, currentState);
   };
   const conditionalAccordionItems = (component) => {
-    const parseContent = resolveReferences(
-      component.component.definition.properties.parseContent?.value ?? false,
-      currentState
-    );
+    const parseContent = resolveReferences({
+      object: component.component.definition.properties.parseContent?.value ?? false,
+      currentState,
+    });
     const accordionItems = [];
     const options = ['parseContent'];
 

--- a/frontend/src/Editor/Inspector/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table/Table.jsx
@@ -173,7 +173,9 @@ class TableComponent extends React.Component {
         id="popover-basic-2"
         className={`${this.props.darkMode && 'dark-theme'} shadow`}
         style={{
-          maxHeight: resolveReferences(column.isEditable, this.state.currentState) ? '100vh' : 'inherit',
+          maxHeight: resolveReferences({ object: column.isEditable, currentState: this.state.currentState })
+            ? '100vh'
+            : 'inherit',
           overflowY: 'auto',
         }}
       >
@@ -328,7 +330,7 @@ class TableComponent extends React.Component {
                 />
               </div>
 
-              {resolveReferences(column.isEditable, this.state.currentState) && (
+              {resolveReferences({ object: column.isEditable, currentState: this.state.currentState }) && (
                 <div>
                   <div data-cy={`header-validation`} className="hr-text">
                     {this.props.t('widget.Table.validation', 'Validation')}
@@ -402,45 +404,46 @@ class TableComponent extends React.Component {
             </div>
           )}
 
-          {column.columnType === 'number' && resolveReferences(column.isEditable, this.state.currentState) && (
-            <div>
-              <div className="hr-text" data-cy={`header-validation`}>
-                {this.props.t('widget.Table.validation', 'Validation')}
+          {column.columnType === 'number' &&
+            resolveReferences({ object: column.isEditable, currentState: this.state.currentState }) && (
+              <div>
+                <div className="hr-text" data-cy={`header-validation`}>
+                  {this.props.t('widget.Table.validation', 'Validation')}
+                </div>
+                <div data-cy={`input-and-label-min-value`} className="field mb-2">
+                  <label className="form-label">{this.props.t('widget.Table.minValue', 'Min value')}</label>
+                  <CodeHinter
+                    currentState={this.props.currentState}
+                    initialValue={column.minLength}
+                    theme={this.props.darkMode ? 'monokai' : 'default'}
+                    mode="javascript"
+                    lineNumbers={false}
+                    placeholder={''}
+                    onChange={(value) => this.onColumnItemChange(index, 'minValue', value)}
+                    componentName={this.getPopoverFieldSource(column.columnType, 'minValue')}
+                    popOverCallback={(showing) => {
+                      this.setColumnPopoverRootCloseBlocker('minValue', showing);
+                    }}
+                  />
+                </div>
+                <div data-cy={`input-and-label-max-value`} className="field mb-2">
+                  <label className="form-label">{this.props.t('widget.Table.maxValue', 'Max value')}</label>
+                  <CodeHinter
+                    currentState={this.props.currentState}
+                    initialValue={column.maxLength}
+                    theme={this.props.darkMode ? 'monokai' : 'default'}
+                    mode="javascript"
+                    lineNumbers={false}
+                    placeholder={''}
+                    onChange={(value) => this.onColumnItemChange(index, 'maxValue', value)}
+                    componentName={this.getPopoverFieldSource(column.columnType, 'maxValue')}
+                    popOverCallback={(showing) => {
+                      this.setColumnPopoverRootCloseBlocker('maxValue', showing);
+                    }}
+                  />
+                </div>
               </div>
-              <div data-cy={`input-and-label-min-value`} className="field mb-2">
-                <label className="form-label">{this.props.t('widget.Table.minValue', 'Min value')}</label>
-                <CodeHinter
-                  currentState={this.props.currentState}
-                  initialValue={column.minLength}
-                  theme={this.props.darkMode ? 'monokai' : 'default'}
-                  mode="javascript"
-                  lineNumbers={false}
-                  placeholder={''}
-                  onChange={(value) => this.onColumnItemChange(index, 'minValue', value)}
-                  componentName={this.getPopoverFieldSource(column.columnType, 'minValue')}
-                  popOverCallback={(showing) => {
-                    this.setColumnPopoverRootCloseBlocker('minValue', showing);
-                  }}
-                />
-              </div>
-              <div data-cy={`input-and-label-max-value`} className="field mb-2">
-                <label className="form-label">{this.props.t('widget.Table.maxValue', 'Max value')}</label>
-                <CodeHinter
-                  currentState={this.props.currentState}
-                  initialValue={column.maxLength}
-                  theme={this.props.darkMode ? 'monokai' : 'default'}
-                  mode="javascript"
-                  lineNumbers={false}
-                  placeholder={''}
-                  onChange={(value) => this.onColumnItemChange(index, 'maxValue', value)}
-                  componentName={this.getPopoverFieldSource(column.columnType, 'maxValue')}
-                  popOverCallback={(showing) => {
-                    this.setColumnPopoverRootCloseBlocker('maxValue', showing);
-                  }}
-                />
-              </div>
-            </div>
-          )}
+            )}
 
           {column.columnType === 'toggle' && (
             <div>
@@ -519,7 +522,7 @@ class TableComponent extends React.Component {
 
           {column.columnType === 'dropdown' && (
             <>
-              {resolveReferences(column.isEditable, this.state.currentState) && (
+              {resolveReferences({ object: column.isEditable, currentState: this.state.currentState }) && (
                 <div>
                   <div data-cy={`header-validations`} className="hr-text">
                     {this.props.t('widget.Table.validation', 'Validation')}
@@ -964,34 +967,46 @@ class TableComponent extends React.Component {
       paramUpdated({ name: 'displaySearchBox' }, 'value', true, 'properties');
     const displaySearchBox = component.component.definition.properties.displaySearchBox.value;
     const displayServerSideFilter = component.component.definition.properties.showFilterButton?.value
-      ? resolveReferences(component.component.definition.properties.showFilterButton?.value, currentState)
+      ? resolveReferences({ object: component.component.definition.properties.showFilterButton?.value, currentState })
       : false;
     const displayServerSideSearch = component.component.definition.properties.displaySearchBox?.value
-      ? resolveReferences(component.component.definition.properties.displaySearchBox?.value, currentState)
+      ? resolveReferences({ object: component.component.definition.properties.displaySearchBox?.value, currentState })
       : false;
     const serverSidePagination = component.component.definition.properties.serverSidePagination?.value
-      ? resolveReferences(component.component.definition.properties.serverSidePagination?.value, currentState)
+      ? resolveReferences({
+          object: component.component.definition.properties.serverSidePagination?.value,
+          currentState,
+        })
       : false;
 
     const clientSidePagination = component.component.definition.properties.clientSidePagination?.value
-      ? resolveReferences(component.component.definition.properties.clientSidePagination?.value, currentState)
+      ? resolveReferences({
+          object: component.component.definition.properties.clientSidePagination?.value,
+          currentState,
+        })
       : false;
 
     let enablePagination = !has(component.component.definition.properties, 'enablePagination')
       ? clientSidePagination || serverSidePagination
-      : resolveReferences(component.component.definition.properties.enablePagination?.value, currentState);
+      : resolveReferences({ object: component.component.definition.properties.enablePagination?.value, currentState });
 
     const enabledSort = component.component.definition.properties.enabledSort?.value
-      ? resolveReferences(component.component.definition.properties.enabledSort?.value, currentState)
+      ? resolveReferences({ object: component.component.definition.properties.enabledSort?.value, currentState })
       : true;
     const useDynamicColumn = component.component.definition.properties.useDynamicColumn?.value
-      ? resolveReferences(component.component.definition.properties.useDynamicColumn?.value, currentState) ?? false
+      ? resolveReferences({
+          object: component.component.definition.properties.useDynamicColumn?.value,
+          currentState,
+        }) ?? false
       : false;
     //from app definition values are of string data type if defined or else,undefined
     const allowSelection = component.component.definition.properties?.allowSelection?.value
-      ? resolveReferences(component.component.definition.properties.allowSelection?.value, currentState)
-      : resolveReferences(component.component.definition.properties.highlightSelectedRow.value, currentState) ||
-        resolveReferences(component.component.definition.properties.showBulkSelector.value, currentState);
+      ? resolveReferences({ object: component.component.definition.properties.allowSelection?.value, currentState })
+      : resolveReferences({
+          object: component.component.definition.properties.highlightSelectedRow.value,
+          currentState,
+        }) ||
+        resolveReferences({ object: component.component.definition.properties.showBulkSelector.value, currentState });
     const renderCustomElement = (param, paramType = 'properties') => {
       return renderElement(component, componentMeta, paramUpdated, dataQueries, param, paramType, currentState);
     };
@@ -1030,7 +1045,10 @@ class TableComponent extends React.Component {
                   {({ innerRef, droppableProps, placeholder }) => (
                     <div className="w-100" {...droppableProps} ref={innerRef}>
                       {columns.value.map((item, index) => {
-                        const resolvedItemName = resolveReferences(item.name, this.state.currentState);
+                        const resolvedItemName = resolveReferences({
+                          object: item.name,
+                          currentState: this.state.currentState,
+                        });
                         return (
                           <Draggable key={item.id} draggableId={item.id} index={index}>
                             {(provided, snapshot) => (

--- a/frontend/src/Editor/Inspector/Elements/Code.jsx
+++ b/frontend/src/Editor/Inspector/Elements/Code.jsx
@@ -26,7 +26,7 @@ export const Code = ({
       const clientSidePagination = component?.component?.definition?.properties?.clientSidePagination?.value ?? false;
       const serverSidePagination = component?.component?.definition?.properties?.serverSidePagination?.value ?? false;
       const isPaginationEnabled =
-        resolveReferences(clientSidePagination, currentState) || resolveReferences(serverSidePagination, currentState);
+        resolveReferences({ object: clientSidePagination }) || resolveReferences({ object: serverSidePagination });
 
       if (isPaginationEnabled) return '{{true}}';
       return '{{false}}';
@@ -36,7 +36,7 @@ export const Code = ({
         const highlightSelectedRow = component?.component?.definition?.properties?.highlightSelectedRow?.value ?? false;
         const showBulkSelector = component?.component?.definition?.properties?.showBulkSelector?.value ?? false;
         const allowSelection =
-          resolveReferences(highlightSelectedRow, currentState) || resolveReferences(showBulkSelector, currentState);
+          resolveReferences({ object: highlightSelectedRow }) || resolveReferences({ object: showBulkSelector });
 
         return '{{' + `${allowSelection}` + '}}';
       } else if (param === 'defaultSelectedRow') {

--- a/frontend/src/Editor/Inspector/Inspector.jsx
+++ b/frontend/src/Editor/Inspector/Inspector.jsx
@@ -165,7 +165,7 @@ export const Inspector = ({
       const defaultValue = getDefaultValue(value);
       // This is needed to have enable pagination as backward compatible
       // Whenever enable pagination is false, we turn client and server side pagination as false
-      if (param.name === 'enablePagination' && !resolveReferences(value, currentState)) {
+      if (param.name === 'enablePagination' && !resolveReferences({ object: value, currentState })) {
         if (allParams?.['clientSidePagination']?.[attr]) {
           allParams['clientSidePagination'][attr] = value;
         }
@@ -537,7 +537,7 @@ const RenderStyleOptions = ({ componentMeta, component, paramUpdated, dataQuerie
 const resolveConditionalStyle = (definition, condition, currentState) => {
   const conditionExistsInDefinition = definition[condition] ?? false;
   if (conditionExistsInDefinition) {
-    return resolveReferences(definition[condition]?.value ?? false, currentState);
+    return resolveReferences({ object: definition[condition]?.value ?? false, currentState });
   }
 };
 

--- a/frontend/src/Editor/Inspector/Utils.js
+++ b/frontend/src/Editor/Inspector/Utils.js
@@ -48,7 +48,8 @@ export function renderElement(
     if (conditionallyRender) {
       const { key, value } = conditionallyRender;
       if (paramTypeDefinition?.[key] ?? value) {
-        const resolvedValue = paramTypeDefinition?.[key] && resolveReferences(paramTypeDefinition?.[key], currentState);
+        const resolvedValue =
+          paramTypeDefinition?.[key] && resolveReferences({ object: paramTypeDefinition?.[key], currentState });
         if (resolvedValue?.value !== value) return;
       }
     }

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/operations.js
@@ -54,7 +54,7 @@ function buildPostgrestQuery(filters) {
 
 async function listRows(dataQuery, currentState) {
   const queryOptions = dataQuery.options;
-  const resolvedOptions = resolveReferences(queryOptions, currentState);
+  const resolvedOptions = resolveReferences({ object: queryOptions, currentState });
   if (hasEqualWithNull(resolvedOptions, 'list_rows')) {
     return {
       status: 'failed',
@@ -93,7 +93,7 @@ async function listRows(dataQuery, currentState) {
 
 async function createRow(dataQuery, currentState) {
   const queryOptions = dataQuery.options;
-  const resolvedOptions = resolveReferences(queryOptions, currentState);
+  const resolvedOptions = resolveReferences({ object: queryOptions, currentState });
   const columns = Object.values(resolvedOptions.create_row).reduce((acc, colOpts) => {
     if (isEmpty(colOpts.column)) return acc;
     return { ...acc, ...{ [colOpts.column]: colOpts.value } };
@@ -104,7 +104,7 @@ async function createRow(dataQuery, currentState) {
 
 async function updateRows(dataQuery, currentState) {
   const queryOptions = dataQuery.options;
-  const resolvedOptions = resolveReferences(queryOptions, currentState);
+  const resolvedOptions = resolveReferences({ object: queryOptions, currentState });
   if (hasEqualWithNull(resolvedOptions, 'update_rows')) {
     return {
       status: 'failed',
@@ -132,7 +132,7 @@ async function updateRows(dataQuery, currentState) {
 
 async function deleteRows(dataQuery, currentState) {
   const queryOptions = dataQuery.options;
-  const resolvedOptions = resolveReferences(queryOptions, currentState);
+  const resolvedOptions = resolveReferences({ object: queryOptions, currentState });
   if (hasEqualWithNull(resolvedOptions, 'delete_rows')) {
     return {
       status: 'failed',

--- a/frontend/src/Editor/SubContainer.jsx
+++ b/frontend/src/Editor/SubContainer.jsx
@@ -538,7 +538,7 @@ export const SubContainer = ({
           const box = childWidgets[key];
           const canShowInCurrentLayout =
             box.component.definition.others[currentLayout === 'mobile' ? 'showOnMobile' : 'showOnDesktop'].value;
-          if (box.parent && resolveReferences(canShowInCurrentLayout, currentState)) {
+          if (box.parent && resolveReferences({ object: canShowInCurrentLayout })) {
             return (
               <DraggableBox
                 onComponentClick={onComponentClick}

--- a/frontend/src/Editor/Viewer.jsx
+++ b/frontend/src/Editor/Viewer.jsx
@@ -486,7 +486,7 @@ class ViewerComponent extends React.Component {
       (this.state.appDefinition.globalSettings?.backgroundFxQuery ||
         this.state.appDefinition.globalSettings?.canvasBackgroundColor) ??
       '#2f3c4c';
-    const resolvedBackgroundColor = resolveReferences(bgColor, this.props.currentState);
+    const resolvedBackgroundColor = resolveReferences({ object: bgColor });
     if (['#2f3c4c', '#F2F2F5', '#edeff5'].includes(resolvedBackgroundColor)) {
       return this.props.darkMode ? '#2f3c4c' : '#F2F2F5';
     }

--- a/frontend/src/_components/OrgConstantsVariablesResolver/OrgConstantsVariablesPreviewBox.jsx
+++ b/frontend/src/_components/OrgConstantsVariablesResolver/OrgConstantsVariablesPreviewBox.jsx
@@ -43,7 +43,11 @@ export const OrgConstantVariablesPreviewBox = ({ workspaceVariables, workspaceCo
 };
 
 const ResolvedValue = ({ value, isFocused, state = {}, type }) => {
-  const [preview, error] = resolveReferences(value, state, null, {}, true, true);
+  const [preview, error] = resolveReferences({
+    object: value,
+    withError: true,
+    forPreviewBox: true,
+  });
   const previewType = typeof preview;
 
   let resolvedValue = preview;

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -144,14 +144,14 @@ export function resolveString(str, state, customObjects, reservedKeyword, withEr
   return resolvedStr;
 }
 
-export function resolveReferences(
+export function resolveReferences({
   object,
-  state,
-  defaultValue,
+  currentState,
   customObjects = {},
   withError = false,
-  forPreviewBox = false
-) {
+  forPreviewBox = false,
+}) {
+  const state = currentState ? currentState : getCurrentState();
   if (object === '{{{}}}') return '';
   const reservedKeyword = ['app']; //Keywords that slows down the app
   object = _.clone(object);
@@ -206,10 +206,10 @@ export function resolveReferences(
 
       if (dynamicVariables) {
         if (dynamicVariables.length === 1 && dynamicVariables[0] === object) {
-          object = resolveReferences(dynamicVariables[0], state, null, customObjects);
+          object = resolveReferences({ object: dynamicVariables[0], customObjects: customObjects });
         } else {
           for (const dynamicVariable of dynamicVariables) {
-            const value = resolveReferences(dynamicVariable, state, null, customObjects);
+            const value = resolveReferences({ object: dynamicVariable, customObjects: customObjects });
             if (typeof value !== 'function') {
               object = object.replace(dynamicVariable, value);
             }
@@ -225,7 +225,7 @@ export function resolveReferences(
         const new_array = [];
 
         object.forEach((element, index) => {
-          const resolved_object = resolveReferences(element, state);
+          const resolved_object = resolveReferences({ object: element });
           new_array[index] = resolved_object;
         });
 
@@ -233,7 +233,7 @@ export function resolveReferences(
         return new_array;
       } else if (!_.isEmpty(object)) {
         Object.keys(object).forEach((key) => {
-          const resolved_object = resolveReferences(object[key], state);
+          const resolved_object = resolveReferences({ object: object[key] });
           object[key] = resolved_object;
         });
         if (withError) return [object, error];
@@ -323,7 +323,7 @@ export function resolveWidgetFieldValue(prop, state, _default = [], customResolv
   const widgetFieldValue = prop;
 
   try {
-    return resolveReferences(widgetFieldValue, state, _default, customResolveObjects);
+    return resolveReferences({ object: widgetFieldValue, customObjects: customResolveObjects });
   } catch (err) {
     console.log(err);
   }
@@ -435,7 +435,7 @@ export async function executeMultilineJS(
     queryDetails?.options?.parameters?.reduce(
       (paramObj, param) => ({
         ...paramObj,
-        [param.name]: resolveReferences(param.defaultValue, {}, undefined), //default values will not be resolved with currentState
+        [param.name]: resolveReferences({ object: param.defaultValue, currentState: {} }), //default values will not be resolved with currentState
       }),
       {}
     ) || {};


### PR DESCRIPTION
Currently, the resolveReferences function is frequently used, requiring six separate arguments. This pull request introduces a significant improvement by consolidating these six arguments into a single object.

This enhancement brings about two important benefits:

 1. By using an object as the argument, we ensure that undefined or null values are not inadvertently passed to the function, reducing the risk of unexpected behavior.

 2. Previously, we always retrieved the current state from Zustand to pass it as an argument to resolveReferences, which could lead to unnecessary renders. With this change, resolveReferences in its definition fetches the state directly from Zustand when it's not provided as an argument, minimizing unwanted renders.
 
