### PR TITLE
Fix: EAFNOSUPPORT error

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -124,7 +124,7 @@ async function bootstrap() {
     defaultVersion: VERSION_NEUTRAL,
   });
 
-  const listen_addr = process.env.LISTEN_ADDR || '::';
+  const listen_addr = process.env.LISTEN_ADDR || '0.0.0.0';
   const port = parseInt(process.env.PORT) || 3000;
 
   if (process.env.SERVE_CLIENT !== 'false' && process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
Fix for the below error caused when deploying in k8s 

`The module has been initialized.
node:internal/errors:466
    ErrorCaptureStackTrace(err);
    ^

Error: listen EAFNOSUPPORT: address family not supported :::3000
    at Server.setupListenHandle [as _listen2] (node:net:1397:21)
    at listenInCluster (node:net:1462:12)
    at doListen (node:net:1601:7)
    at process.processTicksAndRejections (node:internal/process/task_queues:83:21) {
  code: 'EAFNOSUPPORT',
  errno: -97,
  syscall: 'listen',
  address: '::',
  port: 3000
}`