### PR TITLE
Fix: Support for converting referenced table-id to table name in ToolJet database custom error handler

### DIFF
--- a/server/src/services/tooljet_db.service.ts
+++ b/server/src/services/tooljet_db.service.ts
@@ -303,12 +303,20 @@ export class TooljetDbService {
       await tjdbQueryRunner.rollbackTransaction();
       await queryRunner.release();
       await tjdbQueryRunner.release();
+      const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
+        ([tableName, tableId]): { id: string; tableName: string } => {
+          return {
+            id: tableId as string,
+            tableName: tableName,
+          };
+        }
+      );
 
       throw new TooljetDatabaseError(
         err.message,
         {
           origin: 'create_table',
-          internalTables: [],
+          internalTables: [...referencedColumnInfoForError],
         },
         err
       );
@@ -577,8 +585,20 @@ export class TooljetDbService {
     } catch (err) {
       await tjdbQueryRunnner.rollbackTransaction();
       await tjdbQueryRunnner.release();
+      const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
+        ([tableName, tableId]): { id: string; tableName: string } => {
+          return {
+            id: tableId as string,
+            tableName: tableName,
+          };
+        }
+      );
 
-      throw new TooljetDatabaseError(err.message, { origin: 'add_column', internalTables: [internalTable] }, err);
+      throw new TooljetDatabaseError(
+        err.message,
+        { origin: 'add_column', internalTables: [internalTable, ...referencedColumnInfoForError] },
+        err
+      );
     }
   }
 
@@ -591,10 +611,13 @@ export class TooljetDbService {
     if (!internalTable) throw new NotFoundException('Internal table not found: ' + tableName);
 
     const query = `ALTER TABLE "${internalTable.id}" DROP COLUMN ${column['column_name']}`;
-
-    const result = await this.tooljetDbManager.query(query);
-    await this.tooljetDbManager.query("NOTIFY pgrst, 'reload schema'");
-    return result;
+    try {
+      const result = await this.tooljetDbManager.query(query);
+      await this.tooljetDbManager.query("NOTIFY pgrst, 'reload schema'");
+      return result;
+    } catch (error) {
+      throw new TooljetDatabaseError(error.message, { origin: 'drop_column', internalTables: [internalTable] }, error);
+    }
   }
 
   private async joinTable(organizationId: string, params: Record<string, unknown>) {
@@ -947,16 +970,20 @@ export class TooljetDbService {
       await tjdbQueryRunner.rollbackTransaction();
       await tjdbQueryRunner.release();
 
-      const referencedTables = Object.entries(referenced_tables_info).map(([key, value]) => ({
-        tableName: key,
-        id: value as string,
-      }));
+      const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
+        ([tableName, tableId]): { id: string; tableName: string } => {
+          return {
+            id: tableId as string,
+            tableName: tableName,
+          };
+        }
+      );
 
       throw new TooljetDatabaseError(
         err.message,
         {
           origin: 'create_foreign_key',
-          internalTables: [internalTable, ...referencedTables],
+          internalTables: [internalTable, ...referencedColumnInfoForError],
         },
         err
       );
@@ -1010,16 +1037,20 @@ export class TooljetDbService {
     } catch (err) {
       await tjdbQueryRunner.rollbackTransaction();
       await tjdbQueryRunner.release();
-      const referencedTables = Object.entries(referenced_tables_info).map(([key, value]) => ({
-        id: key,
-        tableName: value as string,
-      }));
+      const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
+        ([tableName, tableId]): { id: string; tableName: string } => {
+          return {
+            id: tableId as string,
+            tableName: tableName,
+          };
+        }
+      );
 
       throw new TooljetDatabaseError(
         err.message,
         {
           origin: 'update_foreign_key',
-          internalTables: [internalTable, ...referencedTables],
+          internalTables: [internalTable, ...referencedColumnInfoForError],
         },
         err
       );
@@ -1032,10 +1063,21 @@ export class TooljetDbService {
       where: { organizationId: organizationId, tableName: table_name },
     });
     if (!internalTable) throw new NotFoundException('Internal table not found: ' + table_name);
-    const tjdbQueryRunner = this.tooljetDbManager.connection.createQueryRunner();
-    await tjdbQueryRunner.connect();
-    await tjdbQueryRunner.dropForeignKey(internalTable.id, foreign_key_id);
-    return { statusCode: 200, message: 'Foreign key relation deleted successfully!' };
+    try {
+      const tjdbQueryRunner = this.tooljetDbManager.connection.createQueryRunner();
+      await tjdbQueryRunner.connect();
+      await tjdbQueryRunner.dropForeignKey(internalTable.id, foreign_key_id);
+      return { statusCode: 200, message: 'Foreign key relation deleted successfully!' };
+    } catch (error) {
+      throw new TooljetDatabaseError(
+        error.message,
+        {
+          origin: 'delete_foreign_key',
+          internalTables: [internalTable],
+        },
+        error
+      );
+    }
   }
 
   private async checkIfForeignKeyReferencedColumnsAreFromCompositePrimaryKey(foreignKeys, organizationId) {


### PR DESCRIPTION
ToolJet database custom error handler will replace the referenced table-id with table name in the foreign key constraint errors.