### PR TITLE
feat: Getter functions for query data and variables

### DIFF
--- a/frontend/src/Editor/CodeBuilder/utils.js
+++ b/frontend/src/Editor/CodeBuilder/utils.js
@@ -72,6 +72,7 @@ export function getSuggestionKeys(refState, refSource) {
   const actions = [
     'runQuery',
     'setVariable',
+    'getVariable',
     'unSetVariable',
     'showAlert',
     'logout',
@@ -82,6 +83,7 @@ export function getSuggestionKeys(refState, refSource) {
     'goToApp',
     'generateFile',
     'setPageVariable',
+    'getPageVariable',
     'unsetPageVariable',
     'switchPage',
   ];

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -535,6 +535,12 @@ function executeActionWithDebounce(_ref, event, mode, customVariables) {
         });
       }
 
+      case 'get-custom-variable': {
+        const key = resolveReferences(event.key, getCurrentState(), undefined, customVariables);
+        const customAppVariables = { ...getCurrentState().variables };
+        return customAppVariables[key];
+      }
+
       case 'unset-custom-variable': {
         const key = resolveReferences(event.key, getCurrentState(), undefined, customVariables);
         const customAppVariables = { ...getCurrentState().variables };
@@ -557,6 +563,14 @@ function executeActionWithDebounce(_ref, event, mode, customVariables) {
             variables: customPageVariables,
           },
         });
+      }
+
+      case 'get-page-variable': {
+        const key = resolveReferences(event.key, getCurrentState(), undefined, customVariables);
+        const customPageVariables = {
+          ...getCurrentState().page.variables,
+        };
+        return customPageVariables[key];
       }
 
       case 'unset-page-variable': {

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -143,6 +143,18 @@ async function executeRunPycode(_ref, code, query, isPreview, mode) {
         currentState.queries[key] = {
           ...currentState.queries[key],
           run: () => actions.runQuery(key),
+
+          getData: () => {
+            return getCurrentState().queries[key].data;
+          },
+
+          getRawData: () => {
+            return getCurrentState().queries[key].rawData;
+          },
+
+          getloadingState: () => {
+            return getCurrentState().queries[key].isLoading;
+          },
         };
       }
 

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -463,6 +463,18 @@ export async function executeMultilineJS(
         query.options.parameters?.forEach((arg) => (processedParams[arg.name] = params[arg.name]));
         return actions.runQuery(key, processedParams);
       },
+
+      getData: () => {
+        return getCurrentState().queries[key].data;
+      },
+
+      getRawData: () => {
+        return getCurrentState().queries[key].rawData;
+      },
+
+      getloadingState: () => {
+        return getCurrentState().queries[key].isLoading;
+      },
     };
   }
 
@@ -598,9 +610,9 @@ export const generateAppActions = (_ref, queryId, mode, isPreview = false) => {
       );
     }
 
-    if (isPreview) {
-      return previewQuery(_ref, query, true, processedParams);
-    }
+    // if (isPreview) {
+    //   return previewQuery(_ref, query, true, processedParams);
+    // }
 
     const event = {
       actionId: 'run-query',

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -623,6 +623,16 @@ export const generateAppActions = (_ref, queryId, mode, isPreview = false) => {
     }
   };
 
+  const getVariable = (key = '') => {
+    if (key) {
+      const event = {
+        actionId: 'get-custom-variable',
+        key,
+      };
+      return executeAction(_ref, event, mode, {});
+    }
+  };
+
   const unSetVariable = (key = '') => {
     if (key) {
       const event = {
@@ -728,6 +738,14 @@ export const generateAppActions = (_ref, queryId, mode, isPreview = false) => {
     return executeAction(_ref, event, mode, {});
   };
 
+  const getPageVariable = (key = '') => {
+    const event = {
+      actionId: 'get-page-variable',
+      key,
+    };
+    return executeAction(_ref, event, mode, {});
+  };
+
   const unsetPageVariable = (key = '') => {
     const event = {
       actionId: 'unset-page-variable',
@@ -766,6 +784,7 @@ export const generateAppActions = (_ref, queryId, mode, isPreview = false) => {
   return {
     runQuery,
     setVariable,
+    getVariable,
     unSetVariable,
     showAlert,
     logout,
@@ -776,6 +795,7 @@ export const generateAppActions = (_ref, queryId, mode, isPreview = false) => {
     goToApp,
     generateFile,
     setPageVariable,
+    getPageVariable,
     unsetPageVariable,
     switchPage,
   };


### PR DESCRIPTION
Resolves #8242

This PR adds the following actions:

* `actions.getVariable('variable')`: Used to get the latest value of `variable` within RunJS and RunPy
* `actions.getPageVariable('pageVariable')`: Used to get the latest value of `pageVariable` within RunJS and RunPy

and the following functions on queries:

* `queries.<queryName>.getData()`: Used to get the latest value of query's data within RunJS and RunPy
* `queries.<queryName>.getRawData()`: Used to get the latest value of query's raw data within RunJS and RunPy
* `queries.<queryName>.getLoadingState()`: Used to get the latest value of query's loading state within RunJS and RunPy

All these functions are synchronous functions and `await` is not needed while calling them