### PR TITLE
Fixes box shadow not working for table and Hide fx for Make all columns editable field in table

### DIFF
--- a/frontend/src/Editor/BoxUI.jsx
+++ b/frontend/src/Editor/BoxUI.jsx
@@ -11,6 +11,7 @@ import { useAppDataStore } from '@/_stores/appDataStore';
 import _ from 'lodash';
 
 const shouldAddBoxShadowAndVisibility = [
+  'Table',
   'TextInput',
   'PasswordInput',
   'NumberInput',

--- a/frontend/src/Editor/Inspector/Components/Table/Table.jsx
+++ b/frontend/src/Editor/Inspector/Components/Table/Table.jsx
@@ -704,7 +704,7 @@ class TableComponent extends React.Component {
                   property="isAllColumnsEditable"
                   props={{ isAllColumnsEditable: `{{${this.state.isAllColumnsEditable}}}` }}
                   component={this.props.component}
-                  paramMeta={{ type: 'toggle', displayName: 'Make all columns editable' }}
+                  paramMeta={{ type: 'toggle', displayName: 'Make all columns editable', isFxNotRequired: true }}
                   paramType="properties"
                 />
               </div>


### PR DESCRIPTION
This PR 

1. hides the fx for Make all columns editable field in table.
2. Fixes box shadow not working for Table