### PR TITLE
updated the mongodb docs

### DIFF
--- a/docs/docs/data-sources/mongodb.md
+++ b/docs/docs/data-sources/mongodb.md
@@ -11,7 +11,7 @@ ToolJet can connect to MongoDB to read and write data.
 
 Please make sure the host/ip of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please whitelist our IP.
 
-To add a new MongoDB, click on the `+` button on data sources panel at the left-bottom corner of the app editor. Select MongoDB from the modal that pops up.
+To establish a connection with the MongoDB data source, click on the `+Add new data source` button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your MongoDB.
 
@@ -34,7 +34,7 @@ Click on `+` button of the query manager at the bottom panel of the editor and s
 
 
 
-Click on the 'run' button to run the query. NOTE: Query should be saved before running.
+Click on the 'run' button to run the query. 
 
 :::tip
 Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)

--- a/docs/versioned_docs/version-2.18.0/data-sources/mongodb.md
+++ b/docs/versioned_docs/version-2.18.0/data-sources/mongodb.md
@@ -11,7 +11,7 @@ ToolJet can connect to MongoDB to read and write data.
 
 Please make sure the host/ip of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please whitelist our IP.
 
-To add a new MongoDB, click on the `+` button on data sources panel at the left-bottom corner of the app editor. Select MongoDB from the modal that pops up.
+To establish a connection with the MongoDB data source, click on the `+Add new data source` button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your MongoDB.
 
@@ -34,7 +34,7 @@ Click on `+` button of the query manager at the bottom panel of the editor and s
 
 
 
-Click on the 'run' button to run the query. NOTE: Query should be saved before running.
+Click on the 'run' button to run the query. 
 
 :::tip
 Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)

--- a/docs/versioned_docs/version-2.19.0/data-sources/mongodb.md
+++ b/docs/versioned_docs/version-2.19.0/data-sources/mongodb.md
@@ -11,7 +11,7 @@ ToolJet can connect to MongoDB to read and write data.
 
 Please make sure the host/ip of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please whitelist our IP.
 
-To add a new MongoDB, click on the `+` button on data sources panel at the left-bottom corner of the app editor. Select MongoDB from the modal that pops up.
+To establish a connection with the MongoDB data source, click on the `+Add new data source` button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your MongoDB.
 
@@ -34,7 +34,7 @@ Click on `+` button of the query manager at the bottom panel of the editor and s
 
 
 
-Click on the 'run' button to run the query. NOTE: Query should be saved before running.
+Click on the 'run' button to run the query. 
 
 :::tip
 Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)


### PR DESCRIPTION
Fixes #7645 

I removed `NOTE: Query should be saved before running.` and replaced 
`To add a new MongoDB, click on the + button on data sources panel at the left-bottom corner of the app editor. Select MongoDB from the modal that pops up.`
with
`To establish a connection with the MongoDB data source, click on the +Add new data source button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.`

in 
- [X] `docs/docs`
- [X] `docs/versioned_docs/version-2.18.0`
- [X] `docs/versioned_docs/version-2.19.0`

Happy Hacktoberfest! :)