### PR TITLE
Table column popover is not hiding behind query panel

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -11826,8 +11826,6 @@ tbody {
 }
 
 #popover-basic-2 {
-  z-index: 10 !important;
-
   .sketch-picker {
     left: 7px;
     width: 170px !important;


### PR DESCRIPTION
Resolves - 
The column manager of the Table component is hiding behind the query panel

<img width="987" alt="Screenshot 2023-12-13 at 1 39 33 PM" src="https://github.com/ToolJet/ToolJet/assets/37823141/3890925b-1a6a-4dfb-9659-aa4aaef96f23">
