### PR TITLE
Coerce invalid values to empty state values for properties/styles

### DIFF
--- a/frontend/src/Editor/Box.jsx
+++ b/frontend/src/Editor/Box.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useContext, useRef, memo } from 'react';
+import React, { useEffect, useState, useMemo, useContext, memo } from 'react';
 import { Button } from './Components/Button';
 import { Image } from './Components/Image';
 import { Text } from './Components/Text';
@@ -247,7 +247,7 @@ export const Box = memo(
       }
 
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [JSON.stringify({ resolvedProperties, resolvedStyles })]);
+    }, [JSON.stringify({ validatedProperties, validatedStyles })]);
 
     useEffect(() => {
       if (customResolvables && !readOnly && mode === 'edit') {

--- a/frontend/src/Editor/Box.jsx
+++ b/frontend/src/Editor/Box.jsx
@@ -177,30 +177,26 @@ export const Box = memo(
     const [resetComponent, setResetStatus] = useState(false);
 
     const resolvedProperties = resolveProperties(component, currentState, null, customResolvables);
-    const [validatedProperties, propertyErrors] =
-      mode === 'edit' && component.validate
-        ? validateProperties(resolvedProperties, componentMeta.properties)
-        : [resolvedProperties, []];
+    const [validatedProperties, propertyErrors] = component.validate
+      ? validateProperties(resolvedProperties, componentMeta.properties)
+      : [resolvedProperties, []];
 
     const resolvedStyles = resolveStyles(component, currentState, null, customResolvables);
-    const [validatedStyles, styleErrors] =
-      mode === 'edit' && component.validate
-        ? validateProperties(resolvedStyles, componentMeta.styles)
-        : [resolvedStyles, []];
+    const [validatedStyles, styleErrors] = component.validate
+      ? validateProperties(resolvedStyles, componentMeta.styles)
+      : [resolvedStyles, []];
     validatedStyles.visibility = validatedStyles.visibility !== false ? true : false;
 
     const resolvedGeneralProperties = resolveGeneralProperties(component, currentState, null, customResolvables);
-    const [validatedGeneralProperties, generalPropertiesErrors] =
-      mode === 'edit' && component.validate
-        ? validateProperties(resolvedGeneralProperties, componentMeta.general)
-        : [resolvedGeneralProperties, []];
+    const [validatedGeneralProperties, generalPropertiesErrors] = component.validate
+      ? validateProperties(resolvedGeneralProperties, componentMeta.general)
+      : [resolvedGeneralProperties, []];
 
     const resolvedGeneralStyles = resolveGeneralStyles(component, currentState, null, customResolvables);
     resolvedStyles.visibility = resolvedStyles.visibility !== false ? true : false;
-    const [validatedGeneralStyles, generalStylesErrors] =
-      mode === 'edit' && component.validate
-        ? validateProperties(resolvedGeneralStyles, componentMeta.generalStyles)
-        : [resolvedGeneralStyles, []];
+    const [validatedGeneralStyles, generalStylesErrors] = component.validate
+      ? validateProperties(resolvedGeneralStyles, componentMeta.generalStyles)
+      : [resolvedGeneralStyles, []];
 
     const darkMode = localStorage.getItem('darkMode') === 'true';
     const { variablesExposedForPreview, exposeToCodeHinter } = useContext(EditorContext) || {};

--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -339,7 +339,7 @@ export function CodeHinter({
                 </div>
               )}
             </div>
-            {content + coercionPreview}
+            {JSON.stringify(content) + coercionPreview}
           </div>
         </div>
         {/* Todo: Remove this when workspace variables are deprecated */}

--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -100,6 +100,7 @@ export function CodeHinter({
   const [resolvingError, setResolvingError] = useState(null);
   const [coercionPreview, setCoercionPreview] = useState('');
   const [typeAfterCoercion, setTypeAfterCoercion] = useState(null);
+  const [typeBeforeCoercion, setTypeBeforeCoercion] = useState(null);
 
   const [isFocused, setFocused] = useState(false);
   const [heightRef, currentHeight] = useHeight();
@@ -222,10 +223,11 @@ export function CodeHinter({
         setResolvingError(null);
 
         if (validationSchemaExists) {
-          const [coercionPreview, typeAfterCoercion] = computeCoercion(preview, newValue);
+          const [coercionPreview, typeAfterCoercion, typeBeforeCoercion] = computeCoercion(preview, newValue);
 
           setCoercionPreview(coercionPreview);
           setTypeAfterCoercion(typeAfterCoercion);
+          setTypeBeforeCoercion(typeBeforeCoercion);
         }
 
         setResolvedValue(preview);
@@ -331,7 +333,7 @@ export function CodeHinter({
           <div>
             <div className="d-flex my-1">
               <div className="flex-grow-1" style={{ fontWeight: 700, textTransform: 'capitalize' }}>
-                {previewType} {coercionPreview ? ` → ${typeAfterCoercion}` : ''}
+                {typeBeforeCoercion} {coercionPreview ? ` → ${typeAfterCoercion}` : ''}
               </div>
               {isFocused && (
                 <div className="preview-icons position-relative">
@@ -584,13 +586,13 @@ function computeCoercion(oldValue, newValue) {
 
   if (oldValueType === newValueType) {
     if (JSON.stringify(oldValue) != JSON.stringify(newValue)) {
-      return [` → ${JSON.stringify(newValue)}`, newValueType];
+      return [` → ${JSON.stringify(newValue)}`, newValueType, oldValueType];
     }
   } else {
-    return [` → ${JSON.stringify(newValue)}`, newValueType];
+    return [` → ${JSON.stringify(newValue)}`, newValueType, oldValueType];
   }
 
-  return ['', newValueType];
+  return ['', newValueType, oldValueType];
 }
 
 CodeHinter.PopupIcon = PopupIcon;

--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -258,7 +258,7 @@ export function CodeHinter({
         case 'boolean':
           return content.toString();
         default:
-          return content;
+          return JSON.stringify(content);
       }
     } catch (e) {
       return undefined;
@@ -339,7 +339,7 @@ export function CodeHinter({
                 </div>
               )}
             </div>
-            {JSON.stringify(content) + coercionPreview}
+            {content + coercionPreview}
           </div>
         </div>
         {/* Todo: Remove this when workspace variables are deprecated */}

--- a/frontend/src/Editor/Components/Text.jsx
+++ b/frontend/src/Editor/Components/Text.jsx
@@ -85,7 +85,7 @@ export const Text = function Text({
       {!loadingState && (
         <div
           style={{ width: '100%', fontSize: textSize }}
-          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(text || '0') }}
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(text) }}
         />
       )}
       {loadingState === true && (

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -148,7 +148,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Number of rows per page',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
 
@@ -184,7 +184,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Total records server side',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       // clientSidePagination: {
@@ -392,7 +392,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Border radius',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       visibility: {
@@ -1326,7 +1326,7 @@ export const widgets = [
       borderRadius: {
         type: 'code',
         displayName: 'Border radius',
-        validation: { schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] } },
+        validation: { schema: { type: 'number' } },
       },
       visibility: { type: 'toggle', displayName: 'Visibility', validation: { schema: { type: 'boolean' } } },
       disabledState: { type: 'toggle', displayName: 'Disable', validation: { schema: { type: 'boolean' } } },
@@ -1408,21 +1408,21 @@ export const widgets = [
         type: 'code',
         displayName: 'Default value',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       minValue: {
         type: 'code',
         displayName: 'Minimum value',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       maxValue: {
         type: 'code',
         displayName: 'Maximum value',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       placeholder: {
@@ -1469,7 +1469,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Border radius',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       backgroundColor: {
@@ -1566,7 +1566,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Border radius',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       backgroundColor: {
@@ -1680,7 +1680,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Border radius',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
     },
@@ -2046,7 +2046,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Border radius',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
     },
@@ -2197,7 +2197,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Text',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'string' },
         },
       },
       loadingState: {
@@ -2433,7 +2433,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Padding',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       visibility: {
@@ -2851,7 +2851,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Border radius',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       visibility: {
@@ -3182,14 +3182,14 @@ export const widgets = [
         type: 'code',
         displayName: 'Number of stars',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       defaultSelected: {
         type: 'code',
         displayName: 'Default no of selected stars',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       allowHalfStar: {
@@ -3714,7 +3714,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Border radius',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
     },
@@ -4084,7 +4084,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Row height',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       showBorder: {
@@ -4150,7 +4150,7 @@ export const widgets = [
         type: 'number',
         displayName: 'Border radius',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
     },
@@ -4345,7 +4345,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Progress',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
     },
@@ -4369,14 +4369,14 @@ export const widgets = [
         type: 'code',
         displayName: 'Text size',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       strokeWidth: {
         type: 'code',
         displayName: 'Stroke width',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       counterClockwise: {
@@ -4390,7 +4390,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Circle ratio',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       visibility: {
@@ -4606,7 +4606,7 @@ export const widgets = [
         type: 'code',
         displayName: 'Value',
         validation: {
-          schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
+          schema: { type: 'number' },
         },
       },
       enableTwoHandle: {

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -19,7 +19,6 @@ export const widgets = [
           schema: {
             type: 'array',
             element: { type: 'object' },
-            optional: true,
           },
         },
       },

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -1415,14 +1415,14 @@ export const widgets = [
         type: 'code',
         displayName: 'Minimum value',
         validation: {
-          schema: { type: 'number' },
+          schema: { type: 'number', defaultValue: Number.NEGATIVE_INFINITY },
         },
       },
       maxValue: {
         type: 'code',
         displayName: 'Maximum value',
         validation: {
-          schema: { type: 'number' },
+          schema: { type: 'number', defaultValue: Number.POSITIVE_INFINITY },
         },
       },
       placeholder: {
@@ -1499,8 +1499,8 @@ export const widgets = [
       },
       properties: {
         value: { value: '99' },
-        maxValue: { value: '' },
-        minValue: { value: '' },
+        maxValue: { value: '{{Number.POSITIVE_INFINITY}}' },
+        minValue: { value: '{{Number.NEGATIVE_INFINITY}}' },
         placeholder: { value: '0' },
         decimalPlaces: { value: '{{2}}' },
         loadingState: { value: '{{false}}' },

--- a/frontend/src/Editor/component-properties-validation.js
+++ b/frontend/src/Editor/component-properties-validation.js
@@ -9,10 +9,8 @@ const {
   union,
   size,
   pattern,
-  defaulted,
   coerce,
   create,
-  literal,
   never,
 } = require('superstruct');
 

--- a/frontend/src/Editor/component-properties-validation.js
+++ b/frontend/src/Editor/component-properties-validation.js
@@ -13,6 +13,7 @@ const {
   coerce,
   create,
   literal,
+  never,
 } = require('superstruct');
 
 import _ from 'lodash';
@@ -27,7 +28,6 @@ const generateSchemaFromValidationDefinition = (definition, recursionDepth = 0) 
 
       if (recursionDepth === 0) {
         schema = coerce(schema, number(), JSON.stringify);
-        schema = defaulted(schema, () => '', { strict: true });
       }
 
       break;
@@ -41,7 +41,6 @@ const generateSchemaFromValidationDefinition = (definition, recursionDepth = 0) 
           const finalValue = parsedValue ? parsedValue : value;
           return finalValue;
         });
-        schema = defaulted(schema, () => 0, { strict: true });
       }
       break;
     }
@@ -59,13 +58,6 @@ const generateSchemaFromValidationDefinition = (definition, recursionDepth = 0) 
       const elementSchema = generateSchemaFromValidationDefinition(definition.element ?? {}, recursionDepth + 1);
       schema = array(elementSchema);
 
-      if (recursionDepth === 0) {
-        schema = coerce(schema, literal(undefined), (value) => {
-          console.log({ shashi: value, recursionDepth });
-          return [];
-        });
-      }
-
       break;
     }
     case 'object': {
@@ -77,10 +69,11 @@ const generateSchemaFromValidationDefinition = (definition, recursionDepth = 0) 
       );
       schema = type(obJectSchema);
 
-      if (recursionDepth === 0) {
-        schema = defaulted(schema, () => ({}), { strict: true });
-      }
+      break;
+    }
 
+    case 'undefined': {
+      schema = never();
       break;
     }
     default:

--- a/frontend/src/Editor/component-properties-validation.js
+++ b/frontend/src/Editor/component-properties-validation.js
@@ -44,6 +44,10 @@ const generateSchemaFromValidationDefinition = (definition, recursionDepth = 0) 
     }
     case 'boolean': {
       schema = boolean();
+
+      if (recursionDepth === 0) {
+        schema = coerce(schema, any(), (value) => (value ? true : false));
+      }
       break;
     }
     case 'union': {

--- a/frontend/src/Editor/component-properties-validation.js
+++ b/frontend/src/Editor/component-properties-validation.js
@@ -1,17 +1,48 @@
-const { type, number, string, array, any, optional, assert, boolean, union, size, pattern } = require('superstruct');
+const {
+  type,
+  number,
+  string,
+  array,
+  any,
+  optional,
+  boolean,
+  union,
+  size,
+  pattern,
+  defaulted,
+  coerce,
+  create,
+  literal,
+} = require('superstruct');
+
 import _ from 'lodash';
 
-const generateSchemaFromValidationDefinition = (definition) => {
+const generateSchemaFromValidationDefinition = (definition, recursionDepth = 0) => {
   let schema;
 
   switch (definition?.type ?? '') {
     case 'string': {
       schema = string();
       if (definition?.pattern) schema = pattern(schema, RegExp(definition.pattern, 'i'));
+
+      if (recursionDepth === 0) {
+        schema = coerce(schema, number(), JSON.stringify);
+        schema = defaulted(schema, () => '', { strict: true });
+      }
+
       break;
     }
     case 'number': {
       schema = number();
+
+      if (recursionDepth === 0) {
+        schema = coerce(schema, string(), (value) => {
+          const parsedValue = parseFloat(value);
+          const finalValue = parsedValue ? parsedValue : value;
+          return finalValue;
+        });
+        schema = defaulted(schema, () => 0, { strict: true });
+      }
       break;
     }
     case 'boolean': {
@@ -19,22 +50,37 @@ const generateSchemaFromValidationDefinition = (definition) => {
       break;
     }
     case 'union': {
-      schema = union(definition.schemas?.map((subSchema) => generateSchemaFromValidationDefinition(subSchema)));
+      schema = union(
+        definition.schemas?.map((subSchema) => generateSchemaFromValidationDefinition(subSchema, recursionDepth))
+      );
       break;
     }
     case 'array': {
-      const elementSchema = generateSchemaFromValidationDefinition(definition.element ?? {});
+      const elementSchema = generateSchemaFromValidationDefinition(definition.element ?? {}, recursionDepth + 1);
       schema = array(elementSchema);
+
+      if (recursionDepth === 0) {
+        schema = coerce(schema, literal(undefined), (value) => {
+          console.log({ shashi: value, recursionDepth });
+          return [];
+        });
+      }
+
       break;
     }
     case 'object': {
       const obJectSchema = Object.fromEntries(
         Object.entries(definition.object ?? {}).map(([key, value]) => {
-          const generatedSchema = generateSchemaFromValidationDefinition(value);
+          const generatedSchema = generateSchemaFromValidationDefinition(value, recursionDepth + 1);
           return [key, generatedSchema];
         })
       );
       schema = type(obJectSchema);
+
+      if (recursionDepth === 0) {
+        schema = defaulted(schema, () => ({}), { strict: true });
+      }
+
       break;
     }
     default:
@@ -53,20 +99,17 @@ const generateSchemaFromValidationDefinition = (definition) => {
 const validate = (value, schema, _defaultValue) => {
   let valid = true;
   const errors = [];
+  let newValue = undefined;
 
   try {
-    assert(value, schema);
+    newValue = create(value, schema);
   } catch (structError) {
     valid = false;
     errors.push(structError.message);
+    console.log({ structError });
   }
 
-  if (_.isUndefined(value)) {
-    valid = false;
-    errors.push("Received 'undefined'");
-  }
-
-  return [valid, errors];
+  return [valid, errors, newValue];
 };
 
 export const validateProperties = (resolvedProperties, propertyDefinitions) => {
@@ -74,24 +117,27 @@ export const validateProperties = (resolvedProperties, propertyDefinitions) => {
   const coercedProperties = Object.fromEntries(
     Object.entries(resolvedProperties ?? {}).map(([propertyName, value]) => {
       const validationDefinition = propertyDefinitions[propertyName]?.validation?.schema;
-      const defaultValue = propertyDefinitions[propertyName]?.validation?.defaultValue;
+      const defaultValue = validationDefinition ? findDefault(validationDefinition, value) : undefined;
 
       const schema = _.isUndefined(validationDefinition)
         ? any()
         : generateSchemaFromValidationDefinition(validationDefinition);
 
-      const [_valid, errors] = propertyName ? validate(value, schema, defaultValue) : [true, []];
+      const [_valid, errors, newValue] = propertyName ? validate(value, schema, defaultValue) : [true, []];
 
       if (!_.isUndefined(propertyName)) {
         allErrors = [
           ...allErrors,
-          ...errors.map((message) => ({ property: propertyDefinitions[propertyName]?.displayName, message })),
+          ...errors.map((message) => ({
+            property: propertyDefinitions[propertyName]?.displayName,
+            message,
+          })),
         ];
       }
 
-      // return [propertyName, _valid ? value : defaultValue];
-      // uncomment the above line and comment the below line to enable coercing to default values
-      return [propertyName, value];
+      return [propertyName, _valid ? newValue : defaultValue];
+      // comment the above line and uncomment the below line to disable coercing to default values
+      // return [propertyName, value];
     })
   );
   return [coercedProperties, allErrors];
@@ -105,6 +151,25 @@ export const validateProperty = (resolvedProperty, propertyDefinitions, paramNam
   const schema = _.isUndefined(validationDefinition)
     ? any()
     : generateSchemaFromValidationDefinition(validationDefinition);
-  const [_valid, errors] = paramName ? validate(value, schema, defaultValue) : [true, []];
-  return [_valid, errors];
+  const [_valid, errors, newValue] = paramName ? validate(value, schema, defaultValue) : [true, []];
+  return [_valid, errors, newValue];
 };
+
+function findDefault(definition, value) {
+  switch (definition.type) {
+    case 'string':
+      return '';
+    case 'number':
+      return 0;
+    case 'boolean':
+      return value;
+    case 'array':
+      return [];
+    case 'object':
+      return {};
+    case 'union':
+      return findDefault(definition.schemas[0], value);
+    default:
+      return undefined;
+  }
+}

--- a/frontend/src/Editor/component-properties-validation.js
+++ b/frontend/src/Editor/component-properties-validation.js
@@ -100,8 +100,8 @@ const validate = (value, schema, _defaultValue) => {
     newValue = create(value, schema);
   } catch (structError) {
     valid = false;
-    errors.push(structError.message);
-    console.log({ structError });
+    if (structError.type === 'type') errors.push(structError.message);
+    else errors.push(`Expected a value of type ${structError.type}, but received ${JSON.stringify(structError.value)}`);
   }
 
   return [valid, errors, newValue];

--- a/frontend/src/Editor/component-properties-validation.js
+++ b/frontend/src/Editor/component-properties-validation.js
@@ -108,7 +108,11 @@ export const validateProperties = (resolvedProperties, propertyDefinitions) => {
   const coercedProperties = Object.fromEntries(
     Object.entries(resolvedProperties ?? {}).map(([propertyName, value]) => {
       const validationDefinition = propertyDefinitions[propertyName]?.validation?.schema;
-      const defaultValue = validationDefinition ? findDefault(validationDefinition, value) : undefined;
+      const defaultValue = validationDefinition?.defaultValue
+        ? validationDefinition?.defaultValue
+        : validationDefinition
+        ? findDefault(validationDefinition, value)
+        : undefined;
 
       const schema = _.isUndefined(validationDefinition)
         ? any()


### PR DESCRIPTION
Helps #8494 

This PR does the following things:

1. Whenever an invalid or undefined value is passed to a property/style, the component will actually receive only an empty state of the expected data type, however, an error will still be shown. For example, if a string value like `"hello"` is passed into Table component's 'data' property, the component will actually receive `[]`, and an error will be shown nonetheless.
2. For a property/style that expects 'string' data type, if a value of 'number' data type is received, then that value is converted into a string
3. Vice versa of 2
4. Changes many property validations that accept both string and number, to just accept string or number, since values are coerced between string and number anyways.