### PR TITLE
changes required in S3 data source reference #7542

### DIFF
--- a/docs/docs/data-sources/appwrite.md
+++ b/docs/docs/data-sources/appwrite.md
@@ -1,11 +1,11 @@
 ---
 id: appwrite
-title: Appwrite Database
+title: Appwrite
 ---
 
 # Appwrite Database
 
-Now build applications on top of your Appwrite database.
+ToolJet can connect to appwrite database to read/write data.
 
 ## Connection 
 
@@ -20,7 +20,7 @@ You'll find the Secret key and other credentials on your Appwrite's project sett
 You should also set the scope for access to a particular resource. Learn more about the **API keys and scopes** [here](https://appwrite.io/docs/keys).
 :::
 
-To connect Appwrite datasource to your ToolJet application, go to the data source manager on the left-sidebar and click on the `+` button. Select Appwrite from the list of available datasources, provide the credentials and click **Save**. It is recommended to check the connection by clicking on 'Test connection' button to verify if the service account can access Appwrite from the ToolJet server.
+To establish a connection with the Appwrite data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/data-sources/s3.md
+++ b/docs/docs/data-sources/s3.md
@@ -9,7 +9,7 @@ ToolJet can connect to Amazon S3 buckets and perform various operation on them.
 
 ## Connection
 
-To add a new S3 source, go to the **Datasources manager** on the left sidebar of the app editor and click on `Add datasource` button. Select **AWS S3** from the modal that pops up.
+To add a new S3 source, go to the **Data sources manager** on the left sidebar of the app editor and click on `Add data source` button. Select **AWS S3** from the modal that pops up.
 
 ToolJet supports connecting to AWS S3 using **IAM credentials**, **AWS Instance Profile** or **AWS ARN Role**. 
 
@@ -155,5 +155,5 @@ The presigned URLs are useful if you want your user/customer to be able to uploa
 
 
 :::info
-We built an app to view and upload files to AWS S3 buckets. Check out the complete tutorial **[here](https://blog.tooljet.com/building-an-app-to-view-and-upload-files-in-aws-s3-bucket/)**.
+We built an app to view and upload files to AWS S3 buckets. Check out the complete tutorial **[here](https://blog.tooljet.com/build-an-aws-s3-broswer-with-tooljet/)**.
 :::


### PR DESCRIPTION
- Renamed datasource to data source where ever it is used in the doc.
-  Updated the link to https://blog.tooljet.com/build-an-aws-s3-broswer-with-tooljet/