### PR TITLE
Fix/service start without pgrst host

### DIFF
--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -83,7 +83,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(2)}
                   data-cy="button-upload-csv-file"
                 >
-                    <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
                   <span>Upload CSV file</span>
                 </button>
               </div>

--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -75,7 +75,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(1)}
                   data-cy="button-invite-with-email"
                 >
-                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#fff' : '#687076'} />
                   <span> Invite with email</span>
                 </button>
                 <button
@@ -83,7 +83,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(2)}
                   data-cy="button-upload-csv-file"
                 >
-                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#fff' : '#687076'} />
                   <span>Upload CSV file</span>
                 </button>
               </div>

--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -75,7 +75,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(1)}
                   data-cy="button-invite-with-email"
                 >
-                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#fff' : '#687076'} />
+                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#11181C' : '#687076'} />
                   <span> Invite with email</span>
                 </button>
                 <button
@@ -83,7 +83,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(2)}
                   data-cy="button-upload-csv-file"
                 >
-                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#fff' : '#687076'} />
+                    <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
                   <span>Upload CSV file</span>
                 </button>
               </div>

--- a/server/src/services/postgrest_proxy.service.ts
+++ b/server/src/services/postgrest_proxy.service.ts
@@ -24,7 +24,7 @@ export class PostgrestProxyService {
     return this.httpProxy(req, res, next);
   }
 
-  private httpProxy = proxy(this.configService.get<string>('PGRST_HOST'), {
+  private httpProxy = proxy(this.configService.get<string>('PGRST_HOST') || " ", {
     proxyReqPathResolver: function (req) {
       const path = '/api/tooljet_db';
       const pathRegex = new RegExp(`${maybeSetSubPath(path)}/proxy`);


### PR DESCRIPTION
Pull Request Description

Issue Resolved
FIXED #7554

Summary of Changes
In this pull request, I've addressed the issue where the service failed to start when the PGRST_HOST environment variable was not configured. The error occurred due to an empty PGRST_HOST. I've added an "or" condition with an empty string fallback " " to handle this scenario.

Proposed Changes

Modified the httpProxy initialization to use this.configService.get<string>('PGRST_HOST') || " " as a fallback, ensuring that an empty string is used in case PGRST_HOST is not defined or empty.
Adjusted the proxy configuration accordingly to handle the empty string fallback.