### PR TITLE
cast page value to number when inputing a custom page number

### DIFF
--- a/frontend/src/Editor/Components/Table/Pagination.jsx
+++ b/frontend/src/Editor/Components/Table/Pagination.jsx
@@ -127,7 +127,8 @@ export const Pagination = function Pagination({
               className={`form-control h-100`}
               value={pageIndex}
               onChange={(event) => {
-                if (event.target.value <= pageCount) gotoPage(event.target.value);
+                const value = Number(event.target.value);
+                if (value <= pageCount) gotoPage(value);
               }}
             />
             <span


### PR DESCRIPTION
In table page number control for pagination if we add a custom page number, it was inputted as a string which let to next and prev buttons treating it as a string ie ex "5" + 1 = 51. This pr fixes this behaviour by correctly casting the input value.