### PR TITLE
[docs]:Update broken links in quickstart guides from v2.25 onwards

### DIFF
--- a/docs/docs/getting-started/quickstart-guide.md
+++ b/docs/docs/getting-started/quickstart-guide.md
@@ -11,8 +11,9 @@ This tutorial will show you how to create an employee directory application in m
 **[2. Create a Database Table](#2-create-a-database-table)**  <br/>
 **[3. Fetch Data](#3-fetch-data)** <br/>
 **[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
-**[5. Add New Data](#5-add-new-data)** <br/>
-**[6. Preview, Release and Share](#6-preview-release-and-share)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -123,7 +124,7 @@ Frame all the remaining keys in the same format.
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Use Events to Trigger Queries
+### 6. Use Events to Trigger Queries
 
 The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
 
@@ -143,7 +144,7 @@ Now when you click the `+` (Add new row) button, enter the employee data, and cl
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
 The preview, release and share buttons are at the top-right of the App-Builder.
 

--- a/docs/docs/workflows/overview.md
+++ b/docs/docs/workflows/overview.md
@@ -230,7 +230,7 @@ The above code will return success or failure message based on the output we rec
 </div>
 <br/>
 
-We've now successfully used a workflow in our ToolJet Application. You can also use **[webhooks](docs/workflows/workflow-triggers#webhooks)** to execute workflows from third party apps.
+We've now successfully used a workflow in our ToolJet Application. You can also use **[webhooks](/docs/workflows/workflow-triggers#webhooks)** to execute workflows from third party apps.
 
 Continue learning about the different elements of ToolJet Workflows using the below links:
 

--- a/docs/versioned_docs/version-2.25.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.25.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
-This Quickstart Guide will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
+This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,121 +21,77 @@ This Quickstart Guide will show you how to create an employee directory applicat
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-</div>
-
-
-
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
-
-
-### 3. Integrate Data
-
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database
-- Rename the query to `getEmployees`
-- Choose `employees` as Table name, List rows as Operations
-- Toggle Run this query on application load? to automatically run the query when the app starts
-- Click on Run to fetch data
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 3. Fetch Data
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+To display employees in the application, we first need to fetch data from the database using a query.
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
+- Rename the query to `getEmployees`.
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
+
+</div>
+
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+
+### 4. Bind Data to the Table
+
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -143,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database
-- Select `employees` as Table name, Create row as Operations
-- Rename the query to `addEmployee`
-- Click Add Column to add required columns
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
+- Rename the query to `addEmployee`.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -158,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{padding: '10px', marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler
-- Select Query Success as Event and Run Query as Action
-- Select `getEmployees` as Query
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{padding: '10px', marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler
-- Choose Add new rows as Event, Run Query as Action
-- Select `addEmployee` as the Query
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.27.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.27.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
-This Quickstart Guide will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
+This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,121 +21,77 @@ This Quickstart Guide will show you how to create an employee directory applicat
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
+
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
-
-
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
+### 3. Fetch Data
 
-### 3. Integrate Data
+To display employees in the application, we first need to fetch data from the database using a query.
 
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
 - Rename the query to `getEmployees`.
-- Choose `employees` as Table name, List rows as Operations.
-- Toggle Run this query on application load? to automatically run the query when the app starts.
-- Click on Run to fetch data.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -143,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database.
-- Select `employees` as Table name, Create row as Operations.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
 - Rename the query to `addEmployee`.
-- Click Add Column to add required columns.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -158,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{padding: '10px', marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler.
-- Select Query Success as Event and Run Query as Action.
-- Select `getEmployees` as Query.
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{padding: '10px', marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler.
-- Choose Add new rows as Event, Run Query as Action.
-- Select `addEmployee` as the Query.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button.
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.29.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.29.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
 This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,120 +21,77 @@ This tutorial will show you how to create an employee directory application in m
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
+
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
-
-
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 3. Integrate Data
+### 3. Fetch Data
 
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database.
+To display employees in the application, we first need to fetch data from the database using a query.
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
 - Rename the query to `getEmployees`.
-- Choose `employees` as Table name, List rows as Operations.
-- Toggle Run this query on application load? to automatically run the query when the app starts.
-- Click on Run to fetch data.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -142,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database.
-- Select `employees` as Table name, Create row as Operations.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
 - Rename the query to `addEmployee`.
-- Click Add Column to add required columns.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -157,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler.
-- Select Query Success as Event and Run Query as Action.
-- Select `getEmployees` as Query.
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler.
-- Choose Add new rows as Event, Run Query as Action.
-- Select `addEmployee` as the Query.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button.
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.30.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.30.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
 This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,120 +21,77 @@ This tutorial will show you how to create an employee directory application in m
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
+
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
-
-
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 3. Integrate Data
+### 3. Fetch Data
 
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database.
+To display employees in the application, we first need to fetch data from the database using a query.
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
 - Rename the query to `getEmployees`.
-- Choose `employees` as Table name, List rows as Operations.
-- Toggle Run this query on application load? to automatically run the query when the app starts.
-- Click on Run to fetch data.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -142,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database.
-- Select `employees` as Table name, Create row as Operations.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
 - Rename the query to `addEmployee`.
-- Click Add Column to add required columns.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -157,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler.
-- Select Query Success as Event and Run Query as Action.
-- Select `getEmployees` as Query.
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler.
-- Choose Add new rows as Event, Run Query as Action.
-- Select `addEmployee` as the Query.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button.
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.33.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.33.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
 This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,120 +21,77 @@ This tutorial will show you how to create an employee directory application in m
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
+
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
-
-
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 3. Integrate Data
+### 3. Fetch Data
 
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database.
+To display employees in the application, we first need to fetch data from the database using a query.
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
 - Rename the query to `getEmployees`.
-- Choose `employees` as Table name, List rows as Operations.
-- Toggle Run this query on application load? to automatically run the query when the app starts.
-- Click on Run to fetch data.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -142,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database.
-- Select `employees` as Table name, Create row as Operations.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
 - Rename the query to `addEmployee`.
-- Click Add Column to add required columns.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -157,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler.
-- Select Query Success as Event and Run Query as Action.
-- Select `getEmployees` as Query.
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler.
-- Choose Add new rows as Event, Run Query as Action.
-- Select `addEmployee` as the Query.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button.
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.34.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.34.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
 This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,120 +21,77 @@ This tutorial will show you how to create an employee directory application in m
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
+
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
-
-
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 3. Integrate Data
+### 3. Fetch Data
 
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database.
+To display employees in the application, we first need to fetch data from the database using a query.
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
 - Rename the query to `getEmployees`.
-- Choose `employees` as Table name, List rows as Operations.
-- Toggle Run this query on application load? to automatically run the query when the app starts.
-- Click on Run to fetch data.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -142,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database.
-- Select `employees` as Table name, Create row as Operations.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
 - Rename the query to `addEmployee`.
-- Click Add Column to add required columns.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -157,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler.
-- Select Query Success as Event and Run Query as Action.
-- Select `getEmployees` as Query.
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler.
-- Choose Add new rows as Event, Run Query as Action.
-- Select `addEmployee` as the Query.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button.
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.35.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.35.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
 This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,120 +21,77 @@ This tutorial will show you how to create an employee directory application in m
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
+
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
-
-
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 3. Integrate Data
+### 3. Fetch Data
 
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database.
+To display employees in the application, we first need to fetch data from the database using a query.
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
 - Rename the query to `getEmployees`.
-- Choose `employees` as Table name, List rows as Operations.
-- Toggle Run this query on application load? to automatically run the query when the app starts.
-- Click on Run to fetch data.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -142,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database.
-- Select `employees` as Table name, Create row as Operations.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
 - Rename the query to `addEmployee`.
-- Click Add Column to add required columns.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -157,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler.
-- Select Query Success as Event and Run Query as Action.
-- Select `getEmployees` as Query.
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler.
-- Choose Add new rows as Event, Run Query as Action.
-- Select `addEmployee` as the Query.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button.
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.36.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.36.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
 This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,120 +21,77 @@ This tutorial will show you how to create an employee directory application in m
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
+
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
-
-
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 3. Integrate Data
+### 3. Fetch Data
 
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database.
+To display employees in the application, we first need to fetch data from the database using a query.
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
 - Rename the query to `getEmployees`.
-- Choose `employees` as Table name, List rows as Operations.
-- Toggle Run this query on application load? to automatically run the query when the app starts.
-- Click on Run to fetch data.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -142,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database.
-- Select `employees` as Table name, Create row as Operations.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
 - Rename the query to `addEmployee`.
-- Click Add Column to add required columns.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -157,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler.
-- Select Query Success as Event and Run Query as Action.
-- Select `getEmployees` as Query.
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler.
-- Choose Add new rows as Event, Run Query as Action.
-- Select `addEmployee` as the Query.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button.
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.39.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.39.0/getting-started/quickstart-guide.md
@@ -11,8 +11,9 @@ This tutorial will show you how to create an employee directory application in m
 **[2. Create a Database Table](#2-create-a-database-table)**  <br/>
 **[3. Fetch Data](#3-fetch-data)** <br/>
 **[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
-**[5. Add New Data](#5-add-new-data)** <br/>
-**[6. Preview, Release and Share](#6-preview-release-and-share)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -78,7 +79,7 @@ To display employees in the application, we first need to fetch data from the da
 
 ### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query with the Table created in Step 1. 
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
 
 <div class="video-container">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -98,12 +99,12 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Data
+### 5. Create a Query to Add Data
 
 In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
 <div class="video-container">
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/uIRKqda9AUQ?si=jwqoBAOGlgBF7nmf&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 <br/>
 
@@ -119,6 +120,11 @@ In the bottom-right corner of the Table component, there is a `+` (Add new row) 
 ...
 ```
 Frame all the remaining keys in the same format.
+</div>
+
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+
+### 6. Use Events to Trigger Queries
 
 The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
 
@@ -138,7 +144,7 @@ Now when you click the `+` (Add new row) button, enter the employee data, and cl
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
 The preview, release and share buttons are at the top-right of the App-Builder.
 

--- a/docs/versioned_docs/version-2.39.0/workflows/overview.md
+++ b/docs/versioned_docs/version-2.39.0/workflows/overview.md
@@ -230,7 +230,7 @@ The above code will return success or failure message based on the output we rec
 </div>
 <br/>
 
-We've now successfully used a workflow in our ToolJet Application. You can also use **[webhooks](docs/workflows/workflow-triggers#webhooks)** to execute workflows from third party apps.
+We've now successfully used a workflow in our ToolJet Application. You can also use **[webhooks](/docs/workflows/workflow-triggers#webhooks)** to execute workflows from third party apps.
 
 Continue learning about the different elements of ToolJet Workflows using the below links:
 

--- a/docs/versioned_docs/version-2.43.0/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.43.0/getting-started/quickstart-guide.md
@@ -5,15 +5,15 @@ title: Quickstart Guide
 
 <!-- <div style={{paddingTop:'24px', paddingBottom:'24px'}}> -->
 
-
 This tutorial will show you how to create an employee directory application in minutes using ToolJet. This app will let you track and update employee information with a beautiful user interface. Here are the step-by-step instructions:
 
 **[1. Create Your First Application](#1-create-your-first-application)**  <br/>
-**[2. Create Employee Database](#2-create-employee-database)**  <br/>
-**[3. Integrate Data](#3-integrate-data)** <br/>
-**[4. List Employees](#4-list-employees)** <br/>
-**[5. Add New Employee](#5-add-new-employee)** <br/>
-**[6. Preview, Release And Share](#6-preview-release-and-share)** <br/>
+**[2. Create a Database Table](#2-create-a-database-table)**  <br/>
+**[3. Fetch Data](#3-fetch-data)** <br/>
+**[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -21,120 +21,77 @@ This tutorial will show you how to create an employee directory application in m
 
 ### 1. Create Your First Application
 
-Once you have created an account with ToolJet, go to the dashboard and click on the Create new app button. Name your application as "Employee Directory". You are ready to design your application now.
+Once you have created your ToolJet account, follow the steps below.
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b4059c71-812d-407b-9d4a-fc598eac6260-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder='0'
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/LNvd7pZ72Yk?si=h0YzQeC6frmx6pcB&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-Click and drag a **[Table](/docs/widgets/table)** component to the canvas. 
+- Go to the dashboard and click on the **Create new app** button. Name your application as "Employee Directory". Once your application is created, you can see an empty canvas.
+- Click and drag a **[Table](/docs/widgets/table)** component on the canvas. 
 
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/ee10d678-63fb-4fd5-a217-835ddd0898e9-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Optionally, you can style the Table by **[adjusting its styling properties](/docs/tooljet-concepts/what-are-components#customizing-components)** and create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
+Optionally, you can also create a header by placing **[Text](/docs/widgets/text)** components over a **[Container](/docs/widgets/container)** component and styling them. 
 
 <div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v2.png" alt="Database Preview" />
+    <img style={{marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/header-design-v3.png" alt="Database Preview" />
 </div>
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 2. Create Employee Database
+### 2. Create a Database Table
+Now, create a new table in **[ToolJet’s Database](/docs/tooljet-db/tooljet-database/)** to store employee records. 
 
-Now, create a new table in **[ToolJet’s Database](/docs/tooljet-database/)** to store employee records. Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. Also, add a few employee records in the table.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/create-database-v2.png" alt="Database Preview" />
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/sxmXZesw2is?si=HARRc9ILmfLFGNZQ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
+
+- Name the table employees and add the following columns: `firstname`, `lastname`, `email`, `phone`, `department`, `position`, `joining`, and `status`. 
+- Add a few employee records in the table as dummy data.
 
 </div>
-
-
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 3. Integrate Data
+### 3. Fetch Data
 
-To display employees in the application, we first need to fetch data from the database using a query:
-- Click on the Add button in the **[Query Panel](/docs/app-builder/query-panel/)**, select ToolJet Database.
+To display employees in the application, we first need to fetch data from the database using a query.
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/mnLw7avQsEg?si=5oxSo36V-D12316R&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the **[Query Panel](/docs/app-builder/query-panel/)** to create a new query.
+- Select **ToolJet Database** as the data source for the query.
 - Rename the query to `getEmployees`.
-- Choose `employees` as Table name, List rows as Operations.
-- Toggle Run this query on application load? to automatically run the query when the app starts.
-- Click on Run to fetch data.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/de162474-7861-4275-bc8a-da275517908c-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Click on the Preview button to see a preview of the fetched data. 
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/b01e837b-b1b0-468e-a4e3-4b8064ba2e56-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+- Choose `employees` as the Table name, and **List rows** as the Operation.
+- Toggle `Run this query on application load?` setting to automatically run the query when the app starts.
+- Click on **Run** to fetch data.
+- Click on the **Run** button or **Preview** button to see a preview of the fetched data. 
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 4. List Employees
+### 4. Bind Data to the Table
 
-Now, we need to bind the data returned by the `getEmployees` query above with the Table created in Step 1. Click on the Table component to open its properties panel on the right. Under the `Data` property, paste the below code:
+Now, we need to bind the data returned by the `getEmployees` query with the Table created in the first step. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/m_7i_smzh2k?si=_w11gzqJaFjn5PNZ&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the Table component to open its properties panel which is visible on the right.
+- Under the `Data` property, enter the below code:
 
 ```js
 {{queries.getEmployees.data}}
 ```
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/f780f25f-0832-4a06-86f2-46864b891db1-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
 
 Now the Table component is filled with the data returned by the `getEmployees` query. 
 
@@ -142,14 +99,19 @@ Now the Table component is filled with the data returned by the `getEmployees` q
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Add New Employee
+### 5. Create a Query to Add Data
 
-Next step is to create a way to add data for new employees. 
+In the bottom-right corner of the Table component, there is a `+` (Add new row) button that opens a form to add new data to the Table. Follow the steps below to create an `addEmployee` query and execute it when you click the **Save** button on the add new rows form.
 
-- Click on Add in the query panel, select ToolJet Database.
-- Select `employees` as Table name, Create row as Operations.
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/xwGvQfOkHP8?si=pn6gmjpyr4Y0F9Yz&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<br/>
+
+- Click on the **Add** button in the query panel, and select **ToolJet Database** as the data source.
+- Select `employees` as the Table name, and **Create row** as the Operation.
 - Rename the query to `addEmployee`.
-- Click Add Column to add required columns.
+- Click on **Add Column** to add required columns.
 - Enter code below for **email** and **firstname** column keys:
 
 ```js
@@ -157,76 +119,44 @@ Next step is to create a way to add data for new employees.
 {{components.table1.newRows[0].firstname}}
 ...
 ```
-
 Frame all the remaining keys in the same format.
-
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px' }} className="screenshot-full" src="/img/quickstart-guide/add-employee-query-v2.png" alt="Add Employee Query" />
 </div>
 
-Let's continue working on this query. The data needs to reload once this query runs since we want the Table component to be populated with the updated data. Follow the below steps to run the `getEmployees` query after the `addEmployee` query is completed. 
+<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-- Scroll down and click on New event handler.
-- Select Query Success as Event and Run Query as Action.
-- Select `getEmployees` as Query.
+### 6. Use Events to Trigger Queries
 
-<div style={{textAlign: 'center'}}>
-    <img style={{ marginBottom:'15px', borderRadius: '6px'}} className="screenshot-full" src="/img/quickstart-guide/reload-data-v2.png" alt="Reload Table Data" />
+The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/NoPM-Y0fSCs?si=GQRXzJKnQTRQVOQI&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+<br/>
 
-We are now ready with a query that will allow us to add new employee data. Let's link this query to a button.
+- Under the `addEmployee` query settings, Scroll down and click on **New event handler**.
+- Select **Query Success** as the Event, **Run Query** as the Action, and `getEmployees` as the Query.
+- Click on the Table component, go to Events in properties panel and add a **New event handler**.
+- Choose **Add new rows** as the Event, **Run Query** as the Action, and `addEmployee` as the Query.
 
-In the bottom-right corner of the Table component, there is a `+`/Add new row button. Follow the below steps to run the `addEmployee` query on click of the `+`/Add new row button: 
-- Click on the Table component, go to Events in properties panel and add a New event handler.
-- Choose Add new rows as Event, Run Query as Action.
-- Select `addEmployee` as the Query.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/e53c2517-41f1-4ee0-a5c0-59f5c3622c4a-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
-
-Now if you click on the `+`/Add new row button, enter the employee data and click on Save. The `addEmployee` query will run and the data will be written to the `employees` table in the ToolJet Database.
-
-<div style={{marginBottom:'15px', height:'397px', }}>
-    <iframe
-        className="screenshot-full"
-        src="https://www.floik.com/embed/e4f537b5-7b36-4760-9a52-caefc659a90b/a33b3f9d-a33d-49c3-a031-db09b0202cfd-flo.html"
-        style={{width: '100%', height: '100%', border: '0'}}
-        frameborder="0"
-        allowfullscreen="allowfullscreen"
-        webkitallowfullscreen
-        mozallowfullscreen
-        allowfullscreen>
-    </iframe>
-</div>
+Now when you click the `+` (Add new row) button, enter the employee data, and click **Save**, the `addEmployee` query will execute, adding the data to the `employees` table in the ToolJet Database. This will be followed by the Table component reloading with the new data.
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
-The preview, release and share buttons are on the top-right of the App-Builder.
-
-- Click on the Preview on the top-right of app builder to review how your application is coming along while development.
-- Once the development is done and you are ready to use the application, click on Release button to deploy the app.
-- Finally, share your application with your end users using Share button.
-
+The preview, release and share buttons are at the top-right of the App-Builder.
 
 <div style={{textAlign: 'center'}}>
     <img style={{marginBottom:'15px'}} className="screenshot-full" src="/img/quickstart-guide/preview-share-v2.png" alt="Preview And Share" />
 </div>
 
-Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, covered the fundamentals of ToolJet. 
+- Click on the **Preview** button on the top-right of app builder to review how your application is coming along during development.
+- Once the development is done and you are ready to use the application, click on the **Release** button to deploy the app.
+- Finally, share your application with your end users using the **Share** button.
+
+Congratulations on completing the tutorial! You've successfully built an employee directory application and, in the process, learnt the fundamentals of ToolJet. 
 
 To learn more about how ToolJet works, explore the subjects covered in **[ToolJet Concepts](/docs/tooljet-concepts/what-are-components)**.
 

--- a/docs/versioned_docs/version-2.43.0/workflows/overview.md
+++ b/docs/versioned_docs/version-2.43.0/workflows/overview.md
@@ -230,7 +230,7 @@ The above code will return success or failure message based on the output we rec
 </div>
 <br/>
 
-We've now successfully used a workflow in our ToolJet Application. You can also use **[webhooks](docs/workflows/workflow-triggers#webhooks)** to execute workflows from third party apps.
+We've now successfully used a workflow in our ToolJet Application. You can also use **[webhooks](/docs/workflows/workflow-triggers#webhooks)** to execute workflows from third party apps.
 
 Continue learning about the different elements of ToolJet Workflows using the below links:
 

--- a/docs/versioned_docs/version-2.50.0-LTS/getting-started/quickstart-guide.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/getting-started/quickstart-guide.md
@@ -11,8 +11,9 @@ This tutorial will show you how to create an employee directory application in m
 **[2. Create a Database Table](#2-create-a-database-table)**  <br/>
 **[3. Fetch Data](#3-fetch-data)** <br/>
 **[4. Bind Data to the Table](#4-bind-data-to-the-table)** <br/>
-**[5. Add New Data](#5-add-new-data)** <br/>
-**[6. Preview, Release and Share](#6-preview-release-and-share)** <br/>
+**[5. Create a Query to Add Data](#5-create-a-query-to-add-data)** <br/>
+**[6. Use Events to Trigger Queries](#6-use-events-to-trigger-queries)** <br/>
+**[7. Preview, Release and Share](#7-preview-release-and-share)** <br/>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -123,7 +124,7 @@ Frame all the remaining keys in the same format.
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 5. Use Events to Trigger Queries
+### 6. Use Events to Trigger Queries
 
 The `addEmployees` query should run when you click on the **Save** button on the `+` (Add new row) form. And the Table component should reload and display updated data each time a new employee is added. Follow the below steps to use events to setup this functionality. 
 
@@ -143,7 +144,7 @@ Now when you click the `+` (Add new row) button, enter the employee data, and cl
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-### 6. Preview, Release And Share
+### 7. Preview, Release And Share
 
 The preview, release and share buttons are at the top-right of the App-Builder.
 

--- a/docs/versioned_docs/version-2.50.0-LTS/workflows/overview.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/workflows/overview.md
@@ -230,7 +230,7 @@ The above code will return success or failure message based on the output we rec
 </div>
 <br/>
 
-We've now successfully used a workflow in our ToolJet Application. You can also use **[webhooks](docs/workflows/workflow-triggers#webhooks)** to execute workflows from third party apps.
+We've now successfully used a workflow in our ToolJet Application. You can also use **[webhooks](/docs/workflows/workflow-triggers#webhooks)** to execute workflows from third party apps.
 
 Continue learning about the different elements of ToolJet Workflows using the below links:
 


### PR DESCRIPTION
- Update broken links in quickstart guides from v2.25 onwards(also replaced all quickstart guides from 2.25 onwards with the latest quickstart guide)
- Update broken links in workflows overview page