### PR TITLE
Change labels to sentence case for Text Editor Component #7754

### DIFF
--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -361,7 +361,7 @@ export const widgets = [
       },
       actionButtonRadius: {
         type: 'code',
-        displayName: 'Action Button Radius',
+        displayName: 'Action button radius',
         validation: {
           schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'boolean' }] },
         },
@@ -2312,7 +2312,7 @@ export const widgets = [
       },
       borderRadius: {
         type: 'code',
-        displayName: 'Border Radius',
+        displayName: 'Border radius',
         validation: {
           schema: {
             type: 'union',


### PR DESCRIPTION
This pull request addresses issue #7754, where labels for the Text Editor Component were in incorrect capitalization. The labels have been updated to use sentence case for consistency and readability.

Changes Made:
- Updated labels to sentence case.

Please review and merge this pull request at your earliest convenience.

Thank you!