### PR TITLE
Import higher version fix

### DIFF
--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -259,14 +259,8 @@ class HomePageComponent extends React.Component {
       });
       if (error.statusCode === 409) {
         return false;
-      } else if (
-        error.statusCode === 400 &&
-        error?.error == APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR
-      )
-        toast.error(APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR);
-      else {
-        toast.error(error?.error);
       }
+      toast.error(error?.error || 'App import failed');
     }
   };
 

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -265,7 +265,7 @@ class HomePageComponent extends React.Component {
       )
         toast.error(APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR);
       else {
-        toast.error(error?.erro);
+        toast.error(error?.error);
       }
     }
   };

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -259,9 +259,14 @@ class HomePageComponent extends React.Component {
       });
       if (error.statusCode === 409) {
         return false;
-      }
-      if (error.statusCode === 400 && error?.error == APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR)
+      } else if (
+        error.statusCode === 400 &&
+        error?.error == APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR
+      )
         toast.error(APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR);
+      else {
+        toast.error(error?.erro);
+      }
     }
   };
 

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -23,6 +23,7 @@ import BulkIcon from '@/_ui/Icon/bulkIcons/index';
 import { getWorkspaceId, pageTitles, setWindowTitle } from '@/_helpers/utils';
 import { withRouter } from '@/_hoc/withRouter';
 import FolderFilter from './FolderFilter';
+import { APP_ERROR_TYPE } from '@/_helpers/error_constants';
 
 const { iconList, defaultIcon } = configs;
 
@@ -259,7 +260,8 @@ class HomePageComponent extends React.Component {
       if (error.statusCode === 409) {
         return false;
       }
-      toast.error("Couldn't import the app");
+      if (error.statusCode === 400 && error?.error == APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR)
+        toast.error(APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR);
     }
   };
 

--- a/frontend/src/_helpers/error_constants.js
+++ b/frontend/src/_helpers/error_constants.js
@@ -1,0 +1,5 @@
+export const APP_ERROR_TYPE = {
+  IMPORT_EXPORT_SERVICE: {
+    UNSUPPORTED_VERSION_ERROR: "Can't import higher version application to lower version",
+  },
+};

--- a/server/src/controllers/import_export_resources.controller.ts
+++ b/server/src/controllers/import_export_resources.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, UseGuards, Body, ForbiddenException } from '@nestjs/common';
+import { Controller, Post, UseGuards, Body, ForbiddenException, BadRequestException } from '@nestjs/common';
 import { JwtAuthGuard } from '../../src/modules/auth/jwt-auth.guard';
 import { User } from 'src/decorators/user.decorator';
 import { ExportResourcesDto } from '@dto/export-resources.dto';
@@ -7,6 +7,8 @@ import { ImportExportResourcesService } from '@services/import_export_resources.
 import { App } from 'src/entities/app.entity';
 import { AppsAbilityFactory } from 'src/modules/casl/abilities/apps-ability.factory';
 import { CloneResourcesDto } from '@dto/clone-resources.dto';
+import { checkVersionCompatibility } from 'src/helpers/utils.helper';
+import { APP_ERROR_TYPE } from 'src/helpers/error_type.constant';
 
 @Controller({
   path: 'resources',
@@ -41,7 +43,10 @@ export class ImportExportResourcesController {
     if (!ability.can('cloneApp', App)) {
       throw new ForbiddenException('You do not have permissions to perform this action');
     }
-
+    const isNotCompatibleVersion = !checkVersionCompatibility(importResourcesDto.tooljet_version);
+    if (isNotCompatibleVersion) {
+      throw new BadRequestException(APP_ERROR_TYPE.IMPORT_EXPORT_SERVICE.UNSUPPORTED_VERSION_ERROR);
+    }
     const imports = await this.importExportResourcesService.import(user, importResourcesDto);
     return { imports, success: true };
   }

--- a/server/src/helpers/error_type.constant.ts
+++ b/server/src/helpers/error_type.constant.ts
@@ -1,0 +1,5 @@
+export const APP_ERROR_TYPE = {
+  IMPORT_EXPORT_SERVICE: {
+    UNSUPPORTED_VERSION_ERROR: "Can't import higher version application to lower version",
+  },
+};

--- a/server/src/helpers/utils.helper.ts
+++ b/server/src/helpers/utils.helper.ts
@@ -222,6 +222,10 @@ export function extractMajorVersion(version) {
   return semver.valid(semver.coerce(version));
 }
 
+export function checkVersionCompatibility(importingVersion) {
+  return semver.gte(semver.coerce(globalThis.TOOLJET_VERSION), semver.coerce(importingVersion));
+}
+
 /**
  * Checks if a given Tooljet version is compatible with normalized app definition schemas.
  *


### PR DESCRIPTION
1. This fix will toast error when user want to import app from higher version Tooljet to lower version 
2. Adding error constant file for bundling up all existing error. Need to add current error as well