### PR TITLE
fix : Table breaking on clicking max row height / text input slider width not getting updated

### DIFF
--- a/frontend/src/Editor/CodeBuilder/Elements/TableRowHeightInput.jsx
+++ b/frontend/src/Editor/CodeBuilder/Elements/TableRowHeightInput.jsx
@@ -9,6 +9,12 @@ const TableRowHeightInput = ({ value, onChange, cyLabel, staticText, styleDefini
     setInputValue(value < minValue ? minValue : value);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, styleDefinition.cellSize?.value]);
+  useEffect(() => {
+    onChange(
+      styleDefinition.cellSize?.value === 'condensed' ? MIN_TABLE_ROW_HEIGHT_CONDENSED : MIN_TABLE_ROW_HEIGHT_DEFAULT
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const minValue =
     styleDefinition.cellSize?.value === 'condensed' ? MIN_TABLE_ROW_HEIGHT_CONDENSED : MIN_TABLE_ROW_HEIGHT_DEFAULT;

--- a/frontend/src/Editor/CodeBuilder/Elements/TableRowHeightInput.jsx
+++ b/frontend/src/Editor/CodeBuilder/Elements/TableRowHeightInput.jsx
@@ -3,18 +3,15 @@ import React, { useEffect, useState } from 'react';
 const MIN_TABLE_ROW_HEIGHT_CONDENSED = 39;
 const MIN_TABLE_ROW_HEIGHT_DEFAULT = 45;
 
-const TableRowHeightInput = ({ value, onChange, cyLabel, staticText, component: { component } }) => {
+const TableRowHeightInput = ({ value, onChange, cyLabel, staticText, styleDefinition }) => {
   const [inputValue, setInputValue] = useState(value);
-
   useEffect(() => {
     setInputValue(value < minValue ? minValue : value);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, component?.definition?.styles?.cellSize?.value]);
+  }, [value, styleDefinition.cellSize?.value]);
 
   const minValue =
-    component?.definition?.styles?.cellSize?.value === 'condensed'
-      ? MIN_TABLE_ROW_HEIGHT_CONDENSED
-      : MIN_TABLE_ROW_HEIGHT_DEFAULT;
+    styleDefinition.cellSize?.value === 'condensed' ? MIN_TABLE_ROW_HEIGHT_CONDENSED : MIN_TABLE_ROW_HEIGHT_DEFAULT;
 
   const handleBlur = () => {
     const newValue = Math.max(inputValue, minValue);

--- a/frontend/src/Editor/CodeEditor/DynamicFxTypeRenderer.jsx
+++ b/frontend/src/Editor/CodeEditor/DynamicFxTypeRenderer.jsx
@@ -15,6 +15,7 @@ import { Input } from '../CodeBuilder/Elements/Input';
 import { Icon } from '../CodeBuilder/Elements/Icon';
 import { Visibility } from '../CodeBuilder/Elements/Visibility';
 import { NumberInput } from '../CodeBuilder/Elements/NumberInput';
+import TableRowHeightInput from '../CodeBuilder/Elements/TableRowHeightInput';
 
 const AllElements = {
   Color,
@@ -32,6 +33,7 @@ const AllElements = {
   Icon,
   Visibility,
   NumberInput,
+  TableRowHeightInput,
 };
 
 export const DynamicFxTypeRenderer = ({ paramType, ...restProps }) => {

--- a/frontend/src/Editor/CodeEditor/utils.js
+++ b/frontend/src/Editor/CodeEditor/utils.js
@@ -230,7 +230,10 @@ const queryHasStringOtherThanVariable = (query) => {
   return false;
 };
 
-export const resolveReferences = (query, validationSchema, customResolvers = {}) => {
+export const resolveReferences = (query, validationSchema, customResolvers = {}, paramName) => {
+  if (typeof query === 'number') {
+    return [true, null, query];
+  }
   if (query !== '' && (!query || typeof query !== 'string')) return [false, null, null];
   let resolvedValue = query;
   let error = null;
@@ -378,6 +381,7 @@ export const FxParamTypeMapping = Object.freeze({
   icon: 'Icon',
   visibility: 'Visibility',
   numberInput: 'NumberInput',
+  tableRowHeightInput: 'TableRowHeightInput',
 });
 
 export function computeCoercion(oldValue, newValue) {

--- a/frontend/src/Editor/Components/Table/String.jsx
+++ b/frontend/src/Editor/Components/Table/String.jsx
@@ -146,9 +146,9 @@ const StringColumn = ({
             <span
               style={{
                 maxHeight: isMaxRowHeightAuto
-                  ? 'auto'
+                  ? 'fit-content'
                   : maxRowHeightValue
-                  ? maxRowHeightValue
+                  ? `${maxRowHeightValue}px`
                   : cellSize === 'condensed'
                   ? '39px'
                   : '45px',

--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -569,6 +569,8 @@ export function Table({
       highlightSelectedRow,
       JSON.stringify(tableActionEvents),
       JSON.stringify(tableColumnEvents),
+      maxRowHeightValue,
+      isMaxRowHeightAuto,
     ] // Hack: need to fix
   );
 

--- a/frontend/src/Editor/Components/Table/Text.jsx
+++ b/frontend/src/Editor/Components/Table/Text.jsx
@@ -106,12 +106,12 @@ const Text = ({
       <span
         style={{
           maxHeight: isMaxRowHeightAuto
-            ? 'auto'
+            ? 'fit-content'
             : maxRowHeightValue
-            ? maxRowHeightValue - 16 // decreasing 16px for padding fix
+            ? `${maxRowHeightValue}px`
             : cellSize === 'condensed'
-            ? '23px'
-            : '29px',
+            ? '39px'
+            : '45px',
         }}
         ref={nonEditableCellValueRef}
       >

--- a/frontend/src/Editor/WidgetManager/configs/table.js
+++ b/frontend/src/Editor/WidgetManager/configs/table.js
@@ -349,7 +349,7 @@ export const tableConfig = {
       type: 'tableRowHeightInput',
       showLabel: false,
       validation: {
-        schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'boolean' }] },
+        schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },
       },
       accordian: 'Data',
       conditionallyRender: [

--- a/frontend/src/Editor/WidgetManager/configs/table.js
+++ b/frontend/src/Editor/WidgetManager/configs/table.js
@@ -347,6 +347,7 @@ export const tableConfig = {
     },
     maxRowHeightValue: {
       type: 'tableRowHeightInput',
+      isFxNotRequired: true,
       showLabel: false,
       validation: {
         schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] },


### PR DESCRIPTION
Fixes: https://github.com/ToolJet/ToolJet/issues/10053

closes https://github.com/ToolJet/ToolJet/issues/10075
*Table breaks on clicking on max row height and value does not get updated
*on text input slider width in not getting updated when updating from input box
*in general number inputs in styles/properties panel were having issues