### PR TITLE
Fix for handling 'go to app' event for previously added unreleased apps and new apps

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -313,7 +313,14 @@ const EditorComponent = (props) => {
   const fetchApps = async (page) => {
     const { apps } = await appService.getAll(page);
 
-    updateState({ apps: apps.map((app) => ({ id: app.id, name: app.name, slug: app.slug })) });
+    updateState({
+      apps: apps.map((app) => ({
+        id: app.id,
+        name: app.name,
+        slug: app.slug,
+        current_version_id: app.current_version_id,
+      })),
+    });
   };
 
   const fetchOrgEnvironmentVariables = () => {

--- a/frontend/src/Editor/Inspector/EventManager.jsx
+++ b/frontend/src/Editor/Inspector/EventManager.jsx
@@ -204,7 +204,7 @@ export const EventManager = ({
   function getAllApps() {
     let appsOptionsList = [];
     apps
-      .filter((item) => item.slug !== undefined && item.id !== appId)
+      .filter((item) => item.slug !== undefined && item.id !== appId && item.current_version_id)
       .forEach((item) => {
         appsOptionsList.push({
           name: item.name,

--- a/frontend/src/_components/ErrorComponents/ErrorPage.jsx
+++ b/frontend/src/_components/ErrorComponents/ErrorPage.jsx
@@ -27,12 +27,11 @@ export const ErrorModal = ({ errorMsg, appSlug, ...props }) => {
   const { t } = useTranslation();
 
   // Redirect to edit app URL in a new tab
-  const openAppEditorInNewTab = (slug, pageHandle) => {
+  const openAppEditorInNewTab = () => {
     const subpath = getSubpath();
     const path = subpath
-      ? `${subpath}${getPrivateRoute('editor', { slug, pageHandle })}`
-      : getPrivateRoute('editor', { slug, pageHandle });
-    console.log(path, appSlug);
+      ? `${subpath}${getPrivateRoute('editor', { slug: appSlug })}`
+      : getPrivateRoute('editor', { slug: appSlug });
     window.open(path, '_blank');
   };
 
@@ -102,7 +101,7 @@ export const ErrorModal = ({ errorMsg, appSlug, ...props }) => {
           {appSlug && (
             <button
               className={'btn btn-primary action-btn'}
-              onClick={() => openAppEditorInNewTab(appSlug)}
+              onClick={() => openAppEditorInNewTab()}
               data-cy="open-app-button"
             >
               {t('globals.workspace-modal.continue-btn', 'Open app')}

--- a/frontend/src/_components/ErrorComponents/ErrorPage.jsx
+++ b/frontend/src/_components/ErrorComponents/ErrorPage.jsx
@@ -1,5 +1,5 @@
 import { ERROR_MESSAGES } from '@/_helpers/constants';
-import { redirectToDashboard } from '@/_helpers/routes';
+import { redirectToDashboard, getPrivateRoute, getSubpath } from '@/_helpers/routes';
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
@@ -13,15 +13,28 @@ export default function ErrorPage({ darkMode }) {
 
   if (!errorMsg) redirectToDashboard();
 
+  const searchParams = new URLSearchParams(location.search);
+  const appSlug = searchParams.get('appSlug');
+
   return (
     <div style={{ display: 'flex', justifyContent: 'center' }}>
-      <ErrorModal errorMsg={errorMsg} show={true} darkMode={darkMode} />
+      <ErrorModal errorMsg={errorMsg} appSlug={appSlug} show={true} darkMode={darkMode} />
     </div>
   );
 }
 
-export const ErrorModal = ({ errorMsg, ...props }) => {
+export const ErrorModal = ({ errorMsg, appSlug, ...props }) => {
   const { t } = useTranslation();
+
+  // Redirect to edit app URL in a new tab
+  const openAppEditorInNewTab = (slug, pageHandle) => {
+    const subpath = getSubpath();
+    const path = subpath
+      ? `${subpath}${getPrivateRoute('editor', { slug, pageHandle })}`
+      : getPrivateRoute('editor', { slug, pageHandle });
+    console.log(path, appSlug);
+    window.open(path, '_blank');
+  };
 
   return (
     <div className="custom-backdrop">
@@ -86,8 +99,17 @@ export const ErrorModal = ({ errorMsg, ...props }) => {
               {t('globals.workspace-modal.continue-btn', 'Retry')}
             </button>
           )}
+          {appSlug && (
+            <button
+              className={'btn btn-primary action-btn'}
+              onClick={() => openAppEditorInNewTab(appSlug)}
+              data-cy="open-app-button"
+            >
+              {t('globals.workspace-modal.continue-btn', 'Open app')}
+            </button>
+          )}
           <button
-            className={errorMsg?.retry ? 'btn btn-primary' : 'btn btn-primary action-btn'}
+            className={errorMsg?.retry || appSlug ? 'btn btn-primary' : 'btn btn-primary action-btn'}
             onClick={() => redirectToDashboard()}
             data-cy="back-to-home-button"
           >

--- a/frontend/src/_helpers/constants.js
+++ b/frontend/src/_helpers/constants.js
@@ -37,9 +37,9 @@ export const ERROR_TYPES = {
 
 export const ERROR_MESSAGES = {
   'url-unavailable': {
-    title: 'URL unavailable',
+    title: 'App URL Unavailable',
     message:
-      'This URL is not accessible because it has not been released yet. Please either release it or contact admin for access.',
+      'The app URL is currently unavailable because the app has not been released. Please either release it or contact admin for access.',
     cta: 'Back to home page',
     queryParams: [],
   },

--- a/frontend/src/_helpers/handleAppAccess.js
+++ b/frontend/src/_helpers/handleAppAccess.js
@@ -6,8 +6,8 @@ import _ from 'lodash';
 import queryString from 'query-string';
 import { ERROR_TYPES } from './constants';
 
-/*  appId, versionId are olny for old preview URLs */
-export const handleAppAccess = (componentType, slug, version_id) => {
+/*  appId, versionId are only for old preview URLs */
+export const handleAppAccess = async (componentType, slug, version_id) => {
   const previewQueryParams = getPreviewQueryParams();
   const isOldLocalPreview = version_id ? true : false;
   const isLocalPreview = !_.isEmpty(previewQueryParams);
@@ -26,9 +26,17 @@ export const handleAppAccess = (componentType, slug, version_id) => {
     });
   } else {
     /* Released app link [launch/sharable link] */
-    return appsService.validateReleasedApp(slug).catch((error) => {
-      handleError(componentType, error, redirectPath);
-    });
+    try {
+      return await appsService.validateReleasedApp(slug);
+    } catch (error) {
+      let editPermission = true;
+      try {
+        await appsService.validatePrivateApp(slug, queryParams);
+      } catch (err) {
+        editPermission = false;
+      }
+      handleError(componentType, error, redirectPath, editPermission);
+    }
   }
 };
 
@@ -45,7 +53,7 @@ const switchOrganization = (componentType, orgId, redirectPath) => {
   );
 };
 
-const handleError = (componentType, error, redirectPath) => {
+const handleError = (componentType, error, redirectPath, editPermission) => {
   try {
     if (error?.data) {
       const statusCode = error.data?.statusCode;
@@ -70,7 +78,14 @@ const handleError = (componentType, error, redirectPath) => {
         }
         case 501: {
           /* Restrict the users from accessing the sharable app url if the app is not released */
-          redirectToErrorPage(ERROR_TYPES.URL_UNAVAILABLE, {});
+          if (editPermission) {
+            //redirectPath format {apps/appSlug/..}
+            const parts = redirectPath.split('/');
+            const appSlug = parts[2];
+            redirectToErrorPage(ERROR_TYPES.URL_UNAVAILABLE, { appSlug });
+          } else {
+            redirectToErrorPage(ERROR_TYPES.URL_UNAVAILABLE, {});
+          }
           return;
         }
         case 404: {


### PR DESCRIPTION
1. We will only show released apps on the drop down for 'Go to App' action event on app editors.
2. For previously added unreleased apps, we are giving an option to editors to open the app from the error modal and release it.
<img width="642" alt="Screenshot 2023-11-17 at 9 33 18 PM" src="https://github.com/ToolJet/ToolJet/assets/37929460/514c5371-4261-4957-ae1a-bb74a5203ccc">
#8254
