### PR TITLE
[docs]: fix validation error on local docs build

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -143,7 +143,7 @@ module.exports = {
         },
         googleTagManager: isProd
           ? {
-            containerId: process.env.GTM,
+            containerId: process.env.GTM || 'development',
           }
           : undefined,
       },


### PR DESCRIPTION
- Adds 'development' when process.env.GTM isn't found