### PR TITLE
Bugfix/marketplace 1.6 release

### DIFF
--- a/frontend/src/TooljetDatabase/Forms/RowForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/RowForm.jsx
@@ -154,7 +154,7 @@ const RowForm = ({ onCreate, onClose }) => {
             <input
               //defaultValue={!isPrimaryKey && defaultValue?.length > 0 ? removeQuotes(defaultValue.split('::')[0]) : ''}
               type="text"
-              value={inputValues[index]?.value}
+              value={inputValues[index]?.value === null ? '' : inputValues[index]?.value}
               onChange={(e) => handleInputChange(index, e.target.value, columnName)}
               disabled={isPrimaryKey || inputValues[index]?.disabled}
               placeholder={isPrimaryKey ? 'Auto-generated' : inputValues[index]?.value !== null && 'Enter a value'}

--- a/frontend/src/TooljetDatabase/Forms/TableForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableForm.jsx
@@ -71,7 +71,8 @@ const TableForm = ({
   function handleKeyPress(e) {
     if (e.key === 'Enter') {
       e.preventDefault();
-      handleCreate(e);
+      if (!isEditMode) handleCreate(e);
+      if (isEditMode && selectedTable.table_name !== tableName) handleEdit();
     }
   }
 

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -365,7 +365,9 @@ const Table = ({ collapseSidebar }) => {
     if (
       !event.target.closest('.table-cell-click') &&
       !event.target.closest('.table-editable-parent-cell') &&
-      !event.target.closest('.popover-body')
+      !event.target.closest('.popover-body') &&
+      !event.target.closest('.cell-text') &&
+      !event.target.closest('.tjdb-td-wrapper')
     ) {
       setCellClick((prevState) => ({
         ...prevState,
@@ -376,6 +378,7 @@ const Table = ({ collapseSidebar }) => {
       }));
       handleOnCloseEditMenu();
     }
+    event.stopPropagation();
   };
 
   useEffect(() => {
@@ -573,7 +576,6 @@ const Table = ({ collapseSidebar }) => {
       cellVal === null ? setNullValue(true) : setNullValue(false);
       setEditPopover(false);
     }
-    e.stopPropagation();
   };
 
   const closeEditPopover = (previousValue) => {

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -844,7 +844,7 @@ const Table = ({ collapseSidebar }) => {
                             <ToolTip
                               message={index === 0 ? 'Cannot edit primary key values' : cell.value || ''}
                               placement="bottom"
-                              delay={{ show: 0, hide: 0 }}
+                              delay={{ show: 200, hide: 0 }}
                               show={
                                 !(
                                   cellClick.rowIndex === rIndex &&
@@ -852,7 +852,8 @@ const Table = ({ collapseSidebar }) => {
                                   cellClick.editable
                                 ) &&
                                 cell.value !== null &&
-                                cell.column.dataType !== 'boolean'
+                                cell.column.dataType !== 'boolean' &&
+                                cell.value !== ''
                               }
                             >
                               <div className="tjdb-column-select-border">

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -503,6 +503,7 @@ const Table = ({ collapseSidebar }) => {
       cellIndex: index,
       errorState: false,
     }));
+    cellValue === null ? setNullValue(true) : setNullValue(false);
     handleProgressAnimation('column edited successfully', true);
     document.getElementById('edit-input-blur').blur();
   };

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -488,6 +488,7 @@ const Table = ({ collapseSidebar }) => {
           errorState: false,
         }));
         setCellVal(oldValue);
+        oldValue === null ? setNullValue(true) : setNullValue(false);
         document.getElementById('edit-input-blur').blur();
       }, 3000);
       return;

--- a/frontend/src/_ui/Header/index.jsx
+++ b/frontend/src/_ui/Header/index.jsx
@@ -40,7 +40,7 @@ function Header({ enableCollapsibleSidebar = false, collapseSidebar = false, tog
             <div className="row">
               <div className="col-9">
                 <p className="tj-text-md font-weight-500" data-cy="dashboard-section-header">
-                  {routes(pathname)}
+                  {pathname}
                 </p>
               </div>
               {enableCollapsibleSidebar && !collapseSidebar && (


### PR DESCRIPTION
Bugs that will be fixed in this PR

TooljetDB

1. On the 'dashboard-section-header' it shows "Application" only for all sections
2. The tooltip text for empty strings
3. In the case of sort and filter conditions, clicking anywhere on the screen does not close the modal.
4. When creating a row, the input field text overlapped with "NULL"
5. "Set to NULL" toggle became disabled, after getting error messages to make the integer field empty.