### PR TITLE
refactor [docs]: modify try-tooljet with docker

### DIFF
--- a/docs/versioned_docs/version-2.50.0-LTS/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/try-tooljet.md
@@ -29,12 +29,15 @@ docker run \
 
 #### Using the Correct Platform with Docker
 
-- macOS
-  Intel-based Macs: Use `linux/amd64`.
-  Apple Silicon (M1 and M2): Use `linux/arm64`.
+- macOS:
 
-- Windows
-  Most modern Windows systems use `linux/amd64`.
+Intel-based Macs: Use `linux/amd64`.
+
+Apple Silicon (M1 and M2): Use `linux/arm64`.
+
+- Windows:
+
+Most modern Windows systems use `linux/amd64`.
 
 #### Setup information
 

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/try-tooljet.md
@@ -5,7 +5,7 @@ title: Try ToolJet
 
 # Try ToolJet
 
-## On local with Docker
+## Running ToolJet Locally with Docker
 
 You can run the command below to have ToolJet up and running right away.
 
@@ -18,18 +18,42 @@ docker run \
   -v tooljet_data:/var/lib/postgresql/13/main \
   tooljet/try:EE-LTS-latest
 ```
-*If you have any questions feel free to join our [Slack Community](https://tooljet.com/slack) or send us an email at hello@tooljet.com.*
 
+#### Explanation
+
+- `--name tooljet`: Names the container "tooljet".
+- `--restart unless-stopped`: Automatically restarts the container unless it is explicitly stopped.
+- `-p 80:80`: Maps port 80 of the host to port 80 of the container.
+- `--platform linux/amd64`: Ensures the container uses the correct platform.
+- `-v tooljet_data:/var/lib/postgresql/13/main`: Creates a Docker volume named `tooljet_data` - for persistent storage of PostgreSQL data.
+
+#### Using the Correct Platform with Docker
+
+- macOS
+  Intel-based Macs: Use `linux/amd64`.
+  Apple Silicon (M1 and M2): Use `linux/arm64`.
+
+- Windows
+  Most modern Windows systems use `linux/amd64`.
 
 #### Setup information
 
-- Runs the ToolJet server on the port 80 on your machine.
-- Container has postgres already configured within. All the data will be available in the docker volume `tooljet_data`.
-- You can make use of `--env` or `--env-file` flag to test against various env configurables mentioned [here](https://docs.tooljet.com/docs/setup/env-vars).
-- Use `docker stop tooljet` to stop the container and `docker start tooljet` to start the container thereafter.
+- ToolJet will run on port 80 of your machine.
+- The container includes a pre-configured PostgreSQL database.
+- Data will be stored in the Docker volume `tooljet_data`.
 
-#### Dynamic Port Setup
-To run the ToolJet server on a different port, such as 8080 or any other port of your choice, use the following command:
+#### Environment Variables
+
+You can customize the environment settings using `--env` or `--env-file` flags.
+
+#### Stopping and Starting the Container
+
+- To stop the container, use: `docker stop tooljet`
+- To start the container again, use: `docker start tooljet`
+
+#### Running on a Different Port
+
+To run ToolJet on a different port (e.g., port 8080), use the following command:
 
 ```sh
 docker run \
@@ -42,10 +66,16 @@ docker run \
   tooljet/try:EE-LTS-latest
 ```
 
+#### Explanation
+
 - This command will start the ToolJet server on port 8080.
 - The `-e PORT=8080` flag sets the `PORT` environment variable to 8080, allowing the ToolJet server to listen on port 8080.
 
 By following these instructions, you can easily run the ToolJet server on the port of your choice, ensuring flexibility in your setup.
 
+## Need Help ?
 
+If you have any questions, feel free to:
 
+- Join our [Slack Community](https://tooljet.com/slack)
+- Send us an email at hello@tooljet.com


### PR DESCRIPTION
This document provides detailed instructions for running ToolJet locally using Docker. 

It includes the necessary Docker commands, explanations for each command option, and platform-specific instructions that were missing in the previous doc. 