### PR TITLE
chore: Correct casing in File Picker component labels

### DIFF
--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -391,7 +391,7 @@ export const widgets = [
       },
       borderRadius: {
         type: 'code',
-        displayName: 'Border Radius',
+        displayName: 'Border radius',
         validation: {
           schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
         },
@@ -3124,21 +3124,21 @@ export const widgets = [
     properties: {
       instructionText: {
         type: 'code',
-        displayName: 'Instruction Text',
+        displayName: 'Instruction text',
         validation: {
           schema: { type: 'string' },
         },
       },
       enableDropzone: {
         type: 'code',
-        displayName: 'Use Drop zone',
+        displayName: 'Use drop zone',
         validation: {
           schema: { type: 'boolean' },
         },
       },
       enablePicker: {
         type: 'code',
-        displayName: 'Use File Picker',
+        displayName: 'Use file picker',
         validation: {
           schema: { type: 'boolean' },
         },


### PR DESCRIPTION
Addresses issue #7756 

In this commit, I have resolved the issue by correcting the casing of specific labels in the File Picker component. The following changes were made in the `widgetConfig.js` file under the File Picker component object:

- Updated label: 'Instruction Text' to 'Instruction text'
- Updated label: 'Use Drop Zone' to 'Use drop zone'
- Updated label: 'Use File Picker' to 'Use file picker'
- Updated label: 'Border Radius' to 'Border radius'

These changes align the labels with the recommended sentence case format as specified in the issue. The commit resolves the inconsistency reported in issue #7756