### PR TITLE
[hot-fix] Exposing password in basic auth success request URL

### DIFF
--- a/plugins/packages/restapi/lib/index.ts
+++ b/plugins/packages/restapi/lib/index.ts
@@ -159,8 +159,11 @@ export default class RestapiQueryService implements QueryService {
     try {
       const response = await got(url, requestOptions);
       result = this.getResponse(response);
+      const requestUrl = sourceOptions.password
+        ? response.request.requestUrl?.replace(`${sourceOptions.password}@`, '<password>@')
+        : response.request.requestUrl;
       requestObject = {
-        requestUrl: response.request.requestUrl,
+        requestUrl,
         method: response.request.options.method,
         headers: response.request.options.headers,
         params: urrl.parse(response.request.requestUrl, true).query,

--- a/plugins/packages/restapi/lib/index.ts
+++ b/plugins/packages/restapi/lib/index.ts
@@ -160,7 +160,7 @@ export default class RestapiQueryService implements QueryService {
       const response = await got(url, requestOptions);
       result = this.getResponse(response);
       const requestUrl = sourceOptions.password
-        ? response.request.requestUrl?.replace(`${sourceOptions.password}@`, '<password>@')
+        ? response.request.requestUrl?.replace(/:\/\/(.*?):(.*?)@/, '://$1:<password>@')
         : response.request.requestUrl;
       requestObject = {
         requestUrl,


### PR DESCRIPTION
**More info**
We are exposing the password for basic auth in the success request URL. (please check the inspector queries array after the success request)