### PR TITLE
fix : Foreign key drawer fixes of text headings and actions dropdown

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/CreateRow.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/CreateRow.jsx
@@ -98,9 +98,9 @@ const RenderColumnOptions = ({
   darkMode,
   removeColumnOptionsPair,
 }) => {
-  // const filteredColumns = columns.filter(({ isPrimaryKey }) => !isPrimaryKey);
+  const filteredColumns = columns.filter(({ column_default }) => !column_default?.startsWith('nextval('));
   const existingColumnOption = Object.values ? Object.values(columnOptions) : [];
-  let displayColumns = columns.map(({ accessor }) => ({
+  let displayColumns = filteredColumns.map(({ accessor }) => ({
     value: accessor,
     label: accessor,
   }));

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/UpdateRows.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/UpdateRows.jsx
@@ -258,9 +258,9 @@ const RenderColumnOptions = ({
   darkMode,
   removeColumnOptionsPair,
 }) => {
-  // const filteredColumns = columns.filter(({ isPrimaryKey }) => !isPrimaryKey);
+  const filteredColumns = columns.filter(({ column_default }) => !column_default?.startsWith('nextval('));
   const existingColumnOptions = Object.values(updateRowsOptions?.columns).map(({ column }) => column);
-  let displayColumns = columns.map(({ accessor }) => ({
+  let displayColumns = filteredColumns.map(({ accessor }) => ({
     value: accessor,
     label: accessor,
   }));

--- a/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
@@ -94,14 +94,14 @@ function SourceKeyRelation({
     //   value: 'NO ACTION',
     // },
     {
-      name: 'CASCADE',
-      label: 'CASCADE',
-      value: 'CASCADE',
-    },
-    {
       name: 'RESTRICT',
       label: 'RESTRICT',
       value: 'RESTRICT',
+    },
+    {
+      name: 'CASCADE',
+      label: 'CASCADE',
+      value: 'CASCADE',
     },
     {
       name: 'SET NULL',
@@ -121,14 +121,14 @@ function SourceKeyRelation({
     //   value: 'NO ACTION',
     // },
     {
-      name: 'CASCADE',
-      label: 'CASCADE',
-      value: 'CASCADE',
-    },
-    {
       name: 'RESTRICT',
       label: 'RESTRICT',
       value: 'RESTRICT',
+    },
+    {
+      name: 'CASCADE',
+      label: 'CASCADE',
+      value: 'CASCADE',
     },
     {
       name: 'SET NULL',
@@ -245,7 +245,7 @@ function SourceKeyRelation({
             <Source width={18} height={18} />
             <p className="mb-0 source-title">SOURCE</p>
           </div>
-          <span className="source-description">This is the data to which the current table will be referenced to </span>
+          <span className="source-description">The current table on which Foreign Key constraint is being added</span>
         </div>
         <TableDetailsDropdown
           firstColumnName={'Table'}
@@ -271,7 +271,7 @@ function SourceKeyRelation({
             <Target width={18} height={18} />
             <p className="mb-0 source-title">TARGET</p>
           </div>
-          <span className="source-description">This is the current table which will reference source table</span>
+          <span className="source-description">The table that contains foreign key column’s reference</span>
         </div>
         <TableDetailsDropdown
           firstColumnName={'Table'}

--- a/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
@@ -245,7 +245,7 @@ function SourceKeyRelation({
             <Source width={18} height={18} />
             <p className="mb-0 source-title">SOURCE</p>
           </div>
-          <span className="source-description">The current table on which Foreign Key constraint is being added</span>
+          <span className="source-description">The current table on which foreign Key constraint is being added</span>
         </div>
         <TableDetailsDropdown
           firstColumnName={'Table'}


### PR DESCRIPTION
Resolves : 

1 . changed text headings for source and target table in foreign key drawer
2 . in actions dropdown from foreign key drawer now we make RESTRICT as default value
3 . in ToolJet database query manager in create and update rows we are just showing columns which is not serial datatype and now it supports primary key columns