### PR TITLE
Displaying total count with totalRecords with respect to serverside pagination in Table

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -1528,7 +1528,8 @@ export function Table({
                 ) : (
                   !loadingState && (
                     <span data-cy={`footer-number-of-records`} className="font-weight-500 color-slate11">
-                      {`${globalFilteredRows.length} Records`}
+                      {clientSidePagination && !serverSidePagination && `${globalFilteredRows.length} Records`}
+                      {serverSidePagination && totalRecords ? `${totalRecords} Records` : ''}
                     </span>
                   )
                 ))}


### PR DESCRIPTION
Resolves 
When server-side pagination is on, the total number of counts in the table footer should be equal to the total records value if it's truthy, which can be set with `Total records server side field `, if falsy value, then it should be empty string