### PR TITLE
fix: Loader position in text widget , migration fixes

### DIFF
--- a/frontend/src/Editor/Components/Text.jsx
+++ b/frontend/src/Editor/Components/Text.jsx
@@ -156,7 +156,7 @@ export const Text = function Text({ height, properties, fireEvent, styles, darkM
       {isLoading === true && (
         <div style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <center>
-            <Loader width="16" />
+            <Loader width="16" absolute={false} />
           </center>
         </div>
       )}

--- a/frontend/src/ToolJetUI/Loader/Loader.jsx
+++ b/frontend/src/ToolJetUI/Loader/Loader.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import './Loader.scss'; // Import a CSS file for styling
 
-const Loader = ({ width, style }) => {
+const Loader = ({ width, style, absolute = true }) => {
   const viewBoxSize = 240; // Increase the viewBox size as needed
 
   return (
-    <div className="tj-widget-loader" style={style}>
+    <div className="tj-widget-loader d-flex" style={{ ...style, position: absolute ? 'absolute' : 'relative' }}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width={width}

--- a/frontend/src/ToolJetUI/Loader/Loader.scss
+++ b/frontend/src/ToolJetUI/Loader/Loader.scss
@@ -1,4 +1,0 @@
-.tj-widget-loader {
-    position: absolute;
-    display: flex;
-}

--- a/server/data-migrations/1707466537651-MoveVisibilityDisabledStatesToProperties.ts
+++ b/server/data-migrations/1707466537651-MoveVisibilityDisabledStatesToProperties.ts
@@ -65,6 +65,9 @@ export class MoveVisibilityDisabledStatesToProperties1707466537651
         if (properties.label == undefined || null) {
           properties.label = "";
         }
+        if (styles.borderRadius == undefined || null) {
+          styles.borderRadius = {value: "{{4}}"};
+        }
       }
   
       // Moving 'minValue' from properties to validation

--- a/server/data-migrations/1707466537651-MoveVisibilityDisabledStatesToProperties.ts
+++ b/server/data-migrations/1707466537651-MoveVisibilityDisabledStatesToProperties.ts
@@ -66,11 +66,6 @@ export class MoveVisibilityDisabledStatesToProperties1707466537651
           properties.label = "";
         }
       }
-      if (component.type !== "Text" || component !== "NumberInput") {
-        if (properties.value == undefined || null) {
-          properties.value = "";
-        }
-      }
   
       // Moving 'minValue' from properties to validation
       if (component.type == "NumberInput") {


### PR DESCRIPTION
*Loader position was not vertically centered in text widget
* Removed unwanted migration
*Added migration for border radius to set to 4px