### PR TITLE
Updating postgrest image tag

### DIFF
--- a/.github/workflows/cypress-appbuilder.yml
+++ b/.github/workflows/cypress-appbuilder.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           sudo docker run -d --name postgrest --network tooljet -p 3001:3000 \
           -e PGRST_DB_URI="postgres://postgres:postgres@postgres:5432/tooljet" -e PGRST_DB_ANON_ROLE="postgres" -e PGRST_JWT_SECRET="r9iMKoe5CRMgvJBBtp4HrqN7QiPpUToj" \
-          postgrest/postgrest:v10.1.1.20221215
+          postgrest/postgrest
 
       - name: Run plugins compilation in watch mode
         run: cd plugins && npm start &

--- a/.github/workflows/cypress-platform.yml
+++ b/.github/workflows/cypress-platform.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           sudo docker run -d --name postgrest --network tooljet -p 3001:3000 \
           -e PGRST_DB_URI="postgres://postgres:postgres@postgres:5432/tooljet" -e PGRST_DB_ANON_ROLE="postgres" -e PGRST_JWT_SECRET="r9iMKoe5CRMgvJBBtp4HrqN7QiPpUToj" \
-          postgrest/postgrest:v10.1.1.20221215
+          postgrest/postgrest
 
       - name: Run plugins compilation in watch mode
         run: cd plugins && npm start &

--- a/deploy/docker/docker-compose-db.yaml
+++ b/deploy/docker/docker-compose-db.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   tooljet:
@@ -30,7 +30,7 @@ services:
 
   postgrest:
     container_name: postgrest
-    image: postgrest/postgrest:v10.1.1.20221215
+    image: postgrest/postgrest
     restart: always
     depends_on:
       - postgres

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   tooljet:
@@ -16,7 +16,7 @@ services:
     command: npm run start:prod
   # Uncomment if ENABLE_TOOLJET_DB=true
   postgrest:
-    image: postgrest/postgrest:v10.1.1.20221215
+    image: postgrest/postgrest
     restart: always
     env_file: .env
     environment:

--- a/deploy/kubernetes/AKS/postgrest.yaml
+++ b/deploy/kubernetes/AKS/postgrest.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: postgrest
-        image: postgrest/postgrest:v10.1.1.20221215
+        image: postgrest/postgrest
         ports:
         - containerPort: 3000
         env:

--- a/deploy/kubernetes/postgrest.yaml
+++ b/deploy/kubernetes/postgrest.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: postgrest
-        image: postgrest/postgrest:v10.1.1.20221215
+        image: postgrest/postgrest
         ports:
         - containerPort: 3000
         env:

--- a/deploy/openshift/postgrest.yaml
+++ b/deploy/openshift/postgrest.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: postgrest
-        image: postgrest/postgrest:v10.1.1.20221215
+        image: postgrest/postgrest
         ports:
         - containerPort: 3000
         env:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
     command: npm run --prefix server start:dev
 
   postgrest:
-    image: postgrest/postgrest:v10.1.1.20221215
+    image: postgrest/postgrest
     ports:
       - "3001:3000"
     env_file:

--- a/docker/postgrest.render.Dockerfile
+++ b/docker/postgrest.render.Dockerfile
@@ -6,7 +6,7 @@
 
 FROM alpine:latest
 
-COPY --from=postgrest/postgrest:v10.1.1.20221215 /bin/postgrest /bin
+COPY --from=postgrest/postgrest /bin/postgrest /bin
 
 EXPOSE 3000
 


### PR DESCRIPTION
postgrest/postgrest:v10.1.1.20221215 docker image is deprecated. Hence updating to the latest one.