### PR TITLE
fix : Delete column query throws error if the column name starts with uppercase in ToolJet database

### DIFF
--- a/server/src/services/tooljet_db.service.ts
+++ b/server/src/services/tooljet_db.service.ts
@@ -610,7 +610,7 @@ export class TooljetDbService {
 
     if (!internalTable) throw new NotFoundException('Internal table not found: ' + tableName);
 
-    const query = `ALTER TABLE "${internalTable.id}" DROP COLUMN ${column['column_name']}`;
+    const query = `ALTER TABLE "${internalTable.id}" DROP COLUMN "${column['column_name']}"`;
     try {
       const result = await this.tooljetDbManager.query(query);
       await this.tooljetDbManager.query("NOTIFY pgrst, 'reload schema'");


### PR DESCRIPTION
fix : Delete column query throws error if the column name starts with uppercase in ToolJet database