### PR TITLE
Fix : allowed removal of default value after column creation with not null constraint in ToolJet database

### DIFF
--- a/frontend/src/TooljetDatabase/Drawers/CreateColumnDrawer/index.jsx
+++ b/frontend/src/TooljetDatabase/Drawers/CreateColumnDrawer/index.jsx
@@ -5,7 +5,7 @@ import CreateColumnForm from '../../Forms/ColumnForm';
 import { TooljetDatabaseContext } from '../../index';
 import { tooljetDatabaseService } from '@/_services';
 
-const CreateColumnDrawer = ({ setIsCreateColumnDrawerOpen, isCreateColumnDrawerOpen }) => {
+const CreateColumnDrawer = ({ setIsCreateColumnDrawerOpen, isCreateColumnDrawerOpen, rows }) => {
   const { organizationId, selectedTable, setColumns, setPageCount, handleRefetchQuery, pageSize } =
     useContext(TooljetDatabaseContext);
 
@@ -36,6 +36,7 @@ const CreateColumnDrawer = ({ setIsCreateColumnDrawerOpen, isCreateColumnDrawerO
             setIsCreateColumnDrawerOpen(false);
           }}
           onClose={() => setIsCreateColumnDrawerOpen(false)}
+          rows={rows}
         />
       </Drawer>
     </>

--- a/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
@@ -166,7 +166,9 @@ const ColumnForm = ({ onCreate, onClose, rows }) => {
             disabled={dataType === 'serial'}
           />
           {isNotNull === true && rows.length > 0 && defaultValue.length <= 0 ? (
-            <span className="form-error-message">Default value cannot be empty when NOT NULL constraint is added</span>
+            <span className="form-error-message">
+              Default value is required to populate this field in existing rows as NOT NULL constraint is added
+            </span>
           ) : null}
         </div>
 

--- a/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
@@ -10,7 +10,7 @@ import tjdbDropdownStyles, { dataTypes, formatOptionLabel } from '../constants';
 import Tick from '../Icons/Tick.svg';
 import './styles.scss';
 
-const ColumnForm = ({ onCreate, onClose }) => {
+const ColumnForm = ({ onCreate, onClose, rows }) => {
   const [columnName, setColumnName] = useState('');
   const [defaultValue, setDefaultValue] = useState('');
   const [dataType, setDataType] = useState();
@@ -157,13 +157,15 @@ const ColumnForm = ({ onCreate, onClose }) => {
             value={defaultValue}
             type="text"
             placeholder="Enter default value"
-            className={isNotNull === true && defaultValue.length <= 0 ? 'form-error' : 'form-control'}
+            className={
+              isNotNull === true && defaultValue.length <= 0 && rows.length > 0 ? 'form-error' : 'form-control'
+            }
             data-cy="default-value-input-field"
             autoComplete="off"
             onChange={(e) => setDefaultValue(e.target.value)}
             disabled={dataType === 'serial'}
           />
-          {isNotNull === true && defaultValue.length <= 0 ? (
+          {isNotNull === true && rows.length > 0 && defaultValue.length <= 0 ? (
             <span className="form-error-message">Default value cannot be empty when NOT NULL constraint is added</span>
           ) : null}
         </div>
@@ -194,7 +196,7 @@ const ColumnForm = ({ onCreate, onClose }) => {
         onClose={onClose}
         onCreate={handleCreate}
         shouldDisableCreateBtn={
-          isEmpty(columnName) || isEmpty(dataType) || (isNotNull === true && isEmpty(defaultValue))
+          isEmpty(columnName) || isEmpty(dataType) || (isNotNull === true && rows.length > 0 && isEmpty(defaultValue))
         }
       />
     </div>

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -207,7 +207,13 @@ const ColumnForm = ({ onClose, selectedColumn, setColumns, rows }) => {
             disabled={dataType === 'serial'}
           />
           {isNotNull === true && rows.length > 0 && (defaultValue?.length <= 0 || defaultValue === null) ? (
-            <span className="form-error-message">Default value cannot be empty when NOT NULL constraint is added</span>
+            <span className="form-error-message">
+              Default value is required to populate this field in existing rows as NOT NULL constraint is added
+            </span>
+          ) : isNotNull === true && rows.length > 0 && !isEmpty(defaultValue) ? (
+            <span className="form-warning-message">
+              Changing the default value will NOT update the fields having existing default value
+            </span>
           ) : null}
         </div>
         <div className="row mb-3">

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -6,8 +6,9 @@ import { tooljetDatabaseService } from '@/_services';
 import { TooljetDatabaseContext } from '../index';
 import tjdbDropdownStyles, { dataTypes, formatOptionLabel } from '../constants';
 import WarningInfo from '../Icons/Edit-information.svg';
+import { isEmpty } from 'lodash';
 
-const ColumnForm = ({ onClose, selectedColumn, setColumns }) => {
+const ColumnForm = ({ onClose, selectedColumn, setColumns, rows }) => {
   const nullValue = selectedColumn.constraints_type.is_not_null;
 
   const [columnName, setColumnName] = useState(selectedColumn?.Header);
@@ -195,12 +196,19 @@ const ColumnForm = ({ onClose, selectedColumn, setColumns }) => {
             value={defaultValue}
             type="text"
             placeholder="Enter default value"
-            className={'form-control'}
+            className={
+              isNotNull === true && rows.length > 0 && (defaultValue?.length <= 0 || defaultValue === null)
+                ? 'form-control form-error'
+                : 'form-control'
+            }
             data-cy="default-value-input-field"
             autoComplete="off"
             onChange={(e) => setDefaultValue(e.target.value)}
             disabled={dataType === 'serial'}
           />
+          {isNotNull === true && rows.length > 0 && (defaultValue?.length <= 0 || defaultValue === null) ? (
+            <span className="form-error-message">Default value cannot be empty when NOT NULL constraint is added</span>
+          ) : null}
         </div>
         <div className="row mb-3">
           <div className="col-1">
@@ -228,7 +236,7 @@ const ColumnForm = ({ onClose, selectedColumn, setColumns }) => {
         fetching={fetching}
         onClose={onClose}
         onEdit={handleEdit}
-        shouldDisableCreateBtn={columnName === ''}
+        shouldDisableCreateBtn={columnName === '' || (isNotNull === true && isEmpty(defaultValue) && rows.length > 0)}
       />
     </div>
   );

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -8,7 +8,7 @@ import tjdbDropdownStyles, { dataTypes, formatOptionLabel } from '../constants';
 import WarningInfo from '../Icons/Edit-information.svg';
 import { isEmpty } from 'lodash';
 
-const ColumnForm = ({ onClose, selectedColumn, setColumns }) => {
+const ColumnForm = ({ onClose, selectedColumn, setColumns, rows }) => {
   const nullValue = selectedColumn.constraints_type.is_not_null;
 
   const [columnName, setColumnName] = useState(selectedColumn?.Header);
@@ -18,6 +18,7 @@ const ColumnForm = ({ onClose, selectedColumn, setColumns }) => {
   const [isNotNull, setIsNotNull] = useState(nullValue);
   const { organizationId, selectedTable } = useContext(TooljetDatabaseContext);
   const disabledDataType = dataTypes.find((e) => e.value === dataType);
+  const [defaultValueLength, setDefaultValueLength] = useState(defaultValue?.length);
 
   const darkDisabledBackground = '#1f2936';
   const lightDisabledBackground = '#f4f6fa';
@@ -202,6 +203,11 @@ const ColumnForm = ({ onClose, selectedColumn, setColumns }) => {
             onChange={(e) => setDefaultValue(e.target.value)}
             disabled={dataType === 'serial'}
           />
+          {isNotNull === true && rows.length > 0 && !isEmpty(defaultValue) && defaultValueLength > 0 ? (
+            <span className="form-warning-message">
+              Changing the default value will NOT update the fields having existing default value
+            </span>
+          ) : null}
         </div>
         <div className="row mb-3">
           <div className="col-1">

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -8,7 +8,7 @@ import tjdbDropdownStyles, { dataTypes, formatOptionLabel } from '../constants';
 import WarningInfo from '../Icons/Edit-information.svg';
 import { isEmpty } from 'lodash';
 
-const ColumnForm = ({ onClose, selectedColumn, setColumns, rows }) => {
+const ColumnForm = ({ onClose, selectedColumn, setColumns }) => {
   const nullValue = selectedColumn.constraints_type.is_not_null;
 
   const [columnName, setColumnName] = useState(selectedColumn?.Header);
@@ -196,25 +196,12 @@ const ColumnForm = ({ onClose, selectedColumn, setColumns, rows }) => {
             value={defaultValue}
             type="text"
             placeholder="Enter default value"
-            className={
-              isNotNull === true && rows.length > 0 && (defaultValue?.length <= 0 || defaultValue === null)
-                ? 'form-control form-error'
-                : 'form-control'
-            }
+            className={'form-control'}
             data-cy="default-value-input-field"
             autoComplete="off"
             onChange={(e) => setDefaultValue(e.target.value)}
             disabled={dataType === 'serial'}
           />
-          {isNotNull === true && rows.length > 0 && (defaultValue?.length <= 0 || defaultValue === null) ? (
-            <span className="form-error-message">
-              Default value is required to populate this field in existing rows as NOT NULL constraint is added
-            </span>
-          ) : isNotNull === true && rows.length > 0 && !isEmpty(defaultValue) ? (
-            <span className="form-warning-message">
-              Changing the default value will NOT update the fields having existing default value
-            </span>
-          ) : null}
         </div>
         <div className="row mb-3">
           <div className="col-1">
@@ -242,7 +229,7 @@ const ColumnForm = ({ onClose, selectedColumn, setColumns, rows }) => {
         fetching={fetching}
         onClose={onClose}
         onEdit={handleEdit}
-        shouldDisableCreateBtn={columnName === '' || (isNotNull === true && isEmpty(defaultValue) && rows.length > 0)}
+        shouldDisableCreateBtn={columnName === ''}
       />
     </div>
   );

--- a/frontend/src/TooljetDatabase/Forms/styles.scss
+++ b/frontend/src/TooljetDatabase/Forms/styles.scss
@@ -243,3 +243,8 @@
   color: var(--tomato9);
   font-size: 12px;
 }
+
+.form-warning-message {
+  color: var(--slate10);
+  font-size: 12px;
+}

--- a/frontend/src/TooljetDatabase/Table/Header.jsx
+++ b/frontend/src/TooljetDatabase/Table/Header.jsx
@@ -257,6 +257,7 @@ const Header = ({
       <CreateColumnDrawer
         isCreateColumnDrawerOpen={isCreateColumnDrawerOpen}
         setIsCreateColumnDrawerOpen={setIsCreateColumnDrawerOpen}
+        rows={rows}
       />
       <CreateRowDrawer
         isCreateRowDrawerOpen={isCreateRowDrawerOpen}

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -1222,6 +1222,7 @@ const Table = ({ collapseSidebar }) => {
           selectedColumn={selectedColumn}
           setColumns={setColumns}
           onClose={() => setIsEditColumnDrawerOpen(false)}
+          rows={rows}
         />
       </Drawer>
       <ConfirmDialog

--- a/frontend/src/TooljetDatabase/TableListItem/index.jsx
+++ b/frontend/src/TooljetDatabase/TableListItem/index.jsx
@@ -11,7 +11,8 @@ import CreateColumnDrawer from '../Drawers/CreateColumnDrawer';
 
 export const ListItem = ({ active, onClick, text = '', onDeleteCallback }) => {
   const darkMode = localStorage.getItem('darkMode') === 'true';
-  const { organizationId, columns, selectedTable, setSelectedTable } = useContext(TooljetDatabaseContext);
+  const { organizationId, columns, selectedTable, setSelectedTable, selectedTableData } =
+    useContext(TooljetDatabaseContext);
   const [isEditTableDrawerOpen, setIsEditTableDrawerOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [showDropDownMenu, setShowDropDownMenu] = useState(false);
@@ -140,6 +141,7 @@ export const ListItem = ({ active, onClick, text = '', onDeleteCallback }) => {
       <CreateColumnDrawer
         isCreateColumnDrawerOpen={isAddNewColumnDrawerOpen}
         setIsCreateColumnDrawerOpen={setIsAddNewColumnDrawerOpen}
+        rows={selectedTableData}
       />
     </div>
   );


### PR DESCRIPTION
Fix : user should be able to remove the default value after column creation when NOT NULL constraint is present #9015