### PR TITLE
fix/listview-record-click

### DIFF
--- a/frontend/src/Editor/Components/Listview.jsx
+++ b/frontend/src/Editor/Components/Listview.jsx
@@ -62,7 +62,9 @@ export const Listview = function Listview({
     if (isEditorReady) {
       setExposedVariables(exposedVariables);
     }
-    fireEvent('onRecordClicked');
+    setTimeout(() => {
+      fireEvent('onRecordClicked');
+    }, 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }
   function onRowClicked(index) {
@@ -74,7 +76,9 @@ export const Listview = function Listview({
     if (isEditorReady) {
       setExposedVariables(exposedVariables);
     }
-    fireEvent('onRowClicked');
+    setTimeout(() => {
+      fireEvent('onRowClicked');
+    }, 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }
 


### PR DESCRIPTION
Issue: Record click event is fired before the state is updated causing the previous values to be displayed.
Fix: Have added a setTimeout to send the fireEvent event to the end of the task queue so state is updated first.