### PR TITLE
add gstatic to CSP whitelist

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -95,6 +95,7 @@ async function bootstrap() {
           'cdn.jsdelivr.net',
           'https://esm.sh',
           'www.googletagmanager.com',
+          'https://www.gstatic.com',
         ],
         'default-src': [
           'maps.googleapis.com',


### PR DESCRIPTION
- Adds https://www.gstatic.com to Content Security Policy (CSP) whitelist.