### PR TITLE
Update baserow.md

### DIFF
--- a/docs/docs/data-sources/baserow.md
+++ b/docs/docs/data-sources/baserow.md
@@ -7,7 +7,11 @@ title: Baserow
 
 ## Connection
 
-ToolJet can connect to your Baserow account to read and write data. 
+To connect to Baserow, you need to provide the following details:
+
+- **API token**: You can create an API token from your Baserow dashboard. You can follow the steps to create API token from [this link](https://baserow.io/user-docs/personal-api-tokens).
+- **Host**: You can either select the Baserow Cloud or Self-hosted option.
+  - **Base URL**: If you select the self-hosted option, you need to provide the base URL of your Baserow instance.
 Select the hosted version of Baserow or the self-host option.
 
 For [**self-hosted**](https://baserow.io/docs/index#installation) option, base URL is required to connect.
@@ -18,11 +22,7 @@ Baserow API token is required to create an Baserow data source on ToolJet. You c
 <img className="screenshot-full" src="/img/datasource-reference/baserow/baserow-intro.png" alt="Baserow intro" />
 
 
-:::tip
-This guide assumes that you have already gone through [Adding a data source](/docs/tutorial/adding-a-datasource) tutorial.
-:::
-
-## Supported queries
+## Supported Operations
 
 - [List fields](#list-fields)
 - [List rows](#list-rows)


### PR DESCRIPTION
Fixes https://github.com/ToolJet/ToolJet/issues/7595

Changed the Baserow docs as desired.

- Remove it from the `Connection` and it before connection section:
 
  ``
    ToolJet can connect to your Baserow account to read and write data. 
 ``

- Update the following description for the `Connection`:
 
```
 ## Connection

To connect to Baserow, you need to provide the following details:

- **API token**: You can create an API token from your Baserow dashboard. You can follow the steps to create API token from [this link](https://baserow.io/user-docs/personal-api-tokens).
- **Host**: You can either select the Baserow Cloud or Self-hosted option.
  - **Base URL**: If you select the self-hosted option, you need to provide the base URL of your Baserow instance.
```

- Remove the tip `This guide assumes that you have already gone through Adding a data source tutorial.`

- Rename `Supported queries` to `Supported Operations.`
