### PR TITLE
Fix : Popup not showing for string column type for overflow content

### DIFF
--- a/frontend/src/Editor/Components/Table/String.jsx
+++ b/frontend/src/Editor/Components/Table/String.jsx
@@ -142,6 +142,7 @@ const String = ({
             onMouseLeave={() => {
               setHovered(false);
             }}
+            ref={ref}
           >
             <span
               style={{


### PR DESCRIPTION
Resolves :
popup not showing for overflowed content in string column type