### PR TITLE
Fix: Rename global datasource to data source

### DIFF
--- a/docs/docs/data-sources/mysql.md
+++ b/docs/docs/data-sources/mysql.md
@@ -7,7 +7,7 @@ ToolJet can connect to MySQL databases to read and write data.
 
 ## Connection
 
-To establish a connection with the MySQL datasource, you can either click on the `+Add New` button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MySQL data sources, you can either click on the `+Add New` button located on the query panel or navigate to the **[Data Source](/docs/data-sources/overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 


### PR DESCRIPTION
Renamed the global datasource to data source.
Renamed datasource to data source or data sources.