### PR TITLE
Added try catch to all exception filter

### DIFF
--- a/server/src/filters/all-exceptions-filter.ts
+++ b/server/src/filters/all-exceptions-filter.ts
@@ -19,31 +19,32 @@ export class AllExceptionsFilter implements ExceptionFilter {
   constructor(private readonly logger: Logger) {}
 
   catch(exception: any, host: ArgumentsHost) {
-    const ctx = host.switchToHttp();
-    const response = ctx.getResponse();
-    const request = ctx.getRequest();
-
-    let errorResponse: ErrorResponse;
-    const message = exception?.response?.message || exception.message;
-
-    if (exception instanceof HttpException) {
-      errorResponse = { status: exception.getStatus(), message };
-    } else if (exception instanceof QueryFailedError) {
-      errorResponse = this.handleQueryExceptions(exception);
-    } else {
-      errorResponse = { message, status: HttpStatus.INTERNAL_SERVER_ERROR };
-    }
-
-    if (errorResponse.status === HttpStatus.INTERNAL_SERVER_ERROR) {
+    try {
       this.logger.error(exception);
-    }
+      const ctx = host.switchToHttp();
+      const response = ctx.getResponse();
+      const request = ctx.getRequest();
 
-    response.status(errorResponse.status).json({
-      statusCode: errorResponse.status,
-      timestamp: new Date().toISOString(),
-      path: request.url,
-      message: errorResponse.message,
-    });
+      let errorResponse: ErrorResponse;
+      const message = exception?.response?.message || exception.message;
+
+      if (exception instanceof HttpException) {
+        errorResponse = { status: exception.getStatus(), message };
+      } else if (exception instanceof QueryFailedError) {
+        errorResponse = this.handleQueryExceptions(exception);
+      } else {
+        errorResponse = { message, status: HttpStatus.INTERNAL_SERVER_ERROR };
+      }
+
+      response.status(errorResponse.status).json({
+        statusCode: errorResponse.status,
+        timestamp: new Date().toISOString(),
+        path: request.url,
+        message: errorResponse.message,
+      });
+    } catch (error) {
+      this.logger.error('Error while processing uncaught exception', error);
+    }
   }
 
   private handleQueryExceptions(exception: any): ErrorResponse {


### PR DESCRIPTION
Server gets killed if async operation throws error after sending response
```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the 
```
added a try catch to catch the error