### PR TITLE
fix: Inspector icon alignment

### DIFF
--- a/frontend/src/_ui/JSONTreeViewer/JSONNode.jsx
+++ b/frontend/src/_ui/JSONTreeViewer/JSONNode.jsx
@@ -300,7 +300,6 @@ export const JSONNode = ({ data, ...restProps }) => {
             'group-object-container': shouldDisplayIntendedBlock,
             'mx-2': typeofCurrentNode !== 'Object' && typeofCurrentNode !== 'Array',
           })}
-          style={{ alignItems: 'center' }}
           onMouseEnter={() => updateHoveredNode(currentNode, currentNodePath)}
           data-cy={`inspector-node-${String(currentNode).toLowerCase()}`}
         >


### PR DESCRIPTION
*icons in inspector (copy and link) are not aligned with the text beside