### PR TITLE
Add custom time input with dark themeing

### DIFF
--- a/frontend/src/Editor/Components/Datepicker.jsx
+++ b/frontend/src/Editor/Components/Datepicker.jsx
@@ -107,6 +107,7 @@ export const Datepicker = function Datepicker({
         excludeDates={excludedDates}
         customInput={<input style={{ borderRadius: `${borderRadius}px`, boxShadow, height }} />}
         timeInputLabel={<div className={`${darkMode && 'theme-dark'}`}>Time</div>}
+        customTimeInput={ <input type="time" className={`datepicker-widget ${darkMode && 'theme-dark'}`} value={value} onChange={(e) => onChange(e.target.value)} />}
       />
 
       <div data-cy="date-picker-invalid-feedback" className={`invalid-feedback ${isValid ? '' : 'd-flex'}`}>


### PR DESCRIPTION
Removes the dropdown because Chrome doesn't allow styling of the time selection. Adds the theme-dark using prop. Tested in DevTools.