### PR TITLE
[docs]: updated ElasticSearch data source reference

### DIFF
--- a/docs/docs/data-sources/elasticsearch.md
+++ b/docs/docs/data-sources/elasticsearch.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Elasticsearch cluster to read and write data.
 ## Connection 
 Please make sure the host/IP of the Elasticsearch cluster is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist our IP**.
 
-To add a new Elasticsearch database, click on the `+` button on data sources panel at the left-bottom corner of the app editor. Select Elasticsearch from the modal that pops up.
+To establish a connection with the ElasticSearch data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Elasticsearch cluster: 
 - **Host**
@@ -24,7 +24,7 @@ ToolJet requires the following to connect to your Elasticsearch cluster:
 
 </div>
 
-Elastic search datasource is also providing an option for connecting services with ssl certificates. 
+Elastic search data source is also providing an option for connecting services with ssl certificates. 
 - You can either use CA / Client certificates option. 
   
 <img className="screenshot-full" src="/img/datasource-reference/elasticsearch/ssl.png" alt="Elastic ssl" />

--- a/docs/versioned_docs/version-2.18.0/data-sources/elasticsearch.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/elasticsearch.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Elasticsearch cluster to read and write data.
 ## Connection 
 Please make sure the host/IP of the Elasticsearch cluster is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist our IP**.
 
-To add a new Elasticsearch database, click on the `+` button on data sources panel at the left-bottom corner of the app editor. Select Elasticsearch from the modal that pops up.
+To establish a connection with the ElasticSearch data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Elasticsearch cluster: 
 - **Host**
@@ -24,7 +24,7 @@ ToolJet requires the following to connect to your Elasticsearch cluster:
 
 </div>
 
-Elastic search datasource is also providing an option for connecting services with ssl certificates. 
+Elastic search data source is also providing an option for connecting services with ssl certificates. 
 - You can either use CA / Client certificates option. 
   
 <img className="screenshot-full" src="/img/datasource-reference/elasticsearch/ssl.png" alt="Elastic ssl" />

--- a/docs/versioned_docs/version-2.19.0/data-sources/elasticsearch.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/elasticsearch.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Elasticsearch cluster to read and write data.
 ## Connection 
 Please make sure the host/IP of the Elasticsearch cluster is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist our IP**.
 
-To add a new Elasticsearch database, click on the `+` button on data sources panel at the left-bottom corner of the app editor. Select Elasticsearch from the modal that pops up.
+To establish a connection with the ElasticSearch data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Elasticsearch cluster: 
 - **Host**
@@ -24,7 +24,7 @@ ToolJet requires the following to connect to your Elasticsearch cluster:
 
 </div>
 
-Elastic search datasource is also providing an option for connecting services with ssl certificates. 
+Elastic search data source is also providing an option for connecting services with ssl certificates. 
 - You can either use CA / Client certificates option. 
   
 <img className="screenshot-full" src="/img/datasource-reference/elasticsearch/ssl.png" alt="Elastic ssl" />


### PR DESCRIPTION
This PR is raised to update ElasticSearch data source reference.

1. Updated the second paragraph of Connection from this:

```
To add a new Elasticsearch database, click on the + button on the data sources panel at the left-bottom corner of the app editor. Select Elasticsearch from the modal that pops up.
```

To this:

```
To establish a connection with the ElasticSearch data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
```

3. Renamed `datasource` to `data source`  in the doc

Fixes #7611 