### PR TITLE
[docs]:Fix docker local setup link

### DIFF
--- a/docs/docs/contributing-guide/setup/docker.md
+++ b/docs/docs/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-1.x.x/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-1.x.x/contributing-guide/setup/docker.md
@@ -8,7 +8,7 @@ title: Docker
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.0.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.0.0/contributing-guide/setup/docker.md
@@ -8,7 +8,7 @@ title: Docker
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.1.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.1.0/contributing-guide/setup/docker.md
@@ -8,7 +8,7 @@ title: Docker
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.10.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.10.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.11.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.11.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.12.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.12.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.13.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.13.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.14.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.14.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.15.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.15.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.16.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.16.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.17.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.17.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.18.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.18.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.19.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.19.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.2.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.2.0/contributing-guide/setup/docker.md
@@ -8,7 +8,7 @@ title: Docker
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.22.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.22.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.23.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.23.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.24.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.24.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.25.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.25.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.27.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.27.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.29.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.29.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.3.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.3.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.30.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.30.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.4.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.4.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.5.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.5.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.6.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.6.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.7.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.7.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.8.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.8.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.9.0/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.9.0/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites

--- a/docs/versioned_docs/version-2.9.4/contributing-guide/setup/docker.md
+++ b/docs/versioned_docs/version-2.9.4/contributing-guide/setup/docker.md
@@ -10,7 +10,7 @@ The following guide is intended for contributors to set-up ToolJet locally. If y
 Docker compose is the easiest way to setup ToolJet server and client locally.
 
 :::info
-If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/docker-local).
+If you rather want to try out ToolJet locally with docker, you can follow the steps [here](https://docs.tooljet.com/docs/setup/try-tooljet).
 :::
 
 ## Prerequisites


### PR DESCRIPTION
Fixes the link to trying ToolJet using Docker locally