### PR TITLE
[chore] Updated frontend package.json (wepack-dev-server)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -157,7 +157,7 @@
     "terser-webpack-plugin": "^5.3.6",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
-    "webpack-dev-server": "^4.11.1"
+    "webpack-dev-server": "4.11.1"
   },
   "overrides": {
     "react-dates": {


### PR DESCRIPTION
**More info**
For some contributors, when adding new plugins to the frontend package.json, the webpack-dev-server plugin is automatically upgrading to a new version, which is causing webpack error overlays.