### PR TITLE
[Hotfix] - Add TLS settings for redis plugin

### DIFF
--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -20371,7 +20371,7 @@
     },
     "packages/redis": {
       "name": "@tooljet-plugins/redis",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@tooljet-plugins/common": "file:../common",
         "ioredis": "^4.28.5",

--- a/plugins/packages/redis/lib/index.ts
+++ b/plugins/packages/redis/lib/index.ts
@@ -1,16 +1,6 @@
-import { ConnectionTestResult, QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { ConnectionTestResult, isEmpty, QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
 import Redis from 'ioredis';
 import { SourceOptions, QueryOptions } from './types';
-
-function isEmpty(value: number | null | undefined | string) {
-  return (
-    value === undefined ||
-    value === null ||
-    !isNaN(value as number) ||
-    (typeof value === 'object' && Object.keys(value).length === 0) ||
-    (typeof value === 'string' && value.trim().length === 0)
-  );
-}
 
 export default class RedisQueryService implements QueryService {
   connectionOptions(sourceOptions: SourceOptions) {

--- a/plugins/packages/redis/lib/index.ts
+++ b/plugins/packages/redis/lib/index.ts
@@ -45,8 +45,8 @@ export default class RedisQueryService implements QueryService {
       if (sourceOptions.tls_certificate === 'ca_certificate') {
         tls.ca = sourceOptions.ca_cert;
       }
-      if (sourceOptions.tls_certificate === 'self_signed') {
-        tls.ca = sourceOptions.root_cert;
+      if (sourceOptions.tls_certificate === 'client_certificate') {
+        tls.ca = sourceOptions.ca_cert;
         tls.key = sourceOptions.client_key;
         tls.cert = sourceOptions.client_cert;
       }

--- a/plugins/packages/redis/lib/index.ts
+++ b/plugins/packages/redis/lib/index.ts
@@ -25,7 +25,12 @@ export default class RedisQueryService implements QueryService {
 
   async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
     const client = await this.getConnection(sourceOptions);
-    await client.ping();
+    try {
+      await client.ping();
+    } catch (err) {
+      client.disconnect();
+      throw new QueryError('Connection could not be established', err.message, {});
+    }
 
     return {
       status: 'ok',

--- a/plugins/packages/redis/lib/index.ts
+++ b/plugins/packages/redis/lib/index.ts
@@ -1,6 +1,7 @@
 import { ConnectionTestResult, isEmpty, QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
 import Redis from 'ioredis';
 import { SourceOptions, QueryOptions } from './types';
+import { ConnectionOptions } from 'tls';
 
 export default class RedisQueryService implements QueryService {
   connectionOptions(sourceOptions: SourceOptions) {
@@ -49,12 +50,22 @@ export default class RedisQueryService implements QueryService {
     const host = sourceOptions.host;
     const password = sourceOptions.password;
     const port = sourceOptions.port;
-    let tls = undefined;
+    let tls: ConnectionOptions = undefined;
 
-    if (sourceOptions.tls) {
+    if (sourceOptions.tls_enabled) {
       tls = {
         ...this.connectionOptions(sourceOptions),
       };
+
+      tls.rejectUnauthorized = (sourceOptions.tls_certificate ?? 'none') != 'none';
+      if (sourceOptions.tls_certificate === 'ca_certificate') {
+        tls.ca = sourceOptions.ca_cert;
+      }
+      if (sourceOptions.tls_certificate === 'self_signed') {
+        tls.ca = sourceOptions.root_cert;
+        tls.key = sourceOptions.client_key;
+        tls.cert = sourceOptions.client_cert;
+      }
     }
 
     return new Redis(port, host, {

--- a/plugins/packages/redis/lib/index.ts
+++ b/plugins/packages/redis/lib/index.ts
@@ -1,22 +1,9 @@
-import { ConnectionTestResult, isEmpty, QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { ConnectionTestResult, QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
 import Redis from 'ioredis';
 import { SourceOptions, QueryOptions } from './types';
 import { ConnectionOptions } from 'tls';
 
 export default class RedisQueryService implements QueryService {
-  connectionOptions(sourceOptions: SourceOptions) {
-    const _connectionOptions = (sourceOptions.connection_options || []).filter((o) => {
-      return o.some((e) => !isEmpty(e));
-    });
-
-    const connectionOptions = Object.fromEntries(_connectionOptions);
-    Object.keys(connectionOptions).forEach((key) =>
-      connectionOptions[key] === '' ? delete connectionOptions[key] : {}
-    );
-
-    return connectionOptions;
-  }
-
   async run(sourceOptions: SourceOptions, queryOptions: QueryOptions, dataSourceId: string): Promise<QueryResult> {
     let result = {};
     const query = queryOptions.query;
@@ -53,10 +40,7 @@ export default class RedisQueryService implements QueryService {
     let tls: ConnectionOptions = undefined;
 
     if (sourceOptions.tls_enabled) {
-      tls = {
-        ...this.connectionOptions(sourceOptions),
-      };
-
+      tls = {};
       tls.rejectUnauthorized = (sourceOptions.tls_certificate ?? 'none') != 'none';
       if (sourceOptions.tls_certificate === 'ca_certificate') {
         tls.ca = sourceOptions.ca_cert;

--- a/plugins/packages/redis/lib/manifest.json
+++ b/plugins/packages/redis/lib/manifest.json
@@ -25,6 +25,18 @@
         "type": "string",
         "encrypted": true
       },
+      "ca_cert": {
+        "encrypted": true
+      },
+      "client_key": {
+        "encrypted": true
+      },
+      "client_cert": {
+        "encrypted": true
+      },
+      "root_cert": {
+        "encrypted": true
+      },
       "connection_options": {
         "type": "array"
       }
@@ -43,45 +55,102 @@
     "password": {
       "value": ""
     },
-    "tls": {
+    "tls_enabled": {
       "value": false
+    },
+    "tls_certificate": {
+      "value": "none"
     }
   },
   "properties": {
-    "host": {
-      "label": "Host",
-      "key": "host",
-      "type": "text",
-      "description": "Enter host"
+    "tls_certificate": {
+      "label": "TLS Certificate",
+      "key": "tls_certificate",
+      "type": "dropdown-component-flip",
+      "description": "Single select dropdown for choosing certificates",
+      "list": [
+        {
+          "value": "ca_certificate",
+          "name": "CA certificate"
+        },
+        {
+          "value": "self_signed",
+          "name": "Self-signed certificate"
+        },
+        {
+          "value": "none",
+          "name": "None"
+        }
+      ],
+      "commonFields": {
+        "host": {
+          "label": "Host",
+          "key": "host",
+          "type": "text",
+          "description": "Enter host"
+        },
+        "port": {
+          "label": "Port",
+          "key": "port",
+          "type": "text",
+          "description": "Enter port"
+        },
+        "username": {
+          "label": "Username",
+          "key": "username",
+          "type": "text",
+          "description": "Enter username"
+        },
+        "password": {
+          "label": "Password",
+          "key": "password",
+          "type": "password",
+          "description": "Enter password"
+        },
+        "tls_enabled": {
+          "label": "TLS",
+          "key": "tls_enabled",
+          "type": "toggle",
+          "description": "Toggle for TLS"
+        },
+        "connection_options": {
+          "label": "Connection Options",
+          "key": "connection_options",
+          "type": "react-component-headers"
+        }
+      }
     },
-    "port": {
-      "label": "Port",
-      "key": "port",
-      "type": "text",
-      "description": "Enter port"
+    "ca_certificate": {
+      "ca_cert": {
+        "label": "CA Cert",
+        "key": "ca_cert",
+        "type": "textarea",
+        "encrypted": true,
+        "description": "Enter ca certificate"
+      }
     },
-    "username": {
-      "label": "Username",
-      "key": "username",
-      "type": "text",
-      "description": "Enter username"
-    },
-    "password": {
-      "label": "Password",
-      "key": "password",
-      "type": "password",
-      "description": "Enter password"
-    },
-    "tls": {
-      "label": "TLS",
-      "key": "tls",
-      "type": "toggle",
-      "description": "Toggle for TLS"
-    },
-    "connection_options": {
-      "label": "Connection Options",
-      "key": "connection_options",
-      "type": "react-component-headers"
+    "self_signed": {
+      "client_key": {
+        "label": "Client Key",
+        "key": "client_key",
+        "type": "textarea",
+        "encrypted": true,
+        "description": "Enter client key"
+      },
+      "client_cert": {
+        "label": "Client Cert",
+        "key": "client_cert",
+        "type": "textarea",
+        "encrypted": true,
+        "description": "Enter client certificate"
+      },
+      "root_cert": {
+        "label": "Root Cert",
+        "key": "root_cert",
+        "type": "textarea",
+        "encrypted": true,
+        "description": "Enter root certificate"
+      }
     }
   },
   "required": [

--- a/plugins/packages/redis/lib/manifest.json
+++ b/plugins/packages/redis/lib/manifest.json
@@ -33,9 +33,6 @@
       },
       "client_cert": {
         "encrypted": true
-      },
-      "root_cert": {
-        "encrypted": true
       }
     }
   },
@@ -71,8 +68,8 @@
           "name": "CA certificate"
         },
         {
-          "value": "self_signed",
-          "name": "Self-signed certificate"
+          "value": "client_certificate",
+          "name": "Client certificate"
         },
         {
           "value": "none",
@@ -121,7 +118,7 @@
         "description": "Enter ca certificate"
       }
     },
-    "self_signed": {
+    "client_certificate": {
       "client_key": {
         "label": "Client Key",
         "key": "client_key",
@@ -136,12 +133,12 @@
         "encrypted": true,
         "description": "Enter client certificate"
       },
-      "root_cert": {
-        "label": "Root Cert",
-        "key": "root_cert",
+      "ca_cert": {
+        "label": "CA Cert",
+        "key": "ca_cert",
         "type": "textarea",
         "encrypted": true,
-        "description": "Enter root certificate"
+        "description": "Enter ca certificate"
       }
     }
   },

--- a/plugins/packages/redis/lib/manifest.json
+++ b/plugins/packages/redis/lib/manifest.json
@@ -36,9 +36,6 @@
       },
       "root_cert": {
         "encrypted": true
-      },
-      "connection_options": {
-        "type": "array"
       }
     }
   },
@@ -112,11 +109,6 @@
           "key": "tls_enabled",
           "type": "toggle",
           "description": "Toggle for TLS"
-        },
-        "connection_options": {
-          "label": "Connection Options",
-          "key": "connection_options",
-          "type": "react-component-headers"
         }
       }
     },

--- a/plugins/packages/redis/lib/manifest.json
+++ b/plugins/packages/redis/lib/manifest.json
@@ -24,6 +24,9 @@
       "password": {
         "type": "string",
         "encrypted": true
+      },
+      "connection_options": {
+        "type": "array"
       }
     }
   },
@@ -39,6 +42,9 @@
     },
     "password": {
       "value": ""
+    },
+    "tls": {
+      "value": false
     }
   },
   "properties": {
@@ -65,6 +71,17 @@
       "key": "password",
       "type": "password",
       "description": "Enter password"
+    },
+    "tls": {
+      "label": "TLS",
+      "key": "tls",
+      "type": "toggle",
+      "description": "Toggle for TLS"
+    },
+    "connection_options": {
+      "label": "Connection Options",
+      "key": "connection_options",
+      "type": "react-component-headers"
     }
   },
   "required": [

--- a/plugins/packages/redis/lib/types.ts
+++ b/plugins/packages/redis/lib/types.ts
@@ -8,7 +8,6 @@ export type SourceOptions = {
   ca_cert: string;
   client_cert: string;
   client_key: string;
-  root_cert: string;
 };
 export type QueryOptions = {
   operation: string;

--- a/plugins/packages/redis/lib/types.ts
+++ b/plugins/packages/redis/lib/types.ts
@@ -3,6 +3,8 @@ export type SourceOptions = {
   port: string;
   username: string;
   password: string;
+  tls: boolean;
+  connection_options: string[][];
 };
 export type QueryOptions = {
   operation: string;

--- a/plugins/packages/redis/lib/types.ts
+++ b/plugins/packages/redis/lib/types.ts
@@ -3,7 +3,12 @@ export type SourceOptions = {
   port: string;
   username: string;
   password: string;
-  tls: boolean;
+  tls_enabled: boolean;
+  tls_certificate: string;
+  ca_cert: string;
+  client_cert: string;
+  client_key: string;
+  root_cert: string;
   connection_options: string[][];
 };
 export type QueryOptions = {

--- a/plugins/packages/redis/lib/types.ts
+++ b/plugins/packages/redis/lib/types.ts
@@ -9,7 +9,6 @@ export type SourceOptions = {
   client_cert: string;
   client_key: string;
   root_cert: string;
-  connection_options: string[][];
 };
 export type QueryOptions = {
   operation: string;

--- a/plugins/packages/redis/package.json
+++ b/plugins/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tooljet-plugins/redis",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "directories": {


### PR DESCRIPTION
The Redis plugin was not exposing the TLS settings on the UI, which makes the usage of Azure Redis Cache impossible. This PR intention is to fix that.

Obs: This Redis plugin might have to be reviewed again, since at the current version it won't work with Redis clusters.

Video: 
[20240807-0928-21.6391904.zip](https://github.com/user-attachments/files/16522621/20240807-0928-21.6391904.zip)
