### PR TITLE
fix: Change labels to sentence case for Checkbox Component

### DIFF
--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -2427,7 +2427,7 @@ export const widgets = [
       },
       defaultValue: {
         type: 'toggle',
-        displayName: 'Default Status',
+        displayName: 'Default status',
         validation: {
           schema: { type: 'boolean' },
         },
@@ -2447,7 +2447,7 @@ export const widgets = [
       },
       checkboxColor: {
         type: 'color',
-        displayName: 'Checkbox Color',
+        displayName: 'Checkbox color',
         validation: {
           schema: { type: 'string' },
         },
@@ -2624,7 +2624,7 @@ export const widgets = [
       },
       defaultValue: {
         type: 'toggle',
-        displayName: 'Default Status',
+        displayName: 'Default status',
         validation: {
           schema: { type: 'boolean' },
         },


### PR DESCRIPTION
Solves issue #8429 Change labels to sentence case for Checkbox Component.

Made changes at 4 places, 2 each for "Display Status" and "Checkbox Color", in the widgetConfig.js file.