### PR TITLE
fix table mapping for events when cloning and creating new versions

### DIFF
--- a/server/src/services/app_import_export.service.ts
+++ b/server/src/services/app_import_export.service.ts
@@ -1788,6 +1788,10 @@ export class AppImportExportService {
         eventDefinition.modal = oldComponentToNewComponentMapping[eventDefinition.modal];
       }
 
+      if (eventDefinition?.actionId == 'set-table-page' && oldComponentToNewComponentMapping[eventDefinition.table]) {
+        eventDefinition.table = oldComponentToNewComponentMapping[eventDefinition.table];
+      }
+
       event.event = eventDefinition;
 
       await manager.save(event);

--- a/server/src/services/apps.service.ts
+++ b/server/src/services/apps.service.ts
@@ -517,6 +517,9 @@ export class AppsService {
         eventDefinition.modal = oldComponentToNewComponentMapping[eventDefinition.modal];
       }
 
+      if (eventDefinition?.actionId === 'set-table-page') {
+        eventDefinition.table = oldComponentToNewComponentMapping[eventDefinition.table];
+      }
       event.event = eventDefinition;
 
       await manager.save(event);

--- a/server/src/services/page.service.ts
+++ b/server/src/services/page.service.ts
@@ -129,6 +129,10 @@ export class PageService {
               eventDefinition.modal = componentsIdMap[eventDefinition.modal];
             }
 
+            if (eventDefinition?.actionId === 'set-table-page') {
+              eventDefinition.table = componentsIdMap[eventDefinition.table];
+            }
+
             event.event = eventDefinition;
 
             const clonedEvent = new EventHandler();


### PR DESCRIPTION
When cloning or creating a new version, event mapping for table were incorrect. This PR fixes it.