### PR TITLE
fix : Null value is not showing in foreign key dropdown in edit and create column

### DIFF
--- a/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
@@ -178,11 +178,11 @@ const ColumnForm = ({
     // toast.success(`Foreign key Added successfully for selected column`);
   };
 
-  const referenceTableDetails = referencedColumnDetails?.map((item) => {
+  const referenceTableDetails = referencedColumnDetails.map((item) => {
     const [key, _value] = Object.entries(item);
     return {
-      label: key[1],
-      value: key[1],
+      label: key[1] === null ? 'Null' : key[1],
+      value: key[1] === null ? 'Null' : key[1],
     };
   });
 

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -357,10 +357,10 @@ const ColumnForm = ({
   const newChangesInForeignKey = changesInForeignKey();
 
   const referenceTableDetails = referencedColumnDetails.map((item) => {
-    const [key, value] = Object.entries(item);
+    const [key, _value] = Object.entries(item);
     return {
-      label: key[1],
-      value: key[1],
+      label: key[1] === null ? 'Null' : key[1],
+      value: key[1] === null ? 'Null' : key[1],
     };
   });
 
@@ -772,16 +772,22 @@ const ColumnForm = ({
           isEditMode={true}
           fetching={fetching}
           onClose={onClose}
-          onEdit={handleEdit}
+          onEdit={() => {
+            if (foreignKeyDetails?.length > 0 && !isForeignKey) {
+              setOnDeletePopup(true);
+            } else {
+              handleEdit();
+            }
+          }}
           shouldDisableCreateBtn={columnName === ''}
           showToolTipForFkOnReadDocsSection={true}
         />
       </div>
       <ConfirmDialog
-        title={'Delete foreign key'}
+        title={'Delete foreign key relation'}
         show={onDeletePopup}
         message={'Deleting the foreign key relation cannot be reversed. Are you sure you want to continue?'}
-        onConfirm={handleDeleteForeignKeyColumn}
+        onConfirm={foreignKeyDetails?.length > 0 && !isForeignKey ? handleEdit : handleDeleteForeignKeyColumn}
         onCancel={() => {
           setOnDeletePopup(false);
         }}

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -248,7 +248,7 @@ const ColumnForm = ({
       column: {
         column_name: selectedColumn?.Header,
         data_type: selectedColumn?.dataType,
-        ...(selectedColumn?.dataType !== 'serial' && { column_default: defaultValue }),
+        ...(selectedColumn?.dataType !== 'serial' && { column_default: defaultValue === 'Null' ? null : defaultValue }),
         constraints_type: {
           is_not_null: isNotNull,
           is_primary_key: selectedColumn?.constraints_type?.is_primary_key ?? false,

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -773,7 +773,7 @@ const ColumnForm = ({
           fetching={fetching}
           onClose={onClose}
           onEdit={() => {
-            if (foreignKeyDetails?.length > 0 && !isForeignKey) {
+            if (foreignKeyDetails?.length > 0 && !isForeignKey && isMatchingForeignKeyColumn(columnName)) {
               setOnDeletePopup(true);
             } else {
               handleEdit();
@@ -787,7 +787,11 @@ const ColumnForm = ({
         title={'Delete foreign key relation'}
         show={onDeletePopup}
         message={'Deleting the foreign key relation cannot be reversed. Are you sure you want to continue?'}
-        onConfirm={foreignKeyDetails?.length > 0 && !isForeignKey ? handleEdit : handleDeleteForeignKeyColumn}
+        onConfirm={
+          foreignKeyDetails?.length > 0 && !isForeignKey && isMatchingForeignKeyColumn(columnName)
+            ? handleEdit
+            : handleDeleteForeignKeyColumn
+        }
         onCancel={() => {
           setOnDeletePopup(false);
         }}

--- a/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
@@ -430,7 +430,7 @@ function ForeignKeyRelation({
         />
       </Drawer>
       <ConfirmDialog
-        title={'Delete foreign key'}
+        title={'Delete foreign key relation'}
         show={onDeletePopup}
         message={'Deleting the foreign key relation cannot be reversed. Are you sure you want to continue?'}
         onConfirm={() => {

--- a/frontend/src/_services/tooljetDatabase.service.js
+++ b/frontend/src/_services/tooljetDatabase.service.js
@@ -48,7 +48,7 @@ function createColumn(
     column: {
       column_name: columnName,
       data_type: dataType,
-      ...(!isCheckSerialType && { column_default: defaultValue }),
+      ...(!isCheckSerialType && { column_default: defaultValue === 'Null' ? null : defaultValue }),
       constraints_type: {
         is_not_null: isNotNull,
         is_unique: isUniqueConstraint,


### PR DESCRIPTION
Resolves : 

1 . Null value is not showing in foreign key dropdown in edit and create column
2 . in edit column if we make foreign as false state and if click save changes it should show delete modal for foreign key deletion