### PR TITLE
fix TJDB not null value fail for is operation

### DIFF
--- a/frontend/src/_helpers/postgrestQueryBuilder.js
+++ b/frontend/src/_helpers/postgrestQueryBuilder.js
@@ -302,7 +302,11 @@ export default class PostgrestQueryBuilder {
    * @param value  The value to filter with.
    */
   filter(column, operator, value) {
-    this.url.append(`${column}`, `${operator}.${value}`);
+    if (operator === 'is' && value === 'not null') {
+      this.url.append(`${column}`, `not.is.null`);
+    } else {
+      this.url.append(`${column}`, `${operator}.${value}`);
+    }
     return this;
   }
   /**


### PR DESCRIPTION
### Fix: #8067 
PR contains solution for Issue of TJDB where "is" filter option not working when passing "not null" value in value input field.

Solution video:-

https://github.com/ToolJet/ToolJet/assets/111295371/407e320f-90f3-418a-8d04-a186cf42c7a2

