### PR TITLE
[dark mode]: fix color of time selection box in datepicker

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -6767,11 +6767,15 @@ tbody {
       .react-datepicker__month-select,
       .react-datepicker__year-select {
         color: white;
+        
       }
 
       .react-datepicker__month-select,
       .react-datepicker__year-select {
         background-color: transparent;
+        option{
+          background-color: #232e3c;
+        }
       }
     }
 


### PR DESCRIPTION
fixes #10087

Dropdown color has been improved to fit the theme. The styling of the date and time pickers cannot be altered due to Chrome's constraints. Use Bootstrap or custom controls for consistent styling.

**Citation:** [Google Chrome FAQ on Date Picker Styling](https://developers.google.com/web/updates/2012/08/Quick-FAQs-on-input-type-date-in-Google-Chrome#how_do_i_change_the_appearance_of_the_date_picker) - Describes the reasons behind Chrome's prohibition of custom date picker styling.

This is a known issue on [react-datepicker repo](https://github.com/Hacker0x01/react-datepicker/issues/3734).
