### PR TITLE
Fix of enabling export this app button after releasing app

### DIFF
--- a/frontend/src/Editor/Header/GlobalSettings.jsx
+++ b/frontend/src/Editor/Header/GlobalSettings.jsx
@@ -380,7 +380,10 @@ export const GlobalSettings = ({
                   </div>
                 </div>
               </div>
-
+            </div>
+          </div>
+          <div style={{ padding: '0px 16px' }}>
+            <div className="tj-text-xsm color-slate12 ">
               <div className="d-flex align-items-center  global-popover-div-wrap mb-3">
                 <p className="tj-text-xsm color-slate12 w-full m-auto">Export app</p>
                 <div>


### PR DESCRIPTION
Fix: #8403 
Fixed issue where **Export this app** button in global settings is disabled for released app versions. 

Screenshot of solution:
![Full Screen #1](https://github.com/ToolJet/ToolJet/assets/111295371/37775b24-90db-42f1-a24f-cfa6d4af01fe)
