### PR TITLE
Fix input losses focus after changes update

### DIFF
--- a/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeBuilder/CodeHinter.jsx
@@ -126,7 +126,7 @@ export function CodeHinter({
   const isPreviewFocused = useRef(false);
   const [isPropertyHovered, setPropertyHovered] = useState(false);
   const wrapperRef = useRef(null);
-
+  const codeMirrorRef = useRef();
   // Todo: Remove this when workspace variables are deprecated
   const isWorkspaceVariable =
     typeof currentValue === 'string' && (currentValue.includes('%%client') || currentValue.includes('%%server'));
@@ -193,6 +193,12 @@ export function CodeHinter({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (isFocused && codeMirrorRef.current?.editor) {
+      codeMirrorRef.current?.editor.focus();
+    }
+  }, [codeMirrorRef.current, isFocused]);
 
   useEffect(() => {
     const newState = { ...currentState, ..._currentState, ...context };
@@ -434,6 +440,7 @@ export function CodeHinter({
   };
 
   const onFocusHandler = () => {
+    focusPreview();
     setFocused(true);
     updatePreview();
   };
@@ -545,6 +552,7 @@ export function CodeHinter({
                   callgpt={callgpt}
                 >
                   <CodeMirror
+                    ref={codeMirrorRef}
                     value={typeof initialValue === 'string' ? initialValue : ''}
                     realState={realState}
                     scrollbarStyle={null}


### PR DESCRIPTION
Fix: #8584 
Fixed issue where input loses focus after change saved when clicked on it immediately before change updated.

Video of fix:

https://github.com/ToolJet/ToolJet/assets/111295371/966d812b-a97a-420e-9968-3830dce6c98b

