### PR TITLE
Remove alternative styling for Workspace Constants header

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -7932,7 +7932,6 @@ tbody {
   padding-bottom: 24px;
   border-right: 1px solid var(--slate5);
 
-  &[data-name="Workspace constants"],
   &[data-name="Profile settings"] {
     border-right: none;
     border-bottom: 1px solid var(--slate5);


### PR DESCRIPTION
This is a fix to: 
**Header of the Workspace Constant page is not consistent with other pages #9089**

Somehow it got lumped into a the Profile Settings Header. Either way it is fixed and takes the default styling of the other dashboard headers