### PR TITLE
fixed the heroku url

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can use ToolJet Cloud for a fully managed solution. If you want to self-host
 | :------------- | :------------- |
 | Digital Ocean | [Link](https://docs.tooljet.com/docs/setup/digitalocean)  |
 | Docker  | [Link](https://docs.tooljet.com/docs/setup/docker)   |
-| Heroku  | [Link](https://docs.tooljet.com/docs/setup/heroku)  |
+| Heroku  | [Link](https://docs.tooljet.com/docs/2.1.0/setup/heroku)  |
 | AWS EC2 | [Link](https://docs.tooljet.com/docs/setup/ec2)  |
 | AWS ECS | [Link](https://docs.tooljet.com/docs/setup/ecs)   |
 | OpenShift | [Link](https://docs.tooljet.com/docs/setup/openshift)   |


### PR DESCRIPTION
I had changed the documentation url of  Heroku to the correct url. Previous one was showing 404 not found.

<img width="1277" alt="image" src="https://github.com/ToolJet/ToolJet/assets/67964054/8cc84436-257e-41c9-93a6-9676ce37cd60">

<img width="1268" alt="image" src="https://github.com/ToolJet/ToolJet/assets/67964054/fde2ed39-ac31-4dd6-8e4c-081f34cbd296">
