### PR TITLE
Fix/query state issue

### DIFF
--- a/frontend/src/_stores/currentStateStore.js
+++ b/frontend/src/_stores/currentStateStore.js
@@ -106,16 +106,18 @@ useCurrentStateStore.subscribe((state) => {
 
     handleLowPriorityWork(
       () => {
+        const currentState = useCurrentStateStore.getState();
         useResolveStore.getState().actions.addAppSuggestions(
           {
-            queries: state.queries,
-            components: !isPageSwitched ? state.components : {},
-            globals: state.globals,
-            page: state.page,
-            variables: state.variables,
-            client: state.client,
-            server: state.server,
-            constants: state.constants,
+            // get queries from current state so that we can get the latest queries
+            queries: currentState.queries,
+            components: !isPageSwitched ? currentState.components : {},
+            globals: currentState.globals,
+            page: currentState.page,
+            variables: currentState.variables,
+            client: currentState.client,
+            server: currentState.server,
+            constants: currentState.constants,
           },
           true
         );

--- a/frontend/src/_stores/currentStateStore.js
+++ b/frontend/src/_stores/currentStateStore.js
@@ -109,7 +109,7 @@ useCurrentStateStore.subscribe((state) => {
         const currentState = useCurrentStateStore.getState();
         useResolveStore.getState().actions.addAppSuggestions(
           {
-            // get queries from current state so that we can get the latest queries
+            // get state directly to prevent consuming stale data
             queries: currentState.queries,
             components: !isPageSwitched ? currentState.components : {},
             globals: currentState.globals,


### PR DESCRIPTION
On currentState store initialisation we update state in `idleCallback` and pass data to update as a param. This causes issues because if state is manipulated during the time updation is in queue, update overrides the state. This pr updates the function to consume latest state using `getState`.