### PR TITLE
Update confirmation message for revoking access to a data source for a group

### DIFF
--- a/frontend/src/ManageGroupPermissionResources/ManageGroupPermissionResources.jsx
+++ b/frontend/src/ManageGroupPermissionResources/ManageGroupPermissionResources.jsx
@@ -213,7 +213,7 @@ class ManageGroupPermissionResourcesComponent extends React.Component {
   };
 
   removeAppFromGroup = (groupPermissionId, appId, appName) => {
-    if (window.confirm(`Are you sure you want to delete this app - ${appName}?`) === false) return;
+    if (window.confirm(`Are you sure you want to revoke the group's access to this data source - ${appName}?`) === false) return;
     const updateParams = {
       remove_apps: [appId],
     };


### PR DESCRIPTION
## Updated the confirmation message to display the correct information
- Before: "Are you sure you want to delete this data source - <data source name>?"
- After: "Are you sure you want to revoke the group's access to this data source - <data source name>?"

Resolves: #8658