### PR TITLE
fix : In edit and create row the null tag's height is greater than the input field in ToolJet database

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/CreateRow.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/CreateRow.jsx
@@ -98,9 +98,9 @@ const RenderColumnOptions = ({
   darkMode,
   removeColumnOptionsPair,
 }) => {
-  const filteredColumns = columns.filter(({ isPrimaryKey }) => !isPrimaryKey);
+  // const filteredColumns = columns.filter(({ isPrimaryKey }) => !isPrimaryKey);
   const existingColumnOption = Object.values ? Object.values(columnOptions) : [];
-  let displayColumns = filteredColumns.map(({ accessor }) => ({
+  let displayColumns = columns.map(({ accessor }) => ({
     value: accessor,
     label: accessor,
   }));

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
@@ -45,6 +45,7 @@ const DropDownSelect = ({
   actionName,
   fetchTables,
   onTableClick,
+  referencedForeignKeyDetails = [],
 }) => {
   const popoverId = useRef(`dd-select-${uuidv4()}`);
   const popoverBtnId = useRef(`dd-select-btn-${uuidv4()}`);
@@ -180,6 +181,7 @@ const DropDownSelect = ({
             targetTable={targetTable}
             actions={actions}
             actionName={actionName}
+            referencedForeignKeyDetails={referencedForeignKeyDetails}
           />
         </Popover>
       }

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
@@ -89,6 +89,24 @@ const JoinConstraint = ({ darkMode, index, onRemove, onChange, data }) => {
       }
     });
 
+  const foreignKeyTableDetails = Object.values(tableForeignKeyInfo)?.flatMap(
+    (foreignKeyDetails) => foreignKeyDetails || []
+  );
+
+  function isMatchingForeignKeyObjects(foreignKeyTableList, tableList) {
+    const foreignKeyObjects = [];
+    for (const fkObject of foreignKeyTableList) {
+      for (const table of tableList) {
+        if (fkObject.referenced_table_id === table.value) {
+          foreignKeyObjects.push(fkObject);
+        }
+      }
+    }
+    return foreignKeyObjects;
+  }
+
+  const foreignKeyDetails = isMatchingForeignKeyObjects(foreignKeyTableDetails, tableList);
+
   // OnSelecting LHS ro RHS table on Join Operation, Checking if Adjacent table has FK relation and Auto Fill the column values
   function checkIfAdjacentTableHasForeignKey(isChoosingLHStable, tableId) {
     if (isChoosingLHStable && rightFieldTable) {
@@ -309,6 +327,7 @@ const JoinConstraint = ({ darkMode, index, onRemove, onChange, data }) => {
             addBtnLabel={'Add new table'}
             value={tableList.find((val) => val?.value === rightFieldTable)}
             shouldShowForeignKeyIcon
+            referencedForeignKeyDetails={foreignKeyDetails}
           />
         </Col>
       </Row>

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -11,6 +11,8 @@ import { Form } from 'react-bootstrap';
 import SolidIcon from '@/_ui/Icon/SolidIcons';
 import { getPrivateRoute } from '@/_helpers/routes';
 import cx from 'classnames';
+import { ToolTip } from '@/_components/ToolTip';
+import ArrowRight from '@/TooljetDatabase/Icons/ArrowRight.svg';
 
 function DataSourceSelect({
   darkMode,
@@ -48,6 +50,7 @@ function DataSourceSelect({
   targetTable,
   actions,
   actionName,
+  referencedForeignKeyDetails,
 }) {
   const [isLoadingFKDetails, setIsLoadingFKDetails] = useState(false);
   const [searchValue, setSearchValue] = useState('');
@@ -319,7 +322,27 @@ function DataSourceSelect({
                   )}
 
                   {shouldShowForeignKeyIcon && props?.data?.isTargetTable && (
-                    <SolidIcon name="foreignkey" height={'14'} width={'24'} />
+                    <ToolTip
+                      message={referencedForeignKeyDetails?.map(
+                        (item, index) =>
+                          item?.referenced_table_id === props?.data?.value && (
+                            <div key={item?.referenced_table_id}>
+                              <span>Foreign key relation</span>
+                              <div className="d-flex align-item-center justify-content-between mt-2 custom-tooltip-style">
+                                <span>{item?.column_names[0]}</span>
+                                <ArrowRight />
+                                <span>{`${item?.referenced_table_name}.${item?.referenced_column_names[0]}`}</span>
+                              </div>
+                            </div>
+                          )
+                      )}
+                      placement="top"
+                      tooltipClassName="tjdb-table-tooltip"
+                    >
+                      <div>
+                        <SolidIcon name="foreignkey" height={'14'} width={'24'} />
+                      </div>
+                    </ToolTip>
                   )}
                 </div>
                 {foreignKeyAccess && props.data.isDisabled && (
@@ -378,7 +401,7 @@ function DataSourceSelect({
                       <div style={{ borderTop: '1px solid var(--slate5)' }}></div>
                       <div
                         style={{
-                          minHeight: '140px',
+                          // minHeight: '140px',
                           height: 'fit-content',
                           padding: '8px 12px',
                         }}
@@ -679,19 +702,20 @@ const GenerateActionsDescription = ({ targetTable, sourceTable, actionName = '',
         table will not be permitted for any records that references it in{' '}
         <span className="action-description-highlighter">{sourceTable ? sourceTable : '< source table name >'}</span>{' '}
         table.
-        <br />
+        {/* <br />
         It is similar to NO ACTION but NO ACTION allows the check to be deferred until later in the transaction, whereas
-        RESTRICT does not.
+        RESTRICT does not. */}
       </>
     ) : (
       <>
         Deleting a record from{' '}
         <span className="action-description-highlighter">{targetTable ? targetTable : '< target table name >'}</span>{' '}
-        table will not be permitted for any records that references it in{' '}
+        table will not be permitted for any records that reference it in{' '}
         <span className="action-description-highlighter">{sourceTable ? sourceTable : '< source table name >'}</span>{' '}
-        table. <br />
+        table.
+        {/* <br />
         It is similar to NO ACTION but NO ACTION allows the check to be deferred until later in the transaction, whereas
-        RESTRICT does not.
+        RESTRICT does not. */}
       </>
     ),
     setNull: isActionOnUpdate ? (

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -246,7 +246,7 @@ function DataSourceSelect({
                 <div
                   style={{
                     display: 'flex',
-                    justifyContent: showRedirection ? 'space-between' : 'flex-start',
+                    justifyContent: showRedirection || actions ? 'space-between' : 'flex-start',
                     alignItems: 'center',
                     cursor: foreignKeyAccess && props.data.isDisabled && 'not-allowed',
                   }}

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/UpdateRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/UpdateRows.jsx
@@ -258,9 +258,9 @@ const RenderColumnOptions = ({
   darkMode,
   removeColumnOptionsPair,
 }) => {
-  const filteredColumns = columns.filter(({ isPrimaryKey }) => !isPrimaryKey);
+  // const filteredColumns = columns.filter(({ isPrimaryKey }) => !isPrimaryKey);
   const existingColumnOptions = Object.values(updateRowsOptions?.columns).map(({ column }) => column);
-  let displayColumns = filteredColumns.map(({ accessor }) => ({
+  let displayColumns = columns.map(({ accessor }) => ({
     value: accessor,
     label: accessor,
   }));

--- a/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
@@ -88,11 +88,11 @@ function SourceKeyRelation({
     .map((item) => ({ value: item?.table_name, label: item?.table_name, id: item.id }));
 
   const onUpdateOptions = [
-    {
-      name: 'NO ACTION',
-      label: 'NO ACTION',
-      value: 'NO ACTION',
-    },
+    // {
+    //   name: 'NO ACTION',
+    //   label: 'NO ACTION',
+    //   value: 'NO ACTION',
+    // },
     {
       name: 'CASCADE',
       label: 'CASCADE',
@@ -103,23 +103,23 @@ function SourceKeyRelation({
       label: 'RESTRICT',
       value: 'RESTRICT',
     },
-    {
-      name: 'SET NULL',
-      label: 'SET NULL',
-      value: 'SET NULL',
-    },
-    {
-      name: 'SET DEFAULT',
-      label: 'SET DEFAULT',
-      value: 'SET DEFAULT',
-    },
+    // {
+    //   name: 'SET NULL',
+    //   label: 'SET NULL',
+    //   value: 'SET NULL',
+    // },
+    // {
+    //   name: 'SET DEFAULT',
+    //   label: 'SET DEFAULT',
+    //   value: 'SET DEFAULT',
+    // },
   ];
   const onDeleteOptions = [
-    {
-      name: 'NO ACTION',
-      label: 'NO ACTION',
-      value: 'NO ACTION',
-    },
+    // {
+    //   name: 'NO ACTION',
+    //   label: 'NO ACTION',
+    //   value: 'NO ACTION',
+    // },
     {
       name: 'CASCADE',
       label: 'CASCADE',
@@ -130,16 +130,16 @@ function SourceKeyRelation({
       label: 'RESTRICT',
       value: 'RESTRICT',
     },
-    {
-      name: 'SET NULL',
-      label: 'SET NULL',
-      value: 'SET NULL',
-    },
-    {
-      name: 'SET DEFAULT',
-      label: 'SET DEFAULT',
-      value: 'SET DEFAULT',
-    },
+    // {
+    //   name: 'SET NULL',
+    //   label: 'SET NULL',
+    //   value: 'SET NULL',
+    // },
+    // {
+    //   name: 'SET DEFAULT',
+    //   label: 'SET DEFAULT',
+    //   value: 'SET DEFAULT',
+    // },
   ];
 
   useEffect(() => {

--- a/frontend/src/TooljetDatabase/Forms/styles.scss
+++ b/frontend/src/TooljetDatabase/Forms/styles.scss
@@ -320,10 +320,10 @@
 
       .foreignKeyAcces-container {
         width: 125px;
-        height: 36px;
+        height: 100%;
 
         button {
-          height: 100%;
+          height: 35px !important;
           padding: 7px 0px 7px 12px !important;
           border-radius: 4px !important;
 
@@ -625,9 +625,10 @@
 
 .foreignKeyAcces-container-drawer {
   border-radius: 5px;
+  height: 100% !important;
 
   button {
-    height: 100%;
+    height: 35px !important;
     padding: 6px 0px 6px 12px !important;
     border-radius: 4px !important;
     border: 1px solid transparent !important;

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -1113,7 +1113,7 @@ const Table = ({ collapseSidebar }) => {
                       onMouseOver={() => handleMouseOver(index)}
                       onMouseOut={() => handleMouseOut()}
                     >
-                      <div className="d-flex align-items-center justify-content-between">
+                      <div className="d-flex align-items-center justify-content-between" style={{ gap: '4px' }}>
                         {tableHeaderContent(column, index)}
 
                         <TablePopover

--- a/frontend/src/TooljetDatabase/Table/styles.scss
+++ b/frontend/src/TooljetDatabase/Table/styles.scss
@@ -11,9 +11,9 @@
 //   //   height: 20px;
 // }
 
-.header-primaryKey-container {
-  margin-right: 6px !important;
-}
+// .header-primaryKey-container {
+//   margin-right: 6px !important;
+// }
 
 .primaryKeyTooltip {
   display: flex;
@@ -395,7 +395,8 @@
       display: flex;
       flex-direction: column;
       gap: 8px;
-      .unique-constraint-info{
+
+      .unique-constraint-info {
         background-color: var(--slate2);
         border: 1px solid var(--slate5) !important;
         gap: 4px;
@@ -404,12 +405,14 @@
         opacity: 0px;
         display: flex;
         color: var(--slate11);
-        svg{
+
+        svg {
           width: 20%;
           height: 100%;
         }
       }
-      .column-popover{
+
+      .column-popover {
         width: 100% !important;
       }
 

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -8412,6 +8412,7 @@ tbody {
     background-color: #2F3C4C !important;
     background-image: linear-gradient(90deg, #2F3C4C, #2F3C4C, #2F3C4C) !important;
   }
+
   .react-loading-skeleton::after {
     background-image: linear-gradient(90deg, #2F3C4C, #3A4251, #2F3C4C) !important;
   }
@@ -12864,11 +12865,12 @@ tbody {
   }
 }
 
-.action-description-highlighter{
+.action-description-highlighter {
   color: var(--indigo9) !important;
 }
-.read-docs-fk{
-  
+
+.read-docs-fk {
+
   .tooltip-inner {
     padding: 8px 12px 8px 12px !important;
     font-size: 12px;
@@ -12876,11 +12878,12 @@ tbody {
     font-weight: 400;
     text-align: center;
   }
-  .tooltip-outer{
+
+  .tooltip-outer {
     // box-shadow: 0px 4px 6px -2px #10182808 ,0px 12px 16px -4px #10182814 !important;
   }
 }
- 
+
 .change-margin {
   margin-bottom: 10px !important;
 }
@@ -12970,5 +12973,21 @@ tbody {
 
   &:active {
     background-color: var(--interactive-overlays-fill-pressed) !important;
+  }
+}
+
+.tjdb-table-tooltip {
+  width: max-content !important;
+
+  .tooltip-inner {
+    max-width: max-content !important;
+    width: max-content !important;
+
+    .foreignKey-relation-tooltip {
+      span {
+        text-align: left;
+      }
+    }
+
   }
 }


### PR DESCRIPTION
Resolves : 

1 . Tooltip in join constraint's referenced table in query manager
2 . now we are allowing primary key columns as well in create and update rows from query manager
3 . removed No Action,Set Null,Set Default and now we are just showing Cascade and Restrict (Cascade is default option)
4 . In edit and create row the null tag's height is greater than the input field
5 . In foreign key drawer the actions's dropdown selection alignment changes