### PR TITLE
Fix:#8595 Text formatted for marketplacce plugins

### DIFF
--- a/docs/versioned_docs/version-2.27.0/marketplace/plugins/github.md
+++ b/docs/versioned_docs/version-2.27.0/marketplace/plugins/github.md
@@ -3,7 +3,7 @@ id: marketplace-plugin-github
 title: GitHub
 ---
 
-ToolJet can connect to GitHub account to read and write data. In order for ToolJet to access and manipulate data on GitHub, a **GitHub Personal Access Toke**n is necessary to authenticate and interact with the GitHub API.
+ToolJet can connect to GitHub account to read and write data. In order for ToolJet to access and manipulate data on GitHub, a **GitHub Personal Access Token** is necessary to authenticate and interact with the GitHub API.
 
 <div style={{textAlign: 'center'}}>
 


### PR DESCRIPTION
Fix: #8595 
For the text, GitHub Personal Access Token in the first paragraph - the last letter is not formatted in bold. the letter n was outside ** . made it inside ** so it can be bold