### PR TITLE
Inspector is not positioned properly in firefox

### DIFF
--- a/frontend/src/_styles/popover.scss
+++ b/frontend/src/_styles/popover.scss
@@ -53,7 +53,6 @@ div[data-radix-popper-content-wrapper]:has(.PopoverContent.drawer-height) {
 }
 @-moz-document url-prefix() {
   div[data-radix-popper-content-wrapper]{
-    top: 48px !important;
     z-index: 100 !important;
     left: 1px !important;
   }


### PR DESCRIPTION
Resolves - 
The inspector in the left sidebar is positioned by 45px from top in the firefox