### PR TITLE
Fixed issue when clearing number input value

### DIFF
--- a/frontend/src/Editor/Components/NumberInput.jsx
+++ b/frontend/src/Editor/Components/NumberInput.jsx
@@ -50,9 +50,7 @@ export const NumberInput = function NumberInput({
   };
 
   useEffect(() => {
-    if (!isNaN(value)) {
-      setExposedVariable('value', value);
-    }
+    setExposedVariable('value', value || 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 


### PR DESCRIPTION
#### Issue https://github.com/ToolJet/ToolJet/issues/8208

#### Root cause:

When clearing the input value, the state variable "value" of NumberInput component will be set to NaN when the field is empty. There is an effect hook which calls `setExposedVariable` conditionally when value is !isNaN. 

#### Fix: 

Remove the if check in the effect and if value is NaN, 0 is passed to setExposedVariable function.

https://github.com/ToolJet/ToolJet/assets/44577841/e538105f-1fa6-4213-9201-848b03bc32d6

