### PR TITLE
[fixes | improvement] Performance fixes

### DIFF
--- a/frontend/src/Editor/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/Editor/CodeEditor/MultiLineCodeEditor.jsx
@@ -169,7 +169,7 @@ const MultiLineCodeEditor = (props) => {
   const customKeyMaps = [...defaultKeymap, ...completionKeymap];
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const overRideFunction = React.useCallback((context) => autoCompleteExtensionConfig(context), []);
+  const overRideFunction = React.useCallback((context) => autoCompleteExtensionConfig(context), [hints]);
   const { handleTogglePopupExapand, isOpen, setIsOpen, forceUpdate } = portalProps;
 
   return (

--- a/frontend/src/Editor/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/Editor/CodeEditor/SingleLineCodeEditor.jsx
@@ -149,7 +149,7 @@ const EditorInput = ({
   }
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const overRideFunction = React.useCallback((context) => autoCompleteExtensionConfig(context), []);
+  const overRideFunction = React.useCallback((context) => autoCompleteExtensionConfig(context), [hints]);
 
   const autoCompleteConfig = autocompletion({
     override: [overRideFunction],

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -664,8 +664,7 @@ const EditorComponent = (props) => {
   };
 
   const globalSettingsChanged = (globalOptions) => {
-    const copyOfAppDefinition = JSON.parse(JSON.stringify(appDefinition));
-    const newAppDefinition = _.cloneDeep(copyOfAppDefinition);
+    const newAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
     for (const [key, value] of Object.entries(globalOptions)) {
       if (value?.[1]?.a == undefined) newAppDefinition.globalSettings[key] = value;
@@ -774,7 +773,7 @@ const EditorComponent = (props) => {
           if (Array.isArray(entityReferences) && entityReferences?.length > 0) {
             const manager = useResolveStore.getState().referenceMapper;
 
-            let newComponentDefinition = _.cloneDeep(currentComponents);
+            let newComponentDefinition = JSON.parse(JSON.stringify(currentComponents));
             entityReferences.forEach((entity) => {
               const entityrefExists = manager.has(entity);
 
@@ -1186,8 +1185,7 @@ const EditorComponent = (props) => {
     }
 
     if (appDefinition?.pages[currentPageId]?.components[componentDefinition.id]) {
-      // Create a new copy of appDefinition with lodash's cloneDeep
-      const updatedAppDefinition = _.cloneDeep(appDefinition);
+      const updatedAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
       // Update the component definition in the copy
       updatedAppDefinition.pages[currentPageId].components[componentDefinition.id].component =
@@ -1205,7 +1203,7 @@ const EditorComponent = (props) => {
   };
   const removeComponent = (componentId) => {
     if (!isVersionReleased) {
-      let newDefinition = cloneDeep(appDefinition);
+      let newDefinition = JSON.parse(JSON.stringify(appDefinition));
 
       let childComponents = [];
 
@@ -1249,7 +1247,7 @@ const EditorComponent = (props) => {
 
   const moveComponents = (direction) => {
     const gridWidth = (1 * 100) / 43; // width of the canvas grid in percentage
-    const _appDefinition = _.cloneDeep(appDefinition);
+    const _appDefinition = JSON.parse(JSON.stringify(appDefinition));
     let newComponents = _appDefinition?.pages[currentPageId].components;
     const selectedComponents = useEditorStore.getState()?.selectedComponents;
 
@@ -1333,7 +1331,7 @@ const EditorComponent = (props) => {
   const removeComponents = () => {
     const selectedComponents = useEditorStore.getState()?.selectedComponents;
     if (!isVersionReleased && selectedComponents?.length > 1) {
-      let newDefinition = cloneDeep(appDefinition);
+      let newDefinition = JSON.parse(JSON.stringify(appDefinition));
 
       removeSelectedComponent(currentPageId, newDefinition, selectedComponents, appDefinitionChanged);
       const platform = navigator?.userAgentData?.platform || navigator?.platform || 'unknown';
@@ -1542,9 +1540,7 @@ const EditorComponent = (props) => {
       isUpdatingEditorStateInProcess: true,
     });
 
-    const copyOfAppDefinition = JSON.parse(JSON.stringify(appDefinition));
-
-    const newAppDefinition = _.cloneDeep(copyOfAppDefinition);
+    const newAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
     newAppDefinition.pages[pageId].disabled = isDisabled ?? false;
 
@@ -1559,9 +1555,7 @@ const EditorComponent = (props) => {
       isUpdatingEditorStateInProcess: true,
     });
 
-    const copyOfAppDefinition = JSON.parse(JSON.stringify(appDefinition));
-
-    const newAppDefinition = _.cloneDeep(copyOfAppDefinition);
+    const newAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
     newAppDefinition.pages[pageId].hidden = true;
 
@@ -1576,9 +1570,7 @@ const EditorComponent = (props) => {
       isUpdatingEditorStateInProcess: true,
     });
 
-    const copyOfAppDefinition = JSON.parse(JSON.stringify(appDefinition));
-
-    const newAppDefinition = _.cloneDeep(copyOfAppDefinition);
+    const newAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
     newAppDefinition.pages[pageId].hidden = false;
     switchPage(pageId);
@@ -1595,7 +1587,7 @@ const EditorComponent = (props) => {
         const copyOfAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
         const pages = data.pages.reduce((acc, page) => {
-          const currentComponents = buildComponentMetaDefinition(_.cloneDeep(page?.components));
+          const currentComponents = buildComponentMetaDefinition(JSON.parse(JSON.stringify(page?.components)));
 
           page.components = currentComponents;
 
@@ -1624,9 +1616,7 @@ const EditorComponent = (props) => {
       isUpdatingEditorStateInProcess: true,
     });
 
-    const copyOfAppDefinition = JSON.parse(JSON.stringify(appDefinition));
-
-    const newAppDefinition = _.cloneDeep(copyOfAppDefinition);
+    const newAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
     newAppDefinition.homePageId = pageId;
 
@@ -1654,7 +1644,7 @@ const EditorComponent = (props) => {
       return;
     }
 
-    const newDefinition = _.cloneDeep(copyOfAppDefinition);
+    const newDefinition = JSON.parse(JSON.stringify(appDefinition));
 
     newDefinition.pages[pageId].handle = newHandle;
 
@@ -1667,7 +1657,6 @@ const EditorComponent = (props) => {
   };
 
   const updateOnSortingPages = (newSortedPages) => {
-    const copyOfAppDefinition = JSON.parse(JSON.stringify(appDefinition));
     const pagesObj = newSortedPages.reduce((acc, page, index) => {
       acc[page.id] = {
         ...page,
@@ -1676,7 +1665,7 @@ const EditorComponent = (props) => {
       return acc;
     }, {});
 
-    const newAppDefinition = _.cloneDeep(copyOfAppDefinition);
+    const newAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
     newAppDefinition.pages = pagesObj;
 
@@ -1687,8 +1676,7 @@ const EditorComponent = (props) => {
   };
 
   const showHideViewerNavigation = () => {
-    const copyOfAppDefinition = JSON.parse(JSON.stringify(appDefinition));
-    const newAppDefinition = _.cloneDeep(copyOfAppDefinition);
+    const newAppDefinition = JSON.parse(JSON.stringify(appDefinition));
 
     newAppDefinition.showViewerNavigation = !newAppDefinition.showViewerNavigation;
 
@@ -1758,7 +1746,7 @@ const EditorComponent = (props) => {
         <EditorContextWrapper>
           <EditorHeader
             darkMode={props.darkMode}
-            appDefinition={_.cloneDeep(appDefinition)}
+            appDefinition={JSON.parse(JSON.stringify(appDefinition))}
             canUndo={canUndo}
             canRedo={canRedo}
             handleUndo={handleUndo}

--- a/frontend/src/Editor/Header/GlobalSettings.jsx
+++ b/frontend/src/Editor/Header/GlobalSettings.jsx
@@ -352,7 +352,6 @@ export const GlobalSettings = ({
                     {!forceCodeBox && (
                       <CodeHinter
                         cyLabel={`canvas-bg-colour`}
-                        currentState={realState}
                         initialValue={backgroundFxQuery ? backgroundFxQuery : canvasBackgroundColor}
                         lang="javascript"
                         className="canvas-hinter-wrap"

--- a/frontend/src/Editor/Inspector/Components/Chart.jsx
+++ b/frontend/src/Editor/Inspector/Components/Chart.jsx
@@ -131,7 +131,6 @@ class Chart extends React.Component {
         children: (
           <CodeHinter
             type="basic"
-            currentState={this.props.currentState}
             initialValue={jsonDescription?.value ?? {}}
             className="chart-input pr-2"
             onChange={(value) => this.props.paramUpdated({ name: 'jsonDescription' }, 'value', value, 'properties')}
@@ -159,7 +158,6 @@ class Chart extends React.Component {
         children: (
           <CodeHinter
             type="basic"
-            currentState={this.props.currentState}
             initialValue={data.value}
             className="chart-input pr-2"
             onChange={(value) => this.props.paramUpdated({ name: 'data' }, 'value', value, 'properties')}

--- a/frontend/src/Editor/Inspector/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table/Table.jsx
@@ -218,7 +218,6 @@ class TableComponent extends React.Component {
             </label>
             <CodeHinter
               type="basic"
-              currentState={this.props.currentState}
               initialValue={column.name}
               placeholder={column.name}
               onChange={(value) => this.onColumnItemChange(index, 'name', value)}
@@ -257,7 +256,6 @@ class TableComponent extends React.Component {
             <label className="form-label">{this.props.t('widget.Table.key', 'key')}</label>
             <CodeHinter
               type="basic"
-              currentState={this.props.currentState}
               initialValue={column.key}
               placeholder={column.name}
               onChange={(value) => this.onColumnItemChange(index, 'key', value)}
@@ -273,7 +271,6 @@ class TableComponent extends React.Component {
           <div data-cy={`transformation-field`} className="field mb-2 mt-1">
             <label className="form-label">{this.props.t('widget.Table.transformationField', 'Transformation')}</label>
             <CodeHinter
-              currentState={this.props.currentState}
               initialValue={column?.transformation ?? '{{cellValue}}'}
               theme={this.props.darkMode ? 'monokai' : 'default'}
               mode="javascript"
@@ -316,7 +313,6 @@ class TableComponent extends React.Component {
                 <label className="form-label">{this.props.t('widget.Table.textColor', 'Text color')}</label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.textColor}
                   placeholder={'Text color of the cell'}
                   onChange={(value) => this.onColumnItemChange(index, 'textColor', value)}
@@ -335,7 +331,6 @@ class TableComponent extends React.Component {
                 </label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.cellBackgroundColor ?? 'inherit'}
                   placeholder={''}
                   onChange={(value) => this.onColumnItemChange(index, 'cellBackgroundColor', value)}
@@ -357,7 +352,6 @@ class TableComponent extends React.Component {
                     <label className="form-label">{this.props.t('widget.Table.regex', 'Regex')}</label>
                     <CodeHinter
                       type="basic"
-                      currentState={this.props.currentState}
                       initialValue={column.regex}
                       placeholder={''}
                       onChange={(value) => this.onColumnItemChange(index, 'regex', value)}
@@ -373,7 +367,6 @@ class TableComponent extends React.Component {
                     <label className="form-label">{this.props.t('widget.Table.minLength', 'Min length')}</label>
                     <CodeHinter
                       type="basic"
-                      currentState={this.props.currentState}
                       initialValue={column.minLength}
                       placeholder={''}
                       onChange={(value) => this.onColumnItemChange(index, 'minLength', value)}
@@ -389,7 +382,6 @@ class TableComponent extends React.Component {
                     <label className="form-label">{this.props.t('widget.Table.maxLength', 'Max length')}</label>
                     <CodeHinter
                       type="basic"
-                      currentState={this.props.currentState}
                       initialValue={column.maxLength}
                       placeholder={''}
                       onChange={(value) => this.onColumnItemChange(index, 'maxLength', value)}
@@ -405,7 +397,6 @@ class TableComponent extends React.Component {
                     <label className="form-label">{this.props.t('widget.Table.customRule', 'Custom rule')}</label>
                     <CodeHinter
                       type="basic"
-                      currentState={this.props.currentState}
                       initialValue={column.customRule}
                       placeholder={''}
                       onChange={(value) => this.onColumnItemChange(index, 'customRule', value)}
@@ -431,7 +422,6 @@ class TableComponent extends React.Component {
                 <label className="form-label">{this.props.t('widget.Table.minValue', 'Min value')}</label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.minLength}
                   placeholder={''}
                   onChange={(value) => this.onColumnItemChange(index, 'minValue', value)}
@@ -447,7 +437,6 @@ class TableComponent extends React.Component {
                 <label className="form-label">{this.props.t('widget.Table.maxValue', 'Max value')}</label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.maxLength}
                   placeholder={''}
                   onChange={(value) => this.onColumnItemChange(index, 'maxValue', value)}
@@ -502,7 +491,6 @@ class TableComponent extends React.Component {
                 <label className="form-label">{this.props.t('widget.Table.values', 'Values')}</label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.values}
                   placeholder={'{{[1, 2, 3]}}'}
                   onChange={(value) => this.onColumnItemChange(index, 'values', value)}
@@ -518,7 +506,6 @@ class TableComponent extends React.Component {
                 <label className="form-label">{this.props.t('widget.Table.labels', 'Labels')}</label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.labels}
                   placeholder={'{{["one", "two", "three"]}}'}
                   onChange={(value) => this.onColumnItemChange(index, 'labels', value)}
@@ -544,7 +531,6 @@ class TableComponent extends React.Component {
                     <label className="form-label">{this.props.t('widget.Table.customRule', 'Custom Rule')}</label>
                     <CodeHinter
                       type="basic"
-                      currentState={this.props.currentState}
                       initialValue={column.customRule}
                       placeholder={''}
                       onChange={(value) => this.onColumnItemChange(index, 'customRule', value)}
@@ -569,7 +555,6 @@ class TableComponent extends React.Component {
               <div data-cy={`input-date-display-format`} className="field mb-2">
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.dateFormat}
                   placeholder={'DD-MM-YYYY'}
                   onChange={(value) => this.onColumnItemChange(index, 'dateFormat', value)}
@@ -655,7 +640,6 @@ class TableComponent extends React.Component {
                 <label className="form-label">{this.props.t('widget.Table.borderRadius', 'Border radius')}</label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.borderRadius}
                   placeholder={''}
                   onChange={(value) => this.onColumnItemChange(index, 'borderRadius', value)}
@@ -667,7 +651,6 @@ class TableComponent extends React.Component {
                 <label className="form-label">{this.props.t('widget.Table.width', 'Width')}</label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.width}
                   placeholder={''}
                   onChange={(value) => this.onColumnItemChange(index, 'width', value)}
@@ -679,7 +662,6 @@ class TableComponent extends React.Component {
                 <label className="form-label">{this.props.t('widget.Table.height', 'Height')}</label>
                 <CodeHinter
                   type="basic"
-                  currentState={this.props.currentState}
                   initialValue={column.height}
                   placeholder={''}
                   onChange={(value) => this.onColumnItemChange(index, 'height', value)}

--- a/frontend/src/Editor/QueryManager/Components/ParameterForm.jsx
+++ b/frontend/src/Editor/QueryManager/Components/ParameterForm.jsx
@@ -18,12 +18,6 @@ const ParameterForm = ({
   const [defaultValue, setDefaultValue] = useState();
   const [error, setError] = useState();
 
-  /**
-   * Storing {} in a ref to make sure its not a object instance whenever component reload.
-   * passing currentState={{}} to CodeHinter will consider it as a new value whenver this component rerenders
-   */
-  const emptyObj = useRef({});
-
   useEffect(() => {
     setName(_name);
     setDefaultValue(_defaultValue);
@@ -112,7 +106,6 @@ const ParameterForm = ({
                   <CodeHinter
                     onChange={(value) => setDefaultValue(value)}
                     theme={darkMode ? 'monokai' : 'default'}
-                    currentState={emptyObj.current}
                     usePortalEditor={false}
                     style={{ height: '32px', width: '177px', marginBotto: '16px' }}
                     initialValue={defaultValue}

--- a/frontend/src/Editor/QueryManager/Components/SuccessNotificationInputs.jsx
+++ b/frontend/src/Editor/QueryManager/Components/SuccessNotificationInputs.jsx
@@ -16,7 +16,6 @@ export default function SuccessNotificationInputs({ currentState, options, darkM
         <div className="flex-grow-1">
           <CodeHinter
             type="basic"
-            currentState={currentState}
             initialValue={options.successMessage}
             onChange={(value) => optionchanged('successMessage', value)}
             placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}

--- a/frontend/src/Editor/QueryManager/QueryEditors/Runjs/Runjs.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/Runjs/Runjs.jsx
@@ -36,7 +36,6 @@ const Runjs = (props) => {
         }}
         componentName="Runjs"
         cyLabel={`runjs`}
-        currentState={currStateForCodeHinter}
       />
     </Card>
   );

--- a/frontend/src/_stores/currentStateStore.js
+++ b/frontend/src/_stores/currentStateStore.js
@@ -1,7 +1,9 @@
 import { shallow } from 'zustand/shallow';
 import { create, zustandDevTools } from './utils';
-import { omit } from 'lodash';
+import _, { omit } from 'lodash';
 import { useResolveStore } from './resolverStore';
+// eslint-disable-next-line import/no-unresolved
+import { diff } from 'deep-object-diff';
 
 const initialState = {
   queries: {},
@@ -19,6 +21,7 @@ const initialState = {
     variables: {},
   },
   succededQuery: {},
+  isEditorReady: false,
 };
 
 export const useCurrentStateStore = create(
@@ -32,6 +35,7 @@ export const useCurrentStateStore = create(
         setErrors: (error) => {
           set({ errors: { ...get().errors, ...error } }, false, { type: 'SET_ERRORS', error });
         },
+        setEditorReady: (isEditorReady) => set({ isEditorReady }),
       },
     }),
     { name: 'Current State' }
@@ -56,13 +60,95 @@ export const useCurrentState = () =>
     };
   }, shallow);
 
-useCurrentStateStore.subscribe(
-  (state) => {
-    useResolveStore.getState().actions.updateAppSuggestions(state);
-  },
-  (state) => [state]
-);
+useCurrentStateStore.subscribe((state, prevState) => {
+  const isEditorReady = state.isEditorReady;
+
+  if (!isEditorReady) return;
+
+  const stateRequiredForRefs = {
+    queries: state.queries,
+    components: state.components,
+    globals: state.globals,
+    variables: state.variables,
+    client: state.client,
+    server: state.server,
+    page: state.page,
+    constants: state.constants,
+  };
+
+  const previousState = {
+    globals: prevState.globals,
+    variables: prevState.variables,
+    page: prevState.page,
+  };
+
+  const isStoreIntialized = useResolveStore.getState().storeReady;
+
+  if (!isStoreIntialized) {
+    useResolveStore.getState().actions.updateAppSuggestions(stateRequiredForRefs);
+    useResolveStore.getState().actions.updateStoreState({ storeReady: true });
+    console.log('Resolver store initialized with current state.');
+    return;
+  }
+
+  const latestCurrentState = _.omit(stateRequiredForRefs, 'components', 'queries', 'server', 'client', 'constants');
+
+  const didComponentsChange = JSON.stringify(latestCurrentState) !== JSON.stringify(previousState);
+  let diffInState = didComponentsChange ? diff(previousState, latestCurrentState) : {};
+
+  if (!didComponentsChange || _.isEmpty(diffInState)) return;
+
+  const undefinedPaths = Object.keys(findPathForObjWithUndefined(diffInState));
+  diffInState = removeUndefined(diffInState);
+
+  useResolveStore
+    .getState()
+    .actions.removeAppSuggestions(undefinedPaths)
+    .then((resp) => {
+      const suggestionObj = removeChildNodesWithEmptyValues(diffInState);
+
+      if (resp?.status === 'ok' && !_.isEmpty(suggestionObj)) {
+        useResolveStore.getState().actions.addAppSuggestions(suggestionObj);
+      }
+    });
+}, shallow);
 
 export const getCurrentState = () => {
   return omit(useCurrentStateStore.getState(), 'actions');
 };
+
+function removeUndefined(obj) {
+  Object.keys(obj).forEach((key) => {
+    if (obj[key] && typeof obj[key] === 'object') removeUndefined(obj[key]);
+    else if (obj[key] === undefined || _.isEmpty(obj[key])) delete obj[key];
+  });
+
+  return obj;
+}
+
+function removeChildNodesWithEmptyValues(obj) {
+  Object.keys(obj).forEach((key) => {
+    if (obj[key] && typeof obj[key] === 'object') {
+      removeChildNodesWithEmptyValues(obj[key]);
+      if (_.isEmpty(obj[key])) {
+        delete obj[key];
+      }
+    }
+  });
+
+  return obj;
+}
+
+function findPathForObjWithUndefined(obj, path = undefined) {
+  let result = {};
+  Object.keys(obj).forEach((key) => {
+    if (obj[key] && typeof obj[key] === 'object') {
+      const objPath = path ? `${path}.${key}` : key;
+      result = { ...result, ...findPathForObjWithUndefined(obj[key], objPath) };
+    } else if (obj[key] === undefined || _.isEmpty(obj[key])) {
+      result = { ...result, [`${path}.${key}`]: obj[key] };
+    }
+  });
+
+  return result;
+}

--- a/frontend/src/_stores/handleReferenceTransactions.js
+++ b/frontend/src/_stores/handleReferenceTransactions.js
@@ -5,6 +5,37 @@ import { useDataQueriesStore } from './dataQueriesStore';
 // eslint-disable-next-line import/no-unresolved
 import { diff } from 'deep-object-diff';
 
+//*  using binary search to find and remove it from the currentSuggestions array
+
+function binarySearchDelete(array, key) {
+  let start = 0;
+  let end = array.length - 1;
+  while (start <= end) {
+    let middle = Math.floor((start + end) / 2);
+    if (array[middle].hint === key) {
+      // Delete the item at the found index
+      array.splice(middle, 1);
+      return; // Exit after deletion
+    } else if (array[middle].hint < key) {
+      start = middle + 1;
+    } else {
+      end = middle - 1;
+    }
+  }
+}
+
+export function removeAppSuggestions(suggestionsArray, deleteSuggestionsArray) {
+  const sortedSuggestionsArray = JSON.parse(
+    JSON.stringify(suggestionsArray.sort((a, b) => a.hint.localeCompare(b.hint)))
+  );
+
+  deleteSuggestionsArray.forEach((suggestion) => {
+    binarySearchDelete(sortedSuggestionsArray, suggestion);
+  });
+
+  return sortedSuggestionsArray;
+}
+
 //* finding references and update within deeply nested objects using Depth-First Search (DFS) traversal
 export function dfs(node, oldRef, newRef) {
   if (typeof node === 'object') {

--- a/frontend/src/_stores/handleReferenceTransactions.js
+++ b/frontend/src/_stores/handleReferenceTransactions.js
@@ -5,7 +5,7 @@ import { useDataQueriesStore } from './dataQueriesStore';
 // eslint-disable-next-line import/no-unresolved
 import { diff } from 'deep-object-diff';
 
-//* finding references within deeply nested objects using Depth-First Search (DFS) traversal
+//* finding references and update within deeply nested objects using Depth-First Search (DFS) traversal
 export function dfs(node, oldRef, newRef) {
   if (typeof node === 'object') {
     for (let key in node) {

--- a/frontend/src/_stores/resolverStore.js
+++ b/frontend/src/_stores/resolverStore.js
@@ -86,7 +86,17 @@ export const useResolveStore = create(
         const lookupResolvedRefs = new Map([...get().lookupTable.resolvedRefs]);
 
         hintsMap.forEach((value, key) => {
-          lookupHintsMap.set(key, value);
+          const alreadyExists = lookupHintsMap.has(key);
+
+          if (!alreadyExists) {
+            lookupHintsMap.set(key, value);
+          } else {
+            const existingLookupId = lookupHintsMap.get(key);
+            const newResolvedRef = resolvedRefs.get(value);
+
+            resolvedRefs.delete(value);
+            resolvedRefs.set(existingLookupId, newResolvedRef);
+          }
         });
 
         resolvedRefs.forEach((value, key) => {

--- a/frontend/src/_stores/resolverStore.js
+++ b/frontend/src/_stores/resolverStore.js
@@ -49,6 +49,7 @@ class ReferencesBiMap {
 }
 
 const initialState = {
+  storeReady: false,
   suggestions: {
     appHints: [],
     jsHints: [],
@@ -65,12 +66,86 @@ export const useResolveStore = create(
   (set, get) => ({
     ...initialState,
     actions: {
+      updateStoreState: (state) => {
+        set(() => ({ ...state, storeReady: true }));
+      },
       updateAppSuggestions: (refState) => {
-        const { suggestionList, hintsMap, resolvedRefs } = createReferencesLookup(refState);
+        const { suggestionList, hintsMap, resolvedRefs } = createReferencesLookup(refState, false, true);
 
         set(() => ({ suggestions: { ...get().suggestions, appHints: suggestionList } }));
 
         set(() => ({ lookupTable: { ...get().lookupTable, hints: hintsMap, resolvedRefs } }));
+      },
+
+      addAppSuggestions: (partialRefState) => {
+        if (Object.keys(partialRefState).length === 0) return;
+
+        const { suggestionList, hintsMap, resolvedRefs } = createReferencesLookup(partialRefState);
+
+        const lookupHintsMap = new Map([...get().lookupTable.hints]);
+        const lookupResolvedRefs = new Map([...get().lookupTable.resolvedRefs]);
+
+        hintsMap.forEach((value, key) => {
+          lookupHintsMap.set(key, value);
+        });
+
+        resolvedRefs.forEach((value, key) => {
+          lookupResolvedRefs.set(key, value);
+        });
+
+        set(() => ({
+          suggestions: {
+            ...get().suggestions,
+            appHints: [...get().suggestions.appHints, ...suggestionList],
+          },
+        }));
+
+        set(() => ({
+          lookupTable: {
+            ...get().lookupTable,
+            hints: lookupHintsMap,
+            resolvedRefs: lookupResolvedRefs,
+          },
+        }));
+      },
+
+      removeAppSuggestions: (suggestionsArray) => {
+        if (suggestionsArray.length === 0) return new Promise((resolve) => resolve({ status: 'ok' }));
+
+        const lookupHintsMap = new Map([...get().lookupTable.hints]);
+        const lookupResolvedRefs = new Map([...get().lookupTable.resolvedRefs]);
+        const currentSuggestions = get().suggestions.appHints;
+
+        suggestionsArray.forEach((suggestion) => {
+          const index = currentSuggestions.findIndex((s) => s.hint === suggestion);
+
+          if (index === -1) return;
+
+          currentSuggestions.splice(index, 1);
+          const lookUpId = lookupHintsMap.get(suggestion);
+
+          lookupHintsMap.delete(suggestion);
+          lookupResolvedRefs.delete(lookUpId);
+        });
+
+        return new Promise((resolve) => {
+          set(() => ({
+            suggestions: {
+              ...get().suggestions,
+              appHints: currentSuggestions,
+            },
+          }));
+
+          set(() => ({
+            lookupTable: {
+              ...get().lookupTable,
+              hints: lookupHintsMap,
+              resolvedRefs: lookupResolvedRefs,
+            },
+          }));
+
+          resolve({ status: 'ok' });
+        });
       },
 
       updateJSHints: () => {

--- a/frontend/src/_stores/resolverStore.js
+++ b/frontend/src/_stores/resolverStore.js
@@ -153,15 +153,6 @@ export const useResolveStore = create(
         set(() => ({ suggestions: { ...get().suggestions, jsHints: hints } }));
       },
 
-      updateComponentDefaultValues: (componentDefaultValues) => {
-        set(() => ({ componentDefaultValues }));
-      },
-
-      getDefaultComponentValue: (componentName) => {
-        const { componentDefaultValues } = get();
-        return componentDefaultValues[componentName];
-      },
-
       addEntitiesToMap: (entities) => {
         const { referenceMapper } = get();
         entities.forEach((entity) => {

--- a/frontend/src/_stores/utils.js
+++ b/frontend/src/_stores/utils.js
@@ -330,7 +330,7 @@ function toRemoveExposedvariablesFromComponentDiff(object) {
   return copy;
 }
 
-export function createReferencesLookup(refState, forQueryParams = false) {
+export function createReferencesLookup(refState, forQueryParams = false, initalLoad = false) {
   if (forQueryParams && _.isEmpty(refState['parameters'])) {
     return { suggestionList: [] };
   }
@@ -339,22 +339,24 @@ export function createReferencesLookup(refState, forQueryParams = false) {
 
   const state = _.cloneDeep(refState);
   const queries = forQueryParams ? {} : state['queries'];
-  const actions = [
-    'runQuery',
-    'setVariable',
-    'unSetVariable',
-    'showAlert',
-    'logout',
-    'showModal',
-    'closeModal',
-    'setLocalStorage',
-    'copyToClipboard',
-    'goToApp',
-    'generateFile',
-    'setPageVariable',
-    'unsetPageVariable',
-    'switchPage',
-  ];
+  const actions = initalLoad
+    ? [
+        'runQuery',
+        'setVariable',
+        'unSetVariable',
+        'showAlert',
+        'logout',
+        'showModal',
+        'closeModal',
+        'setLocalStorage',
+        'copyToClipboard',
+        'goToApp',
+        'generateFile',
+        'setPageVariable',
+        'unsetPageVariable',
+        'switchPage',
+      ]
+    : [];
 
   if (!forQueryParams) {
     // eslint-disable-next-line no-unused-vars
@@ -365,7 +367,7 @@ export function createReferencesLookup(refState, forQueryParams = false) {
     });
   }
 
-  const currentState = !forQueryParams ? _.merge(state, { queries }) : state;
+  const currentState = !forQueryParams && initalLoad ? _.merge(state, { queries }) : state;
   const suggestionList = [];
   const map = new Map();
 
@@ -418,7 +420,7 @@ export function createReferencesLookup(refState, forQueryParams = false) {
     }
     return suggestionList.push({ hint: key, type: resolvedRefTypes.get(hintsMap.get(key)) });
   });
-  if (!forQueryParams) {
+  if (!forQueryParams && initalLoad) {
     actions.forEach((action) => {
       suggestionList.push({ hint: `actions.${action}()`, type: 'method' });
     });


### PR DESCRIPTION
1. Create suggestions and resolving tables only on editor is ready, reducing the update to 1
2. Avoids redundant updates to resolver store on current state updates
3. Only on new entries of hints, create and update the mapper hash table
4. Handles deleting of an hint from the suggestions list, and resolver hash table