### PR TITLE
minor typo causing build issues

### DIFF
--- a/docs/docs/contributing-guide/setup/codespaces.md
+++ b/docs/docs/contributing-guide/setup/codespaces.md
@@ -97,7 +97,7 @@ npm run build:plugins
 
 ```
 npm run --prefix server db:create
-npm run --prefix server db:mirgate
+npm run --prefix server db:migrate
 ```
 
 If at any point you need to reset the database, use this command `npm run --prefix server db:reset`

--- a/docs/versioned_docs/version-2.25.0/contributing-guide/setup/codespaces.md
+++ b/docs/versioned_docs/version-2.25.0/contributing-guide/setup/codespaces.md
@@ -97,7 +97,7 @@ npm run build:plugins
 
 ```
 npm run --prefix server db:create
-npm run --prefix server db:mirgate
+npm run --prefix server db:migrate
 ```
 
 If at any point you need to reset the database, use this command `npm run --prefix server db:reset`


### PR DESCRIPTION
changed
npm run --prefix server db:mirgate

to npm run --prefix server db:migrate

You can ignore this PR. raising this so that if accepted then other contributors wont face this minor issue