### PR TITLE
fix/event-fire-editor-ready

### DIFF
--- a/frontend/src/Editor/BoxUI.jsx
+++ b/frontend/src/Editor/BoxUI.jsx
@@ -58,6 +58,7 @@ const BoxUI = (props) => {
   const { variablesExposedForPreview, exposeToCodeHinter } = useContext(EditorContext) || {};
 
   const currentState = useCurrentState();
+  const isEditorReady = useCurrentStateStore((state) => state.isEditorReady);
 
   const validate = (value) =>
     validateWidget({
@@ -97,8 +98,6 @@ const BoxUI = (props) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const isEditorReady = useCurrentStateStore((state) => state.isEditorReady);
 
   return (
     <OverlayTrigger

--- a/frontend/src/Editor/BoxUI.jsx
+++ b/frontend/src/Editor/BoxUI.jsx
@@ -77,6 +77,7 @@ const BoxUI = (props) => {
 
   let exposedVariables = !_.isEmpty(currentState?.components) ? currentState?.components[component.name] ?? {} : {};
   const fireEvent = (eventName, options) => {
+    if (!isEditorReady) return;
     if (mode === 'edit' && eventName === 'onClick') {
       onComponentClick(id, component);
     }


### PR DESCRIPTION
Issue: When the exposed variables have been not set if user triggers some event it will work with undefined values.
Fix: Events are only triggered when editorState is ready