### PR TITLE
Setting app themes default values on global settings

### DIFF
--- a/server/ce/apps/services/apps.service.sep.ts
+++ b/server/ce/apps/services/apps.service.sep.ts
@@ -1,0 +1,16 @@
+import { OrganizationThemes, TJDefaultTheme } from '../types/OrganizationThemes';
+
+export class AppsServiceSep {
+  getTheme(organizationId: string, themeId?: string): OrganizationThemes {
+    return {
+      id: '63277bf2-1849-4374-965c-2e296319d619',
+      name: 'TJ default',
+      definition: {
+        brand: new TJDefaultTheme(),
+      },
+      isDefault: true,
+      isBasic: true,
+      isDisabled: false,
+    };
+  }
+}

--- a/server/ce/apps/types/OrganizationThemes.ts
+++ b/server/ce/apps/types/OrganizationThemes.ts
@@ -1,0 +1,42 @@
+export interface OrganizationThemes {
+  id: string;
+  name: string;
+  definition: Definition;
+  isDefault: boolean;
+  isBasic: boolean;
+  isDisabled: boolean;
+}
+
+interface Colors {
+  primary: {
+    light: string;
+    dark: string;
+  };
+  secondary?: {
+    light: string;
+    dark: string;
+  };
+  tertiary?: {
+    light: string;
+    dark: string;
+  };
+}
+
+interface Definition {
+  brand: Colors;
+}
+
+export class TJDefaultTheme {
+  primary = {
+    light: '#4368E3',
+    dark: '#4A6DD9',
+  };
+  secondary = {
+    light: '#6A727C',
+    dark: '#CFD3D8',
+  };
+  tertiary = {
+    light: '#1E823B',
+    dark: '#318344',
+  };
+}

--- a/server/src/modules/apps/apps.module.ts
+++ b/server/src/modules/apps/apps.module.ts
@@ -43,6 +43,7 @@ import { ComponentsService } from '@services/components.service';
 import { PageService } from '@services/page.service';
 import { EventsService } from '@services/events_handler.service';
 import { TooljetDbModule } from '../tooljet_db/tooljet_db.module';
+import { AppsServiceSep } from '@apps/services/apps.service.sep';
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { TooljetDbModule } from '../tooljet_db/tooljet_db.module';
   ],
   providers: [
     AppsService,
+    AppsServiceSep,
     AppUsersService,
     UsersService,
     FoldersService,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -14,6 +14,7 @@
     "incremental": true,
     "paths": {
       "@ee/*": ["ee/*"],
+      "@apps/*": ["ce/apps/*"],
       "@services/*": ["src/services/*"],
       "@controllers/*": ["src/controllers/*"],
       "@repositories/*": ["src/repositories/*"],


### PR DESCRIPTION
GET v2/apps/:id (editor)

GET v2/apps/slugs/:slug (viewer)

GET v2/apps/:id/versions/:versionId (preview)

these APIs should include theme object in global settings