### PR TITLE
Fix/users scroll UI

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -8998,6 +8998,9 @@ tbody {
 .workspace-settings-table-wrap {
   max-width: 880px;
   margin: 0 auto;
+  .tj-user-table-wrapper{
+    padding-right: 4px;
+   }
 }
 
 .workspace-settings-filters {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -9001,6 +9001,22 @@ tbody {
   .tj-user-table-wrapper{
     padding-right: 4px;
    }
+   &:hover{
+     .tj-user-table-wrapper{
+       padding-right: 0px;
+     }
+     ::-webkit-scrollbar{
+       display: block;
+       width: 4px;
+     }
+     ::-webkit-scrollbar-track{
+       background: var(--base);
+     }
+     ::-webkit-scrollbar-thumb{
+       background: var(--slate7);
+       border-radius: 6px;
+     }
+   }
 }
 
 .workspace-settings-filters {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -8936,7 +8936,6 @@ tbody {
       height: 40px;
       display: flex;
       align-items: center;
-      margin-top: 6px;
     }
 
     tr>th {


### PR DESCRIPTION
Fixes: #9956
- Added padding to fix the layout shift when scrollbar is visible
- Added hover styling to show the hover only when hovering over the users container
- Removed margin-top in table row styling to remove the gap in visible text in the space above table header

Before:
![image](https://github.com/user-attachments/assets/8f05fe52-7048-4ae3-ae19-7acefcb439f2)

After:
![Screenshot 2024-07-27 170757](https://github.com/user-attachments/assets/5c769eb6-4ad8-47f9-97bd-667c218a0cd3)

https://github.com/user-attachments/assets/7479b576-1b84-43cd-80d2-50691a59f67a

