### PR TITLE
Fix: 9809 error not show in toast when clone

### DIFF
--- a/frontend/src/_components/AppModal.jsx
+++ b/frontend/src/_components/AppModal.jsx
@@ -89,7 +89,7 @@ export function AppModal({
           setInfoText('');
           closeModal();
         }
-      } catch (error) {
+      } catch (e) {
         toast.error(e.error, {
           position: 'top-center',
         });


### PR DESCRIPTION
Fix: [9809](https://github.com/ToolJet/ToolJet/issues/9809) error not show in toast when clone