### PR TITLE
Fix textarea value blurr issue when inside container

### DIFF
--- a/frontend/src/Editor/Components/TextArea.jsx
+++ b/frontend/src/Editor/Components/TextArea.jsx
@@ -29,24 +29,30 @@ export const TextArea = function TextArea({
   }, [properties.value, setValue]);
 
   return (
-    <textarea
-      disabled={styles.disabledState}
-      onChange={(e) => {
-        setValue(e.target.value);
-        setExposedVariable('value', e.target.value);
-      }}
-      type="text"
-      className="form-control textarea"
-      placeholder={properties.placeholder}
+    <div
+      className="textarea-wrapper"
       style={{
-        height,
-        resize: 'none',
-        display: styles.visibility ? '' : 'none',
-        borderRadius: `${styles.borderRadius}px`,
-        boxShadow: styles.boxShadow,
+        borderRadius: `${styles?.borderRadius || 0}px`,
       }}
-      value={value}
-      data-cy={dataCy}
-    ></textarea>
+    >
+      <textarea
+        disabled={styles.disabledState}
+        onChange={(e) => {
+          setValue(e.target.value);
+          setExposedVariable('value', e.target.value);
+        }}
+        type="text"
+        className="form-control textarea"
+        placeholder={properties.placeholder}
+        style={{
+          height,
+          resize: 'none',
+          display: styles.visibility ? '' : 'none',
+          boxShadow: styles.boxShadow,
+        }}
+        value={value}
+        data-cy={dataCy}
+      ></textarea>
+    </div>
   );
 };

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -10756,6 +10756,14 @@ tbody {
 
 }
 
+.textarea-wrapper{
+  border: 1px solid #dadcde;
+  .form-control.textarea{
+    border: 0px;
+    border-radius: 0px;
+  }
+}
+
 .tj-app-input-wrapper {
   display: flex;
 


### PR DESCRIPTION
### FIX: #8483 
PR contains solution of textarea value getting blurred when placed inside container component.
It was happening because textarea had border-radius style. In some browsers or browser versions, this issue appears. A good approach is to wrap it with wrapper div and apply border related styles to it.

### Solution Screenshot
![8483-issue](https://github.com/ToolJet/ToolJet/assets/111295371/aa626fc3-0fa2-46d5-91b5-5bcfba1d4704)
