### PR TITLE
Fix string text table column type not pasting in plain-text

### DIFF
--- a/frontend/src/Editor/Components/Table/AddNewRowComponent.jsx
+++ b/frontend/src/Editor/Components/Table/AddNewRowComponent.jsx
@@ -131,6 +131,7 @@ export function AddNewRowComponent({
                           // [cellSize]: true,
                           'selector-column': cell.column.columnType === 'selector' && cell.column.id === 'selection',
                           'has-select': ['select', 'newMultiSelect'].includes(cell.column.columnType),
+                          isEditable: isEditable,
                         })}
                       >
                         <div

--- a/frontend/src/Editor/Components/Table/String.jsx
+++ b/frontend/src/Editor/Components/Table/String.jsx
@@ -61,7 +61,7 @@ const String = ({
   const _renderString = () => (
     <div
       ref={ref}
-      contentEditable={true}
+      contentEditable={'plaintext-only'} // this allows to paste plain text only and gets rids of styling when pasting
       className={`${!isValid ? 'is-invalid' : ''} h-100 text-container long-text-input d-flex align-items-center ${
         darkMode ? ' textarea-dark-theme' : ''
       } justify-content-${determineJustifyContentValue(horizontalAlignment)}`}

--- a/frontend/src/Editor/Components/Table/Text.jsx
+++ b/frontend/src/Editor/Components/Table/Text.jsx
@@ -54,7 +54,7 @@ const Text = ({
 
   const _renderTextArea = () => (
     <div
-      contentEditable={true}
+      contentEditable={'plaintext-only'} // this allows to paste plain text only and gets rids of styling when pasting
       className={`${!isValid ? 'is-invalid' : ''} h-100 long-text-input text-container ${
         darkMode ? ' textarea-dark-theme' : ''
       }`}


### PR DESCRIPTION
Fixes :
1.  string text table column type not pasting in plain-text.
2. In add new row, datepicker calender icon overlapping.