### PR TITLE
[Hotfix] Table component column generations issues

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -1862,8 +1862,15 @@ export const buildComponentMetaDefinition = (components = {}) => {
 
     const mergedDefinition = {
       ...componentMeta.definition,
-
-      properties: _.merge(componentMeta.definition.properties, currentComponentData?.component.definition.properties),
+      properties: _.mergeWith(
+        componentMeta.definition.properties,
+        currentComponentData?.component?.definition?.properties,
+        (objValue, srcValue) => {
+          if (currentComponentData?.component?.component === 'Table' && _.isArray(objValue)) {
+            return srcValue;
+          }
+        }
+      ),
       styles: _.merge(componentMeta.definition.styles, currentComponentData?.component.definition.styles),
       generalStyles: _.merge(
         componentMeta.definition.generalStyles,

--- a/server/src/services/components.service.ts
+++ b/server/src/services/components.service.ts
@@ -70,7 +70,7 @@ export class ComponentsService {
       for (const componentId in componentDiff) {
         const { component } = componentDiff[componentId];
 
-        const componentData = await manager.findOne(Component, componentId);
+        const componentData: Component = await manager.findOne(Component, componentId);
 
         if (!componentData) {
           return {
@@ -87,9 +87,14 @@ export class ComponentsService {
           const columnsUpdated = Object.keys(updatedDefinition);
 
           const newComponentsData = columnsUpdated.reduce((acc, column) => {
-            const newColumnData = _.merge(
+            const newColumnData = _.mergeWith(
               componentData[column === 'others' ? 'displayPreferences' : column],
-              updatedDefinition[column]
+              updatedDefinition[column],
+              (objValue, srcValue) => {
+                if (componentData.type === 'Table' && _.isArray(objValue)) {
+                  return srcValue;
+                }
+              }
             );
 
             if (column === 'others') {


### PR DESCRIPTION
Fixes:

- [x]  Despite having a deleted column listed in the deletion history, reloading the editor or viewer results in the reappearance of the deleted column.

- [x]  When fetching table data from the source, if only one column is present and it matches the default column name, the table crashes upon reloading the editor or viewer.