### PR TITLE
[HF23-AB] Fixed/[Icon component] the background color should be of same as the currently active theme of ToolJet 

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -11459,7 +11459,7 @@ tbody {
   box-shadow: 0px 4px 6px -2px rgba(16, 24, 40, 0.03), 0px 12px 16px -4px rgba(16, 24, 40, 0.08);
 
   .popover-body {
-    background-color: var(--base);
+    background-color: #232e3c;
     color: var(--slate12);
     border: 1px solid var(--slate3, #F1F3F5);
     border-radius: 6px;

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -6281,7 +6281,7 @@ input.hide-input-arrows {
     .popover-body {
       background-color: #232e3c;
       border-radius: 6px;
-  }
+    }
   }
 
   .popover-header {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -6278,6 +6278,10 @@ input.hide-input-arrows {
       background-color: #232e3c;
       border-bottom: 1px solid #324156;
     }
+    .popover-body {
+      background-color: #232e3c;
+      border-radius: 6px;
+  }
   }
 
   .popover-header {
@@ -11459,7 +11463,7 @@ tbody {
   box-shadow: 0px 4px 6px -2px rgba(16, 24, 40, 0.03), 0px 12px 16px -4px rgba(16, 24, 40, 0.08);
 
   .popover-body {
-    background-color: #232e3c;
+    background-color: var(--base);
     color: var(--slate12);
     border: 1px solid var(--slate3, #F1F3F5);
     border-radius: 6px;


### PR DESCRIPTION
# Fixed Issue

- The issue https://github.com/ToolJet/ToolJet/issues/7715 is to change the background color of dark(#232e3c) when icon component popover is in dark mode .

# Changes 

- I have chnage the .popover-body -> backgroungcolor : `#232e3c`

![image](https://github.com/ToolJet/ToolJet/assets/113838908/27d0ca07-71bf-4920-b070-f52e1814363e)

fixes #7715 