### PR TITLE
fix: Fixed inconsistent behaviour of check box inside ListView

### DIFF
--- a/frontend/src/Editor/Components/Listview.jsx
+++ b/frontend/src/Editor/Components/Listview.jsx
@@ -127,7 +127,6 @@ export const Listview = function Listview({
             key={index}
             data-cy={`${String(component.name).toLowerCase()}-row-${index}`}
             onClick={(event) => {
-              event.preventDefault();
               onRecordClicked(index);
               onRowClicked(index);
             }}


### PR DESCRIPTION
This commit removes the event.preventDefault added to the list item click inside ListView. This prevent default was blocking checkbox rerender when the checked state changes causing the UI to behave inconsistently. 
Fixes: #8840 