### PR TITLE
Fix naming logic for copying and pasting widgets

### DIFF
--- a/frontend/src/Editor/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/Editor/CodeEditor/SingleLineCodeEditor.jsx
@@ -3,7 +3,7 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { PreviewBox } from './PreviewBox';
 import { ToolTip } from '@/Editor/Inspector/Elements/Components/ToolTip';
 import { useTranslation } from 'react-i18next';
-import { camelCase, isEmpty } from 'lodash';
+import { camelCase, isEmpty, noop } from 'lodash';
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 import { autocompletion, completionKeymap } from '@codemirror/autocomplete';
@@ -310,7 +310,7 @@ const DynamicEditorBridge = (props) => {
     fieldMeta,
     darkMode,
     className,
-    onFxPress,
+    onFxPress = noop,
     cyLabel = '',
     onChange,
     styleDefinition,

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -1845,7 +1845,7 @@ export const addNewWidgetToTheEditor = (
   const defaultWidth = componentMetaData.defaultSize.width;
   const defaultHeight = componentMetaData.defaultSize.height;
 
-  componentData.name = computeComponentName(componentData.name, currentComponents);
+  componentData.name = computeComponentName(componentData.component, currentComponents);
 
   let left = 0;
   let top = 0;

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -12,6 +12,7 @@ import { staticDataSources } from '@/Editor/QueryManager/constants';
 import { getDateTimeFormat } from '@/Editor/Components/Table/Datepicker';
 import { useDataQueriesStore } from '@/_stores/dataQueriesStore';
 import { validateMultilineCode } from './utility';
+import { componentTypes } from '@/Editor/WidgetManager/components';
 
 const reservedKeyword = ['app', 'window'];
 
@@ -268,20 +269,20 @@ export function computeComponentName(componentType, currentComponents) {
     (component) => component.component.component === componentType
   );
   let found = false;
-  let componentName = '';
+  const componentName = componentTypes.find((component) => component?.component === componentType)?.name;
   let currentNumber = currentComponentsForKind.length + 1;
-
+  let _componentName = '';
   while (!found) {
-    componentName = `${componentType.toLowerCase()}${currentNumber}`;
+    _componentName = `${componentName.toLowerCase()}${currentNumber}`;
     if (
-      Object.values(currentComponents).find((component) => component.component.name === componentName) === undefined
+      Object.values(currentComponents).find((component) => component.component.name === _componentName) === undefined
     ) {
       found = true;
     }
     currentNumber = currentNumber + 1;
   }
 
-  return componentName;
+  return _componentName;
 }
 
 export function computeActionName(actions) {


### PR DESCRIPTION
Fixes :

1. New widgets wrong name change when copying and pasting
2. Remove console error on clicking fx in Event manager.