### PR TITLE
[appdef-2] fixes: triggering confirmation box for button click

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -939,8 +939,9 @@ export function runQuery(_ref, queryId, queryName, confirmed = undefined, mode =
   const options = getQueryVariables(dataQuery.options, getCurrentState());
 
   if (dataQuery.options?.requestConfirmation) {
-    const runOnPageLoad = dataQuery.options?.runOnPageLoad ?? false;
-    const queryConfirmationList = runOnPageLoad ? _ref.queryConfirmationList : [];
+    const queryConfirmationList = useEditorStore.getState().queryConfirmationList
+      ? [...useEditorStore.getState().queryConfirmationList]
+      : [];
 
     const queryConfirmation = {
       queryId,


### PR DESCRIPTION
This PR fixes run query with confirmation was not working on button click event. Reverted [this](https://github.com/ToolJet/ToolJet/pull/7704/files#diff-6bbc690806e52c1047668953b0a492bbb38a87d4c40ae18e8a53acbc2ff34e9fR931-R932) with the value fetched directly from the store