### PR TITLE
fix : Number input in table shows 2 arrows in firefox

### DIFF
--- a/frontend/src/Editor/Components/Table/columns/index.jsx
+++ b/frontend/src/Editor/Components/Table/columns/index.jsx
@@ -324,7 +324,6 @@ export default function generateColumnsData({
                     type="number"
                     style={{
                       ...cellStyles,
-                      maxWidth: width,
                       outline: 'none',
                       border: 'none',
                       background: 'inherit',

--- a/frontend/src/Editor/Components/Table/datepicker.scss
+++ b/frontend/src/Editor/Components/Table/datepicker.scss
@@ -1,4 +1,7 @@
 .tj-datepicker-widget {
+    &.react-datepicker-popper {
+       z-index: 3;
+    }
     border-radius: 6px !important;
     border: 1px solid var(--slate5) !important;
     box-shadow: 0px 32px 64px -12px rgba(16, 24, 40, 0.14);
@@ -6,9 +9,12 @@
     padding: 0px;
 }
 
+
+
 .tj-timepicker-widget {
     &.react-datepicker-popper {
         background-color: unset;
+        z-index: 3;
     }
 
     .react-datepicker__time-container {

--- a/frontend/src/Editor/Inspector/Components/Table/ColumnManager/DatepickerProperties.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table/ColumnManager/DatepickerProperties.jsx
@@ -93,7 +93,7 @@ const DatepickerProperties = ({ column, index, darkMode, currentState, onColumnI
           <div className="grey-bg-section mb-2 border">
             <div style={{ background: 'var(--surfaces-surface-02)', padding: '8px 12px', borderRadius: '6px' }}>
               <ProgramaticallyHandleProperties
-                label="Enable date selection"
+                label="Enable date"
                 currentState={currentState}
                 index={index}
                 darkMode={darkMode}
@@ -102,7 +102,7 @@ const DatepickerProperties = ({ column, index, darkMode, currentState, onColumnI
                 props={column}
                 component={component}
                 paramType="properties"
-                paramMeta={{ type: 'toggle', displayName: 'Enable date selection' }}
+                paramMeta={{ type: 'toggle', displayName: 'Enable date' }}
               />
             </div>
             {resolveReferences(column?.isDateSelectionEnabled, currentState) && (
@@ -163,7 +163,7 @@ const DatepickerProperties = ({ column, index, darkMode, currentState, onColumnI
           <div className="grey-bg-section mb-2 border">
             <div style={{ background: 'var(--surfaces-surface-02)', padding: '8px 12px', borderRadius: '6px' }}>
               <ProgramaticallyHandleProperties
-                label="Enable time selection"
+                label="Enable time"
                 currentState={currentState}
                 index={index}
                 darkMode={darkMode}
@@ -172,7 +172,7 @@ const DatepickerProperties = ({ column, index, darkMode, currentState, onColumnI
                 props={column}
                 component={component}
                 paramType="properties"
-                paramMeta={{ type: 'toggle', displayName: 'Enable time selection' }}
+                paramMeta={{ type: 'toggle', displayName: 'Enable time' }}
               />
             </div>
             {resolveReferences(column?.isTimeChecked, currentState) && (

--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -1446,3 +1446,7 @@
     max-height: max-content !important;
   }
 }
+
+.table-column-type-input-element[type="number"] {
+  -moz-appearance: textfield !important;
+}


### PR DESCRIPTION
Table have both default and custom one which we gave for controlling input
Zindex issue in datepicker
copy change in date picker label
column hidden bug in number input