### PR TITLE
Fix max row height being not displayed on initial table drop

### DIFF
--- a/frontend/src/Editor/Components/Table/String.jsx
+++ b/frontend/src/Editor/Components/Table/String.jsx
@@ -93,7 +93,7 @@ const String = ({
         e.stopPropagation();
       }}
     >
-      <span>{cellValue}</span>
+      {cellValue && <span>{cellValue}</span>}
     </div>
   );
 

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -623,7 +623,7 @@ export const widgets = [
         borderRadius: { value: '8' },
         tableType: { value: 'table-classic' },
         maxRowHeight: { value: 'auto' },
-        maxRowHeightValue: { value: 0 },
+        maxRowHeightValue: { value: 0 }, // Setting it here as 0 since TableRowHeightInput component will set the value
         contentWrap: { value: '{{true}}' },
         boxShadow: { value: '0px 0px 0px 0px #00000090' },
         padding: { value: 'default' },

--- a/frontend/src/Editor/WidgetManager/widgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/widgetConfig.js
@@ -623,7 +623,7 @@ export const widgets = [
         borderRadius: { value: '8' },
         tableType: { value: 'table-classic' },
         maxRowHeight: { value: 'auto' },
-        maxRowHeightValue: { value: '80px' },
+        maxRowHeightValue: { value: 0 },
         contentWrap: { value: '{{true}}' },
         boxShadow: { value: '0px 0px 0px 0px #00000090' },
         padding: { value: 'default' },


### PR DESCRIPTION
Fixes :
1. Fix max row height being not displayed on initial table drop
2. Fix string value when adding a new row to the table, is appearing twice.