### PR TITLE
changes in Appwrite data source reference (#7543)

### DIFF
--- a/docs/docs/data-sources/appwrite.md
+++ b/docs/docs/data-sources/appwrite.md
@@ -1,11 +1,11 @@
 ---
 id: appwrite
-title: Appwrite Database
+title: Appwrite
 ---
 
 # Appwrite Database
 
-Now build applications on top of your Appwrite database.
+ToolJet can connect to appwrite database to read/write data.
 
 ## Connection 
 
@@ -20,7 +20,7 @@ You'll find the Secret key and other credentials on your Appwrite's project sett
 You should also set the scope for access to a particular resource. Learn more about the **API keys and scopes** [here](https://appwrite.io/docs/keys).
 :::
 
-To connect Appwrite datasource to your ToolJet application, go to the data source manager on the left-sidebar and click on the `+` button. Select Appwrite from the list of available datasources, provide the credentials and click **Save**. It is recommended to check the connection by clicking on 'Test connection' button to verify if the service account can access Appwrite from the ToolJet server.
+To establish a connection with the Appwrite data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 


### PR DESCRIPTION
- Renamed document title from 'Appwrite database' to 'Appwrite'
-  Updated the description to: 'ToolJet can connect to Appwrite database to read/write data.'
- Replaced the text: 'To connect Appwrite datasource to your ToolJet application, go to the data source manager on the left-sidebar and click on the + button. Select Appwrite from the list of available datasources, provide the credentials and click Save. It is recommended to check the connection by clicking on 'Test connection' button to verify if the service account can access Appwrite from the ToolJet server.' with the following text:
To establish a connection with the Appwrite data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.