### PR TITLE
Fix : Codehinter values not getting saved on switching page / table crash upon switching page / crash on delete table

### DIFF
--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -644,9 +644,15 @@ export const Container = ({
       if (id === 'resizingComponentId') {
         return;
       }
+      console.trace('id, param, value,---', id, param, value);
       if (Object.keys(value)?.length > 0) {
-        setBoxes((boxes) =>
-          update(boxes, {
+        setBoxes((boxes) => {
+          // Ensure boxes[id] exists
+          if (!boxes[id]) {
+            console.error(`Box with id ${id} does not exist`);
+            return boxes;
+          }
+          return update(boxes, {
             [id]: {
               $merge: {
                 component: {
@@ -661,8 +667,9 @@ export const Container = ({
                 },
               },
             },
-          })
-        );
+          });
+        });
+
         if (!_.isEmpty(opts)) {
           paramUpdatesOptsRef.current = opts;
         }

--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -644,7 +644,6 @@ export const Container = ({
       if (id === 'resizingComponentId') {
         return;
       }
-      console.trace('id, param, value,---', id, param, value);
       if (Object.keys(value)?.length > 0) {
         setBoxes((boxes) => {
           // Ensure boxes[id] exists

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -282,13 +282,18 @@ const EditorComponent = (props) => {
 
   const lastKeyPressTimestamp = useDebouncedArrowKeyPress(500); // 500 milliseconds delay
 
+  const debounceAutoSave = debounce(() => {
+    handleLowPriorityWork(() => {
+      autoSave();
+    });
+  }, 300);
+
   useEffect(() => {
     const didAppDefinitionChanged = !_.isEqual(appDefinition, prevAppDefinition.current);
 
     if (didAppDefinitionChanged) {
       prevAppDefinition.current = appDefinition;
     }
-
     if (mounted && didAppDefinitionChanged && currentPageId) {
       const components = appDefinition?.pages[currentPageId]?.components || {};
 
@@ -296,7 +301,7 @@ const EditorComponent = (props) => {
 
       if (appDiffOptions?.skipAutoSave === true || appDiffOptions?.entityReferenceUpdated === true) return;
 
-      handleLowPriorityWork(() => autoSave());
+      debounceAutoSave();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify({ appDefinition, currentPageId, dataQueries })]);

--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -283,10 +283,8 @@ const EditorComponent = (props) => {
   const lastKeyPressTimestamp = useDebouncedArrowKeyPress(500); // 500 milliseconds delay
 
   const debounceAutoSave = debounce(() => {
-    handleLowPriorityWork(() => {
-      autoSave();
-    });
-  }, 300);
+    autoSave();
+  }, 100);
 
   useEffect(() => {
     const didAppDefinitionChanged = !_.isEqual(appDefinition, prevAppDefinition.current);


### PR DESCRIPTION

closes #9974

Scenario 1: Adding Data to table component
Steps:
Pin the page inspector for debugging.
Create two separate pages.
Drop a table component on a page.
Connect a query to the dropped table.
Connect data to a table using keyboard suggestions (not mouse click).
Switch to the other page before the "onblur" event (focus loss) triggers on the table's data field.
Result: App crashes.

Scenario 2: Deleting Table Component
Steps:
Drop a table component on a page.
Connect a query with data to the table.
Before the "onblur" event triggers on the table's data field, delete the table component.
Result: App crashes.




https://github.com/ToolJet/ToolJet/assets/31006028/a964248e-3cec-437c-bfef-21840c70d6ee





