### PR TITLE
fixes: Special handling for 'window' keyword in multiline code editors

### DIFF
--- a/frontend/src/_helpers/utility.js
+++ b/frontend/src/_helpers/utility.js
@@ -2,7 +2,7 @@ import { useResolveStore } from '@/_stores/resolverStore';
 import _ from 'lodash';
 
 export function validateMultilineCode(code) {
-  const reservedKeyword = ['app', 'window', 'this']; // Case-sensitive reserved keywords
+  const reservedKeyword = ['app', 'this']; // Case-sensitive reserved keywords except 'window'
   const keywordRegex = new RegExp(`\\b(${reservedKeyword.join('|')})\\b`, 'i');
   let inString = false;
   let inComment = false;
@@ -33,6 +33,18 @@ export function validateMultilineCode(code) {
 
     // If we are not within a string or a comment, check for keywords
     if (!inString && !inComment) {
+      // Special handling for 'window'
+      if (code.substring(i, i + 6) === 'window' && (code[i + 6] === undefined || code[i + 6] !== '.')) {
+        return {
+          status: 'failed',
+          data: {
+            message: `Code contains reserved keyword 'window'`,
+            description:
+              'Cannot resolve code with reserved keyword "window" in it unless it is followed by a dot. Please remove it and try again.',
+          },
+        };
+      }
+
       const restOfCode = code.substring(i);
       const match = restOfCode.match(keywordRegex);
 


### PR DESCRIPTION
- Updated validation logic to allow 'window.x' while treating standalone 'window' as a reserved keyword.
- Refined keyword matching to ensure keywords are not part of a string or a comment and are exact matches.
- Applied a hotfix to both CE-LTS and the latest non-LTS CE versions, effective by end of day.
- Note: This update is specifically for multiline code editors; single line editors will continue to support 'window.x' or any usage of 'window' as it breaks the app otherwise.