### PR TITLE
Fix: Remove null values from the foreign key drop-down list

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -190,16 +190,12 @@ function DataSourceSelect({
       columnDataType === 'character varying'
         ? filterQuery.ilike(referencedColumns?.referenced_column_names[0], `%${searchValue}%`)
         : filterQuery.eq(referencedColumns?.referenced_column_names[0], searchValue);
-      // Filtering out null values & bringing empty values to top
-      filterQuery.is(referencedColumns?.referenced_column_names[0], 'notNull');
-      orderQuery.order(referencedColumns?.referenced_column_names[0], 'nullsfirst');
-      query = query + `&${filterQuery.url.toString()}&${orderQuery.url.toString()}`;
-    } else {
-      // Filtering out null values & bringing empty values to top
-      filterQuery.is(referencedColumns?.referenced_column_names[0], 'notNull');
-      orderQuery.order(referencedColumns?.referenced_column_names[0], 'nullsfirst');
-      query = query + `&${filterQuery.url.toString()}&${orderQuery.url.toString()}`;
     }
+
+    // Filtering out null values & bringing empty values to top
+    filterQuery.is(referencedColumns?.referenced_column_names[0], 'notNull');
+    orderQuery.order(referencedColumns?.referenced_column_names[0], 'nullsfirst');
+    query = query + `&${filterQuery.url.toString()}&${orderQuery.url.toString()}`;
 
     tooljetDatabaseService
       .findOne(organizationId, referencedColumns?.referenced_table_id, query)

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -182,6 +182,7 @@ function DataSourceSelect({
 
     const selectQuery = new PostgrestQueryBuilder();
     const filterQuery = new PostgrestQueryBuilder();
+    const orderQuery = new PostgrestQueryBuilder();
     selectQuery.select(referencedColumns?.referenced_column_names[0]);
     let query = `${selectQuery.url.toString()}&limit=${limit}&offset=${offset}`;
 
@@ -189,7 +190,15 @@ function DataSourceSelect({
       columnDataType === 'character varying'
         ? filterQuery.ilike(referencedColumns?.referenced_column_names[0], `%${searchValue}%`)
         : filterQuery.eq(referencedColumns?.referenced_column_names[0], searchValue);
-      query = query + `&${filterQuery.url.toString()}`;
+      // Filtering out null values & bringing empty values to top
+      filterQuery.is(referencedColumns?.referenced_column_names[0], 'notNull');
+      orderQuery.order(referencedColumns?.referenced_column_names[0], 'nullsfirst');
+      query = query + `&${filterQuery.url.toString()}&${orderQuery.url.toString()}`;
+    } else {
+      // Filtering out null values & bringing empty values to top
+      filterQuery.is(referencedColumns?.referenced_column_names[0], 'notNull');
+      orderQuery.order(referencedColumns?.referenced_column_names[0], 'nullsfirst');
+      query = query + `&${filterQuery.url.toString()}&${orderQuery.url.toString()}`;
     }
 
     tooljetDatabaseService
@@ -523,6 +532,7 @@ function DataSourceSelect({
             ...style,
             cursor: 'pointer',
             color: isDisabled ? 'var(--slate8, #c1c8cd)' : 'inherit',
+            height: '33.5px',
             backgroundColor:
               isSelected && highlightSelected
                 ? 'var(--indigo3, #F0F4FF)'

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -528,7 +528,7 @@ function DataSourceSelect({
             ...style,
             cursor: 'pointer',
             color: isDisabled ? 'var(--slate8, #c1c8cd)' : 'inherit',
-            height: '33.5px',
+            minHeight: '33.5px',
             backgroundColor:
               isSelected && highlightSelected
                 ? 'var(--indigo3, #F0F4FF)'

--- a/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
@@ -251,7 +251,7 @@ function SourceKeyRelation({
           firstColumnName={'Table'}
           secondColumnName={'Column'}
           tableList={sourceTable}
-          tableColumns={sourceColumns}
+          tableColumns={sourceColumns.filter((column) => !isEmpty(column.value.trim()))}
           source={true}
           isEditColumn={isEditColumn}
           isCreateColumn={isCreateColumn}

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -781,6 +781,7 @@ const Table = ({ collapseSidebar }) => {
         'cell-text',
         'css-18kmycr-Input',
         ' css-18kmycr-Input',
+        'foreignkey-cell',
       ].includes(e.target.classList.value)
     ) {
       const isCellValueDefault =

--- a/frontend/src/TooljetDatabase/Table/styles.scss
+++ b/frontend/src/TooljetDatabase/Table/styles.scss
@@ -158,18 +158,9 @@
     border: 2px solid transparent;
 
     .foreignkey-cell {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      height: 100% !important;
-
       .cell-text {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        width: 80%;
+        // width: 80%;
       }
-
     }
   }
 


### PR DESCRIPTION
Problem:
The Foreign key drop-down should not include null values.

Solution:
If there are any null values, remove them and if there is an empty string, put it at the top of the foreign key drop down list.