### PR TITLE
fix: renaming the PageHandle cursor stays where we click

### DIFF
--- a/frontend/src/Editor/LeftSidebar/SidebarPageSelector/EditInput.jsx
+++ b/frontend/src/Editor/LeftSidebar/SidebarPageSelector/EditInput.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { ToolTip } from '@/Editor/Inspector/Elements/Components/ToolTip';
 
 export const EditInput = ({ slug, error, setError, pageHandle, setPageHandle, isSaving = false }) => {
   const [value, set] = useState(pageHandle);
+  const inputRef = useRef(null);
+  const cursorPositionRef = useRef(null);
 
   const onChangePageHandleValue = (event) => {
     setError(null);
@@ -14,14 +16,24 @@ export const EditInput = ({ slug, error, setError, pageHandle, setPageHandle, is
     set(newHandle);
   };
 
-  React.useEffect(() => {
+  const handleInput = () => {
+    if (inputRef.current) {
+      cursorPositionRef.current = inputRef.current.selectionStart;
+    }
+  };
+
+  useEffect(() => {
     if (!isSaving) {
       setPageHandle(value);
+
+      if (inputRef.current && cursorPositionRef.current !== null) {
+        inputRef.current.setSelectionRange(cursorPositionRef.current, cursorPositionRef.current);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isSaving) {
       set(pageHandle);
     }
@@ -36,11 +48,13 @@ export const EditInput = ({ slug, error, setError, pageHandle, setPageHandle, is
         <ToolTip label={label} meta={{ tip: slug }} labelClass="page-handle-tip" />
       </div>
       <input
+        ref={inputRef}
         type="text"
         className={`page-handler-input  form-control form-control-sm ${error ? 'is-invalid' : ''}`}
         placeholder={'Enter page handle'}
         onChange={onChangePageHandleValue}
-        value={pageHandle}
+        onInput={handleInput}
+        value={value}
         data-cy={'page-handle-input-field'}
       />
       <div className="invalid-feedback" data-cy={'page-handle-invalid-feedback'}>


### PR DESCRIPTION
fixes #8157 

**video for reference:**


https://github.com/ToolJet/ToolJet/assets/92514129/f4aae11f-8229-490d-905e-49047d132497

