### PR TITLE
Hotfix: Elasticsearch connection with special chars

### DIFF
--- a/plugins/packages/elasticsearch/lib/index.ts
+++ b/plugins/packages/elasticsearch/lib/index.ts
@@ -57,11 +57,11 @@ export default class ElasticsearchService implements QueryService {
     return sslEnabled ? 'https' : 'http';
   }
 
-  async getConnection(sourceOptions: SourceOptions): Promise<any> {
+  async getConnection(sourceOptions: SourceOptions): Promise<Client> {
     const host = sourceOptions.host;
     const port = sourceOptions.port;
-    const username = sourceOptions.username;
-    const password = sourceOptions.password;
+    const username = encodeURIComponent(sourceOptions.username);
+    const password = encodeURIComponent(sourceOptions.password);
     const sslEnabled = sourceOptions.ssl_enabled;
     const protocol = this.determineProtocol(sourceOptions);
     const sslCertificate = sourceOptions.ssl_certificate;


### PR DESCRIPTION
closes: #8807

Steps to test:

- Setup ES with password having special chars
```sh
# set a password with special chars
export ES_PASSWORD='E$!5aSt1c_S3@rch!:!@#$%^&*()'

# run elasticsearch
docker run --name es01 --net elastic -p 9200:9200 -e ELASTIC_PASSWORD=$ES_PASSWORD -it -m 1GB docker.elastic.co/elasticsearch/elasticsearch:8.13.2

# copy ca cert
docker cp es01:/usr/share/elasticsearch/config/certs/http_ca.crt .

# check curl works
- curl --cacert http_ca.crt -u elastic:$ES_PASSWORD https://localhost:9200                 
{
  "name" : "b2dc0dc8cbd5",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "Jpj9IP0mQ16HeF_C8pEwtA",
  "version" : {
    "number" : "8.13.2",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "16cc90cd2d08a3147ce02b07e50894bc060a4cbf",
    "build_date" : "2024-04-05T14:45:26.420424304Z",
    "build_snapshot" : false,
    "lucene_version" : "9.10.0",
    "minimum_wire_compatibility_version" : "7.17.0",
    "minimum_index_compatibility_version" : "7.0.0"
  },
  "tagline" : "You Know, for Search"
}

# copy ca cert for test connection
cat http_ca.crt
-----BEGIN CERTIFICATE-----
MIIFWjCCA0KgAwIBAgIVAK1GEDcsoF5ciWnnA8N8uzN42ZHTMA0GCSqGSIb3DQEB
CwUAMDwxOjA4BgNVBAMTMUVsYXN0aWNzZWFyY2ggc2VjdXJpdHkgYXV0by1jb25m
aWd1cmF0aW9uIEhUVFAgQ0EwHhcNMjQwNDE1MTIzNzA0WhcNMjcwNDE1MTIzNzA0
WjA8MTowOAYDVQQDEzFFbGFzdGljc2VhcmNoIHNlY3VyaXR5IGF1dG8tY29uZmln
dXJhdGlvbiBIVFRQIENBMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA
u7CJvYV1kaq1TEdLVSy8iD32eppM8xfx2Xen1ZIjmRScMqnctN3XuK6xoY4nntbu
rInxrcwqiFAHXewhhsYcoD5guuCIw7e+i1136suabMea3hZZcrv3Na/ixw95QqOW
eq2XnhXCAYEyZ8uRwMRkLjbc8AKcbrs+dZ0aPECQjG0hJ4bRjgx1SAb5SY2Mq4C7
eCXYqtqxHHcaEPYlREfB3q6us8aE5bmazxRnCat6YlZZUtLLZ7OcmC9SpkHkIAK9
vUGLaPIDJpQkHSFnkGRx+wBz1/IBW2NRcj6XkhcdXLf0QpAZioIpFZAwKyeEOvnP
6/ggJYwF2xjIt0LicKgjbwbmPEv8Jpr50T7yzMAJZ+ncoGQg7ejfyRfuBiv8Mevb
4XAzO6498mEeoWRTPHe1JSxpFF7bw1bvjgbQbrb+zqcV9jlRvRSqZYfqzqFWacDB
jGGzsCO6AHBih8059LEbF8XZr14Z5wGhc0LgLKLhsO5NgmIos0HJcOpRCGjMEqTL
kc0WA+6I1xbL4mq+wY9HQ07OXlQW1kjsxZq2kyR5AapdurCF18q+/qB+Ax/f9Ja9
5INiOkobqVNzcoRT1YVAD2YWz2AK32TH4dEFYJZ12VrNDU7svpLRvIoB/qpYQ1Qm
srBeLX6jpEHMzEttDTcV9Nbukl4sq9E/DXxLY6RSkBECAwEAAaNTMFEwHQYDVR0O
BBYEFL12C3zLuF2zuVigK/CvZkHz+vTzMB8GA1UdIwQYMBaAFL12C3zLuF2zuVig
K/CvZkHz+vTzMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIBAGo6
VjBzL5OIVfHCN5CFBz+hEXxHQnsCLQ9cFylKtgbV+9/ZPaSRwEoO8WvtUEy7vn8e
JUvTokYW7Q9XSOrWW2av/F0cpFrbO4VKr89zHbzdGembHQgDpBP/xxmIzkz4c58k
MlO/ditNMxRY3ymDTJHAqVHUtO6jtKHRH/K3g5x33Qy7Y8bL6/vD64BiCWlHWr7r
2B/x442uZKs6MIlhy7rwI1S00TF68YyconL45CvrXWgUZFi2Hueqw0sucDuvDqTB
XWHCcdFlPmxamAw4XA2xiDUXCTdcE5pQu/OJZidZePiVqk2HM5SzkNzp/eMdeUsw
1Y6+SvOEpJk1kQbzUaDs7SIw3ZIj+HT6i5vUsULeDeAG8gE2NveWr0Gwt263KUkr
vI21ZxhnidiheiykxGbLd6Qy/OtXqbYR8PJ0LU+tmqvK2MtzNRmRUre6uDfAdJ9R
dVVmuSZbIiCL1/K2AfJRq495JT36+7pdsuAjOH98tH291x/oxeR6Kr8ReWn+qgn8
5rXg9BC0iu7fJ837wngyXkyzW0lN2R7rCktZrRnleQwAIV92MVCwjgigja94skV2
Z+Gv/DoClqFBzEr/bJ8E0W5RvNcxTMNhr+6myOlvc21rlIu3o2RtcFejpW0g916F
dlWrcxuo7WXhbki3QJlQiXHBkHpOYaDkAGpOalYQ
-----END CERTIFICATE-----
```
- Try test connection from Elasticsearch data source