### PR TITLE
fix: helm chart url

### DIFF
--- a/docs/versioned_docs/version-2.19.0/setup/helm.md
+++ b/docs/versioned_docs/version-2.19.0/setup/helm.md
@@ -13,7 +13,7 @@ This repository contains Helm charts for deploying [ToolJet](https://github.com/
 
 ### From Helm repo
 ```bash
-helm repo add tooljet https://github.com/ToolJet/helm-charts.git
+helm repo add tooljet https://tooljet.github.io/helm-charts
 helm install tooljet tooljet/tooljet
 ```
 


### PR DESCRIPTION
The previous url didn't work for me. The new one is copied from the instructions in the helm-charts repo.