### PR TITLE
fix : Boolean default value not applied on create row in ToolJet database

### DIFF
--- a/frontend/src/TooljetDatabase/Forms/RowForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/RowForm.jsx
@@ -182,7 +182,7 @@ const RowForm = ({ onCreate, onClose, referencedColumnDetails, setReferencedColu
         const { dataType, column_default } = column;
         if (dataType !== 'serial') {
           if (column.dataType === 'boolean') {
-            result[column.accessor] = false;
+            result[column.accessor] = column_default ? column_default : false;
           } else {
             result[column.accessor] = column_default ? column_default : '';
           }


### PR DESCRIPTION
Resolves : 

while creating a row for boolean datatype only the default value is selected by default if the column have default value, but when we click create the default value is not actually adding to the row.