### PR TITLE
Fix chart not updating when using custom schema and dynamic data 

### DIFF
--- a/frontend/src/Editor/WidgetManager/configs/chart.js
+++ b/frontend/src/Editor/WidgetManager/configs/chart.js
@@ -89,7 +89,8 @@ export const chartConfig = {
       displayName: 'Json Description',
       validation: {
         schema: {
-          type: 'string',
+          type: 'union',
+          schemas: [{ type: 'string' }, { type: 'object' }],
         },
         defaultValue: '{ "data": [ { "x": [ "Jan", "Feb", "Mar" ], "y": [ 100, 80, 40 ], "type": "bar" } ] }',
       },


### PR DESCRIPTION
When setting chart data from a query the json response was getting invalidated. This fix adds object as a valid data type for chart `jsonDescription`.