### PR TITLE
Fix: Removed the org id from the query option details of the ToolJet database.

### DIFF
--- a/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
+++ b/frontend/src/Editor/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
@@ -436,7 +436,6 @@ const ToolJetDbOperations = ({ optionchanged, options, darkMode, isHorizontalLay
   const handleTableNameSelect = (tableId) => {
     setSelectedTableId(tableId);
     fetchTableInformation(tableId, true, tables);
-    optionchanged('organization_id', organizationId);
     optionchanged('table_id', tableId);
 
     setJoinTableOptions(() => {

--- a/frontend/src/HomePage/ExportAppModal.jsx
+++ b/frontend/src/HomePage/ExportAppModal.jsx
@@ -50,7 +50,7 @@ export default function ExportAppModal({ title, show, closeModal, customClassNam
         const { dataQueries } = tbl;
         const extractedIdData = [];
         dataQueries.forEach((item) => {
-          if (item.kind === 'tooljetdb') {
+          if (item.kind === 'tooljetdb' && item.options?.operation === 'join_tables') {
             const joinOptions = item.options?.join_table?.joins ?? [];
             (joinOptions || []).forEach((join) => {
               const { table, conditions } = join;
@@ -66,6 +66,8 @@ export default function ExportAppModal({ title, show, closeModal, customClassNam
               });
             });
           }
+
+          if (item.kind === 'tooljetdb' && item.options.table_id) extractedIdData.push(item.options.table_id);
         });
         const uniqueSet = new Set(extractedIdData);
         const selectedVersiontable = Array.from(uniqueSet).map((item) => ({ table_id: item }));

--- a/server/src/services/data_queries.service.ts
+++ b/server/src/services/data_queries.service.ts
@@ -185,7 +185,11 @@ export class DataQueriesService {
         dataSourceOptions.updatedAt,
         {
           user: { id: user?.id },
-          app: { id: app?.id, isPublic: app?.isPublic },
+          app: {
+            id: app?.id,
+            isPublic: app?.isPublic,
+            ...(dataSource.kind === 'tooljetdb' && { organization_id: app.organizationId }),
+          },
         }
       );
     } catch (api_error) {


### PR DESCRIPTION
Issues Fixed

1. The OrgID is removed from the ToolJet database query options, and the dependent logic in the TJDB Operations service was also updated.
2. Exporting a app with ToolJet database schema, for a selected version, exports table which isn't used in the Tooljet database queries

closes #10307 
