### PR TITLE
Fix : arrow indicators vertical alignment in number column

### DIFF
--- a/frontend/src/Editor/Components/Table/columns/index.jsx
+++ b/frontend/src/Editor/Components/Table/columns/index.jsx
@@ -348,7 +348,7 @@ export default function generateColumnsData({
                       }
                     }}
                     onFocus={(e) => e.stopPropagation()}
-                    className={`table-column-type-input-element input-number ${!isValid ? 'is-invalid' : ''}`}
+                    className={`table-column-type-input-element input-number h-100 ${!isValid ? 'is-invalid' : ''}`}
                     defaultValue={cellValue}
                   />
                   <div className="arror-container">

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -132,6 +132,9 @@
   td {
     overflow-x: initial;
     padding: 8px 12px !important;
+    &.has-number{
+      padding: 0px 0px 0px 12px !important;
+    }
 
 
     // &.has-number {
@@ -1301,7 +1304,7 @@
       top: 0px;
       bottom: 0px;
       flex-direction: column;
-      justify-content: space-around;
+      justify-content: center;
 
       .numberinput-up-arrow-table {
         right: 1px !important;

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -691,8 +691,8 @@
   --tblr-table-accent-bg: var(--slate2);
 }
 .table-striped>tbody>tr:nth-of-type(even):hover{
-  background-color: var(--interactive-overlays-fill-hover) !important;
-  --tblr-table-accent-bg: var(--interactive-overlays-fill-hover) !important;
+  background-color: var(--interactive-overlays-fill-hover) ;
+  --tblr-table-accent-bg: var(--interactive-overlays-fill-hover);
 }
 .resizing-column {
   background-color: var(--slate4, #ECEEF0) !important;

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -690,7 +690,10 @@
   background-color: var(--slate2);
   --tblr-table-accent-bg: var(--slate2);
 }
-
+.table-striped>tbody>tr:nth-of-type(even):hover{
+  background-color: var(--interactive-overlays-fill-hover) !important;
+  --tblr-table-accent-bg: var(--interactive-overlays-fill-hover) !important;
+}
 .resizing-column {
   background-color: var(--slate4, #ECEEF0) !important;
   border-right: 4px solid var(--slate5, #E6E8EB) !important;


### PR DESCRIPTION
Resolves
1. Arrow indicators vertical alignment in the number column
2. For the striped table, add a hover effect on even rows.