### PR TITLE
fix/render-active-tab-default

### DIFF
--- a/frontend/src/Editor/WidgetManager/configs/tabs.js
+++ b/frontend/src/Editor/WidgetManager/configs/tabs.js
@@ -102,7 +102,7 @@ export const tabsConfig = {
         schema: {
           type: 'boolean',
         },
-        defaultValue: true,
+        defaultValue: false,
       },
     },
   },
@@ -170,7 +170,7 @@ export const tabsConfig = {
       },
       defaultTab: { value: '0' },
       hideTabs: { value: false },
-      renderOnlyActiveTab: { value: true },
+      renderOnlyActiveTab: { value: false },
     },
     events: [],
     styles: {


### PR DESCRIPTION
Issue: Incorrect default config for tabs caused only selected tab to be rendered so collecting data from another tab was not possible.
Fix: Changed the default value in config for renderOnlyActiveTab to false