### PR TITLE
[improvement] Component layout table : Add updatedAt column

### DIFF
--- a/server/migrations/1709794417386-AddUpdatedAtColumnToLayouts.ts
+++ b/server/migrations/1709794417386-AddUpdatedAtColumnToLayouts.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUpdatedAtColumnToLayouts1709794417386 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE layouts ADD COLUMN "updated_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE layouts DROP COLUMN "updated_at"');
+  }
+}

--- a/server/src/entities/layout.entity.ts
+++ b/server/src/entities/layout.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, UpdateDateColumn } from 'typeorm';
 import { Component } from './component.entity';
 
 @Entity({ name: 'layouts' })
@@ -23,6 +23,9 @@ export class Layout {
 
   @Column({ name: 'component_id' })
   componentId: string;
+
+  @UpdateDateColumn({ default: () => 'now()', name: 'updated_at' })
+  updatedAt: Date;
 
   @ManyToOne(() => Component, (component) => component.layouts)
   @JoinColumn({ name: 'component_id' })

--- a/server/src/services/components.service.ts
+++ b/server/src/services/components.service.ts
@@ -177,6 +177,18 @@ export class ComponentsService {
         .createQueryBuilder(Component, 'component')
         .leftJoinAndSelect('component.layouts', 'layout')
         .where('component.pageId = :pageId', { pageId })
+        .andWhere((qb) => {
+          const subQuery = qb
+            .subQuery()
+            .select('layout.id')
+            .from('layouts', 'layout')
+            .where('layout.componentId = component.id')
+            .andWhere('layout.type IN (:...types)', { types: ['desktop', 'mobile'] })
+            .orderBy('layout.updatedAt', 'DESC')
+            .limit(2)
+            .getQuery();
+          return `layout.id IN ${subQuery}`;
+        })
         .getMany()
         .then((components) => {
           return components.reduce((acc, component) => {


### PR DESCRIPTION
adds a new column named updatedAt to the layouts table in the database. The column has a default value of CURRENT_TIMESTAMP, which automatically sets the timestamp to the current date and time when a new row is inserted.

This change enables us to track the last update time of each layout entry, which is essential for various functionalities such as querying the latest versions of layouts and implementing dynamic component rendering based on the most recent updates.

The migration script responsible for adding the updatedAt column has been executed successfully, and the column has been verified to exist in the layouts table.