### PR TITLE
Fix/users scroll UI

### DIFF
--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -99,7 +99,7 @@ export default function AppCard({
           </div>
         </div>
         <div>
-          <ToolTip trigger={['hover']} message={app.name} checkOverflow={true}>
+          <ToolTip trigger={['hover']} message={app.name}>
             <h3
               className="app-card-name font-weight-500 tj-text-md"
               data-cy={`${app.name.toLowerCase().replace(/\s+/g, '-')}-title`}

--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -99,7 +99,7 @@ export default function AppCard({
           </div>
         </div>
         <div>
-          <ToolTip trigger={['hover']} message={app.name}>
+          <ToolTip trigger={['hover']} message={app.name} checkOverflow={true}>
             <h3
               className="app-card-name font-weight-500 tj-text-md"
               data-cy={`${app.name.toLowerCase().replace(/\s+/g, '-')}-title`}

--- a/frontend/src/_components/ToolTip.jsx
+++ b/frontend/src/_components/ToolTip.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
-import Tooltip from 'react-bootstrap/esm/Tooltip';
-import 'bootstrap/dist/css/bootstrap.min.css';
+import React, { cloneElement, useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import OverlayTrigger from "react-bootstrap/esm/OverlayTrigger";
+import Tooltip from "react-bootstrap/esm/Tooltip";
+import "bootstrap/dist/css/bootstrap.min.css";
 
 export function ToolTip({
   message,
@@ -12,11 +12,21 @@ export function ToolTip({
   delay = { show: 50, hide: 100 },
   show = true,
   tooltipClassName = '',
+  checkOverflow = false,
   ...rest
 }) {
-  if (!show) {
-    return children;
-  }
+  const [isOverflow, setIsOverflow] = useState(false);
+  const childRef = useRef(null);
+
+  useEffect(() => {
+    const checkOverflowCondition = () => {
+      if (childRef.current) setIsOverflow(childRef.current.scrollWidth > childRef.current.clientWidth);
+    };
+    if (checkOverflow) checkOverflowCondition();
+  }, [checkOverflow, children]);
+
+  if (!show || (checkOverflow && !isOverflow)) return cloneElement(children, { ref: childRef });
+
   return (
     <OverlayTrigger
       trigger={trigger}
@@ -37,4 +47,5 @@ ToolTip.propTypes = {
   children: PropTypes.object.isRequired,
   placement: PropTypes.string,
   trigger: PropTypes.array,
+  checkOverflow: PropTypes.bool,
 };

--- a/frontend/src/_components/ToolTip.jsx
+++ b/frontend/src/_components/ToolTip.jsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, useCallback, useEffect, useRef, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
 import Tooltip from 'react-bootstrap/esm/Tooltip';
@@ -12,22 +12,11 @@ export function ToolTip({
   delay = { show: 50, hide: 100 },
   show = true,
   tooltipClassName = '',
-  checkOverflow = false,
   ...rest
 }) {
-  const [isOverflow, setIsOverflow] = useState(false);
-  const childRef = useRef(null);
-
-  const checkOverflowCondition = useCallback(() => {
-    if (childRef.current) setIsOverflow(childRef.current.scrollWidth > childRef.current.clientWidth);
-  }, [childRef]);
-  
-  useEffect(() => {
-    if (checkOverflow)checkOverflowCondition();
-  }, [checkOverflow, checkOverflowCondition, children]);
-
-  if (!show || (checkOverflow && !isOverflow)) return cloneElement(children, { ref: childRef });
-
+  if (!show) {
+    return children;
+  }
   return (
     <OverlayTrigger
       trigger={trigger}

--- a/frontend/src/_components/ToolTip.jsx
+++ b/frontend/src/_components/ToolTip.jsx
@@ -1,8 +1,8 @@
-import React, { cloneElement, useEffect, useRef, useState } from "react";
-import PropTypes from "prop-types";
-import OverlayTrigger from "react-bootstrap/esm/OverlayTrigger";
-import Tooltip from "react-bootstrap/esm/Tooltip";
-import "bootstrap/dist/css/bootstrap.min.css";
+import React, { cloneElement, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
+import Tooltip from 'react-bootstrap/esm/Tooltip';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 export function ToolTip({
   message,

--- a/frontend/src/_components/ToolTip.jsx
+++ b/frontend/src/_components/ToolTip.jsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, useEffect, useRef, useState } from 'react';
+import React, { cloneElement, useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
 import Tooltip from 'react-bootstrap/esm/Tooltip';
@@ -18,12 +18,13 @@ export function ToolTip({
   const [isOverflow, setIsOverflow] = useState(false);
   const childRef = useRef(null);
 
+  const checkOverflowCondition = useCallback(() => {
+    if (childRef.current) setIsOverflow(childRef.current.scrollWidth > childRef.current.clientWidth);
+  }, [childRef]);
+  
   useEffect(() => {
-    const checkOverflowCondition = () => {
-      if (childRef.current) setIsOverflow(childRef.current.scrollWidth > childRef.current.clientWidth);
-    };
-    if (checkOverflow) checkOverflowCondition();
-  }, [checkOverflow, children]);
+    if (checkOverflow)checkOverflowCondition();
+  }, [checkOverflow, checkOverflowCondition, children]);
 
   if (!show || (checkOverflow && !isOverflow)) return cloneElement(children, { ref: childRef });
 

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -8998,6 +8998,12 @@ tbody {
 .workspace-settings-table-wrap {
   max-width: 880px;
   margin: 0 auto;
+
+  .tj-user-table-wrapper{
+    padding-right: 4px;   
+   }
+
+   
 }
 
 .workspace-settings-filters {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -8936,7 +8936,7 @@ tbody {
       height: 40px;
       display: flex;
       align-items: center;
-      margin-top: 6px;
+
     }
 
     tr>th {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -9003,7 +9003,22 @@ tbody {
     padding-right: 4px;   
    }
 
-   
+   &:hover{
+    .tj-user-table-wrapper{
+      padding-right: 0px;
+    }
+    ::-webkit-scrollbar{
+      display: block;
+      width: 4px;
+    }
+    ::-webkit-scrollbar-track{
+      background: var(--base);
+    }
+    ::-webkit-scrollbar-thumb{
+      background: var(--slate7);
+      border-radius: 6px;
+    }
+  }
 }
 
 .workspace-settings-filters {


### PR DESCRIPTION
fixes: #9956 

Removed `padding-top:6px;` to resolve : `Text should not be visible in the space above the table headers.`

![image](https://github.com/user-attachments/assets/18ac9129-d8b2-42e0-8a60-d8cb011baedf)

Added css properties to make scrollbar visible on hover in both light and dark modes

Screen recording of changes made...

https://github.com/user-attachments/assets/feb49052-e135-4906-a78f-095c1ab7789e

