### PR TITLE
Add RepoCloud deployment option to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ ToolJet is an **open-source low-code framework** to build and deploy internal to
 ## Quickstart
 The easiest way to get started with ToolJet is by creating a [ToolJet Cloud](https://tooljet.com) account. ToolJet Cloud offers a hosted solution of ToolJet. If you want to self-host ToolJet, kindly proceed to [deployment documentation](https://docs.tooljet.com/docs/setup/).
 
-You can deploy ToolJet on DigitalOcean using one-click-deployment.
+You can deploy ToolJet on DigitalOcean or RepoCloud using one-click-deployment.
 
 <p align="center">
   <a href="https://cloud.digitalocean.com/apps/new?repo=https://github.com/ToolJet/ToolJet/tree/main"><img src="https://www.deploytodo.com/do-btn-blue.svg" alt="Deploy to DigitalOcean" height=32></a>
+  <a href="https://repocloud.io/details/?app_id=192"><img src="https://d16t0pc4846x52.cloudfront.net/deploy-md.png" alt="Deploy to RepoCloud" height=32></a>
 </p>
+
 
 ### Try using Docker
 Want to give ToolJet a quick spin on your local machine? You can run the following command from your terminal to have ToolJet up and running right away.


### PR DESCRIPTION
This commit introduces an additional deployment option for users, allowing them to deploy ToolJet on RepoCloud with a single click. Alongside the existing DigitalOcean deployment button, a new RepoCloud deployment button is added, complete with a corresponding link and image. This update provides users with more flexibility in choosing their hosting service, catering to a wider audience who may prefer RepoCloud's features or pricing model.