### PR TITLE
Fix: Deselect selected rows in the TJDB table

### DIFF
--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -86,9 +86,11 @@ const Table = ({ collapseSidebar }) => {
       editable: false,
       errorState: false,
     });
-    const isSelectAll =
+
+    const shouldDeselect = Object.keys(selectedRowIds).length > 0 && Object.keys(selectedRowIds).length < rows.length;
+    const shouldSelectAll =
       Object.keys(selectedRowIds).length !== totalRowsCount && Object.keys(selectedRowIds).length < totalRowsCount;
-    if (!isSelectAll) {
+    if (!shouldSelectAll || shouldDeselect) {
       setSelectedRowIds({});
       return;
     }


### PR DESCRIPTION
Currently, there are no means to deselect the rows that have been selected all at once. This feature has been added now