### PR TITLE
Form Submit Button does not get Reset in New Application Versions anymore

### DIFF
--- a/server/src/services/apps.service.ts
+++ b/server/src/services/apps.service.ts
@@ -525,10 +525,9 @@ export class AppsService {
         const newComponent = new Component();
         const componentEvents = allEvents.filter((event) => event.sourceId === component.id);
 
-        newComponent.id = uuid.v4();
-
         oldComponentToNewComponentMapping[component.id] = newComponent.id;
 
+        newComponent.id = component.id;
         newComponent.name = component.name;
         newComponent.type = component.type;
         newComponent.pageId = savedPage.id;

--- a/server/src/services/apps.service.ts
+++ b/server/src/services/apps.service.ts
@@ -525,9 +525,10 @@ export class AppsService {
         const newComponent = new Component();
         const componentEvents = allEvents.filter((event) => event.sourceId === component.id);
 
+        newComponent.id = component.id;
+
         oldComponentToNewComponentMapping[component.id] = newComponent.id;
 
-        newComponent.id = component.id;
         newComponent.name = component.name;
         newComponent.type = component.type;
         newComponent.pageId = savedPage.id;

--- a/server/src/services/apps.service.ts
+++ b/server/src/services/apps.service.ts
@@ -525,7 +525,7 @@ export class AppsService {
         const newComponent = new Component();
         const componentEvents = allEvents.filter((event) => event.sourceId === component.id);
 
-        newComponent.id = component.id;
+        newComponent.id = uuid.v4();
 
         oldComponentToNewComponentMapping[component.id] = newComponent.id;
 
@@ -575,6 +575,11 @@ export class AppsService {
 
       newComponents.forEach((component) => {
         let parentId = component.parent ? component.parent : null;
+
+        if (component.properties.buttonToSubmit) {
+          const newButtonToSubmit = oldComponentToNewComponentMapping[component.properties.buttonToSubmit.value];
+          component.properties.buttonToSubmit.value = newButtonToSubmit;
+        }
 
         if (!parentId) return;
 


### PR DESCRIPTION
Resolves: #8959 

This PR introduces changes that will make sure that the Form Submit Button does not get Reset after a new version is created. It maps the new ID of the submit button to the new Form in the `createNewPagesAndComponentsForVersion()` function