### PR TITLE
Setting "#3A4251" as the highlight color for dark mode loading animation

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -8398,6 +8398,9 @@ tbody {
     background-color: #2F3C4C !important;
     background-image: linear-gradient(90deg, #2F3C4C, #2F3C4C, #2F3C4C) !important;
   }
+  .react-loading-skeleton::after {
+    background-image: linear-gradient(90deg, #2F3C4C, #3A4251, #2F3C4C) !important;
+  }
 }
 
 @keyframes up-and-down {


### PR DESCRIPTION
Resolves: #9296 

This PR sets "#3A4251" as the highlight color for loading state. The base color was overriden for dark mode but the highlight color was not. Hence, the highlight color was the same as that of light mode.  