### PR TITLE
fix: Changed the 'Global data source' to 'data source' in the required docs

### DIFF
--- a/docs/docs/app-builder/query-panel.md
+++ b/docs/docs/app-builder/query-panel.md
@@ -27,7 +27,7 @@ Query Manager will list all the queries that has been created in the application
 
 ### Add
 
-Add button is used to add new query in the application. When Add button is clicked, a menu will open with a list of options for creating a query from **Default** datasources such as **Rest API**, **ToolJet Database**, **JavaScript Code**, **Python Code** or from connected **Global Datasources**.
+Add button is used to add new query in the application. When Add button is clicked, a menu will open with a list of options for creating a query from **Default** datasources such as **Rest API**, **ToolJet Database**, **JavaScript Code**, **Python Code** or from connected **Data sources**.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/dashboard.md
+++ b/docs/docs/dashboard.md
@@ -161,7 +161,7 @@ Selecting this option will immediately open the cloned app in the app builder wi
 
 ### Export app
 
-This option will download a JSON file of the application. This JSON file can be [imported](#import) to ToolJet to create a new app. The exported app will include all the queries connected to global data sources including the data source created from Marketplace plugins.
+This option will download a JSON file of the application. This JSON file can be [imported](#import) to ToolJet to create a new app. The exported app will include all the queries connected to data sources including the data source created from Marketplace plugins.
 
 This option allows you to select a specific version of the app to export or export all the versions of the app. To export a specific version of the app, select a version from the list of available versions in the modal and click on the `Export selected version` and to export all the versions of the app, click on the `Export All` button.
 

--- a/docs/docs/data-sources/azureblob.md
+++ b/docs/docs/data-sources/azureblob.md
@@ -7,9 +7,9 @@ ToolJet offers the capability to establish a connection with Azure Blob storage 
 
 ## Connection
 
-To connect ToolJet with the Azure Blob global datasource, you have two options:
-1. Click on the `+Add new global datasource` button in the query panel.
-2. Go to the **[Global Datasources](/docs/data-sources/overview)** page on the ToolJet dashboard.
+To connect ToolJet with the Azure Blob data source, you have two options:
+1. Click on the `+Add new data source` button in the query panel.
+2. Go to the **[Data sources](/docs/data-sources/overview)** page on the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -24,11 +24,11 @@ Once you have entered the connection string, click on the **Test connection** bu
 
 ## Querying Azure Blob
 
-Once you have connected to the Azure Blob global datasource, follow these steps to create queries and interact with a Azure Blob storage from the ToolJet application:
+Once you have connected to the Azure Blob data source, follow these steps to create queries and interact with a Azure Blob storage from the ToolJet application:
 
 1. Open the ToolJet application and navigate to the query panel at the bottom of the app builder.
-2. Click the `+Add` button to open the list of available `local` and `global datasources`.
-3. Select **Azure Blob** from the global datasource section.
+2. Click the `+Add` button to open the list of available `local` and `data sources`.
+3. Select **Azure Blob** from the data source section.
 4. Select the desired **operation** from the dropdown and enter the required **parameters**.
 5. **Rename**(optional) and **Create** the query.
 6. Click **Preview** to view the data returned from the query or click **Run** to execute the query.

--- a/docs/docs/data-sources/dynamodb.md
+++ b/docs/docs/data-sources/dynamodb.md
@@ -8,7 +8,7 @@ DynamoDB is a managed non-relational database service provided by Amazon. ToolJe
 
 ## Connection
 
-To establish a connection with the DynamoDB global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the DynamoDB data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/data-sources/google.sheets.md
+++ b/docs/docs/data-sources/google.sheets.md
@@ -20,7 +20,7 @@ If you decide to self-host ToolJet, there are a few additional steps you need to
 
 ## Connection
 
-To establish a connection with Google Sheet, you have two options. First, you can click on the **+Add new global datasource** button found on the query panel. Alternatively, you can go to the **[Global Datasources](/docs/data-sources/overview)** page within the ToolJet dashboard.
+To establish a connection with Google Sheet, you have two options. First, you can click on the **+Add new data source** button found on the query panel. Alternatively, you can go to the **[Data sources](/docs/data-sources/overview)** page within the ToolJet dashboard.
 
 ### Authorization Scopes
 
@@ -37,7 +37,7 @@ When connecting to a Google Sheets datasource, you can choose between two permis
 
 ## Querying Google Sheet
 
-To perform operations on a Google Sheet, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the Google Sheet datasource under the Global datasource section. Choose the desired operation from the dropdown and click **Save** to save the query.
+To perform operations on a Google Sheet, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the Google Sheet datasource under the data source section. Choose the desired operation from the dropdown and click **Save** to save the query.
 
 Using Google sheets data source you can perform several operations from your applications like:
 

--- a/docs/docs/data-sources/graphql.md
+++ b/docs/docs/data-sources/graphql.md
@@ -7,7 +7,7 @@ ToolJet can establish connections with GraphQL endpoints, enabling the execution
 
 ## Connection
 
-To establish a connection with the GraphQL global datasource, you can either click on the **Add new global datasource** button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the GraphQL data source, you can either click on the **Add new data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -27,7 +27,7 @@ ToolJet requires the following to connect to a GraphQL datasource:
 
 ## Querying GraphQL
 
-Click on **`+Add`** button of the query manager at the bottom panel of the editor and select the GraphQL global datasource added in previous step.
+Click on **`+Add`** button of the query manager at the bottom panel of the editor and select the GraphQL data source added in previous step.
 
 ### Required Parameters:
 - **Query**

--- a/docs/docs/data-sources/grpc.md
+++ b/docs/docs/data-sources/grpc.md
@@ -54,7 +54,7 @@ docker-compose up -d
 
 ## Querying gRPC
 
-After setting up your proto files, you should be able to establish a connection to gRPC by going to the [global datasource](/docs/data-sources/overview) page.
+After setting up your proto files, you should be able to establish a connection to gRPC by going to the [data source](/docs/data-sources/overview) page.
 
 ### Connect the gRPC datasource
 
@@ -69,7 +69,7 @@ ToolJet requires the following to connect to gRPC servers:
 
 </div>
 
-Once you have added the gRPC from the global datasource page, you'll find it on the query panel of the application.
+Once you have added the gRPC from the data source page, you'll find it on the query panel of the application.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/data-sources/mariadb.md
+++ b/docs/docs/data-sources/mariadb.md
@@ -9,7 +9,7 @@ ToolJet can connect to both self-hosted and cloud-based MariaDB servers to read 
 
 ## Connection
 
-To establish a connection with the MariaDB global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MariaDB data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -46,8 +46,8 @@ Click on **Test connection** button to verify if the credentials are correct and
 Once you have connected to the MariaDB datasource, follow these steps to write queries and interact with a MariaDB database from the ToolJet application:
 
 1. Open the ToolJet application and navigate to the query panel at the bottom of the app builder.
-2. Click the `+Add` button to open the list of available `local` and `global datasources`.
-3. Select **MariaDB** from the global datasource section.
+2. Click the `+Add` button to open the list of available `local` and `data sources`.
+3. Select **MariaDB** from the data source section.
 4. Enter the SQL query in the editor.
 5. **Rename**(optional) and **Create** the query.
 6. Click **Preview** to view the data returned from the query or click **Run** to execute the query.

--- a/docs/docs/data-sources/mysql.md
+++ b/docs/docs/data-sources/mysql.md
@@ -7,7 +7,7 @@ ToolJet can connect to MySQL databases to read and write data.
 
 ## Connection
 
-To establish a connection with the MySQL datasource, you can either click on the `+Add New` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MySQL datasource, you can either click on the `+Add New` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/data-sources/openapi.md
+++ b/docs/docs/data-sources/openapi.md
@@ -9,7 +9,7 @@ OpenAPI is a specification for designing and documenting RESTful APIs. Using Ope
 
 ## Connection
 
-To establish a connection with the OpenAPI global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the OpenAPI data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 - Connections are created based on OpenAPI specifications.
 - The available authentication methods currently supported are Basic Auth, API Key, Bearer Token, and OAuth 2.0.

--- a/docs/docs/data-sources/overview.md
+++ b/docs/docs/data-sources/overview.md
@@ -124,7 +124,7 @@ To configure these permissions, navigate to **Workspace Settings** -> **Groups S
 
 ## Changing scope of data sources on an app created on older versions of ToolJet
 
-On ToolJet versions below 2.3.0, the data source connection was made from within the individual apps. To make it backward compatible, we added an option to change the scope of the data sources and make it global data source.
+On ToolJet versions below 2.3.0, the data source connection was made from within the individual apps. To make it backward compatible, we added an option to change the scope of the data sources and make it data source.
 
 1. When dealing with apps that were created using ToolJet versions prior to 2.3.0, you will notice the presence of the data source manager in the left sidebar of the App Builder.
   <div style={{textAlign: 'center'}}>
@@ -140,8 +140,8 @@ On ToolJet versions below 2.3.0, the data source connection was made from within
 
   </div>
 
-3. Once you change the scope of the data source and make it global, you'll see that the **data source manager** is removed from the left sidebar and now you'll find the data source on the **query panel** under Global Data sources. You can now configure the data source from the Data Sources page on the **dashboard**.
-3. Once you have successfully changed the scope of the data source, thereby transforming it into a global data source, you will observe that the **data source manager** from the left sidebar is removed. Subsequently, the data source will be accessible within the **query panel** under the Available data sources section. Now you can configure this data source from the Data Sources page located on the **Dashboard**.
+3. Once you change the scope of the data source and make it global, you'll see that the **data source manager** is removed from the left sidebar and now you'll find the data source on the **query panel** under Data sources. You can now configure the data source from the Data Sources page on the **dashboard**.
+3. Once you have successfully changed the scope of the data source, thereby transforming it into a data source, you will observe that the **data source manager** from the left sidebar is removed. Subsequently, the data source will be accessible within the **query panel** under the Available data sources section. Now you can configure this data source from the Data Sources page located on the **Dashboard**.
 
   <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/data-sources/postgresql.md
+++ b/docs/docs/data-sources/postgresql.md
@@ -7,7 +7,7 @@ ToolJet has the capability to connect to PostgreSQL databases for data retrieval
 
 ## Establishing a Connection
 
-To establish a connection with the PostgreSQL global datasource, you can take either of the following steps: click on the "Add new global datasource" button in the query panel, or access the [Global Datasources](/docs/data-sources/overview) page through the ToolJet dashboard.
+To establish a connection with the PostgreSQL data source, you can take either of the following steps: click on the "Add new data source" button in the query panel, or access the [Data sources](/docs/data-sources/overview) page through the ToolJet dashboard.
 
 ToolJet requires the following information to connect to your PostgreSQL database:
 
@@ -36,7 +36,7 @@ Click the **Test connection** button to verify the correctness of the credential
 
 ## Querying PostgreSQL
 
-Click on `+Add` button on the query panel and select the PostgreSQL from the global datasources. 
+Click on `+Add` button on the query panel and select the PostgreSQL from the data sources. 
 
 PostgreSQL query editor has two modes, **SQL** & **GUI**. **[SQL mode](/docs/data-sources/postgresql#sql-mode)** can be used to write raw SQL queries and **[GUI mode](/docs/data-sources/postgresql#gui-mode)** can be used to query your PostgreSQL database without writing queries.
 

--- a/docs/docs/data-sources/redis.md
+++ b/docs/docs/data-sources/redis.md
@@ -7,7 +7,7 @@ ToolJet enables you to execute Redis commands on your Redis instances.
 
 ## Connecting to Redis
 
-To establish a connection with the Redis global datasource, you have two options. You can either click on the **`+Add new global datasource`** button on the query panel or access the **[Global Datasources](/docs/data-sources/overview)** page from the ToolJet dashboard.
+To establish a connection with the Redis data source, you have two options. You can either click on the **`+Add new data source`** button on the query panel or access the **[Data sources](/docs/data-sources/overview)** page from the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/data-sources/smtp.md
+++ b/docs/docs/data-sources/smtp.md
@@ -37,7 +37,7 @@ To create a query for sending an email, follow these steps:
 
 1. Open the query panel located at the bottom panel of the editor.
 2. Click the `+Add` button on the left to create a new query.
-3. Select `SMTP` from the global datasource.
+3. Select `SMTP` from the data source.
 4. Provide the following properties:
  - **From** `required` : Email address of the sender
  - **From Name** : Name of the sender

--- a/docs/docs/marketplace/marketplace_overview.md
+++ b/docs/docs/marketplace/marketplace_overview.md
@@ -51,7 +51,7 @@ Under the **Marketplace** tab, you will see a list of all the available plugins 
 
 You can access any installed plugins by following these steps:
 
-- Navigate to the **Global Datasources** Page.
+- Navigate to the **Data sources** Page.
 - Click on the **Add new datasource** button.
 - Open the **Plugins** tab in the modal that appears.
 - From here, you can connect to any of the plugins that were installed from the Marketplace.
@@ -62,7 +62,7 @@ You can access any installed plugins by following these steps:
 
 </div>
 
-- After successfully connecting to a plugin, you can access it under the Global Datasource section when creating queries.
+- After successfully connecting to a plugin, you can access it under the Data source section when creating queries.
 
 <div style={{textAlign: 'center'}}>
 
@@ -79,7 +79,7 @@ If you remove a plugin, all the queries associated with it will be eliminated fr
 To remove a plugin, follow these steps:
 - Go to the Marketplace page from the dashboard.
 - Go to the **Installed** tab and click on the **Remove** button next to the plugin that you want to remove.
-- By doing so, the plugin will be removed from the global datasource section, and no user will be able to establish a connection with it.
+- By doing so, the plugin will be removed from the data source section, and no user will be able to establish a connection with it.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/marketplace/plugins/harperdb.md
+++ b/docs/docs/marketplace/plugins/harperdb.md
@@ -31,7 +31,7 @@ To establish a connection with HarperDB, you need the following credentials:
 </div>
 
 ## Querying HarperDB
-To perform queries on HarperDB, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the HarperDB from the Global Datasource section in the query editor.
+To perform queries on HarperDB, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the HarperDB from the Data source section in the query editor.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/org-management/workspaces/workspace-variables.md
+++ b/docs/docs/org-management/workspaces/workspace-variables.md
@@ -34,9 +34,9 @@ Suppose there is an `API key` or a value that you want to use in the queries or 
 
 ### Types of variables
 
-- **Client**: The client variable can be utilized in components, queries, and global datasources.
+- **Client**: The client variable can be utilized in components, queries, and data sources.
 
-- **Server**: The server variables can be employed in all queries except for `RunJS` and the connection form for global datasources. The restriction on using server variables with components is due to their resolution occurring solely during runtime, ensuring a high level of security.
+- **Server**: The server variables can be employed in all queries except for `RunJS` and the connection form for data sources. The restriction on using server variables with components is due to their resolution occurring solely during runtime, ensuring a high level of security.
 
 :::info
 Variable Type cannot be changed once it has been created.
@@ -74,7 +74,7 @@ So, the syntax for using the variable that we created before will be `%%client.p
 
 </div>
 
-Starting from ToolJet version `2.10.0` and onwards, it is possible to utilize Server-type workspace variables in the global datasources connection form.
+Starting from ToolJet version `2.10.0` and onwards, it is possible to utilize Server-type workspace variables in the data sources connection form.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/org-management/workspaces/workspace_constants.md
+++ b/docs/docs/org-management/workspaces/workspace_constants.md
@@ -17,9 +17,9 @@ Workspace constants are designed to be resolved on the server side only. This me
 
 Creating, updating, and deleting constants are exclusive privileges granted to **Admins** (workspaces). Only users with administrative rights can perform these operations. Workspace constants are specific to the workspace where they are created and cannot be utilized in other workspaces.
 
-## Usage in App Builder and Global Datasource connection
+## Usage in App Builder and Data source connection
 
-All users with edit app permissions have access to consume and utilize constants in the app builder and global datasource connection forms. This enables you to use the same constant values across different components of your application, ensuring consistency and reducing duplication of effort.
+All users with edit app permissions have access to consume and utilize constants in the app builder and data source connection forms. This enables you to use the same constant values across different components of your application, ensuring consistency and reducing duplication of effort.
 
 ## Syntax
 
@@ -40,7 +40,7 @@ To create workspace constants, follow these steps:
     
 </div>
 
-- If you are an admin, you have the privilege to edit or delete constants. However, if you are a user with edit app permissions in the workspace, you can only view the constants and consume them in the app builder and global datasource connection forms.
+- If you are an admin, you have the privilege to edit or delete constants. However, if you are a user with edit app permissions in the workspace, you can only view the constants and consume them in the app builder and data source connection forms.
 
 <div style={{textAlign: 'center'}}>
 
@@ -50,15 +50,15 @@ To create workspace constants, follow these steps:
 
 ## Using Workspace Constants
 
-Workspace constants can be used in the app builder and the global datasource connection forms.
+Workspace constants can be used in the app builder and the data source connection forms.
 
-### Using Workspace Constants in Global Datasource Connection
+### Using Workspace Constants in Data source Connection
 
-You can use workspace constants in the **[global datasource connection](/docs/data-sources/overview#connecting-global-datasources)** form to store sensitive information like API keys, tokens, etc. This will ensure that the data remains secure and is not exposed to the client-side. You can use the syntax `{{constants.constant_name}}` to access the value of the constant. 
+You can use workspace constants in the **[data source connection](/docs/data-sources/overview#connecting-global-datasources)** form to store sensitive information like API keys, tokens, etc. This will ensure that the data remains secure and is not exposed to the client-side. You can use the syntax `{{constants.constant_name}}` to access the value of the constant. 
 
  <div style={{textAlign: 'center'}}>
 
- <img className="screenshot-full" src="/img/workspace-const/globaldatasource.png" alt="Workspace constants: global datasource"/>
+ <img className="screenshot-full" src="/img/workspace-const/globaldatasource.png" alt="Workspace constants: data source"/>
 
  </div>
 

--- a/docs/docs/workflows/overview.md
+++ b/docs/docs/workflows/overview.md
@@ -22,7 +22,7 @@ You're currently exploring the beta version of ToolJet Workflows. Please be awar
 This introductory guide will help you understand the basics of ToolJet Workflows. We'll create a workflow that fetches the sales data from the database, transforms the data using JavaScript and sends an SMS notification to the Sales Manager using Twilio. The workflow will also conditionally return a success/failure message that can be used in a ToolJet Application to show a pop-up alert. 
 
 :::info
-All data sources that are configured in **Global Datasources** will be available in Workflows.
+All data sources that are configured in **Data sources** will be available in Workflows.
 :::
 
 To create a new workflow, click on the workflow icon in the left sidebar and click on the **Create New Workflow** button. You'll be taken to the flow builder with a new workflow. Let's start by renaming the workflow to *Quickstart Guide*. 

--- a/docs/versioned_docs/version-2.18.0/app-builder/query-panel.md
+++ b/docs/versioned_docs/version-2.18.0/app-builder/query-panel.md
@@ -27,7 +27,7 @@ Query Manager will list all the queries that has been created in the application
 
 ### Add
 
-Add button is used to add new query in the application. When Add button is clicked, a menu will open with a list of options for creating a query from **Default** datasources such as **Rest API**, **ToolJet Database**, **JavaScript Code**, **Python Code** or from connected **Global Datasources**.
+Add button is used to add new query in the application. When Add button is clicked, a menu will open with a list of options for creating a query from **Default** datasources such as **Rest API**, **ToolJet Database**, **JavaScript Code**, **Python Code** or from connected **Datasources**.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/dashboard.md
+++ b/docs/versioned_docs/version-2.18.0/dashboard.md
@@ -161,7 +161,7 @@ Selecting this option will immediately open the cloned app in the app builder wi
 
 ### Export app
 
-This option will download a JSON file of the application. This JSON file can be [imported](#import) to ToolJet to create a new app. The exported app will include all the queries connected to global data sources including the data source created from Marketplace plugins.
+This option will download a JSON file of the application. This JSON file can be [imported](#import) to ToolJet to create a new app. The exported app will include all the queries connected to data sources including the data source created from Marketplace plugins.
 
 This option allows you to select a specific version of the app to export or export all the versions of the app. To export a specific version of the app, select a version from the list of available versions in the modal and click on the `Export selected version` and to export all the versions of the app, click on the `Export All` button.
 

--- a/docs/versioned_docs/version-2.18.0/data-sources/azureblob.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/azureblob.md
@@ -7,9 +7,9 @@ ToolJet offers the capability to establish a connection with Azure Blob storage 
 
 ## Connection
 
-To connect ToolJet with the Azure Blob global datasource, you have two options:
-1. Click on the `+Add new global datasource` button in the query panel.
-2. Go to the **[Global Datasources](/docs/data-sources/overview)** page on the ToolJet dashboard.
+To connect ToolJet with the Azure Blob data source, you have two options:
+1. Click on the `+Add new data source` button in the query panel.
+2. Go to the **[Data sources](/docs/data-sources/overview)** page on the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -24,11 +24,11 @@ Once you have entered the connection string, click on the **Test connection** bu
 
 ## Querying Azure Blob
 
-Once you have connected to the Azure Blob global datasource, follow these steps to create queries and interact with a Azure Blob storage from the ToolJet application:
+Once you have connected to the Azure Blob data source, follow these steps to create queries and interact with a Azure Blob storage from the ToolJet application:
 
 1. Open the ToolJet application and navigate to the query panel at the bottom of the app builder.
-2. Click the `+Add` button to open the list of available `local` and `global datasources`.
-3. Select **Azure Blob** from the global datasource section.
+2. Click the `+Add` button to open the list of available `local` and `data sources`.
+3. Select **Azure Blob** from the data source section.
 4. Select the desired **operation** from the dropdown and enter the required **parameters**.
 5. **Rename**(optional) and **Create** the query.
 6. Click **Preview** to view the data returned from the query or click **Run** to execute the query.

--- a/docs/versioned_docs/version-2.18.0/data-sources/dynamodb.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/dynamodb.md
@@ -8,7 +8,7 @@ DynamoDB is a managed non-relational database service provided by Amazon. ToolJe
 
 ## Connection
 
-To establish a connection with the DynamoDB global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the DynamoDB data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/data-sources/google.sheets.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/google.sheets.md
@@ -20,7 +20,7 @@ If you decide to self-host ToolJet, there are a few additional steps you need to
 
 ## Connection
 
-To establish a connection with Google Sheet, you have two options. First, you can click on the **+Add new global datasource** button found on the query panel. Alternatively, you can go to the **[Global Datasources](/docs/data-sources/overview)** page within the ToolJet dashboard.
+To establish a connection with Google Sheet, you have two options. First, you can click on the **+Add new data source** button found on the query panel. Alternatively, you can go to the **[Data sources](/docs/data-sources/overview)** page within the ToolJet dashboard.
 
 ### Authorization Scopes
 
@@ -37,7 +37,7 @@ When connecting to a Google Sheets datasource, you can choose between two permis
 
 ## Querying Google Sheet
 
-To perform operations on a Google Sheet, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the Google Sheet datasource under the Global datasource section. Choose the desired operation from the dropdown and click **Save** to save the query.
+To perform operations on a Google Sheet, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the Google Sheet datasource under the data source section. Choose the desired operation from the dropdown and click **Save** to save the query.
 
 Using Google sheets data source you can perform several operations from your applications like:
 

--- a/docs/versioned_docs/version-2.18.0/data-sources/graphql.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/graphql.md
@@ -7,7 +7,7 @@ ToolJet can establish connections with GraphQL endpoints, enabling the execution
 
 ## Connection
 
-To establish a connection with the GraphQL global datasource, you can either click on the **Add new global datasource** button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the GraphQL data source, you can either click on the **Add new data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -27,7 +27,7 @@ ToolJet requires the following to connect to a GraphQL datasource:
 
 ## Querying GraphQL
 
-Click on **`+Add`** button of the query manager at the bottom panel of the editor and select the GraphQL global datasource added in previous step.
+Click on **`+Add`** button of the query manager at the bottom panel of the editor and select the GraphQL data source added in previous step.
 
 ### Required Parameters:
 - **Query**

--- a/docs/versioned_docs/version-2.18.0/data-sources/grpc.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/grpc.md
@@ -54,7 +54,7 @@ docker-compose up -d
 
 ## Querying gRPC
 
-After setting up your proto files, you should be able to establish a connection to gRPC by going to the [global datasource](/docs/data-sources/overview) page.
+After setting up your proto files, you should be able to establish a connection to gRPC by going to the [data source](/docs/data-sources/overview) page.
 
 ### Connect the gRPC datasource
 
@@ -69,7 +69,7 @@ ToolJet requires the following to connect to gRPC servers:
 
 </div>
 
-Once you have added the gRPC from the global datasource page, you'll find it on the query panel of the application.
+Once you have added the gRPC from the data source page, you'll find it on the query panel of the application.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/data-sources/mariadb.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/mariadb.md
@@ -9,7 +9,7 @@ ToolJet can connect to both self-hosted and cloud-based MariaDB servers to read 
 
 ## Connection
 
-To establish a connection with the MariaDB global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MariaDB data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -46,8 +46,8 @@ Click on **Test connection** button to verify if the credentials are correct and
 Once you have connected to the MariaDB datasource, follow these steps to write queries and interact with a MariaDB database from the ToolJet application:
 
 1. Open the ToolJet application and navigate to the query panel at the bottom of the app builder.
-2. Click the `+Add` button to open the list of available `local` and `global datasources`.
-3. Select **MariaDB** from the global datasource section.
+2. Click the `+Add` button to open the list of available `local` and `data sources`.
+3. Select **MariaDB** from the data source section.
 4. Enter the SQL query in the editor.
 5. **Rename**(optional) and **Create** the query.
 6. Click **Preview** to view the data returned from the query or click **Run** to execute the query.

--- a/docs/versioned_docs/version-2.18.0/data-sources/mysql.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/mysql.md
@@ -7,7 +7,7 @@ ToolJet can connect to MySQL databases to read and write data.
 
 ## Connection
 
-To establish a connection with the MySQL datasource, you can either click on the `+Add New` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MySQL datasource, you can either click on the `+Add New` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/data-sources/openapi.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/openapi.md
@@ -9,7 +9,7 @@ OpenAPI is a specification for designing and documenting RESTful APIs. Using Ope
 
 ## Connection
 
-To establish a connection with the OpenAPI global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the OpenAPI data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 - Connections are created based on OpenAPI specifications.
 - The available authentication methods currently supported are Basic Auth, API Key, Bearer Token, and OAuth 2.0.

--- a/docs/versioned_docs/version-2.18.0/data-sources/overview.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/overview.md
@@ -124,7 +124,7 @@ To configure these permissions, navigate to **Workspace Settings** -> **Groups S
 
 ## Changing scope of data sources on an app created on older versions of ToolJet
 
-On ToolJet versions below 2.3.0, the data source connection was made from within the individual apps. To make it backward compatible, we added an option to change the scope of the data sources and make it global data source.
+On ToolJet versions below 2.3.0, the data source connection was made from within the individual apps. To make it backward compatible, we added an option to change the scope of the data sources and make it data source.
 
 1. When dealing with apps that were created using ToolJet versions prior to 2.3.0, you will notice the presence of the data source manager in the left sidebar of the App Builder.
   <div style={{textAlign: 'center'}}>
@@ -140,8 +140,8 @@ On ToolJet versions below 2.3.0, the data source connection was made from within
 
   </div>
 
-3. Once you change the scope of the data source and make it global, you'll see that the **data source manager** is removed from the left sidebar and now you'll find the data source on the **query panel** under Global Data sources. You can now configure the data source from the Data Sources page on the **dashboard**.
-3. Once you have successfully changed the scope of the data source, thereby transforming it into a global data source, you will observe that the **data source manager** from the left sidebar is removed. Subsequently, the data source will be accessible within the **query panel** under the Available data sources section. Now you can configure this data source from the Data Sources page located on the **Dashboard**.
+3. Once you change the scope of the data source and make it global, you'll see that the **data source manager** is removed from the left sidebar and now you'll find the data source on the **query panel** under Data sources. You can now configure the data source from the Data Sources page on the **dashboard**.
+3. Once you have successfully changed the scope of the data source, thereby transforming it into a data source, you will observe that the **data source manager** from the left sidebar is removed. Subsequently, the data source will be accessible within the **query panel** under the Available data sources section. Now you can configure this data source from the Data Sources page located on the **Dashboard**.
 
   <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/data-sources/postgresql.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/postgresql.md
@@ -7,7 +7,7 @@ ToolJet has the capability to connect to PostgreSQL databases for data retrieval
 
 ## Establishing a Connection
 
-To establish a connection with the PostgreSQL global datasource, you can take either of the following steps: click on the "Add new global datasource" button in the query panel, or access the [Global Datasources](/docs/data-sources/overview) page through the ToolJet dashboard.
+To establish a connection with the PostgreSQL data source, you can take either of the following steps: click on the "Add new data source" button in the query panel, or access the [Data sources](/docs/data-sources/overview) page through the ToolJet dashboard.
 
 ToolJet requires the following information to connect to your PostgreSQL database:
 
@@ -36,7 +36,7 @@ Click the **Test connection** button to verify the correctness of the credential
 
 ## Querying PostgreSQL
 
-Click on `+Add` button on the query panel and select the PostgreSQL from the global datasources. 
+Click on `+Add` button on the query panel and select the PostgreSQL from the data sources. 
 
 PostgreSQL query editor has two modes, **SQL** & **GUI**. **[SQL mode](/docs/data-sources/postgresql#sql-mode)** can be used to write raw SQL queries and **[GUI mode](/docs/data-sources/postgresql#gui-mode)** can be used to query your PostgreSQL database without writing queries.
 

--- a/docs/versioned_docs/version-2.18.0/data-sources/redis.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/redis.md
@@ -7,7 +7,7 @@ ToolJet enables you to execute Redis commands on your Redis instances.
 
 ## Connecting to Redis
 
-To establish a connection with the Redis global datasource, you have two options. You can either click on the **`+Add new global datasource`** button on the query panel or access the **[Global Datasources](/docs/data-sources/overview)** page from the ToolJet dashboard.
+To establish a connection with the Redis data source, you have two options. You can either click on the **`+Add new data source`** button on the query panel or access the **[Data sources](/docs/data-sources/overview)** page from the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/data-sources/smtp.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/smtp.md
@@ -37,7 +37,7 @@ To create a query for sending an email, follow these steps:
 
 1. Open the query panel located at the bottom panel of the editor.
 2. Click the `+Add` button on the left to create a new query.
-3. Select `SMTP` from the global datasource.
+3. Select `SMTP` from the data source.
 4. Provide the following properties:
  - **From** `required` : Email address of the sender
  - **From Name** : Name of the sender

--- a/docs/versioned_docs/version-2.18.0/marketplace/marketplace_overview.md
+++ b/docs/versioned_docs/version-2.18.0/marketplace/marketplace_overview.md
@@ -51,7 +51,7 @@ Under the **Marketplace** tab, you will see a list of all the available plugins 
 
 You can access any installed plugins by following these steps:
 
-- Navigate to the **Global Datasources** Page.
+- Navigate to the **Data sources** Page.
 - Click on the **Add new datasource** button.
 - Open the **Plugins** tab in the modal that appears.
 - From here, you can connect to any of the plugins that were installed from the Marketplace.
@@ -62,7 +62,7 @@ You can access any installed plugins by following these steps:
 
 </div>
 
-- After successfully connecting to a plugin, you can access it under the Global Datasource section when creating queries.
+- After successfully connecting to a plugin, you can access it under the Data source section when creating queries.
 
 <div style={{textAlign: 'center'}}>
 
@@ -79,7 +79,7 @@ If you remove a plugin, all the queries associated with it will be eliminated fr
 To remove a plugin, follow these steps:
 - Go to the Marketplace page from the dashboard.
 - Go to the **Installed** tab and click on the **Remove** button next to the plugin that you want to remove.
-- By doing so, the plugin will be removed from the global datasource section, and no user will be able to establish a connection with it.
+- By doing so, the plugin will be removed from the data source section, and no user will be able to establish a connection with it.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/marketplace/plugins/harperdb.md
+++ b/docs/versioned_docs/version-2.18.0/marketplace/plugins/harperdb.md
@@ -31,7 +31,7 @@ To establish a connection with HarperDB, you need the following credentials:
 </div>
 
 ## Querying HarperDB
-To perform queries on HarperDB, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the HarperDB from the Global Datasource section in the query editor.
+To perform queries on HarperDB, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the HarperDB from the Data source section in the query editor.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/org-management/workspaces/workspace-variables.md
+++ b/docs/versioned_docs/version-2.18.0/org-management/workspaces/workspace-variables.md
@@ -34,9 +34,9 @@ Suppose there is an `API key` or a value that you want to use in the queries or 
 
 ### Types of variables
 
-- **Client**: The client variable can be utilized in components, queries, and global datasources.
+- **Client**: The client variable can be utilized in components, queries, and data sources.
 
-- **Server**: The server variables can be employed in all queries except for `RunJS` and the connection form for global datasources. The restriction on using server variables with components is due to their resolution occurring solely during runtime, ensuring a high level of security.
+- **Server**: The server variables can be employed in all queries except for `RunJS` and the connection form for data sources. The restriction on using server variables with components is due to their resolution occurring solely during runtime, ensuring a high level of security.
 
 :::info
 Variable Type cannot be changed once it has been created.
@@ -74,7 +74,7 @@ So, the syntax for using the variable that we created before will be `%%client.p
 
 </div>
 
-Starting from ToolJet version `2.10.0` and onwards, it is possible to utilize Server-type workspace variables in the global datasources connection form.
+Starting from ToolJet version `2.10.0` and onwards, it is possible to utilize Server-type workspace variables in the data sources connection form.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.18.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.18.0/org-management/workspaces/workspace_constants.md
@@ -17,9 +17,9 @@ Workspace constants are designed to be resolved on the server side only. This me
 
 Creating, updating, and deleting constants are exclusive privileges granted to **Admins** (workspaces). Only users with administrative rights can perform these operations. Workspace constants are specific to the workspace where they are created and cannot be utilized in other workspaces.
 
-## Usage in App Builder and Global Datasource connection
+## Usage in App Builder and Data source connection
 
-All users with edit app permissions have access to consume and utilize constants in the app builder and global datasource connection forms. This enables you to use the same constant values across different components of your application, ensuring consistency and reducing duplication of effort.
+All users with edit app permissions have access to consume and utilize constants in the app builder and data source connection forms. This enables you to use the same constant values across different components of your application, ensuring consistency and reducing duplication of effort.
 
 ## Syntax
 
@@ -40,7 +40,7 @@ To create workspace constants, follow these steps:
     
 </div>
 
-- If you are an admin, you have the privilege to edit or delete constants. However, if you are a user with edit app permissions in the workspace, you can only view the constants and consume them in the app builder and global datasource connection forms.
+- If you are an admin, you have the privilege to edit or delete constants. However, if you are a user with edit app permissions in the workspace, you can only view the constants and consume them in the app builder and data source connection forms.
 
 <div style={{textAlign: 'center'}}>
 
@@ -50,15 +50,15 @@ To create workspace constants, follow these steps:
 
 ## Using Workspace Constants
 
-Workspace constants can be used in the app builder and the global datasource connection forms.
+Workspace constants can be used in the app builder and the data source connection forms.
 
-### Using Workspace Constants in Global Datasource Connection
+### Using Workspace Constants in Data source Connection
 
-You can use workspace constants in the **[global datasource connection](/docs/data-sources/overview#connecting-global-datasources)** form to store sensitive information like API keys, tokens, etc. This will ensure that the data remains secure and is not exposed to the client-side. You can use the syntax `{{constants.constant_name}}` to access the value of the constant. 
+You can use workspace constants in the **[data source connection](/docs/data-sources/overview#connecting-global-datasources)** form to store sensitive information like API keys, tokens, etc. This will ensure that the data remains secure and is not exposed to the client-side. You can use the syntax `{{constants.constant_name}}` to access the value of the constant. 
 
  <div style={{textAlign: 'center'}}>
 
- <img className="screenshot-full" src="/img/workspace-const/globaldatasource.png" alt="Workspace constants: global datasource"/>
+ <img className="screenshot-full" src="/img/workspace-const/globaldatasource.png" alt="Workspace constants: data source"/>
 
  </div>
 

--- a/docs/versioned_docs/version-2.18.0/workflows/overview.md
+++ b/docs/versioned_docs/version-2.18.0/workflows/overview.md
@@ -22,7 +22,7 @@ You're currently exploring the beta version of ToolJet Workflows. Please be awar
 This introductory guide will help you understand the basics of ToolJet Workflows. We'll create a workflow that fetches the sales data from the database, transforms the data using JavaScript and sends an SMS notification to the Sales Manager using Twilio. The workflow will also conditionally return a success/failure message that can be used in a ToolJet Application to show a pop-up alert. 
 
 :::info
-All data sources that are configured in **Global Datasources** will be available in Workflows.
+All data sources that are configured in **Data sources** will be available in Workflows.
 :::
 
 To create a new workflow, click on the workflow icon in the left sidebar and click on the **Create New Workflow** button. You'll be taken to the flow builder with a new workflow. Let's start by renaming the workflow to *Quickstart Guide*. 

--- a/docs/versioned_docs/version-2.19.0/app-builder/query-panel.md
+++ b/docs/versioned_docs/version-2.19.0/app-builder/query-panel.md
@@ -27,7 +27,7 @@ Query Manager will list all the queries that has been created in the application
 
 ### Add
 
-Add button is used to add new query in the application. When Add button is clicked, a menu will open with a list of options for creating a query from **Default** datasources such as **Rest API**, **ToolJet Database**, **JavaScript Code**, **Python Code** or from connected **Global Datasources**.
+Add button is used to add new query in the application. When Add button is clicked, a menu will open with a list of options for creating a query from **Default** datasources such as **Rest API**, **ToolJet Database**, **JavaScript Code**, **Python Code** or from connected **Data sources**.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/dashboard.md
+++ b/docs/versioned_docs/version-2.19.0/dashboard.md
@@ -161,7 +161,7 @@ Selecting this option will immediately open the cloned app in the app builder wi
 
 ### Export app
 
-This option will download a JSON file of the application. This JSON file can be [imported](#import) to ToolJet to create a new app. The exported app will include all the queries connected to global data sources including the data source created from Marketplace plugins.
+This option will download a JSON file of the application. This JSON file can be [imported](#import) to ToolJet to create a new app. The exported app will include all the queries connected to data sources including the data source created from Marketplace plugins.
 
 This option allows you to select a specific version of the app to export or export all the versions of the app. To export a specific version of the app, select a version from the list of available versions in the modal and click on the `Export selected version` and to export all the versions of the app, click on the `Export All` button.
 

--- a/docs/versioned_docs/version-2.19.0/data-sources/azureblob.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/azureblob.md
@@ -7,9 +7,9 @@ ToolJet offers the capability to establish a connection with Azure Blob storage 
 
 ## Connection
 
-To connect ToolJet with the Azure Blob global datasource, you have two options:
-1. Click on the `+Add new global datasource` button in the query panel.
-2. Go to the **[Global Datasources](/docs/data-sources/overview)** page on the ToolJet dashboard.
+To connect ToolJet with the Azure Blob data source, you have two options:
+1. Click on the `+Add new data source` button in the query panel.
+2. Go to the **[Data sources](/docs/data-sources/overview)** page on the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -24,11 +24,11 @@ Once you have entered the connection string, click on the **Test connection** bu
 
 ## Querying Azure Blob
 
-Once you have connected to the Azure Blob global datasource, follow these steps to create queries and interact with a Azure Blob storage from the ToolJet application:
+Once you have connected to the Azure Blob data source, follow these steps to create queries and interact with a Azure Blob storage from the ToolJet application:
 
 1. Open the ToolJet application and navigate to the query panel at the bottom of the app builder.
-2. Click the `+Add` button to open the list of available `local` and `global datasources`.
-3. Select **Azure Blob** from the global datasource section.
+2. Click the `+Add` button to open the list of available `local` and `data sources`.
+3. Select **Azure Blob** from the data source section.
 4. Select the desired **operation** from the dropdown and enter the required **parameters**.
 5. **Rename**(optional) and **Create** the query.
 6. Click **Preview** to view the data returned from the query or click **Run** to execute the query.

--- a/docs/versioned_docs/version-2.19.0/data-sources/dynamodb.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/dynamodb.md
@@ -8,7 +8,7 @@ DynamoDB is a managed non-relational database service provided by Amazon. ToolJe
 
 ## Connection
 
-To establish a connection with the DynamoDB global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the DynamoDB data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/data-sources/google.sheets.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/google.sheets.md
@@ -20,7 +20,7 @@ If you decide to self-host ToolJet, there are a few additional steps you need to
 
 ## Connection
 
-To establish a connection with Google Sheet, you have two options. First, you can click on the **+Add new global datasource** button found on the query panel. Alternatively, you can go to the **[Global Datasources](/docs/data-sources/overview)** page within the ToolJet dashboard.
+To establish a connection with Google Sheet, you have two options. First, you can click on the **+Add new data source** button found on the query panel. Alternatively, you can go to the **[Data sources](/docs/data-sources/overview)** page within the ToolJet dashboard.
 
 ### Authorization Scopes
 
@@ -37,7 +37,7 @@ When connecting to a Google Sheets datasource, you can choose between two permis
 
 ## Querying Google Sheet
 
-To perform operations on a Google Sheet, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the Google Sheet datasource under the Global datasource section. Choose the desired operation from the dropdown and click **Save** to save the query.
+To perform operations on a Google Sheet, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the Google Sheet datasource under the data source section. Choose the desired operation from the dropdown and click **Save** to save the query.
 
 Using Google sheets data source you can perform several operations from your applications like:
 

--- a/docs/versioned_docs/version-2.19.0/data-sources/graphql.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/graphql.md
@@ -7,7 +7,7 @@ ToolJet can establish connections with GraphQL endpoints, enabling the execution
 
 ## Connection
 
-To establish a connection with the GraphQL global datasource, you can either click on the **Add new global datasource** button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the GraphQL data source, you can either click on the **Add new data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -27,7 +27,7 @@ ToolJet requires the following to connect to a GraphQL datasource:
 
 ## Querying GraphQL
 
-Click on **`+Add`** button of the query manager at the bottom panel of the editor and select the GraphQL global datasource added in previous step.
+Click on **`+Add`** button of the query manager at the bottom panel of the editor and select the GraphQL data source added in previous step.
 
 ### Required Parameters:
 - **Query**

--- a/docs/versioned_docs/version-2.19.0/data-sources/grpc.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/grpc.md
@@ -54,7 +54,7 @@ docker-compose up -d
 
 ## Querying gRPC
 
-After setting up your proto files, you should be able to establish a connection to gRPC by going to the [global datasource](/docs/data-sources/overview) page.
+After setting up your proto files, you should be able to establish a connection to gRPC by going to the [data source](/docs/data-sources/overview) page.
 
 ### Connect the gRPC datasource
 
@@ -69,7 +69,7 @@ ToolJet requires the following to connect to gRPC servers:
 
 </div>
 
-Once you have added the gRPC from the global datasource page, you'll find it on the query panel of the application.
+Once you have added the gRPC from the data source page, you'll find it on the query panel of the application.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/data-sources/mariadb.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/mariadb.md
@@ -9,7 +9,7 @@ ToolJet can connect to both self-hosted and cloud-based MariaDB servers to read 
 
 ## Connection
 
-To establish a connection with the MariaDB global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MariaDB data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -46,8 +46,8 @@ Click on **Test connection** button to verify if the credentials are correct and
 Once you have connected to the MariaDB datasource, follow these steps to write queries and interact with a MariaDB database from the ToolJet application:
 
 1. Open the ToolJet application and navigate to the query panel at the bottom of the app builder.
-2. Click the `+Add` button to open the list of available `local` and `global datasources`.
-3. Select **MariaDB** from the global datasource section.
+2. Click the `+Add` button to open the list of available `local` and `data sources`.
+3. Select **MariaDB** from the data source section.
 4. Enter the SQL query in the editor.
 5. **Rename**(optional) and **Create** the query.
 6. Click **Preview** to view the data returned from the query or click **Run** to execute the query.

--- a/docs/versioned_docs/version-2.19.0/data-sources/mysql.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/mysql.md
@@ -7,7 +7,7 @@ ToolJet can connect to MySQL databases to read and write data.
 
 ## Connection
 
-To establish a connection with the MySQL datasource, you can either click on the `+Add New` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MySQL datasource, you can either click on the `+Add New` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/data-sources/openapi.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/openapi.md
@@ -9,7 +9,7 @@ OpenAPI is a specification for designing and documenting RESTful APIs. Using Ope
 
 ## Connection
 
-To establish a connection with the OpenAPI global datasource, you can either click on the `+Add new global datasource` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the OpenAPI data source, you can either click on the `+Add new data source` button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 - Connections are created based on OpenAPI specifications.
 - The available authentication methods currently supported are Basic Auth, API Key, Bearer Token, and OAuth 2.0.

--- a/docs/versioned_docs/version-2.19.0/data-sources/overview.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/overview.md
@@ -124,7 +124,7 @@ To configure these permissions, navigate to **Workspace Settings** -> **Groups S
 
 ## Changing scope of data sources on an app created on older versions of ToolJet
 
-On ToolJet versions below 2.3.0, the data source connection was made from within the individual apps. To make it backward compatible, we added an option to change the scope of the data sources and make it global data source.
+On ToolJet versions below 2.3.0, the data source connection was made from within the individual apps. To make it backward compatible, we added an option to change the scope of the data sources and make it data source.
 
 1. When dealing with apps that were created using ToolJet versions prior to 2.3.0, you will notice the presence of the data source manager in the left sidebar of the App Builder.
   <div style={{textAlign: 'center'}}>
@@ -140,8 +140,8 @@ On ToolJet versions below 2.3.0, the data source connection was made from within
 
   </div>
 
-3. Once you change the scope of the data source and make it global, you'll see that the **data source manager** is removed from the left sidebar and now you'll find the data source on the **query panel** under Global Data sources. You can now configure the data source from the Data Sources page on the **dashboard**.
-3. Once you have successfully changed the scope of the data source, thereby transforming it into a global data source, you will observe that the **data source manager** from the left sidebar is removed. Subsequently, the data source will be accessible within the **query panel** under the Available data sources section. Now you can configure this data source from the Data Sources page located on the **Dashboard**.
+3. Once you change the scope of the data source and make it global, you'll see that the **data source manager** is removed from the left sidebar and now you'll find the data source on the **query panel** under Data sources. You can now configure the data source from the Data Sources page on the **dashboard**.
+3. Once you have successfully changed the scope of the data source, thereby transforming it into a data source, you will observe that the **data source manager** from the left sidebar is removed. Subsequently, the data source will be accessible within the **query panel** under the Available data sources section. Now you can configure this data source from the Data Sources page located on the **Dashboard**.
 
   <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/data-sources/postgresql.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/postgresql.md
@@ -7,7 +7,7 @@ ToolJet has the capability to connect to PostgreSQL databases for data retrieval
 
 ## Establishing a Connection
 
-To establish a connection with the PostgreSQL global datasource, you can take either of the following steps: click on the "Add new global datasource" button in the query panel, or access the [Global Datasources](/docs/data-sources/overview) page through the ToolJet dashboard.
+To establish a connection with the PostgreSQL data source, you can take either of the following steps: click on the "Add new data source" button in the query panel, or access the [Data sources](/docs/data-sources/overview) page through the ToolJet dashboard.
 
 ToolJet requires the following information to connect to your PostgreSQL database:
 
@@ -36,7 +36,7 @@ Click the **Test connection** button to verify the correctness of the credential
 
 ## Querying PostgreSQL
 
-Click on `+Add` button on the query panel and select the PostgreSQL from the global datasources. 
+Click on `+Add` button on the query panel and select the PostgreSQL from the data sources. 
 
 PostgreSQL query editor has two modes, **SQL** & **GUI**. **[SQL mode](/docs/data-sources/postgresql#sql-mode)** can be used to write raw SQL queries and **[GUI mode](/docs/data-sources/postgresql#gui-mode)** can be used to query your PostgreSQL database without writing queries.
 

--- a/docs/versioned_docs/version-2.19.0/data-sources/redis.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/redis.md
@@ -7,7 +7,7 @@ ToolJet enables you to execute Redis commands on your Redis instances.
 
 ## Connecting to Redis
 
-To establish a connection with the Redis global datasource, you have two options. You can either click on the **`+Add new global datasource`** button on the query panel or access the **[Global Datasources](/docs/data-sources/overview)** page from the ToolJet dashboard.
+To establish a connection with the Redis data source, you have two options. You can either click on the **`+Add new data source`** button on the query panel or access the **[Data sources](/docs/data-sources/overview)** page from the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/data-sources/smtp.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/smtp.md
@@ -37,7 +37,7 @@ To create a query for sending an email, follow these steps:
 
 1. Open the query panel located at the bottom panel of the editor.
 2. Click the `+Add` button on the left to create a new query.
-3. Select `SMTP` from the global datasource.
+3. Select `SMTP` from the data source.
 4. Provide the following properties:
  - **From** `required` : Email address of the sender
  - **From Name** : Name of the sender

--- a/docs/versioned_docs/version-2.19.0/marketplace/marketplace_overview.md
+++ b/docs/versioned_docs/version-2.19.0/marketplace/marketplace_overview.md
@@ -51,7 +51,7 @@ Under the **Marketplace** tab, you will see a list of all the available plugins 
 
 You can access any installed plugins by following these steps:
 
-- Navigate to the **Global Datasources** Page.
+- Navigate to the **Data sources** Page.
 - Click on the **Add new datasource** button.
 - Open the **Plugins** tab in the modal that appears.
 - From here, you can connect to any of the plugins that were installed from the Marketplace.
@@ -62,7 +62,7 @@ You can access any installed plugins by following these steps:
 
 </div>
 
-- After successfully connecting to a plugin, you can access it under the Global Datasource section when creating queries.
+- After successfully connecting to a plugin, you can access it under the Data source section when creating queries.
 
 <div style={{textAlign: 'center'}}>
 
@@ -79,7 +79,7 @@ If you remove a plugin, all the queries associated with it will be eliminated fr
 To remove a plugin, follow these steps:
 - Go to the Marketplace page from the dashboard.
 - Go to the **Installed** tab and click on the **Remove** button next to the plugin that you want to remove.
-- By doing so, the plugin will be removed from the global datasource section, and no user will be able to establish a connection with it.
+- By doing so, the plugin will be removed from the data source section, and no user will be able to establish a connection with it.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/marketplace/plugins/harperdb.md
+++ b/docs/versioned_docs/version-2.19.0/marketplace/plugins/harperdb.md
@@ -31,7 +31,7 @@ To establish a connection with HarperDB, you need the following credentials:
 </div>
 
 ## Querying HarperDB
-To perform queries on HarperDB, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the HarperDB from the Global Datasource section in the query editor.
+To perform queries on HarperDB, click the `+Add` button in the query manager located at the bottom panel of the app builder. Select the HarperDB from the Data source section in the query editor.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/org-management/workspaces/workspace-variables.md
+++ b/docs/versioned_docs/version-2.19.0/org-management/workspaces/workspace-variables.md
@@ -34,9 +34,9 @@ Suppose there is an `API key` or a value that you want to use in the queries or 
 
 ### Types of variables
 
-- **Client**: The client variable can be utilized in components, queries, and global datasources.
+- **Client**: The client variable can be utilized in components, queries, and datasources.
 
-- **Server**: The server variables can be employed in all queries except for `RunJS` and the connection form for global datasources. The restriction on using server variables with components is due to their resolution occurring solely during runtime, ensuring a high level of security.
+- **Server**: The server variables can be employed in all queries except for `RunJS` and the connection form for datasources. The restriction on using server variables with components is due to their resolution occurring solely during runtime, ensuring a high level of security.
 
 :::info
 Variable Type cannot be changed once it has been created.
@@ -74,7 +74,7 @@ So, the syntax for using the variable that we created before will be `%%client.p
 
 </div>
 
-Starting from ToolJet version `2.10.0` and onwards, it is possible to utilize Server-type workspace variables in the global datasources connection form.
+Starting from ToolJet version `2.10.0` and onwards, it is possible to utilize Server-type workspace variables in the data sources connection form.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.19.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.19.0/org-management/workspaces/workspace_constants.md
@@ -17,9 +17,9 @@ Workspace constants are designed to be resolved on the server side only. This me
 
 Creating, updating, and deleting constants are exclusive privileges granted to **Admins** (workspaces). Only users with administrative rights can perform these operations. Workspace constants are specific to the workspace where they are created and cannot be utilized in other workspaces.
 
-## Usage in App Builder and Global Datasource connection
+## Usage in App Builder and Data source connection
 
-All users with edit app permissions have access to consume and utilize constants in the app builder and global datasource connection forms. This enables you to use the same constant values across different components of your application, ensuring consistency and reducing duplication of effort.
+All users with edit app permissions have access to consume and utilize constants in the app builder and data source connection forms. This enables you to use the same constant values across different components of your application, ensuring consistency and reducing duplication of effort.
 
 ## Syntax
 
@@ -40,7 +40,7 @@ To create workspace constants, follow these steps:
     
 </div>
 
-- If you are an admin, you have the privilege to edit or delete constants. However, if you are a user with edit app permissions in the workspace, you can only view the constants and consume them in the app builder and global datasource connection forms.
+- If you are an admin, you have the privilege to edit or delete constants. However, if you are a user with edit app permissions in the workspace, you can only view the constants and consume them in the app builder and data source connection forms.
 
 <div style={{textAlign: 'center'}}>
 
@@ -50,15 +50,15 @@ To create workspace constants, follow these steps:
 
 ## Using Workspace Constants
 
-Workspace constants can be used in the app builder and the global datasource connection forms.
+Workspace constants can be used in the app builder and the data source connection forms.
 
-### Using Workspace Constants in Global Datasource Connection
+### Using Workspace Constants in Data source Connection
 
-You can use workspace constants in the **[global datasource connection](/docs/data-sources/overview#connecting-global-datasources)** form to store sensitive information like API keys, tokens, etc. This will ensure that the data remains secure and is not exposed to the client-side. You can use the syntax `{{constants.constant_name}}` to access the value of the constant. 
+You can use workspace constants in the **[data source connection](/docs/data-sources/overview#connecting-global-datasources)** form to store sensitive information like API keys, tokens, etc. This will ensure that the data remains secure and is not exposed to the client-side. You can use the syntax `{{constants.constant_name}}` to access the value of the constant. 
 
  <div style={{textAlign: 'center'}}>
 
- <img className="screenshot-full" src="/img/workspace-const/globaldatasource.png" alt="Workspace constants: global datasource"/>
+ <img className="screenshot-full" src="/img/workspace-const/globaldatasource.png" alt="Workspace constants: datasource"/>
 
  </div>
 

--- a/docs/versioned_docs/version-2.19.0/workflows/overview.md
+++ b/docs/versioned_docs/version-2.19.0/workflows/overview.md
@@ -22,7 +22,7 @@ You're currently exploring the beta version of ToolJet Workflows. Please be awar
 This introductory guide will help you understand the basics of ToolJet Workflows. We'll create a workflow that fetches the sales data from the database, transforms the data using JavaScript and sends an SMS notification to the Sales Manager using Twilio. The workflow will also conditionally return a success/failure message that can be used in a ToolJet Application to show a pop-up alert. 
 
 :::info
-All data sources that are configured in **Global Datasources** will be available in Workflows.
+All data sources that are configured in **Data sources** will be available in Workflows.
 :::
 
 To create a new workflow, click on the workflow icon in the left sidebar and click on the **Create New Workflow** button. You'll be taken to the flow builder with a new workflow. Let's start by renaming the workflow to *Quickstart Guide*. 


### PR DESCRIPTION
Fixes #7609

This PR fixes the documentation bug of #7609. 
Change made in the required docs of "Global data source" to "data source"

Changes made for the following docs:

* docs/docs
* docs/versioned_docs/version-2.19.0
* docs/versioned_docs/version-2.18.0