### PR TITLE
Chore: Fix test suite

### DIFF
--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -1,7 +1,7 @@
 module.exports = async () => {
   return {
     verbose: true,
-    moduleFileExtensions: ['js', 'json', 'ts'],
+    moduleFileExtensions: ['js', 'json', 'ts', 'node'],
     rootDir: '.',
     testEnvironment: 'node',
     testRegex: '.spec.ts$',

--- a/server/test/jest-e2e.json
+++ b/server/test/jest-e2e.json
@@ -1,5 +1,10 @@
 {
-  "moduleFileExtensions": ["js", "json", "ts"],
+  "moduleFileExtensions": [
+    "js",
+    "json",
+    "ts",
+    "node"
+  ],
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",


### PR DESCRIPTION
- Add jest module extension for databricks .node dependency

```
 FAIL  test/controllers/library_apps.e2e-spec.ts
  ● Test suite failed to run

    Cannot find module '../build/Release/xxhash' from '../../plugins/node_modules/lz4/lib/utils.js'

    Require stack:
      /Users/akshay/code/ToolJet/plugins/node_modules/lz4/lib/utils.js
      /Users/akshay/code/ToolJet/plugins/node_modules/lz4/lib/static.js
      /Users/akshay/code/ToolJet/plugins/node_modules/lz4/lib/lz4.js
      /Users/akshay/code/ToolJet/plugins/node_modules/@databricks/sql/dist/result/ArrowResultHandler.js
      /Users/akshay/code/ToolJet/plugins/node_modules/@databricks/sql/dist/DBSQLOperation.js
      /Users/akshay/code/ToolJet/plugins/node_modules/@databricks/sql/dist/DBSQLSession.js
      /Users/akshay/code/ToolJet/plugins/node_modules/@databricks/sql/dist/DBSQLClient.js
      /Users/akshay/code/ToolJet/plugins/node_modules/@databricks/sql/dist/index.js
      /Users/akshay/code/ToolJet/plugins/dist/packages/databricks/lib/index.js
      /Users/akshay/code/ToolJet/plugins/dist/server.js
      /Users/akshay/code/ToolJet/server/src/modules/data_sources/query.errors.ts
      /Users/akshay/code/ToolJet/server/src/helpers/utils.helper.ts
      /Users/akshay/code/ToolJet/server/src/services/seeds.service.ts
      /Users/akshay/code/ToolJet/server/src/modules/seeds/seeds.module.ts
      /Users/akshay/code/ToolJet/server/src/app.module.ts
      test.helper.ts
      controllers/library_apps.e2e-spec.ts


    However, Jest was able to find:
    	'../build/Release/xxhash.node'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'ts'].

    See https://jestjs.io/docs/configuration#modulefileextensions-arraystring

      14 | Object.defineProperty(exports, "__esModule", { value: true });
      15 | const common_1 = require("@tooljet-plugins/common");
    > 16 | const sql_1 = require("@databricks/sql");
         |               ^
      17 | const node_int64_1 = __importDefault(require("node-int64"));
      18 | class Databricks {
      19 |     testConnection(sourceOptions) {

      at Resolver._throwModNotFoundError (../node_modules/jest-resolve/build/resolver.js:427:11)
      at Object.<anonymous> (../../plugins/node_modules/lz4/lib/utils.js:4:11)
      at Object.<anonymous> (../../plugins/node_modules/lz4/lib/static.js:60:17)
      at Object.<anonymous> (../../plugins/node_modules/lz4/lib/lz4.js:7:18)
      at Object.<anonymous> (../../plugins/node_modules/@databricks/sql/lib/result/ArrowResultHandler.ts:1:1)
      at Object.<anonymous> (../../plugins/node_modules/@databricks/sql/lib/DBSQLOperation.ts:24:1)
      at Object.<anonymous> (../../plugins/node_modules/@databricks/sql/lib/DBSQLSession.ts:27:1)
      at Object.<anonymous> (../../plugins/node_modules/@databricks/sql/lib/DBSQLClient.ts:11:1)
      at Object.<anonymous> (../../plugins/node_modules/@databricks/sql/lib/index.ts:7:1)
      at Object.<anonymous> (../../plugins/dist/packages/databricks/lib/index.js:16:15)
      at Object.<anonymous> (../../plugins/dist/server.js:17:32)
      at Object.<anonymous> (../src/modules/data_sources/query.errors.ts:1:1)
      at Object.<anonymous> (../src/helpers/utils.helper.ts:1:1)
      at Object.<anonymous> (../src/services/seeds.service.ts:10:1)
      at Object.<anonymous> (../src/modules/seeds/seeds.module.ts:2:1)
      at Object.<anonymous> (../src/app.module.ts:8:1)
      at Object.<anonymous> (test.helper.ts:13:1)
      at Object.<anonymous> (controllers/library_apps.e2e-spec.ts:3:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        41.794 s
Ran all test suites matching /test\/controllers\/library_apps.e2e-spec.ts/i with tests matching "should be able to create app if user has app create permission or has instance user type".
(node:60355) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.
```