### PR TITLE
Change message for when there are no action buttons

### DIFF
--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/tableRegression.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/tableRegression.cy.js
@@ -241,7 +241,7 @@ describe("Table", () => {
     openAccordion("Action buttons");
     cy.get('[data-cy="no-items-banner-action-button"]').should(
       "have.text",
-      "There are no action buttons"
+      "No action buttons"
     );
     cy.get('[data-cy="button-add-new-action-button"]')
       .should("have.text", "New action button")

--- a/frontend/src/Editor/Inspector/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table/Table.jsx
@@ -1140,7 +1140,7 @@ class TableComponent extends React.Component {
           <div className="row g-2">
             <div>{actions.value.map((action, index) => this.renderActionButton(action, index))}</div>
             {actions.value.length === 0 && (
-              <NoListItem text={'There are no action buttons'} dataCy={`-action-button`} />
+              <NoListItem text={'No action buttons'} dataCy={`-action-button`} />
             )}
             <AddNewButton dataCy="button-add-new-action-button" onClick={this.addNewAction} className="mt-0">
               New action button


### PR DESCRIPTION
Resolves: #9273 

This PR changes the message from "There are no actions buttons" to "No action buttons" to maintain consistency with other messages 