### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ For general help using ToolJet, please refer to the official [documentation](htt
 - [Slack](https://tooljet.com/slack) - Discussions with the community and the team.
 - [GitHub](https://github.com/ToolJet/ToolJet/issues) - For bug reports and feature requests.
 - [Twitter](https://twitter.com/ToolJet) - Get the product updates easily.
+- [LinkedIn](https://www.linkedin.com/company/tooljet) - Connect with us on LinkedIn for updates.  
+- [YouTube](https://www.youtube.com/@tooljet) - Check out our video tutorials.
 
 ## Roadmap
 Check out our [roadmap](https://github.com/ToolJet/ToolJet/projects/2) to stay updated on recently released features and to learn about what's coming next.


### PR DESCRIPTION
Added YouTube and LinkedIn links In Community Support Section 
 of the README.

I have added links to ToolJet YouTube channel and LinkedIn company page in the README to provide  users with additional resources for learning and staying updated about ToolJet through video tutorials and professional networking.

I verified the YouTube and LinkedIn link works by clicking on it and visiting the channel and page.

Screen Shots :

![YouTube](https://github.com/ToolJet/ToolJet/assets/110784317/f9f7e61c-2dd1-496f-a619-ee1c38babfe3)

![LinkedIn](https://github.com/ToolJet/ToolJet/assets/110784317/a531d8ce-2efe-4261-b367-617eb43847f8)
