### PR TITLE
fix: apps breaking when functions are used in codehinter

### DIFF
--- a/frontend/src/Editor/CodeEditor/utils.js
+++ b/frontend/src/Editor/CodeEditor/utils.js
@@ -167,6 +167,7 @@ function resolveCode(code, customObjects = {}, withError = false, reservedKeywor
         ...Object.values(customObjects),
         null
       );
+      result = typeof result === 'function' ? undefined : result;
     } catch (err) {
       error = err.toString();
     }


### PR DESCRIPTION
Issue: Apps were breaking when functions were present in codehinter.
Fix: Made changes so that the uninvoked function would return an undefined value & wouldn't break the app