### PR TITLE
fix:users scroll ui

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -8936,7 +8936,7 @@ tbody {
       height: 40px;
       display: flex;
       align-items: center;
-      margin-top: 6px;
+      
     }
 
     tr>th {


### PR DESCRIPTION
fixes: #9956
Because of adding `margin-top` to the `table heading row` this was happening:
![users](https://github.com/user-attachments/assets/7459afbe-3ac1-4e14-b492-c138ce7edecd)
FIxed this issue

and as for the original issue it was fixed in current version i think..!!
![image](https://github.com/user-attachments/assets/482de001-78c3-4897-933e-ced490599b94)


https://github.com/user-attachments/assets/0664146a-0a57-4ec1-8358-9e91804149e3

