### PR TITLE
fix:Changed the label of text editor component to sentence case

### DIFF
--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -2707,7 +2707,7 @@ export const widgets = [
       },
       defaultValue: {
         type: 'code',
-        displayName: 'Default Value',
+        displayName: 'Default value',
         validation: {
           schema: { type: 'string' },
         },


### PR DESCRIPTION
### What change does this PR introduce ?

This pull request addresses issue #7754, where labels for the Text Editor Component were not in sentence case. The labels have now been updated to sentence case for consistency and readability.

### What changes were made ?

updated the label of 'Default Value' from text editor component to 'Default value'.
Please review and merge this pull request at your earliest convenience.

Thank you!