### PR TITLE
fix:QueryManager filter-list button issue

### DIFF
--- a/frontend/src/Editor/QueryPanel/FilterandSortPopup.jsx
+++ b/frontend/src/Editor/QueryPanel/FilterandSortPopup.jsx
@@ -310,8 +310,8 @@ const MenuButton = ({
   };
 
   return (
-    <div className={`field p-2 ${noMargin ? '' : 'mx-1'} tj-list-btn`}>
-      <Button.UnstyledButton onClick={handleOnClick} disabled={disabled} classNames="d-flex justify-content-between">
+    <div onClick={handleOnClick} className={`field p-2 ${noMargin ? '' : 'mx-1'} tj-list-btn`}>
+      <Button.UnstyledButton disabled={disabled} classNames="d-flex justify-content-between">
         <Button.Content title={text} iconSrc={iconSrc} direction="left" />
         {active && <Tick width="20" height="20" viewBox="0 0 22 22" fill="var(--indigo9)" />}
       </Button.UnstyledButton>

--- a/frontend/src/Editor/QueryPanel/FilterandSortPopup.jsx
+++ b/frontend/src/Editor/QueryPanel/FilterandSortPopup.jsx
@@ -310,8 +310,8 @@ const MenuButton = ({
   };
 
   return (
-    <div onClick={handleOnClick} className={`field p-2 ${noMargin ? '' : 'mx-1'} tj-list-btn`}>
-      <Button.UnstyledButton disabled={disabled} classNames="d-flex justify-content-between">
+    <div className={`field ${noMargin ? '' : 'mx-1'} tj-list-btn`}>
+      <Button.UnstyledButton onClick={handleOnClick} disabled={disabled} classNames="d-flex justify-content-between p-2">
         <Button.Content title={text} iconSrc={iconSrc} direction="left" />
         {active && <Tick width="20" height="20" viewBox="0 0 22 22" fill="var(--indigo9)" />}
       </Button.UnstyledButton>

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -12148,6 +12148,7 @@ tbody {
 
   &:hover {
     background-color: var(--slate4);
+    cursor: pointer;
   }
 
   &.active {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -12148,7 +12148,6 @@ tbody {
 
   &:hover {
     background-color: var(--slate4);
-    cursor: pointer;
   }
 
   &.active {


### PR DESCRIPTION
 # Problem
  The list of filters in the query manager header is only clickable on textual parts of the list button but is expected to be clickable on the entire button. #9538 

# Changes Made
1. The click function is only applied to `button.UnstyledButton` so I move it into the outer `div` to make entire button clickable 
   File => frontend/src/Editor/QueryPanel/FilterandSortPopup.jsx => MenuButton
2. To make a cursor pointer on the entire button(div) I made changes in styling of class `tj-list-btn` in
   File => frontend/src/_styles/theme.scss
