### PR TITLE
Fixed: The dashboard needs a refresh to get the add folder icon(+) back once the search icon is clicked #8679

### DIFF
--- a/frontend/src/_components/SearchBox.jsx
+++ b/frontend/src/_components/SearchBox.jsx
@@ -75,15 +75,11 @@ export const SearchBox = forwardRef(
             autoFocus={autoFocus}
             ref={ref}
           />
-          {searchText.length > 0 ? (
             <span className="input-icon-addon end" onMouseDown={clearSearchText}>
               <div className="d-flex tj-common-search-input-clear-icon" title="clear">
                 <SolidIcon name="remove" />
               </div>
             </span>
-          ) : (
-            ''
-          )}
         </div>
       </div>
     );


### PR DESCRIPTION
I have fixed the mentioned issue. There was a condition that was causing this issue. #8679