### PR TITLE
fix: Changed widget to component

### DIFF
--- a/frontend/src/Editor/Inspector/Inspector.jsx
+++ b/frontend/src/Editor/Inspector/Inspector.jsx
@@ -386,7 +386,7 @@ export const Inspector = ({
     <div className="inspector">
       <ConfirmDialog
         show={showWidgetDeleteConfirmation}
-        message={'Widget will be deleted, do you want to continue?'}
+        message={'Component will be deleted, do you want to continue?'}
         onConfirm={() => {
           switchSidebarTab(2);
           removeComponent(component);


### PR DESCRIPTION
# Fixes issue:
- Issue: https://github.com/ToolJet/ToolJet/issues/7714
- Correction in inspector.jsx

<br> 

# Changes to be made:
- Change ```Widget``` to ```Component```

<br>

# Files changed:
- Inspector.jsx (frontend/src/Editor/Inspector/Inspector.jsx)

<br>

# Total changes: 1