### PR TITLE
Hotfix: old component mapping to new component mapping on version promotion

### DIFF
--- a/frontend/src/Editor/Editor.jsx
+++ b/frontend/src/Editor/Editor.jsx
@@ -1751,7 +1751,6 @@ const EditorComponent = (props) => {
     }
 
     await clearAllQueuedTasks();
-    useResolveStore.getState().actions.resetStore();
     useEditorStore.getState().actions.setPageProgress(true);
     useCurrentStateStore.getState().actions.setEditorReady(false);
     // This are fetched from store to handle runQueriesOnAppLoad

--- a/server/src/services/apps.service.ts
+++ b/server/src/services/apps.service.ts
@@ -542,9 +542,9 @@ export class AppsService {
 
     let homePageId = prevHomePagePage;
 
-    let newComponents = [];
+    const newComponents = [];
     const newComponentLayouts = [];
-    let oldComponentToNewComponentMapping = {};
+    const oldComponentToNewComponentMapping = {};
     const oldPageToNewPageMapping = {};
 
     const isChildOfTabsOrCalendar = (component, allComponents = [], componentParentId = undefined) => {
@@ -703,8 +703,6 @@ export class AppsService {
 
       await manager.save(newComponents);
       await manager.save(newComponentLayouts);
-      newComponents = [];
-      oldComponentToNewComponentMapping = {};
     }
 
     await manager.update(AppVersion, { id: appVersion.id }, { homePageId });


### PR DESCRIPTION
Issue: Pervious versions component id being reference in places where dynamic value is consumed
Fix: Retain the mapping of all components to use it for event mapping