### PR TITLE
fix: column transformations not working

### DIFF
--- a/frontend/src/Editor/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Components/Table/Table.jsx
@@ -484,7 +484,7 @@ export function Table({
           // Single-level nested property
           const [nestedKey, subKey] = nestedKeys;
           const nestedObject = transformedObject?.[nestedKey] || { ...row[nestedKey] }; // Retain existing nested object
-          const newValue = resolveReferences(transformation, row[key], {
+          const newValue = resolveReferences(transformation, undefined, row[key], {
             cellValue: row?.[nestedKey]?.[subKey],
             rowData: row,
           });
@@ -496,7 +496,7 @@ export function Table({
           transformedObject[nestedKey] = nestedObject;
         } else {
           // Non-nested property
-          transformedObject[key] = resolveReferences(transformation, row[key], {
+          transformedObject[key] = resolveReferences(transformation, undefined, row[key], {
             cellValue: row[key],
             rowData: row,
           });


### PR DESCRIPTION
Issue: Column transformations return empty text
Fix: Resolvereference function had its no of parameters changed but some places wherein it was invoked weren't changed.