### PR TITLE
fix: rerender component on visibility change

### DIFF
--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -1041,8 +1041,6 @@ const WidgetWrapper = ({
 
   useEditorStore((state) => state.componentsNeedsUpdateOnNextRender.some((compId) => compId === id));
 
-  console.log('shouldRerender-' + widget.component.name, shouldRerender);
-
   const isDragging = useGridStore((state) => state?.draggingComponentId === id);
 
   const canShowInCurrentLayout = otherDefinition[currentLayout === 'mobile' ? 'showOnMobile' : 'showOnDesktop'].value;

--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -1028,7 +1028,7 @@ const WidgetWrapper = ({
     component: { parent },
     layouts,
   } = widget;
-  const { isSelected, isHovered, shouldRerender } = useEditorStore((state) => {
+  const { isSelected, isHovered } = useEditorStore((state) => {
     const isSelected = !!(state.selectedComponents || []).find((selected) => selected?.id === id);
     const isHovered = state?.hoveredComponent == id;
     /*
@@ -1038,8 +1038,6 @@ const WidgetWrapper = ({
     const shouldRerender = state.componentsNeedsUpdateOnNextRender.some((compId) => compId === id);
     return { isSelected, isHovered, shouldRerender };
   }, shallow);
-
-  useEditorStore((state) => state.componentsNeedsUpdateOnNextRender.some((compId) => compId === id));
 
   const isDragging = useGridStore((state) => state?.draggingComponentId === id);
 

--- a/frontend/src/_helpers/appUtils.js
+++ b/frontend/src/_helpers/appUtils.js
@@ -633,12 +633,15 @@ function executeActionWithDebounce(_ref, event, mode, customVariables) {
         const value = resolveReferences(event.value, state, undefined, customVariables);
         const customAppVariables = { ...state.variables };
         customAppVariables[key] = value;
+        const resp = useCurrentStateStore.getState().actions.setCurrentState({
+          variables: customAppVariables,
+        });
+
         useResolveStore.getState().actions.addAppSuggestions({
           variables: customAppVariables,
         });
-        return useCurrentStateStore.getState().actions.setCurrentState({
-          variables: customAppVariables,
-        });
+
+        return resp;
       }
 
       case 'get-custom-variable': {

--- a/frontend/src/_helpers/editorHelpers.js
+++ b/frontend/src/_helpers/editorHelpers.js
@@ -166,6 +166,19 @@ function convertToBracketNotation(base, accessors) {
 }
 
 function verifyDotAndBracketNotations(jsString) {
+  if (
+    !(
+      jsString.includes('components.') ||
+      jsString.includes('globals.') ||
+      jsString.includes('queries.') ||
+      jsString.includes('page.') ||
+      jsString.includes('variables.') ||
+      jsString.includes('constants.')
+    )
+  ) {
+    return false;
+  }
+
   const notations = findNotations(jsString);
 
   for (const { base, accessors } of notations) {


### PR DESCRIPTION
This fix makes sure the WidgetWrapper is rendered when the component visibility on devices are updated