### PR TITLE
Fixes undefined values for text input

### DIFF
--- a/frontend/src/Editor/Components/TextInput.jsx
+++ b/frontend/src/Editor/Components/TextInput.jsx
@@ -336,7 +336,7 @@ export const TextInput = function TextInput({
           type="text"
           placeholder={placeholder}
           style={computedStyles}
-          value={value}
+          value={value ?? ''}
           disabled={disable || loading}
         />
         {loading && <Loader style={{ ...loaderStyle }} width="16" />}


### PR DESCRIPTION
When default value for text input is dependent on some undefined objects, the input is not cleared and the older values are retained