### PR TITLE
Fix: navigation alignment of list view component

### DIFF
--- a/frontend/src/Editor/Components/Listview.jsx
+++ b/frontend/src/Editor/Components/Listview.jsx
@@ -201,7 +201,7 @@ export const Listview = function Listview({
       {enablePagination && _.isArray(data) && (
         <div
           className="fixed-bottom position-fixed"
-          style={{ border: '1px solid', borderColor, margin: '1px', borderTop: 0 }}
+          style={{ border: '1px solid', borderColor, margin: '1px', borderTop: 0, left: '1px', right: '1px' }}
         >
           <div style={{ backgroundColor }}>
             {data?.length > 0 ? (


### PR DESCRIPTION
Issue: There is a difference in padding when pagination is enable for listview
Fix: Aligned position to account for border width