### PR TITLE
Dark mode issue for invite user with email #7513

### DIFF
--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -75,7 +75,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(1)}
                   data-cy="button-invite-with-email"
                 >
-                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#fff' : '#687076'} />
                   <span> Invite with email</span>
                 </button>
                 <button
@@ -83,7 +83,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(2)}
                   data-cy="button-upload-csv-file"
                 >
-                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#fff' : '#687076'} />
                   <span>Upload CSV file</span>
                 </button>
               </div>


### PR DESCRIPTION
Pull Request Description

Fixes #7513 

Issue Resolved
This pull request addresses the dark mode issue for the "Invite user with email" feature, as reported in issue #7513.

Proposed Changes
To enhance visibility in dark mode, the icon color for the "Email" feature has been updated to a lighter shade, specifically white, ensuring improved contrast and visibility.

Steps to Verify
Navigate to the workspace settings.
Select "Users" and click "Add Users."
Proceed to invite users via email and observe the icon color in dark mode.
Screenshots
Attached screenshots showcasing the updated icon color in dark mode.
Before resolving the issue: -
![image](https://github.com/ToolJet/ToolJet/assets/99464832/fe742a53-ae08-41c4-82a9-791007d4470a)

After resolving the issue: -
![image](https://github.com/ToolJet/ToolJet/assets/99464832/e7c4d85f-aed3-4ed4-a61e-a6b0638ad1ec)

Version Information
Previous Version: 2.17.5-ee2.5.10-cloud2.0.9
Updated Version: [Insert version with the proposed changes]
Additional Notes
This change is aimed at improving the user experience in dark mode by addressing the visibility concerns for the "Invite user with email" feature.
Any feedback or further adjustments are welcomed for an optimal resolution of the reported issue.