### PR TITLE
[docs]: Update readme, docker and subpath guides

### DIFF
--- a/docs/docs/setup/tooljet-subpath.md
+++ b/docs/docs/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/docs/setup/try-tooljet.md
+++ b/docs/docs/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-1.x.x/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-1.x.x/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-1.x.x/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-1.x.x/setup/try-tooljet.md
@@ -9,7 +9,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.0.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.0.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.0.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.0.0/setup/try-tooljet.md
@@ -9,7 +9,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.1.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.1.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.1.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.1.0/setup/try-tooljet.md
@@ -9,7 +9,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.10.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.10.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.10.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.10.0/setup/try-tooljet.md
@@ -9,7 +9,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.11.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.11.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.11.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.11.0/setup/try-tooljet.md
@@ -9,7 +9,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.12.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.12.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.12.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.12.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.13.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.13.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.13.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.13.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.14.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.14.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.14.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.14.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.15.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.15.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.15.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.15.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.16.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.16.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.16.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.16.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.17.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.17.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.17.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.17.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.18.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.18.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.18.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.18.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.19.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.19.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.19.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.19.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.2.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.2.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.2.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.2.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.22.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.22.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.22.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.22.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.23.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.23.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.24.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.24.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.24.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.24.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.25.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.25.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.25.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.25.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.27.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.27.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.27.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.27.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.29.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.29.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.29.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.29.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.3.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.3.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.3.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.3.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.30.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.30.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.30.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.30.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.33.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.33.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.33.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.33.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.34.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.34.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.34.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.34.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.35.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.35.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.35.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.35.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.36.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.36.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.36.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.36.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.39.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.39.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.39.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.39.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.4.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.4.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.4.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.4.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.43.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.43.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.43.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.43.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.5.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.5.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.5.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.5.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.6.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.6.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.6.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.6.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.7.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.7.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.7.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.7.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.8.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.8.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.8.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.8.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.9.0/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.9.0/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.9.0/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.9.0/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \

--- a/docs/versioned_docs/version-2.9.4/setup/tooljet-subpath.md
+++ b/docs/versioned_docs/version-2.9.4/setup/tooljet-subpath.md
@@ -12,7 +12,6 @@ You'll need to setup the following environment variables if ToolJet installation
 | variable | value |
 | -------- | ---------------------- |
 | TOOLJET_HOST | the public URL ( eg: https://www.yourcompany.com )  |
-| SERVE_CLIENT | By default, this variable will be unset and the server will serve the client at its `/` end-point. You can set `SERVE_CLIENT` to `false` to disable this behaviour. |
 | SUB_PATH | Set a subpath to this variable. The subpath is to be set with trailing `/` and is applicable only when the server is serving the frontend client. ( eg: `/apps/tooljet/` )  |
 
 

--- a/docs/versioned_docs/version-2.9.4/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.9.4/setup/try-tooljet.md
@@ -10,7 +10,7 @@ title: Try ToolJet
 You can run the command below to have ToolJet up and running right away.
 
 ```bash
-docker run -d \
+docker run \
   --name tooljet \
   --restart unless-stopped \
   -p 80:80 \


### PR DESCRIPTION
Update docker command and remove outdated instructions in readme file, and docker and subpath setups.