### PR TITLE
[docs]: Update information on workspace constants

### DIFF
--- a/docs/docs/org-management/workspaces/workspace_constants.md
+++ b/docs/docs/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/docs/tutorial/transformations.md
+++ b/docs/docs/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.14.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.14.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.14.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.14.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.15.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.15.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.15.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.15.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.16.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.16.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.16.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.16.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.17.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.17.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.17.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.17.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.18.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.18.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.18.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.18.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.19.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.19.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.19.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.19.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.22.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.22.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.22.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.22.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.23.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.23.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.23.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.23.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.24.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.24.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.24.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.24.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.25.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.25.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.25.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.25.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.27.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.27.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.27.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.27.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.29.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.29.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.29.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.29.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.30.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.30.0/org-management/workspaces/workspace_constants.md
@@ -5,9 +5,7 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces. 
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
+
 
 ## Environment-Specific Configurations
 

--- a/docs/versioned_docs/version-2.30.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.30.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.33.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.33.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 ## Environment-Specific Configurations
 
 Users can define environment-specific configurations by setting different values for constants across environments. It is useful for managing sensitive information such as API keys, database credentials, or external service endpoints. For Community edition only production environment is available and for Cloud/EE we will have multi environments (development, staging, production).

--- a/docs/versioned_docs/version-2.33.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.33.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.34.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.34.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.34.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.34.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.35.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.35.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.35.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.35.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.36.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.36.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.36.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.36.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.39.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.39.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.39.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.39.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.43.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.43.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.43.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.43.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.50.0-LTS/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.50.0-LTS/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.61.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.61.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.61.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.61.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.62.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.62.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.62.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.62.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 

--- a/docs/versioned_docs/version-2.65.0/org-management/workspaces/workspace_constants.md
+++ b/docs/versioned_docs/version-2.65.0/org-management/workspaces/workspace_constants.md
@@ -5,10 +5,6 @@ title: Workspace Constants
 
 Workspace constants are predefined values(usually tokens/secret keys/API keys) that can be used across your application to maintain consistency and facilitate easy updates. They allow you to store important data or configurations that should remain unchanged during the application's runtime. This doc will guide you through the usage and management of workspace constants within your workspaces.
 
-:::danger
-Workspace constants are handled server-side and are not intended for use in query transformations or RunJS and RunPy queries. For these operations, employ variables and page variables instead.
-:::
-
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
 ## Environment-Specific Configurations

--- a/docs/versioned_docs/version-2.65.0/tutorial/transformations.md
+++ b/docs/versioned_docs/version-2.65.0/tutorial/transformations.md
@@ -14,7 +14,6 @@ Transformations can be enabled on queries to transform the query results. ToolJe
 
 :::caution
 - Every transformation is scoped to the query it's written for. 
-- Workspace Constants are resolved server side and will not work with transformations.
 - Actions and CSA(Component Specific Actions) cannot be called within the transformation, they can only be called within **[RunJS](/docs/data-sources/run-js)** query or **[RunPy](/docs/data-sources/run-py)** query.
 :::
 


### PR DESCRIPTION
- Removes warning that workspace constants won't work with transformations