### PR TITLE
Fix: #8260 Map component crash fix when no google map api key

### DIFF
--- a/frontend/src/Editor/Components/Map/Map.jsx
+++ b/frontend/src/Editor/Components/Map/Map.jsx
@@ -183,7 +183,7 @@ export const Map = function Map({
               ))}
             </>
           )}
-          {polygonPoints.length > 1 && (
+          {window.public_config.GOOGLE_MAPS_API_KEY && polygonPoints.length > 1 && (
             <Polygon
               path={polygonPoints}
               onClick={() => {


### PR DESCRIPTION
Fix: #8260 Map component crashes when no Google Map API key is available.