### PR TITLE
Fix: ToolJet database cell edit menu issues

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
@@ -242,7 +242,7 @@ const DropDownSelect = ({
           style={{
             position: 'relative',
             left: '-10px',
-            top: selected.label === null ? '0px' : '2px',
+            top: selected.label === null || selected.label === undefined ? '0px' : '2px',
             paddingLeft: '10px',
             paddingBottom: '4px',
           }}
@@ -253,16 +253,16 @@ const DropDownSelect = ({
         >
           <span
             className={cx({
-              'd-flex align-items-center justify-content-center': selected.label === null,
+              'd-flex align-items-center justify-content-center':
+                selected.label === null || selected.label === undefined,
             })}
             style={{
-              display: 'inline-block',
               color: darkMode ? '#fff' : '',
-              width: selected.label === null && '40px',
-              background: selected.label === null && 'var(--slate3)',
+              width: (selected.label === null || selected.label === undefined) && '40px',
+              background: (selected.label === null || selected.label === undefined) && 'var(--slate3)',
             }}
           >
-            {selected.label === null ? 'Null' : selected.label}
+            {selected.label === null || selected.label === undefined ? 'Null' : selected.label}
           </span>
         </div>
       ) : (

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
@@ -61,6 +61,8 @@ const DropDownSelect = ({
   saveFKValue,
   loader,
   isLoading = false,
+  columnDefaultValue = '',
+  setColumnDefaultValue = () => {},
 }) => {
   const popoverId = useRef(`dd-select-${uuidv4()}`);
   const popoverBtnId = useRef(`dd-select-btn-${uuidv4()}`);
@@ -228,6 +230,8 @@ const DropDownSelect = ({
             isForeignKeyInEditCell={isForeignKeyInEditCell}
             closeFKMenu={closeFKMenu}
             saveFKValue={saveFKValue}
+            columnDefaultValue={columnDefaultValue}
+            setColumnDefaultValue={setColumnDefaultValue}
           />
         </Popover>
       }

--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -152,6 +152,8 @@ function DataSourceSelect({
   saveFKValue,
   loader,
   isLoading = false,
+  columnDefaultValue,
+  setColumnDefaultValue,
 }) {
   const [isLoadingFKDetails, setIsLoadingFKDetails] = useState(isLoading);
   const [searchValue, setSearchValue] = useState('');
@@ -162,6 +164,12 @@ function DataSourceSelect({
   const scrollContainerRef = useRef(null);
 
   const handleChangeDataSource = (source) => {
+    if (source.value !== columnDefaultValue) {
+      setColumnDefaultValue(false);
+    } else {
+      setColumnDefaultValue(true);
+    }
+
     onSelect && onSelect(source);
     closePopup && !isMulti && closePopup();
   };

--- a/frontend/src/TooljetDatabase/Drawers/BulkUploadDrawer/index.jsx
+++ b/frontend/src/TooljetDatabase/Drawers/BulkUploadDrawer/index.jsx
@@ -87,7 +87,7 @@ function BulkUploadDrawer({
               Bulk upload data
             </h3>
           </div>
-          <div className="card-body">
+          <div className="card-body tjdb-bulkupload-drawer">
             <div className="manage-users-drawer-content-bulk">
               <div className="manage-users-drawer-content-bulk-download-prompt">
                 <div className="user-csv-template-wrap">

--- a/frontend/src/TooljetDatabase/Drawers/BulkUploadDrawer/styles.scss
+++ b/frontend/src/TooljetDatabase/Drawers/BulkUploadDrawer/styles.scss
@@ -50,6 +50,10 @@
   }
 }
 
+.tjdb-bulkupload-drawer {
+  padding: 1rem !important;
+}
+
 .bulk-upload-btn {
   .text-muted {
     color: white !important;

--- a/frontend/src/TooljetDatabase/Forms/styles.scss
+++ b/frontend/src/TooljetDatabase/Forms/styles.scss
@@ -11,12 +11,16 @@
 
 .drawer-card-wrapper {
 
+  .tj-base-btn {
+    padding: 10px;
+  }
+
   .card-body {
 
     padding: 0;
 
     .list-group-item {
-      padding: 0 !important;
+      padding: 0;
     }
   }
 
@@ -351,7 +355,7 @@
 
   .table-schema {
     background-color: var(--slate3) !important;
-    padding: 8px 0 !important;
+    padding: 8px 5px !important;
     margin-bottom: 6px !important;
     border: 1px solid transparent !important;
 
@@ -364,6 +368,10 @@
       align-items: center;
       justify-content: start;
       gap: 6px;
+
+      input.form-control {
+        margin-bottom: 0px;
+      }
 
       .foreign-key-relation {
         width: 20px !important;

--- a/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
+++ b/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
@@ -42,8 +42,8 @@ export const CellEditMenu = ({
   const [selectedValue, setSelectedValue] = useState(cellValue);
   const [shouldCloseFkMenu, setShouldCloseFKMenu] = useState(0);
   const [selectedForeignKeyValue, setSelectedForeignKeyValue] = useState({
-    value: previousCellValue === 'Null' ? null : previousCellValue,
-    label: previousCellValue === 'Null' ? null : previousCellValue,
+    value: previousCellValue === 'Null' ? null : previousCellValue?.toString(),
+    label: previousCellValue === 'Null' ? null : previousCellValue?.toString(),
   });
 
   const handleDefaultChange = (defaultColumnValue, defaultBooleanValue) => {
@@ -55,6 +55,13 @@ export const CellEditMenu = ({
       });
     } else {
       setCellValue(previousCellValue);
+      setSelectedForeignKeyValue({
+        label: previousCellValue?.toString(),
+        value: previousCellValue?.toString(),
+      });
+    }
+    if (previousCellValue !== defaultColumnValue) {
+      setDefaultValue(false);
     }
     setDefaultValue(defaultBooleanValue);
     setNullValue(false);
@@ -147,8 +154,8 @@ export const CellEditMenu = ({
   const referencedFKDataList = referencedColumnDetails.map((item) => {
     const [key, _value] = Object.entries(item);
     return {
-      label: key[1] === null ? 'Null' : key[1],
-      value: key[1] === null ? 'Null' : key[1],
+      label: key[1] === null ? 'Null' : key[1]?.toString(),
+      value: key[1] === null ? 'Null' : key[1]?.toString(),
     };
   });
 
@@ -376,6 +383,8 @@ export const CellEditMenu = ({
           shouldCloseFkMenu={shouldCloseFkMenu}
           cachedOptions={cachedOptions}
           columnDataType={dataType}
+          columnDefaultValue={defaultValue}
+          setColumnDefaultValue={setDefaultValue}
         />
       ) : (
         children

--- a/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
+++ b/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
@@ -383,7 +383,7 @@ export const CellEditMenu = ({
           shouldCloseFkMenu={shouldCloseFkMenu}
           cachedOptions={cachedOptions}
           columnDataType={dataType}
-          columnDefaultValue={defaultValue}
+          columnDefaultValue={columnDetails?.column_default}
           setColumnDefaultValue={setDefaultValue}
         />
       ) : (

--- a/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
+++ b/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
@@ -194,7 +194,10 @@ export const CellEditMenu = ({
                     className="form-check-input"
                     type="checkbox"
                     checked={nullValue}
-                    onChange={() => handleNullChange(!nullValue)}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      handleNullChange(!nullValue);
+                    }}
                   />
                 </label>
               </div>
@@ -211,7 +214,10 @@ export const CellEditMenu = ({
                     className="form-check-input"
                     type="checkbox"
                     checked={defaultValue}
-                    onChange={() => handleDefaultChange(columnDetails?.column_default, !defaultValue)}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      handleDefaultChange(columnDetails?.column_default, !defaultValue);
+                    }}
                   />
                 </label>
               </div>

--- a/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
+++ b/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
@@ -74,12 +74,20 @@ export const CellEditMenu = ({
         label: null,
         value: null,
       });
+      setDefaultValue(false);
     } else {
       if (previousCellValue === null) {
         setCellValue('');
         setSelectedForeignKeyValue({
           label: '',
           value: '',
+        });
+      } else if (previousCellValue === columnDetails?.column_default) {
+        setDefaultValue(true);
+        setCellValue(previousCellValue);
+        setSelectedForeignKeyValue({
+          label: previousCellValue,
+          value: previousCellValue,
         });
       } else {
         setCellValue(previousCellValue);
@@ -90,7 +98,6 @@ export const CellEditMenu = ({
       }
     }
     setNullValue(nullVal);
-    setDefaultValue(false);
   };
 
   const handleSelectedState = (value) => {

--- a/frontend/src/TooljetDatabase/Table/styles.scss
+++ b/frontend/src/TooljetDatabase/Table/styles.scss
@@ -329,7 +329,7 @@
     justify-content: center;
     cursor: default;
     border-radius: 6px;
-    width: 40px;
+    width: 40px !important;
     height: 20px;
     font-size: 12px;
   }

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -10213,6 +10213,8 @@ tbody {
 
 
 .manage-users-drawer-content-bulk {
+  margin: 24px 15px;
+
   form {
     display: flex;
     flex-direction: column;
@@ -10659,6 +10661,7 @@ tbody {
   padding: 16px 20px;
   border-bottom: 1px solid var(--slate5);
   height: 64px;
+
   h3 {
     margin-bottom: 0px !important;
     font-size: 18px;
@@ -10817,6 +10820,7 @@ tbody {
         -webkit-text-fill-color: var(--slate12) !important;
       }
     }
+
     &::placeholder {
       font-size: 12px;
       line-height: 20px;

--- a/frontend/src/_ui/Drawer/DrawerFooter/index.jsx
+++ b/frontend/src/_ui/Drawer/DrawerFooter/index.jsx
@@ -107,7 +107,7 @@ function DrawerFooter({
             message={'Foreign key relations checks for referential integrity between two tables. Read more.'}
             placement="top"
             tooltipClassName="tootip-table read-docs-fk"
-            show={showToolTipForFkOnReadDocsSection}
+            show={initiator === 'ForeignKeyTableForm'}
           >
             <div className="d-flex align-items-center">
               <Student />

--- a/frontend/src/_ui/Drawer/DrawerFooter/styles.scss
+++ b/frontend/src/_ui/Drawer/DrawerFooter/styles.scss
@@ -8,7 +8,12 @@
 .action-btns {
 	align-items: center !important;
 	gap: 10px !important;
+
+	.tj-base-btn {
+		padding: 20px !important;
+	}
 }
+
 .tjdb-cell-menu-shortcuts-text {
 	font-size: 12px;
 	color: #7E868C;
@@ -18,7 +23,7 @@
 	display: flex;
 	justify-content: center;
 	width: 16px;
-	height:16px;
+	height: 16px;
 	margin-right: 6px !important;
 	border-radius: 4px;
 	border: 1px solid #D7DBDF;
@@ -32,7 +37,7 @@
 	justify-content: center;
 	align-items: center;
 	width: 26px;
-	height:16px;
+	height: 16px;
 	border-radius: 4px;
 	border: 1px solid #D7DBDF;
 	padding: 4px;


### PR DESCRIPTION
Problems that have been sorted out.

1. Not able to set null and default values.
2. The null tag width is extended when a cell with a null value is selected.
3. When we change the options, if the values are not the default values, the default toggle should be turned off.
4. Toggling off Default and null value should result in the cell clearing the value.