### PR TITLE
feature/allow-google-tag-manager-to-csp

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -94,6 +94,7 @@ async function bootstrap() {
           'cdn.skypack.dev',
           'cdn.jsdelivr.net',
           'https://esm.sh',
+          'www.googletagmanager.com',
         ],
         'default-src': [
           'maps.googleapis.com',
@@ -103,6 +104,7 @@ async function bootstrap() {
           '*.sentry.io',
           "'self'",
           'blob:',
+          'www.googletagmanager.com',
         ],
         'connect-src': ['ws://' + domain, "'self'", '*'],
         'frame-ancestors': ['*'],


### PR DESCRIPTION
Adding `www.googletagmanager.com` domain  to the `script-src` and `default-src`  array, under the `helmet.contentSecurityPolicy` definition.

Following the details described here: https://github.com/ToolJet/ToolJet/issues/9345