### PR TITLE
feat: skip onDragStop execution if drag event is empty

### DIFF
--- a/frontend/src/Editor/DragContainer.jsx
+++ b/frontend/src/Editor/DragContainer.jsx
@@ -529,7 +529,7 @@ export default function DragContainer({
               isDraggingRef.current = false;
             }
 
-            if (draggedSubContainer) {
+            if (draggedSubContainer || !e.lastEvent) {
               return;
             }
 

--- a/frontend/src/_stores/utils.js
+++ b/frontend/src/_stores/utils.js
@@ -174,7 +174,7 @@ const updateFor = (appDiff, currentPageId, opts, currentLayout) => {
       try {
         return processingFunction(appDiff, currentPageId, optionsTypes, currentLayout);
       } catch (error) {
-        console.log('Error processing diff for update type: ', updateTypes, appDiff, error);
+        console.error('Error processing diff for update type: ', updateTypes, appDiff, error);
         return { error, updateDiff: {}, type: null, operation: null };
       }
     }

--- a/frontend/src/_stores/utils.js
+++ b/frontend/src/_stores/utils.js
@@ -174,6 +174,7 @@ const updateFor = (appDiff, currentPageId, opts, currentLayout) => {
       try {
         return processingFunction(appDiff, currentPageId, optionsTypes, currentLayout);
       } catch (error) {
+        console.log('Error processing diff for update type: ', updateTypes, appDiff, error);
         return { error, updateDiff: {}, type: null, operation: null };
       }
     }


### PR DESCRIPTION
Fixed issue that caused the element to reset to grid 0, 0 when you change the label size and click on the element. This is caused by the onDrag event triggered on click which does not have any event details on