### PR TITLE
Accessibility features for Tooljet markdown files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -114,15 +114,13 @@ the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), [version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
 
-[homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
+- For answers to common questions about this code of conduct, see the FAQs at
+https://www.contributor-covenant.org/faq.
+- Translations are available at
 https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ We love your input! We want to make contributing to this project as easy and tra
 
 ## Setup 
 
-[Mac OS](https://docs.tooljet.io/docs/contributing-guide/setup/macos)
-[Docker](https://docs.tooljet.io/docs/contributing-guide/setup/docker)
-[Ubuntu](https://docs.tooljet.io/docs/contributing-guide/setup/ubuntu)
+- [Mac OS](https://docs.tooljet.io/docs/contributing-guide/setup/macos)
+- [Docker](https://docs.tooljet.io/docs/contributing-guide/setup/docker)
+- [Ubuntu](https://docs.tooljet.io/docs/contributing-guide/setup/ubuntu)
 
 ## We Develop with GitHub
 We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
@@ -51,4 +51,4 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 By contributing, you agree that your contributions will be licensed under its AGPL v3 License.
 
 ## Questions? 
-Contact us on [Slack](https://tooljet.com/slack) or mail us at [hello@tooljet.io](mailto:hello@tooljet.io).
+Contact us [on Slack](https://tooljet.com/slack) or [email us at hello@tooljet.io](mailto:hello@tooljet.io).

--- a/README.md
+++ b/README.md
@@ -1,44 +1,44 @@
 ToolJet is an **open-source low-code framework** to build and deploy internal tools with minimal engineering effort. ToolJet's drag-and-drop frontend builder allows you to create complex, responsive frontends within minutes. Additionally, you can integrate various data sources, including databases like PostgreSQL, MongoDB, and Elasticsearch; API endpoints with OpenAPI spec and OAuth2 support; SaaS tools such as Stripe, Slack, Google Sheets, Airtable, and Notion; as well as object storage services like S3, GCS, and Minio, to fetch and write data.
 
-⭐ If you find ToolJet useful, please consider giving us a star on GitHub! Your support helps us continue to innovate and deliver exciting features.
+ :star: If you find ToolJet useful, please consider giving us a star on GitHub! Your support helps us continue to innovate and deliver exciting features.
 
 ![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/tooljet/tooljet-ce)
-![GitHub contributors](https://img.shields.io/github/contributors/tooljet/tooljet)
-[![GitHub issues](https://img.shields.io/github/issues/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet/issues)
-[![GitHub stars](https://img.shields.io/github/stars/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet/stargazers)
-![GitHub closed issues](https://img.shields.io/github/issues-closed/tooljet/tooljet)
-![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/tooljet/tooljet)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/tooljet/tooljet)
+![Number of GitHub contributors](https://img.shields.io/github/contributors/tooljet/tooljet)
+[![Number of GitHub issues that are open](https://img.shields.io/github/issues/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet/issues)
+[![Number of GitHub stars](https://img.shields.io/github/stars/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet/stargazers)
+![Number of GitHub closed issues](https://img.shields.io/github/issues-closed/tooljet/tooljet)
+![Number of GitHub pull requests that are open](https://img.shields.io/github/issues-pr-raw/tooljet/tooljet)
+![GitHub release; latest by date](https://img.shields.io/github/v/release/tooljet/tooljet)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/tooljet/tooljet)
-[![GitHub license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
-[![Twitter Follow](https://img.shields.io/twitter/follow/ToolJet?style=social)](https://twitter.com/ToolJet)
+[![GitHub license which is APGL license](https://img.shields.io/github/license/ToolJet/ToolJet)](https://github.com/ToolJet/ToolJet)
+[![Follow us on X, formerly Twitter](https://img.shields.io/twitter/follow/ToolJet?style=social)](https://twitter.com/ToolJet)
 
 <p align="center">
-    <img src="https://user-images.githubusercontent.com/7828962/211444352-4d6d2e4a-13c9-4980-9e16-4aed4af9811b.png"/>
+    <img src="https://user-images.githubusercontent.com/7828962/211444352-4d6d2e4a-13c9-4980-9e16-4aed4af9811b.png" alt="Tooljet dashboard showing inventory and orders"/>
 </p>
 
 <p align="center">
   <kbd>
-    <img src="https://user-images.githubusercontent.com/7828962/202402863-2851a072-9dca-4b8b-9473-0d044373928b.png"/>
+    <img src="https://user-images.githubusercontent.com/7828962/202402863-2851a072-9dca-4b8b-9473-0d044373928b.png" alt="Tooljet visual front end builder"/>
 
   </kbd>
 </p>
 
 <p align="center">
   <kbd>
-<img src="https://user-images.githubusercontent.com/7828962/211364385-10714e24-f1ac-4e72-a2a1-ec7dc2d412ab.png"/>
+<img src="https://user-images.githubusercontent.com/7828962/211364385-10714e24-f1ac-4e72-a2a1-ec7dc2d412ab.png" alt="Tooljet database showing over 40 integrations"/>
   </kbd>
 </p>
 
 <p align="center">
   <kbd>
-<img src="https://user-images.githubusercontent.com/7828962/202402422-8f1df2a4-5c07-4125-9c2e-5450b90f464c.png"/>
+<img src="https://user-images.githubusercontent.com/7828962/202402422-8f1df2a4-5c07-4125-9c2e-5450b90f464c.png" alt="Tooljet showing ability to run in Python, import your React component, and build your own plugins using the dev kit"/>
   </kbd>
 </p>
 
 <p align="center">
   <kbd>
-<img src="https://user-images.githubusercontent.com/7828962/202402574-7cd7c606-d751-4de1-ba56-abbedba54b13.png"/>
+<img src="https://user-images.githubusercontent.com/7828962/202402574-7cd7c606-d751-4de1-ba56-abbedba54b13.png" alt="Deploy from anywhere, showing various cloud services"/>
   </kbd>
 </p>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-If you notice a security vulnerability, please let the team know by sending an email to `security@tooljet.com`.
+If you notice a security vulnerability, please let the team know by [sending an email to security@tooljet.com](mailto:security@tooljet.com).


### PR DESCRIPTION
Accessibility for markdowns, based on: https://github.blog/2023-10-26-5-tips-for-making-your-github-profile-page-accessible/

Some typos as well. Checked all markdown files in the main repo folder.