### PR TITLE
Fix/Tooltip to be shown only for truncated text #10453

### DIFF
--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -99,7 +99,7 @@ export default function AppCard({
           </div>
         </div>
         <div>
-          <ToolTip trigger={['hover']} message={app.name}>
+          <ToolTip trigger={['hover']} message={app.name} checkOverflow={true}>
             <h3
               className="app-card-name font-weight-500 tj-text-md"
               data-cy={`${app.name.toLowerCase().replace(/\s+/g, '-')}-title`}

--- a/frontend/src/_components/ToolTip.jsx
+++ b/frontend/src/_components/ToolTip.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
-import Tooltip from 'react-bootstrap/esm/Tooltip';
-import 'bootstrap/dist/css/bootstrap.min.css';
+import React, { cloneElement, useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import OverlayTrigger from "react-bootstrap/esm/OverlayTrigger";
+import Tooltip from "react-bootstrap/esm/Tooltip";
+import "bootstrap/dist/css/bootstrap.min.css";
 
 export function ToolTip({
   message,
@@ -12,11 +12,21 @@ export function ToolTip({
   delay = { show: 50, hide: 100 },
   show = true,
   tooltipClassName = '',
+  checkOverflow = false,
   ...rest
 }) {
-  if (!show) {
-    return children;
-  }
+  const [isOverflow, setIsOverflow] = useState(false);
+  const childRef = useRef(null);
+
+  useEffect(() => {
+    const checkOverflowCondition = () => {
+      if (childRef.current) setIsOverflow(childRef.current.scrollWidth > childRef.current.clientWidth);
+    };
+    if (checkOverflow) checkOverflowCondition();
+  }, [checkOverflow, children]);
+
+  if (!show || (checkOverflow && !isOverflow)) return cloneElement(children, { ref: childRef });
+
   return (
     <OverlayTrigger
       trigger={trigger}
@@ -37,4 +47,5 @@ ToolTip.propTypes = {
   children: PropTypes.object.isRequired,
   placement: PropTypes.string,
   trigger: PropTypes.array,
+  checkOverflow: PropTypes.bool,
 };

--- a/frontend/src/_components/ToolTip.jsx
+++ b/frontend/src/_components/ToolTip.jsx
@@ -1,8 +1,8 @@
-import React, { cloneElement, useEffect, useRef, useState } from "react";
-import PropTypes from "prop-types";
-import OverlayTrigger from "react-bootstrap/esm/OverlayTrigger";
-import Tooltip from "react-bootstrap/esm/Tooltip";
-import "bootstrap/dist/css/bootstrap.min.css";
+import React, { cloneElement, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
+import Tooltip from 'react-bootstrap/esm/Tooltip';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 export function ToolTip({
   message,

--- a/frontend/src/_components/ToolTip.jsx
+++ b/frontend/src/_components/ToolTip.jsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, useEffect, useRef, useState } from 'react';
+import React, { cloneElement, useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
 import Tooltip from 'react-bootstrap/esm/Tooltip';
@@ -18,12 +18,13 @@ export function ToolTip({
   const [isOverflow, setIsOverflow] = useState(false);
   const childRef = useRef(null);
 
+  const checkOverflowCondition = useCallback(() => {
+    if (childRef.current) setIsOverflow(childRef.current.scrollWidth > childRef.current.clientWidth);
+  }, [childRef]);
+  
   useEffect(() => {
-    const checkOverflowCondition = () => {
-      if (childRef.current) setIsOverflow(childRef.current.scrollWidth > childRef.current.clientWidth);
-    };
-    if (checkOverflow) checkOverflowCondition();
-  }, [checkOverflow, children]);
+    if (checkOverflow)checkOverflowCondition();
+  }, [checkOverflow, checkOverflowCondition, children]);
 
   if (!show || (checkOverflow && !isOverflow)) return cloneElement(children, { ref: childRef });
 


### PR DESCRIPTION
Fixes: #10453
Display Tooltip Based on Text Overflow
```
.app-card-name {
  color: var(—-slate12);
  margin-bottom: 2px;
  white-space: nowrap;
  overflow: hidden;
 ` text-overflow: ellipsis; `
}
```
Added a new boolean type prop `checkOverflow` that allows conditional display of tooltip based on text overflow.
Utilize a `ref` to access the DOM element and compare its scroll width and client width.

Demonstration:

![2024-07-25 20-55-07](https://github.com/user-attachments/assets/21c113d7-2708-4bb4-aa73-94cbe2ec0163)

This change is backward compatible; existing implementations of ToolTip will continue to function as before unless `checkOverflow` is explicitly set to true or ommited.