### PR TITLE
Fix/icon popover bgcolor

### DIFF
--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -75,7 +75,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(1)}
                   data-cy="button-invite-with-email"
                 >
-                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#fff' : '#687076'} />
+                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#11181C' : '#687076'} />
                   <span> Invite with email</span>
                 </button>
                 <button
@@ -83,7 +83,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(2)}
                   data-cy="button-upload-csv-file"
                 >
-                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#fff' : '#687076'} />
+                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
                   <span>Upload CSV file</span>
                 </button>
               </div>

--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -75,7 +75,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(1)}
                   data-cy="button-invite-with-email"
                 >
-                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#fff' : '#687076'} />
                   <span> Invite with email</span>
                 </button>
                 <button
@@ -83,7 +83,7 @@ function InviteUsersForm({
                   onClick={() => setActiveTab(2)}
                   data-cy="button-upload-csv-file"
                 >
-                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
+                  <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#fff' : '#687076'} />
                   <span>Upload CSV file</span>
                 </button>
               </div>

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -6276,6 +6276,10 @@ input.hide-input-arrows {
       background-color: #232e3c;
       border-bottom: 1px solid #324156;
     }
+    .popover-body {
+      background-color: #232e3c;
+      border-radius: 6px;
+  }
   }
 
   .popover-header {


### PR DESCRIPTION
Pull Request Description
Fixed #7715 

Issue Resolved
This pull request addresses the issue where the Icon component's popover color does not match the ToolJet light/dark mode, as reported in issue #7715 

Proposed Changes
The popover color for the Icon component will now dynamically adjust based on the current ToolJet mode, providing a consistent and visually pleasing experience for both light and dark modes.

Steps to Verify
Switch ToolJet between light and dark modes.
Drag the Icon component onto the canvas.
Open the popover and observe the color change based on the ToolJet mode.
Screenshots
Screenshot 1: Popover in before fix
![image](https://github.com/ToolJet/ToolJet/assets/99464832/e8b2c9e7-cd86-4067-b6fe-b7eb7ba43107)

Screenshot 2: Popover in after fix
![image](https://github.com/ToolJet/ToolJet/assets/99464832/42daf7b6-3c17-46ad-b293-9f15e3c31ccb)
