### PR TITLE
Fix :  Wrapping the content of selected options of multiselect column type

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -1389,11 +1389,10 @@ export function Table({
                 rowProps.style.minHeight = cellSize === 'condensed' ? '39px' : '45px'; // 1px is removed to accomodate 1px border-bottom
                 let cellMaxHeight;
                 let cellHeight;
-                console.log('contentWrap', contentWrap, isMaxRowHeightAuto);
                 if (contentWrap) {
                   cellMaxHeight = isMaxRowHeightAuto
                     ? 'fit-content'
-                    : resolveReferences(maxRowHeightValue, currentState);
+                    : resolveReferences(maxRowHeightValue, currentState) + 'px';
                   rowProps.style.maxHeight = cellMaxHeight;
                 } else {
                   cellMaxHeight = cellSize === 'condensed' ? 40 : 46;

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -903,6 +903,11 @@
             display: flex;
             align-items: center;
           }
+          .react-select__value-container--is-multi{
+            flex-flow: wrap ;
+            gap: 6px;
+            max-height: 100%;
+          }
         }
 
         .react-select__indicators {


### PR DESCRIPTION
Resolves 
When custom maximum row height is applied, the content of selected options in the multi-select column type should be wrapped.