### PR TITLE
fix: updated parentid check to account for tab children

### DIFF
--- a/frontend/src/Editor/DragContainer.jsx
+++ b/frontend/src/Editor/DragContainer.jsx
@@ -819,16 +819,11 @@ function findChildrenAndGrandchildren(parentId, widgets) {
   if (isEmpty(widgets)) {
     return [];
   }
-  const type = widgets.find(({ id }) => id === parentId)?.component?.component;
-  let pid = parentId;
-  if (type === 'Kanban') {
-    pid = pid + '-modal';
-  }
-  const children = widgets.filter((widget) => widget?.component?.parent === pid);
+  const children = widgets.filter((widget) => widget?.component?.parent?.startsWith(parentId));
   let result = [];
   for (const child of children) {
     result.push(child.id);
-    result = result.concat(...findChildrenAndGrandchildren(child.id));
+    result = result.concat(...findChildrenAndGrandchildren(child.id, widgets));
   }
   return result;
 }


### PR DESCRIPTION
Fixes children search inside drag container. This should fix the issue where deeply nested children inside a modal is not selectable
Fixes: https://github.com/ToolJet/ToolJet/issues/10204