### PR TITLE
fix : padding issue in foreign key relation dropdown and tooltip width issue in create and edit row in ToolJet database

### DIFF
--- a/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
@@ -285,7 +285,7 @@ const ColumnForm = ({
                 />
               ) : (
                 <DropDownSelect
-                  buttonClasses="border border-end-1 foreignKeyAcces-container mb-2"
+                  buttonClasses="border border-end-1 foreignKeyAcces-container-drawer mb-2"
                   showPlaceHolder={true}
                   options={referenceTableDetails}
                   darkMode={darkMode}

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -523,7 +523,7 @@ const ColumnForm = ({
                   />
                 ) : (
                   <DropDownSelect
-                    buttonClasses="border border-end-1 foreignKeyAcces-container mb-2"
+                    buttonClasses="border border-end-1 foreignKeyAcces-container-drawer mb-2"
                     showPlaceHolder={true}
                     options={referenceTableDetails}
                     darkMode={darkMode}

--- a/frontend/src/TooljetDatabase/Forms/EditRowForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditRowForm.jsx
@@ -213,7 +213,7 @@ const EditRowForm = ({
           <div style={{ position: 'relative' }}>
             {isMatchingForeignKeyColumn(columnName) ? (
               <DropDownSelect
-                buttonClasses="border border-end-1 foreignKeyAcces-container"
+                buttonClasses="border border-end-1 foreignKeyAcces-container-drawer"
                 showPlaceHolder={true}
                 options={referenceTableDetails}
                 darkMode={darkMode}
@@ -380,7 +380,7 @@ const EditRowForm = ({
                             ) : null
                           }
                           placement="top"
-                          tooltipClassName="tootip-table"
+                          tooltipClassName="tjdb-table-tooltip"
                         >
                           <div>
                             {isMatchingForeignKeyColumn(Header) && (

--- a/frontend/src/TooljetDatabase/Forms/RowForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/RowForm.jsx
@@ -217,7 +217,7 @@ const RowForm = ({ onCreate, onClose, referencedColumnDetails, setReferencedColu
           <div style={{ position: 'relative' }}>
             {isMatchingForeignKeyColumn(columnName) ? (
               <DropDownSelect
-                buttonClasses="border border-end-1 foreignKeyAcces-container"
+                buttonClasses="border border-end-1 foreignKeyAcces-container-drawer"
                 showPlaceHolder={true}
                 options={referenceTableDetails}
                 darkMode={darkMode}
@@ -356,7 +356,7 @@ const RowForm = ({ onCreate, onClose, referencedColumnDetails, setReferencedColu
                           ) : null
                         }
                         placement="top"
-                        tooltipClassName="tootip-table"
+                        tooltipClassName="tjdb-table-tooltip"
                       >
                         <div>
                           {isMatchingForeignKeyColumn(Header) && (

--- a/frontend/src/TooljetDatabase/Forms/TableSchema.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableSchema.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { UniqueConstraintPopOver } from '../Table/ActionsPopover/UniqueConstraintPopOver';
 import cx from 'classnames';
 import { ToolTip } from '@/_components/ToolTip';
@@ -51,12 +51,15 @@ function TableSchema({
 
   const columnDetails = isEditMode ? editColumns : columns;
 
-  const [defaultValue, setDefaultValue] = useState(
-    Object.keys(columnDetails).map((key, index) => ({
-      label: columnDetails[index]?.column_default,
-      value: columnDetails[index]?.column_default,
-    }))
-  );
+  const [defaultValue, setDefaultValue] = useState([]);
+
+  useEffect(() => {
+    const newDefaultValue = Object.keys(columnDetails).map((key, index) => ({
+      label: columnDetails[index]?.column_default || '',
+      value: columnDetails[index]?.column_default || '',
+    }));
+    setDefaultValue(newDefaultValue);
+  }, [columnDetails]);
 
   const CustomSelectOption = (props) => {
     return (
@@ -115,17 +118,6 @@ function TableSchema({
   }
 
   const primaryKeyLength = countPrimaryKeyLength(columnDetails);
-  // const indexOfActiveForeignKey = Object.values(columnDetails).findIndex((obj) =>
-  //   Object.values(obj).includes(foreignKeyDetails?.column_names?.value)
-  // );
-  const indexesOfForeignKey = foreignKeyDetails.flatMap((foreignKey) => {
-    return Object.values(columnDetails).reduce((acc, column, index) => {
-      if (foreignKey.column_names[0] === column.column_name) {
-        acc.push(index);
-      }
-      return acc;
-    }, []);
-  });
 
   function checkMatchingColumnNamesInForeignKey(foreignKeys, columnName) {
     return foreignKeys?.some((foreignKey) => foreignKey?.column_names?.includes(columnName));
@@ -138,8 +130,6 @@ function TableSchema({
       value: key[1] === null ? 'Null' : key[1],
     };
   });
-
-  // const objectsAtIndexes = indexesOfForeignKey.map((index) => columnDetails[index]);
 
   return (
     <div className="column-schema-container">

--- a/frontend/src/TooljetDatabase/Forms/styles.scss
+++ b/frontend/src/TooljetDatabase/Forms/styles.scss
@@ -324,6 +324,27 @@
 
         button {
           height: 100%;
+          padding: 7px 0px 7px 12px !important;
+          border-radius: 4px !important;
+
+          &:hover {
+            border: 1px solid transparent !important;
+            // background: transparent !important;
+          }
+
+          &:focus {
+            border: 1px solid transparent !important;
+            background: transparent !important;
+            box-shadow: 0px 0px 0px 1px #C6D4F9
+          }
+
+          .text-truncate {
+            font-size: 14px !important;
+          }
+
+          .dd-select-control-chevron {
+            margin-right: 10px !important;
+          }
         }
       }
 
@@ -598,6 +619,36 @@
 
     path {
       fill: white;
+    }
+  }
+}
+
+.foreignKeyAcces-container-drawer {
+  border-radius: 5px;
+
+  button {
+    height: 100%;
+    padding: 6px 0px 6px 12px !important;
+    border-radius: 4px !important;
+    border: 1px solid transparent !important;
+
+    &:hover {
+      border: 1px solid transparent !important;
+      // background: transparent !important;
+    }
+
+    &:focus {
+      border: 1px solid var(--indigo-09, #3E63DD) !important;
+      background: transparent !important;
+      box-shadow: 0px 0px 0px 1px #C6D4F9
+    }
+
+    .text-truncate {
+      font-size: 14px !important;
+    }
+
+    .dd-select-control-chevron {
+      margin-right: 10px !important;
     }
   }
 }

--- a/frontend/src/_styles/queryManager.scss
+++ b/frontend/src/_styles/queryManager.scss
@@ -1637,6 +1637,7 @@ $border-radius: 4px;
       background: transparent !important;
       box-shadow: 0px 0px 0px 1px #C6D4F9
     }
+
   }
 }
 


### PR DESCRIPTION
Resolves : 

1 . padding increased for foreign key relation dropdown
2 . tooltip width adjusted based on its content in create and edit row
3 . undefined check error while we create foreign key relation and if we try to select any value from foreign key dropdown it throws error of undefined (In create table)