### PR TITLE
all charts getting deleted when some other component is deleted becau…

### DIFF
--- a/frontend/src/Editor/WidgetManager/configs/chart.js
+++ b/frontend/src/Editor/WidgetManager/configs/chart.js
@@ -179,9 +179,9 @@ export const chartConfig = {
   },
   exposedVariables: {
     show: null,
-    chartTitle: undefined,
-    xAxisTitle: undefined,
-    yAxisTitle: undefined,
+    chartTitle: null,
+    xAxisTitle: null,
+    yAxisTitle: null,
     clickedDataPoint: {},
   },
   definition: {


### PR DESCRIPTION
Char component had undefined values in its definition. While calculating the diff we clone the app definition using JSON.parse & JSON.stringify  which removes the keys with undefined values. Because of this the diff included chards which are not supposed to be deleted thus deleting all charts. This PR sets those values to null instead of undefined.