### PR TITLE
fix : Darkmode color fix for box shadow and default size fix for labels in input

### DIFF
--- a/frontend/src/Editor/CodeBuilder/Elements/BoxShadow.jsx
+++ b/frontend/src/Editor/CodeBuilder/Elements/BoxShadow.jsx
@@ -187,7 +187,13 @@ export const BoxShadow = ({ value, onChange, cyLabel }) => {
                 }}
                 data-cy={`${cyLabel}-picker-icon`}
               ></div>
-              <small className="col p-0" data-cy={`${cyLabel}-value`}>
+              <small
+                className="col p-0"
+                data-cy={`${cyLabel}-value`}
+                style={{
+                  color: 'var(--slate12)',
+                }}
+              >
                 {_value}
               </small>
             </div>

--- a/frontend/src/Editor/CodeBuilder/Elements/Icon.jsx
+++ b/frontend/src/Editor/CodeBuilder/Elements/Icon.jsx
@@ -101,7 +101,13 @@ export const Icon = ({ value, onChange, onVisibilityChange, component }) => {
                       style={{ width: '24px', height: '24px' }}
                     />
                   </div>
-                  <div className="text-truncate tj-text-xsm" style={{ width: '80px' }}>
+                  <div
+                    className="text-truncate tj-text-xsm"
+                    style={{
+                      width: '80px',
+                      color: 'var(--slate12)',
+                    }}
+                  >
                     {value}
                   </div>
                   <Visibility

--- a/frontend/src/Editor/Components/NumberInput.jsx
+++ b/frontend/src/Editor/Components/NumberInput.jsx
@@ -286,6 +286,7 @@ export const NumberInput = function NumberInput({
                 display: 'flex',
                 fontWeight: 500,
                 justifyContent: direction == 'right' ? 'flex-end' : 'flex-start',
+                fontSize: '12px',
               }}
             >
               <span

--- a/frontend/src/Editor/Components/PasswordInput.jsx
+++ b/frontend/src/Editor/Components/PasswordInput.jsx
@@ -238,6 +238,7 @@ export const PasswordInput = function PasswordInput({
               display: 'flex',
               fontWeight: 500,
               justifyContent: direction == 'right' ? 'flex-end' : 'flex-start',
+              fontSize: '12px',
             }}
           >
             <span

--- a/frontend/src/Editor/Components/TextInput.jsx
+++ b/frontend/src/Editor/Components/TextInput.jsx
@@ -247,6 +247,7 @@ export const TextInput = function TextInput({
               display: 'flex',
               fontWeight: 500,
               justifyContent: direction == 'right' ? 'flex-end' : 'flex-start',
+              fontSize: '12px',
             }}
           >
             <span


### PR DESCRIPTION
Default size for labels is changes from 14px to 12px
Texts in icon and box shadow was not visible in inspector in drakmode