### PR TITLE
Fix: scrolling issue when color picker is opened

### DIFF
--- a/frontend/src/Editor/Components/ColorPicker.jsx
+++ b/frontend/src/Editor/Components/ColorPicker.jsx
@@ -154,7 +154,7 @@ export const ColorPicker = function ({
           >
             <SketchPicker color={color} onChangeComplete={handleColorChange} />
           </div>
-          <div className="comment-overlay" onClick={() => setShowColorPicker(false)}></div>
+          <div onClick={() => setShowColorPicker(false)}></div>
         </>
       )}
     </div>


### PR DESCRIPTION
Issue: There is scroll on canvas for preview mode if color picker is opened.
Fix: removed unnecessary styling