### PR TITLE
Fix : Bug fixes from foreign key feature

### DIFF
--- a/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
@@ -375,9 +375,9 @@ const ColumnForm = ({
                   </div>
                 </div>
               ))}
-            {foreignKeyDetails?.length > 0 && (
+            {/* {foreignKeyDetails?.length > 0 && (
               <p className="fw-400 secondary-text tj-text-xsm mb-2">Create column to add foreign key relation</p>
-            )}
+            )} */}
           </div>
         </div>
 

--- a/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
@@ -371,10 +371,10 @@ function ForeignKeyRelation({
             {disableAddRelationButton && <Tooltip id="add-relation-tooltip" place="bottom" className="tooltip" />}
           </ButtonSolid>
         </div>
-        {!isEditMode && foreignKeyDetails.length >= 1 && (
+        {/* {!isEditMode && foreignKeyDetails.length >= 1 && (
           <span className="tj-text-xsm"> Create table to add foreign key relation</span>
-        )}
-        <div></div>
+        )} */}
+        {/* <div></div> */}
       </div>
       <Drawer
         isOpen={isForeignKeyDraweOpen}

--- a/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
@@ -292,13 +292,12 @@ function ForeignKeyRelation({
       return tableLength < 1;
     }
   };
-
   const disableAddRelationButton =
     checkTablelength(tables?.length, isEditMode) ||
     isEmpty(tableName) ||
     isEmpty(columns) ||
-    (!isEditMode && !Object.values(columns).every(isRequiredFieldsExistForCreateTableOperation)) ||
-    (isEditMode && !Object.values(columns).every(isRequiredFieldsExistForCreateTableOperation));
+    (!isEditMode && !Object.values(columns).some(isRequiredFieldsExistForCreateTableOperation)) ||
+    (isEditMode && !Object.values(columns).some(isRequiredFieldsExistForCreateTableOperation));
 
   const getTooltipContentFordisableAddRelationButton = (tableLength, tableName, columns) => {
     if (tableLength < 2) {
@@ -307,6 +306,11 @@ function ForeignKeyRelation({
       return 'Table name is required to add foreign key relation';
     } else if (isEmpty(columns)) {
       return 'At least 1 column is required to add foreign key relation';
+    } else if (
+      (!isEditMode && !Object.values(columns).some(isRequiredFieldsExistForCreateTableOperation)) ||
+      (isEditMode && !Object.values(columns).some(isRequiredFieldsExistForCreateTableOperation))
+    ) {
+      return 'Please fill all the required fields for at least 1 available column to add foreign key relation';
     } else {
       return '';
     }

--- a/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
@@ -76,7 +76,7 @@ function SourceKeyRelation({
           return {
             name: item?.column_name,
             label: item?.column_name,
-            icon: item?.dataTypeDetails?.icon ?? item?.dataTypeDetails[0]?.icon,
+            icon: item?.dataTypeDetails?.icon ?? item?.dataTypeDetails?.[0]?.icon,
             value: item?.column_name,
             dataType: item?.data_type,
             isDisabled: item?.data_type === 'serial' ? true : false,


### PR DESCRIPTION
Resolves :
1. Removed info messages such as `Create table to add foreign key` or `Create column to add foreign key` while creating a table or column

2. Enabled add-relation button when at least one column is present and filled otherwise disabled. Also, added tooltip for the same add-relation button when it is disabled due to at least one column being not filled.