### PR TITLE
#5527 - Allow esm.sh as a allowed source for importing ES6 modules from a URL in script-src

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -93,6 +93,7 @@ async function bootstrap() {
           'https://unpkg.com/react-dom@16.7.0/umd/react-dom.production.min.js',
           'cdn.skypack.dev',
           'cdn.jsdelivr.net',
+          'https://esm.sh',
         ],
         'default-src': [
           'maps.googleapis.com',


### PR DESCRIPTION
Resolves #5527 