### PR TITLE
fix/tabs-equal-width

### DIFF
--- a/frontend/src/Editor/Components/Tabs.jsx
+++ b/frontend/src/Editor/Components/Tabs.jsx
@@ -143,7 +143,7 @@ export const Tabs = function Tabs({
   return (
     <div
       data-disabled={parsedDisabledState}
-      className="jet-tabs card"
+      className="jet-tabs card tabs-component"
       style={{ height, display: parsedWidgetVisibility ? 'flex' : 'none', backgroundColor: bgColor, boxShadow }}
       data-cy={dataCy}
     >

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -13325,3 +13325,8 @@ div.ds-svg-container svg {
   }
 }
 
+  .tabs-component{
+    .tab-pane{
+      top: initial !important;
+    }
+  }


### PR DESCRIPTION
Issue: Tabs would overlap content inside the tabs-body when equal-width is set
Fix: Removed the top:0 px CSS property to avoid this behaviour.