### PR TITLE
docs/8454: adjust spacing around screenshots

### DIFF
--- a/docs/docs/org-management/licensing.md
+++ b/docs/docs/org-management/licensing.md
@@ -12,8 +12,10 @@ This comprehensive guide aims to assist you in the process of configuring paid p
 Let's look into three types of licenses:
 
 1. **Trial License**: This is a free license that grants access to premium features for a 14-day trial period.
- - **New Users**: Choose the 14-day trial during onboarding.
- - **Existing Users**: Request a trial license key from our sales or support team.
+
+- **New Users**: Choose the 14-day trial during onboarding.
+- **Existing Users**: Request a trial license key from our sales or support team.
+
 2. **Business License**: This is a paid license that you can purchase **[directly](https://www.tooljet.com/pricing)**.
 3. **Enterprise License**: This is a paid license with customizable options. To obtain this license, you have to contact our sales team.
 
@@ -28,7 +30,7 @@ If you are an existing user and wish to update your trial license key, follow th
 3. In the license key tab, make the necessary updates to the provided license key.
 4. Within the license tab of the Settings page, you can access the limit tab, which displays the current status of available super admins, builders, and end users.
 
-:::caution Note 
+:::caution Note
 The trial license key will be valid for 14 days. To fully enjoy ToolJet, we recommend upgrading to premium plans within this period. If you wish to upgrade from the trial to the business or enterprise edition, you can click the **Upgrade or Renew** button or contact our team via **[Slack](https://tooljet.com/slack)**. Upon expiration, access to premium features like OpenID SSO login and Audit logs will be restricted, ensuring no data loss occurs. However, don't worry! You can still upgrade to any of our premium plans and enjoy the benefits of ToolJet.
 :::
 
@@ -52,7 +54,6 @@ If you decide to proceed with the Business Plan and have made the purchase, plea
 The business license key will be valid for 3 months only. You can renew it to continue using ToolJet to its fullest potential.
 :::
 
-
 ### B) Chosen Plan: Enterprise Plan
 
 - If you've selected the Enterprise Plan, expect a response from our team within 24-48 hours for onboarding.
@@ -64,6 +65,7 @@ The business license key will be valid for 3 months only. You can renew it to co
 ## Updating License Key
 
 **To update the license key, follow these steps:**
+
 1. Log in as a **[Super Admin](/docs/Enterprise/superadmin)**, ensuring that you are on the correct instance URL.
 2. Go to the Settings page.
 3. In the license key tab, update the provided license key.
@@ -73,7 +75,7 @@ The business license key will be valid for 3 months only. You can renew it to co
 As a super admin, you can conveniently view the remaining days of your enterprise edition period on the dashboard. (Refer to screenshots below)
 :::
 
-<div style={{textAlign: 'center'}}>
+<div style={{textAlign: 'center', marginBottom: '8px'}}>
 
 <img className="screenshot-full" src="/img/licensing/licensingpage2.png" alt="Licensing" />
 
@@ -90,9 +92,10 @@ As a super admin, you can conveniently view the remaining days of your enterpris
 ## Frequently Asked Questions (FAQs)
 
 ### 1) How can I upgrade or renew my license?
+
 If your business or enterprise edition license key is nearing expiration, please click the **Upgrade or Renew** button or contact us via email at hello@tooljet.com to obtain an extended license key. If you intend to increase the number of users, please reach out to us via **[Slack](https://tooljet.com/slack)** or review our pricing page at https://www.tooljet.com/pricing before making a request.
 
-<div style={{textAlign: 'center'}}>
+<div style={{textAlign: 'center', marginTop: '-8px'}}>
 
 <img className="screenshot-full" src="/img/licensing/licensingpage4.png" alt="Licensing" />
 
@@ -101,19 +104,23 @@ If your business or enterprise edition license key is nearing expiration, please
 **Ref: Screenshot addressing upgrade/renew CTAs. Note that there are a couple of other pages which will display banners or CTAs, from where you can upgrade/renew.**
 
 ### 2) What is the duration of my license's validity?
+
 If you have an active license, you can find its validity period in the Settings. Generally, the duration of your license varies based on the type:
+
 - Trial licenses are valid for 14 days.
 - Business licenses are valid for 3 months.
 - Enterprise licenses can be customized to suit your needs.
 
 ### 3) What happens if my license expires?
+
 If your business or enterprise license key expires, your instance will revert to operating as a free plan. While you can still create unlimited apps, workspaces, and add users, premium features such as OpenID and Audit logs will no longer be accessible. For further information, please refer to the relevant **[plans](https://www.tooljet.com/pricing)**.
 
-### 4) How can I add more users? 
+### 4) How can I add more users?
+
 There are different methods to do this:
 
 **a)** You can renew directly using the **[business plan](https://www.tooljet.com/pricing)**. (Note: Please do check the list of premium features available with this plan)
 
-**b)** You can directly reach out to us via **[Slack](https://tooljet.com/slack)** or **[email](mailto:hello@tooljet.com)** and we will be happy to provide you the support. 
+**b)** You can directly reach out to us via **[Slack](https://tooljet.com/slack)** or **[email](mailto:hello@tooljet.com)** and we will be happy to provide you the support.
 
-***Lastly, please keep in mind that your license key is private and strictly prohibited from being shared with any third parties.***
+**_Lastly, please keep in mind that your license key is private and strictly prohibited from being shared with any third parties._**


### PR DESCRIPTION
The padding on the images looked okay to me, but I added some margin to even out the spacing around a couple of the screenshots (made change in main docs/licensing.md file)


<img width="698" alt="Screenshot 2023-12-29 at 9 37 48 PM" src="https://github.com/ToolJet/ToolJet/assets/12886956/efcca6a5-991d-4cc6-a503-f676cf7be5ef">


<img width="717" alt="Screenshot 2023-12-29 at 9 37 33 PM" src="https://github.com/ToolJet/ToolJet/assets/12886956/bc59672e-a44e-4869-9c9d-10ac99641bc3">