### PR TITLE
fix: set preview loader only when running query is executed

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -337,7 +337,16 @@ export function onQueryConfirmOrCancel(_ref, queryConfirmationData, isConfirm = 
   );
 
   _ref.updateQueryConfirmationList(filtertedQueryConfirmation, 'check');
-  isConfirm && runQuery(_ref, queryConfirmationData.queryId, queryConfirmationData.queryName, true, mode);
+  isConfirm &&
+    runQuery(
+      _ref,
+      queryConfirmationData.queryId,
+      queryConfirmationData.queryName,
+      true,
+      mode,
+      undefined,
+      queryConfirmationData.shouldSetPreviewData
+    );
 }
 
 export async function copyToClipboard(text) {
@@ -1004,10 +1013,6 @@ export function runQuery(
   const queryPanelState = useQueryPanelStore.getState();
   const { queryPreviewData } = queryPanelState;
   const { setPreviewLoading, setPreviewData } = queryPanelState.actions;
-  if (shouldSetPreviewData) {
-    setPreviewLoading(true);
-    queryPreviewData && setPreviewData('');
-  }
 
   if (query) {
     dataQuery = JSON.parse(JSON.stringify(query));
@@ -1037,6 +1042,7 @@ export function runQuery(
     const queryConfirmation = {
       queryId,
       queryName,
+      shouldSetPreviewData,
     };
     if (!queryConfirmationList.some((query) => queryId === query.queryId)) {
       queryConfirmationList.push(queryConfirmation);
@@ -1054,6 +1060,10 @@ export function runQuery(
   // eslint-disable-next-line no-unused-vars
   return new Promise(function (resolve, reject) {
     setTimeout(() => {
+      if (shouldSetPreviewData) {
+        setPreviewLoading(true);
+        queryPreviewData && setPreviewData('');
+      }
       if (!isOnLoad) {
         useCurrentStateStore.getState().actions.setCurrentState({
           queries: {


### PR DESCRIPTION
Fixes issue: https://github.com/ToolJet/ToolJet/issues/9613
