### PR TITLE
docs: Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can deploy ToolJet on Heroku using one-click deployment.
 <p align="center">
   <a href="https://heroku.com/deploy?template=https://github.com/tooljet/tooljet/tree/main"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku" height=32></a>
   <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/ToolJet/ToolJet/tree/main"><img src="https://www.deploytodo.com/do-btn-blue.svg" alt="Deploy to DigitalOcean" height=32></a>
+  <a href="https://app.trydome.io/signup?package=tooljet"><img src="https://trydome.io/button.svg" alt="Deploy to Dome" height=32></a>
 </p>
 
 ### Try using Docker


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://tooljet-5796.dome.tools/

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.