### PR TITLE
Save button on Datasource changes not enabled

### DIFF
--- a/frontend/src/_ui/HttpHeaders/index.js
+++ b/frontend/src/_ui/HttpHeaders/index.js
@@ -27,9 +27,14 @@ export default ({
         addNewKeyValuePair();
       }, 100);
     }
-    const newOptions = _.cloneDeep(options);
-    newOptions[index][keyIndex] = value;
-    optionchanged(getter, newOptions);
+    if (!isRenderedAsQueryEditor) {
+      const newOptions = _.cloneDeep(options);
+      newOptions[index][keyIndex] = value;
+      optionchanged(getter, newOptions);
+    } else {
+      options[index][keyIndex] = value;
+      optionchanged(getter, options);
+    }
   }
 
   const commonProps = {

--- a/frontend/src/_ui/HttpHeaders/index.js
+++ b/frontend/src/_ui/HttpHeaders/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import QueryEditor from './QueryEditor';
 import SourceEditor from './SourceEditor';
 
@@ -26,8 +27,9 @@ export default ({
         addNewKeyValuePair();
       }, 100);
     }
-    options[index][keyIndex] = value;
-    optionchanged(getter, options);
+    const newOptions = _.cloneDeep(options);
+    newOptions[index][keyIndex] = value;
+    optionchanged(getter, newOptions);
   }
 
   const commonProps = {


### PR DESCRIPTION
When editing a HTTP header field inside a DataSource, save button doesn't get enabled on changes. 