### PR TITLE
Setting "#3A4251" as the highlight color for loader animation in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -8393,6 +8393,9 @@ tbody {
     background-color: #2F3C4C !important;
     background-image: linear-gradient(90deg, #2F3C4C, #2F3C4C, #2F3C4C) !important;
   }
+  .react-loading-skeleton::after {
+    background-image: linear-gradient(90deg, #2F3C4C, #3A4251, #2F3C4C) !important;
+  }
 }
 
 @keyframes up-and-down {


### PR DESCRIPTION
Resolves: #9296 

Currently, `react-loading-skeleton` is being used for animated loading skeletons. For dark mode we have overridden the base color and set it to "#2F3C4C" but we did not override the highlight color hence it was coming to be the same as that of light mode.
I have overridden the highlight color to "#3A4251" as requested in the issue. 