### PR TITLE
[fix] Multiple `ws` binding issues & release button disabled if the proxy don't support `ws` connections

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -157,7 +157,7 @@
     "terser-webpack-plugin": "^5.3.6",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
-    "webpack-dev-server": "^4.11.1"
+    "webpack-dev-server": "4.11.1"
   },
   "overrides": {
     "react-dates": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -157,7 +157,7 @@
     "terser-webpack-plugin": "^5.3.6",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
-    "webpack-dev-server": "4.11.1"
+    "webpack-dev-server": "^4.11.1"
   },
   "overrides": {
     "react-dates": {

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -62,7 +62,6 @@ import { EMPTY_ARRAY, useEditorActions, useEditorStore } from '@/_stores/editorS
 import { useAppDataActions, useAppInfo, useAppDataStore } from '@/_stores/appDataStore';
 import { useMounted } from '@/_hooks/use-mount';
 import EditorSelecto from './EditorSelecto';
-import { useSocketOpen } from '@/_hooks/use-socket-open';
 // eslint-disable-next-line import/no-unresolved
 import { diff } from 'deep-object-diff';
 
@@ -78,7 +77,6 @@ const decimalToHex = (alpha) => (alpha === 0 ? '00' : Math.round(255 * alpha).to
 
 const EditorComponent = (props) => {
   const { socket } = createWebsocketConnection(props?.params?.id);
-  const isSocketOpen = useSocketOpen(socket);
   const mounted = useMounted();
 
   const {
@@ -1713,7 +1711,6 @@ const EditorComponent = (props) => {
           appName={appName}
           appId={appId}
           slug={slug}
-          isSocketOpen={isSocketOpen}
         />
         <DndProvider backend={HTML5Backend}>
           <div className="sub-section">

--- a/frontend/src/Editor/Header/index.js
+++ b/frontend/src/Editor/Header/index.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import AppLogo from '@/_components/AppLogo';
 import EditAppName from './EditAppName';
 import HeaderActions from './HeaderActions';
 import RealtimeAvatars from '../RealtimeAvatars';
@@ -16,7 +15,6 @@ import { useCurrentStateStore } from '@/_stores/currentStateStore';
 import { shallow } from 'zustand/shallow';
 import { useAppDataActions, useAppInfo, useCurrentUser } from '@/_stores/appDataStore';
 import SolidIcon from '@/_ui/Icon/SolidIcons';
-import { redirectToDashboard } from '@/_helpers/routes';
 import queryString from 'query-string';
 import { isEmpty } from 'lodash';
 import LogoNavDropdown from '@/_components/LogoNavDropdown';
@@ -35,7 +33,6 @@ export default function EditorHeader({
   onVersionDelete,
   slug,
   darkMode,
-  isSocketOpen,
 }) {
   const currentUser = useCurrentUser();
 
@@ -80,6 +77,8 @@ export default function EditorHeader({
     setAppPreviewLink(appVersionPreviewLink);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slug, currentVersionId, editingVersion]);
+
+  const shouldRenderReleaseButton = !!app?.id;
 
   return (
     <div className="header" style={{ width: '100%' }}>
@@ -191,7 +190,7 @@ export default function EditorHeader({
                   </div>
                 </div>
 
-                {isSocketOpen && (
+                {shouldRenderReleaseButton && (
                   <div className="nav-item dropdown promote-release-btn">
                     <ReleaseVersionButton
                       appId={appId}

--- a/frontend/src/_helpers/websocketConnection.js
+++ b/frontend/src/_helpers/websocketConnection.js
@@ -1,10 +1,17 @@
 import config from 'config';
 
 class WebSocketConnection {
-  constructor(appId) {
-    this.socket = new WebSocket(`${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${this.getWebsocketUrl()}`);
+  static instance;
 
+  constructor(appId) {
+    if (WebSocketConnection.instance) {
+      return WebSocketConnection.instance;
+    }
+
+    this.socket = new WebSocket(`${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${this.getWebsocketUrl()}`);
     this.addListeners(appId);
+
+    WebSocketConnection.instance = this;
   }
 
   getWebsocketUrl() {

--- a/frontend/src/_helpers/websocketConnection.js
+++ b/frontend/src/_helpers/websocketConnection.js
@@ -2,9 +2,10 @@ import config from 'config';
 
 class WebSocketConnection {
   static instance;
+  static appId;
 
   constructor(appId) {
-    if (WebSocketConnection.instance) {
+    if (WebSocketConnection.instance && WebSocketConnection.appId === appId) {
       return WebSocketConnection.instance;
     }
 
@@ -46,6 +47,8 @@ class WebSocketConnection {
           data: appId,
         })
       );
+
+      this.appId = appId;
     });
 
     // Connection closed


### PR DESCRIPTION
**More info about the problem**
1. `yjs` was making multiple `ws` binding connections for every render on `Editor` page.
2. For proxy deployments if the clients don't add the `upgrade` web-socket headers to the configurations list. then the app-builder won't show the release button due the socket enabled check 