### PR TITLE
Fix child component delete issue for calendar component - #8692

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1159,8 +1159,11 @@ const EditorComponent = (props) => {
           newDefinition.pages[currentPageId].components[key].component.parent?.startsWith(componentId)
         );
       } else {
+        const isChildOfParent = (key, componentId) => {
+          return newDefinition.pages[currentPageId].components[key].component.parent === componentId;
+        };
         childComponents = Object.keys(newDefinition.pages[currentPageId].components).filter(
-          (key) => newDefinition.pages[currentPageId].components[key].component.parent === componentId
+          (key) => isChildOfParent(key, componentId) || isChildOfParent(key, `${componentId}-popover`)
         );
       }
 


### PR DESCRIPTION
### Fix #8692 
PR contains the solution to an issue where child components added in popover not getting deleted for calendar component.

### Solution video

https://github.com/ToolJet/ToolJet/assets/111295371/734309ce-3540-4629-903f-3b6d5ee0e684

