### PR TITLE
fix label text issue for text, password and number inputs

### DIFF
--- a/frontend/src/Editor/Components/Form/FormUtils.js
+++ b/frontend/src/Editor/Components/Form/FormUtils.js
@@ -55,7 +55,8 @@ export function generateUIComponents(JSONSchema, advanced) {
               uiComponentsDraft[index * 2 + 1]['definition']['properties']['value']['value'] = value?.value;
             if (value?.placeholder)
               uiComponentsDraft[index * 2 + 1]['definition']['properties']['placeholder']['value'] = value?.placeholder;
-            if (value?.label) uiComponentsDraft[index * 2 + 1]['definition']['properties']['label']['value'] = '';
+            // prevent label from showing up in text input, because it is already shown in the text component. (Defaults to "Label" if not updated explicitly with an empty string)
+            uiComponentsDraft[index * 2 + 1]['definition']['properties']['label']['value'] = '';
             break;
           case 'DropDown':
             if (value?.styles?.disabled)
@@ -156,7 +157,7 @@ export function generateUIComponents(JSONSchema, advanced) {
               uiComponentsDraft[index * 2 + 1]['definition']['properties']['minValue']['value'] = value?.minValue;
             if (value?.placeholder)
               uiComponentsDraft[index * 2 + 1]['definition']['properties']['placeholder']['value'] = value?.placeholder;
-            if (value?.label) uiComponentsDraft[index * 2 + 1]['definition']['properties']['label']['value'] = '';
+            uiComponentsDraft[index * 2 + 1]['definition']['properties']['label']['value'] = '';
             break;
 
           case 'PasswordInput':
@@ -187,7 +188,7 @@ export function generateUIComponents(JSONSchema, advanced) {
               uiComponentsDraft[index * 2 + 1]['definition']['validation']['regex']['value'] = value?.validation?.regex;
             if (value?.placeholder)
               uiComponentsDraft[index * 2 + 1]['definition']['properties']['placeholder']['value'] = value?.placeholder;
-            if (value?.label) uiComponentsDraft[index * 2 + 1]['definition']['properties']['label']['value'] = '';
+            uiComponentsDraft[index * 2 + 1]['definition']['properties']['label']['value'] = '';
 
             break;
           case 'Datepicker':
@@ -274,8 +275,7 @@ export function generateUIComponents(JSONSchema, advanced) {
 
             if (value?.value)
               uiComponentsDraft[index * 2 + 1]['definition']['properties']['defaultValue']['value'] = value?.value;
-            if (value?.label)
-              uiComponentsDraft[index * 2 + 1]['definition']['properties']['label']['value'] = value?.label;
+            uiComponentsDraft[index * 2 + 1]['definition']['properties']['label']['value'] = value?.label;
             break;
 
           case 'TextArea':

--- a/frontend/src/Editor/WidgetManager/configs/form.js
+++ b/frontend/src/Editor/WidgetManager/configs/form.js
@@ -315,7 +315,7 @@ export const formConfig = {
       advanced: { value: '{{false}}' },
       JSONSchema: {
         value:
-          "{{ {title: 'User registration form', properties: {firstname: {type: 'textinput',value: 'Maria',label:'First name', validation:{maxLength:6}, styles: {backgroundColor: '#f6f5ff',textColor: 'black'},},lastname:{type: 'textinput',value: 'Doe', label:'Last name', styles: {backgroundColor: '#f6f5ff',textColor: 'black'},},age:{type:'number'},}, submitButton: {value: 'Submit', styles: {backgroundColor: '#3a433b',borderColor:'#595959'}}} }}",
+          "{{ {title: 'User registration form', properties: {firstname: {type: 'textinput',value: 'Maria',label:'First name', validation:{maxLength:6}, styles: {backgroundColor: '#f6f5ff',textColor: 'black'},},lastname:{type: 'textinput',value: 'Doe', label:'Last name', styles: {backgroundColor: '#f6f5ff',textColor: 'black'},},age:{type:'number', label:'Age'},}, submitButton: {value: 'Submit', styles: {backgroundColor: '#3a433b',borderColor:'#595959'}}} }}",
       },
     },
     events: [],


### PR DESCRIPTION
When using custom schema in form if user didn't specify a label for field we fallback to displaying `Label` text next to the input. This PR fixes this behaviour and removes the  `Label` text from Input  and fieldName becomes the label.
Also added label to age field in the default custom schema for form.