### PR TITLE
fix: removed duplicate REST method from stripe datasource

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/Stripe.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Stripe.jsx
@@ -142,7 +142,7 @@ class StripeComponent extends React.Component {
       for (const path of Object.keys(paths)) {
         for (const operation of Object.keys(paths[path])) {
           options.push({
-            value: `${operation},${path}`,
+            value: path,
             name: path,
             operation: operation,
           });


### PR DESCRIPTION
Fixes #4459 

This PR fixes the duplicate REST method being seen in the stripe datasource list once as badge and once in the URL