### PR TITLE
[Appdef-2] copy-paste, cut and  clone fix for widgets

### DIFF
--- a/frontend/src/Editor/Components/Listview.jsx
+++ b/frontend/src/Editor/Components/Listview.jsx
@@ -113,7 +113,7 @@ export const Listview = function Listview({
             key={index}
             data-cy={`${String(component.name).toLowerCase()}-row-${index}`}
             onClick={(event) => {
-              event.stopPropagation();
+              event.preventDefault();
               onRecordClicked(index);
               onRowClicked(index);
             }}

--- a/frontend/src/Editor/ConfigHandle.jsx
+++ b/frontend/src/Editor/ConfigHandle.jsx
@@ -32,7 +32,6 @@ export const ConfigHandle = function ConfigHandle({
           style={{ display: 'flex', alignItems: 'center' }}
           onClick={(e) => {
             e.preventDefault();
-            e.stopPropagation();
             setSelectedComponent(id, component, e.shiftKey);
           }}
           role="button"

--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -95,7 +95,6 @@ export const Container = ({
   useHotkeys(
     'meta+v, control+v',
     async () => {
-      console.log('---arpit pasting:: before [container] ', { parentId: focusedParentIdRef.current });
       if (isContainerFocused && !isVersionReleased) {
         // Check if the clipboard API is available
         if (navigator.clipboard && typeof navigator.clipboard.readText === 'function') {

--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -95,6 +95,7 @@ export const Container = ({
   useHotkeys(
     'meta+v, control+v',
     async () => {
+      console.log('---arpit pasting:: before [container] ', { parentId: focusedParentIdRef.current });
       if (isContainerFocused && !isVersionReleased) {
         // Check if the clipboard API is available
         if (navigator.clipboard && typeof navigator.clipboard.readText === 'function') {
@@ -105,7 +106,8 @@ export const Container = ({
               appDefinition,
               appDefinitionChanged,
               focusedParentIdRef.current,
-              JSON.parse(cliptext)
+              JSON.parse(cliptext),
+              true
             );
           } catch (err) {
             console.log(err);
@@ -116,7 +118,7 @@ export const Container = ({
       }
       enableReleasedVersionPopupState();
     },
-    [isContainerFocused, appDefinition, focusedParentIdRef]
+    [isContainerFocused, appDefinition, focusedParentIdRef.current]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes:

- [x] Copy/cut/paste and cloning components in the container layer
- [x] Copy/cut/paste and cloning components in the sub-container layer
- [x] Copy or Cut from one container widget (subcontainer layer) to another container widget (another subcontainer layer)
- [x] Copy/Cut - Paste or Cloning Multiple components (in the container layer)
- [x] Copy/Cut - Paste or Clone container widgets with child components
- [x] adding support of copy/paste and cloning for listview 