### PR TITLE
Bugfix: Filter order for toggle component in new and old version in widget manager

### DIFF
--- a/frontend/src/Editor/WidgetManager.jsx
+++ b/frontend/src/Editor/WidgetManager.jsx
@@ -27,14 +27,29 @@ export const WidgetManager = function WidgetManager({ componentTypes, zoomLevel,
 
   function filterComponents(value) {
     if (value !== '') {
-      const fuse = new Fuse(componentTypes, { keys: ['displayName'], shouldSort: true, threshold: 0.4 });
+      const fuse = new Fuse(componentTypes, {
+        keys: ['displayName'],
+        shouldSort: true,
+        threshold: 0.4,
+      });
       const results = fuse.search(value);
+
+      // Find the indices of ToggleSwitchLegacy and ToggleSwitch
+      const legacyIndex = componentTypes.findIndex((component) => component?.name === 'ToggleSwitchLegacy');
+      const toggleIndex = componentTypes.findIndex((component) => component?.name === 'ToggleSwitch');
+
+      // Swap the indices (if both are found)
+      if (legacyIndex !== -1 && toggleIndex !== -1) {
+        [componentTypes[legacyIndex], componentTypes[toggleIndex]] = [
+          componentTypes[toggleIndex],
+          componentTypes[legacyIndex],
+        ];
+      }
       setFilteredComponents(results.map((result) => result.item));
     } else {
       setFilteredComponents(componentTypes);
     }
   }
-
   function renderComponentCard(component, index) {
     return <DraggableBox key={index} index={index} component={component} zoomLevel={zoomLevel} />;
   }


### PR DESCRIPTION
order in which both toggles are shown new one must be shown first