### PR TITLE
Fix: App could not save error on resizing column width fixed

### DIFF
--- a/frontend/src/_stores/utils.js
+++ b/frontend/src/_stores/utils.js
@@ -98,7 +98,8 @@ function updateValueInJson(json, path, value) {
 }
 
 export function isParamFromTableColumn(appDiff, definition) {
-  const path = generatePath(appDiff, 'columns') || generatePath(appDiff, 'actions');
+  const path =
+    generatePath(appDiff, 'columns') || generatePath(appDiff, 'actions') || generatePath(appDiff, 'columnSizes');
   if (!path) {
     return false;
   }


### PR DESCRIPTION
Resolves
While resizing the width of table columns, an error message, stating the app could not save pops-up