### PR TITLE
Fix/widget deletion confirmation keys

### DIFF
--- a/frontend/src/Editor/Inspector/Inspector.jsx
+++ b/frontend/src/Editor/Inspector/Inspector.jsx
@@ -79,6 +79,29 @@ export const Inspector = ({
   const [inputRef, setInputFocus] = useFocus();
   const [selectedTab, setSelectedTab] = useState('properties');
   const [showHeaderActionsMenu, setShowHeaderActionsMenu] = useState(false);
+  const [confirmKeyPressed, setConfirmKeyPressed] = useState(false);
+  useEffect(() => {
+    const handleKeyPress = (event) => {
+      if (event.key === 'Enter' || event.key === 'Return') {
+        setConfirmKeyPressed(true); // Set the confirmation key pressed state
+      } else if (event.key === 'Escape') {
+        setWidgetDeleteConfirmation(false); // Cancel the confirmation if the Esc key was pressed
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyPress);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyPress);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (confirmKeyPressed) {
+      setWidgetDeleteConfirmation(true); // Trigger the confirmation if the confirmation key was pressed
+      setConfirmKeyPressed(false); // Reset the confirmation key pressed state
+    }
+  }, [confirmKeyPressed]);
   const { isVersionReleased } = useAppVersionStore(
     (state) => ({
       isVersionReleased: state.isVersionReleased,

--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -75,7 +75,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(1)}
                   data-cy="button-invite-with-email"
                 >
-                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#fff' : '#687076'} />
+                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#11181C' : '#687076'} />
                   <span> Invite with email</span>
                 </button>
                 <button
@@ -83,7 +83,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(2)}
                   data-cy="button-upload-csv-file"
                 >
-                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#fff' : '#687076'} />
+                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
                   <span>Upload CSV file</span>
                 </button>
               </div>

--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -75,7 +75,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(1)}
                   data-cy="button-invite-with-email"
                 >
-                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#fff' : '#687076'} />
                   <span> Invite with email</span>
                 </button>
                 <button
@@ -83,7 +83,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(2)}
                   data-cy="button-upload-csv-file"
                 >
-                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#fff' : '#687076'} />
                   <span>Upload CSV file</span>
                 </button>
               </div>


### PR DESCRIPTION
PR Summary
This pull request addresses issue #7711 , where the confirmation modal for deleting a component should allow users to confirm deletion using the Enter/return key and cancel using the Esc key.

Changes
Added event listeners for the Enter/return and Esc keys to trigger deletion confirmation and cancellation, respectively.
Updated the useEffect hook to handle these key events and manage the confirmation accordingly.