### PR TITLE
Adding tooljet AWS 1-click installer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You can use ToolJet Cloud for a fully managed solution. If you want to self-host
 | :------------- | :------------- |
 | Digital Ocean | [Link](https://docs.tooljet.com/docs/setup/digitalocean)  |
 | Docker  | [Link](https://docs.tooljet.com/docs/setup/docker)   |
+| AWS installer | [Link](https://docs.tooljet.com/docs/setup/aws-installer)  |
 | AWS EC2 | [Link](https://docs.tooljet.com/docs/setup/ec2)  |
 | AWS ECS | [Link](https://docs.tooljet.com/docs/setup/ecs)   |
 | OpenShift | [Link](https://docs.tooljet.com/docs/setup/openshift)   |

--- a/docs/docs/setup/aws-stacksnap.md
+++ b/docs/docs/setup/aws-stacksnap.md
@@ -1,0 +1,8 @@
+---
+id: aws-installer
+title: AWS 1-click installer
+---
+
+### 1-click installation
+
+Deploy Tooljet on AWS with the community-supported [AWS Stacksnap installer](https://klo.dev/stacksnap/apps/tooljet/). It will be deployed on an ECS task running ToolJet, a Postgres DB on RDS for data storage, Redis on MemoryDB for caching, and exposed and load balanced with CloudFront and an Application Load Balancer.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -52,6 +52,7 @@ const sidebars = {
         'setup/system-requirements',
         'setup/digitalocean',
         'setup/docker',
+        'setup/aws-installer',
         'setup/ec2',
         'setup/ecs',
         'setup/openshift',


### PR DESCRIPTION
Adding instructions and a link to the AWS installer for Tooljet using Stacksnap.