### PR TITLE
Fix: Change Image Component label to sentence case

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -508,7 +508,7 @@
             "showOnDesktop": "Show on desktop",
             "showOnMobile": "Show on mobile",
             "showLoadingState": "Show loading state",
-            "backgroundColor": "Background Color",
+            "backgroundColor": "Background color",
             "textColor": "Text color",
             "loaderColor": "Loader color",
             "defaultValue": "Default value",


### PR DESCRIPTION
fixes #7773.

The issue occurred due to the namespace in en.json

### Output screenshot:
<img width="966" alt="image" src="https://github.com/ToolJet/ToolJet/assets/58350132/5c83f70b-3b0f-400d-9d8e-eaa638cd72e3">




