### PR TITLE
[patch-fix] Codehinter : fix auto generated hints

### DIFF
--- a/frontend/src/Editor/CodeEditor/autocompleteExtensionConfig.js
+++ b/frontend/src/Editor/CodeEditor/autocompleteExtensionConfig.js
@@ -68,11 +68,11 @@ export const generateHints = (hints) => {
   const suggestions = hints.map(({ hint, type }) => {
     let displayedHint = type === 'js_method' ? `${hint}()` : hint;
 
-    // need to check if the hint is `queries.queryName` and not `queries.queryName.data`
-    // add the `.data` to the hint
-    if (displayedHint.includes('queries') && displayedHint.split('.').length === 2) {
-      displayedHint = `${displayedHint}.data`;
-    }
+    // // need to check if the hint is `queries.queryName` and not `queries.queryName.data`
+    // // add the `.data` to the hint
+    // if (displayedHint.includes('queries') && displayedHint.split('.').length === 2) {
+    //   displayedHint = `${displayedHint}.data`;
+    // }
 
     return {
       displayLabel: hint,
@@ -87,6 +87,8 @@ export const generateHints = (hints) => {
 };
 
 function filterHintsByDepth(input, hints) {
+  if (input === '') return hints;
+
   const inputDepth = input.split('.').length;
   const filteredHints = hints.filter((cm) => {
     const hintParts = cm.hint.split('.');

--- a/frontend/src/Editor/CodeEditor/utils.js
+++ b/frontend/src/Editor/CodeEditor/utils.js
@@ -204,8 +204,6 @@ const resolveMultiDynamicReferences = (code, lookupTable) => {
     });
   }
 
-  console.log('---arpit dynamic variables---', { resolvedValue });
-
   return resolvedValue;
 };
 


### PR DESCRIPTION
Fixes:
1. selecting a hint should not auto complete to an unpredictable outcome.
2. n-depth filtering and rendering of suggestions should only be done when a there is an input string