### PR TITLE
Fix query panel data persistency issue on version change

### DIFF
--- a/frontend/src/Editor/AppVersionsManager/AppVersionsManager.jsx
+++ b/frontend/src/Editor/AppVersionsManager/AppVersionsManager.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
 import { appVersionService } from '@/_services';
 import { CustomSelect } from './CustomSelect';
+import { useQueryPanelActions } from '@/_stores/queryPanelStore';
 import { toast } from 'react-hot-toast';
 import { shallow } from 'zustand/shallow';
 import { useAppVersionStore } from '@/_stores/appVersionStore';
@@ -26,6 +27,7 @@ export const AppVersionsManager = function ({
     versionName: '',
     showModal: false,
   });
+  const { setPreviewData } = useQueryPanelActions();
 
   const { releasedVersionId, editingVersion, appVersions, setAppVersions } = useAppVersionStore(
     (state) => ({
@@ -61,6 +63,7 @@ export const AppVersionsManager = function ({
       .then((data) => {
         const isCurrentVersionReleased = data.currentVersionId ? true : false;
         setAppDefinitionFromVersion(data, isCurrentVersionReleased);
+        setPreviewData('');
       })
       .catch((error) => {
         toast.error(error);

--- a/frontend/src/Editor/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/Editor/QueryManager/Components/QueryManagerBody.jsx
@@ -270,7 +270,7 @@ export const QueryManagerBody = ({
     >
       {selectedQuery?.data_source_id && selectedDataSource !== null ? renderChangeDataSource() : null}
       {selectedDataSource === null || !selectedQuery ? renderDataSourcesList() : renderQueryElement()}
-      {selectedDataSource !== null ? renderQueryOptions() : null}
+      {selectedDataSource !== null && selectedQueryId && selectedQuery ? renderQueryOptions() : null}
     </div>
   );
 };


### PR DESCRIPTION
### FIX: #8268 
Fix for unecessary data persistency in preview and showing settings/preview and other sections in the query panel when we change version as per described in issue.

### Solution Video

https://github.com/ToolJet/ToolJet/assets/111295371/af2163f6-8689-47dc-afe6-07aa20cdf16f

