### PR TITLE
Chore: Disabled state color code for add foreign key relation button

### DIFF
--- a/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
@@ -370,7 +370,12 @@ function ForeignKeyRelation({
             data-tooltip-id="add-relation-tooltip"
             data-tooltip-content={getTooltipContentFordisableAddRelationButton(tables?.length, tableName, columns)}
           >
-            <AddRectangle width="15" fill="#3E63DD" opacity="1" secondaryFill="#ffffff" />
+            <AddRectangle
+              width="15"
+              fill={disableAddRelationButton ? 'var(--slate8)' : '#3E63DD'}
+              opacity="1"
+              secondaryFill="#ffffff"
+            />
             &nbsp;&nbsp; Add relation
             {disableAddRelationButton && <Tooltip id="add-relation-tooltip" place="bottom" className="tooltip" />}
           </ButtonSolid>


### PR DESCRIPTION
The add foreign key relation button now has a disabled state color code.