### PR TITLE
fix : Page change doesn't happen for table with CSA in viewer

### DIFF
--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -69,7 +69,7 @@ export function setCurrentStateAsync(_ref, changes) {
   });
 }
 
-const debouncedChange = _.debounce(() => {
+const debouncedChange = _.debounce((duplicateCurrentState) => {
   const newComponentsState = {};
   for (const [key, value] of Object.entries(getCurrentState().components)) {
     if (duplicateCurrentState[key]) {
@@ -177,7 +177,7 @@ export function onComponentOptionsChanged(component, options, id) {
 
     duplicateCurrentState = { ...components, [componentName]: componentData };
 
-    debouncedChange();
+    debouncedChange(duplicateCurrentState);
   }
   return Promise.resolve();
 }
@@ -246,7 +246,7 @@ export function onComponentOptionChanged(component, option_name, value, id) {
   } else {
     // Update the duplicate state if editor is not ready
     duplicateCurrentState = { ...components, [componentName]: componentData };
-    debouncedChange();
+    debouncedChange(duplicateCurrentState);
   }
 
   return Promise.resolve();


### PR DESCRIPTION
fixes : Page change doesn't happen for table with CSA(use button) in viewer mode.

steps 
1) Add table
2)Copy table
3) attach query to table 1  and add a button and use Contol component action to page change
4) preview and in viewer page doesn't switch
<img width="495" alt="Screenshot 2024-07-25 at 3 32 06 PM" src="https://github.com/user-attachments/assets/67d1ea3b-8203-4df8-acb0-7c583d0e8e1d">
