### PR TITLE
fix: Reset canvas background color to the default value of the component

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -90,6 +90,7 @@ import { decimalToHex, EditorConstants } from './editorConstants';
 import { handleLowPriorityWork, updateCanvasBackground, clearAllQueuedTasks } from '@/_helpers/editorHelpers';
 import { TJLoader } from '@/_ui/TJLoader/TJLoader';
 import cx from 'classnames';
+import { resolveReferences } from './CodeEditor/utils';
 
 setAutoFreeze(false);
 enablePatches();
@@ -1461,6 +1462,7 @@ const EditorComponent = (props) => {
           newGlobalSettings = dfs(newGlobalSettings, entity, value);
         }
       });
+      const [_, error, resolvedCanvasBackgroundColor] = resolveReferences(newGlobalSettings?.backgroundFxQuery, {});
 
       const newAppDefinition = produce(appJson, (draft) => {
         draft.globalSettings = newGlobalSettings;
@@ -1469,7 +1471,7 @@ const EditorComponent = (props) => {
       // Setting the canvas background to the editor store
       setCanvasBackground({
         backgroundFxQuery: newGlobalSettings?.backgroundFxQuery,
-        canvasBackgroundColor: newGlobalSettings?.canvasBackgroundColor,
+        canvasBackgroundColor: resolvedCanvasBackgroundColor || '',
       });
 
       updateEditorState({

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -1232,6 +1232,13 @@ export function runQuery(
               const err = query.kind == 'tooljetdb' ? data?.error || data : data;
               toast.error(err?.message ? err?.message : 'Something went wrong');
             }
+            useResolveStore.getState().actions.addAppSuggestions({
+              queries: {
+                [queryName]: {
+                  isLoading: false,
+                },
+              },
+            });
             return;
           } else {
             let rawData = data.data;


### PR DESCRIPTION
This PR solves the following issues when the canvas background color is linked with the component: 

1) Resets the color when the component is deleted
2) Set the canvas color to the default value of the linked component