### PR TITLE
Fixed Page name to be restricted to less than 50 characters

### DIFF
--- a/frontend/src/Editor/LeftSidebar/SidebarPageSelector/PageHandler.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPageSelector/PageHandler.jsx
@@ -216,13 +216,17 @@ export const PageHandler = ({
 
 export const AddingPageHandler = ({ addNewPage, setNewPageBeingCreated, darkMode }) => {
   const handleAddingNewPage = (pageName) => {
-    if (pageName.trim().length === 0) {
+    if (pageName.trim().length === 0 ) {
       toast('Page name should have at least 1 character', {
         icon: '⚠️',
       });
     }
-
-    if (pageName && pageName.trim().length > 0) {
+    else if(pageName.trim().length > 50){
+      toast('Page name cannot exceed 50 characters', {
+        icon: '⚠️',
+      });
+    }
+    else {
       addNewPage({ name: pageName, handle: _.kebabCase(pageName.toLowerCase()) });
     }
     setNewPageBeingCreated(false);


### PR DESCRIPTION
### What change does this PR introduce?
The PR introduces a character limit of 50 characters on page names. It ensures that when adding a new page. The pageName is validated to be less than or equal to 50 characters in length. If the pageName exceeds this limit, a warning toast message is displayed, and the new page is not added. This change ensures that page names are restricted to a maximum of 50 characters.

### Why was this change needed?
 Without a character limit on page names, users could potentially create page names that are excessively long, which could lead to issues with layout and readability. Enforcing a character limit of 50 characters helps maintain a clean and organized user interface by preventing overly lengthy page names.

Fixes #6744
