### PR TITLE
Fix: #6816 App crashes in runjs for alert actions

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -410,7 +410,10 @@ function executeActionWithDebounce(_ref, event, mode, customVariables) {
     }
     switch (event.actionId) {
       case 'show-alert': {
-        const message = resolveReferences(event.message, getCurrentState(), undefined, customVariables);
+        let message = resolveReferences(event.message, getCurrentState(), undefined, customVariables);
+        if (!!message && ['object', 'function'].includes(typeof message)) {
+          message = 'Invalid data';
+        }
         switch (event.alertType) {
           case 'success':
           case 'error':


### PR DESCRIPTION
Fix: #6816 

App crashes when passing invalid data to alert action. In the issue, it's mentioned for error action alert but it also happens for warning and info alerts. So this fix will work for them also.