### PR TITLE
Fixed import text for automation failure

### DIFF
--- a/cypress-tests/cypress/constants/texts/exportImport.js
+++ b/cypress-tests/cypress/constants/texts/exportImport.js
@@ -18,7 +18,7 @@ export const exportAppModalText = {
 };
 
 export const importText = {
-  importOption: "Import",
+  importOption: "Import from device",
   couldNotImportAppToastMessage: `Could not import: SyntaxError: Unexpected token`,
   appImportedToastMessage: "App imported successfully.",
 };


### PR DESCRIPTION
Fixes: https://github.com/ToolJet/ToolJet/issues/9398

Cypress:
<img width="1433" alt="Screenshot 2024-04-16 at 4 24 33 PM" src="https://github.com/ToolJet/ToolJet/assets/59684099/97757d9c-cc90-4484-b6c5-1f43e1d97f48">
