### PR TITLE
[docs]: add LTS .31 tag

### DIFF
--- a/docs/docs/setup/choose-your-tooljet.md
+++ b/docs/docs/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.15.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.15.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.16.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.16.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.17.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.17.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.18.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.18.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.19.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.19.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.22.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.22.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.23.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.23.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.24.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.24.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.25.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.25.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.27.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.27.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.29.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.29.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.30.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.30.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.33.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.33.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.34.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.34.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.35.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.35.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.36.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.36.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.39.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.39.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.43.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.43.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.61.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.61.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.62.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.62.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 

--- a/docs/versioned_docs/version-2.65.0/setup/choose-your-tooljet.md
+++ b/docs/versioned_docs/version-2.65.0/setup/choose-your-tooljet.md
@@ -15,6 +15,7 @@ Please find the latest LTS version here: <br/>
 | Version | Release Date | Docker Pull Command |
 |---------|--------------|----------------------|
 | Latest EE-LTS | N/A | `docker pull tooljet/tooljet:EE-LTS-latest` |
+| [EE-LTS-2.50.9.31](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.31/images/sha256-9610b8a125ea622a4b07c17657c44e04e1b582df8a18c228bab3a876cdc49407?context=explore) | August 26, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.31` |
 | [EE-LTS-2.50.9.30](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.30/images/sha256-a7b0967aca4c4d29e423a78e91a7084073e2750d0a67fa2a8926d0da5eaf4ad4?context=explore) | August 21, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.30` |
 | [EE-LTS-2.50.9.29](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.29/images/sha256-ecea7ddae821fa8828dc49ad52d4c03efbc1df8d6485122ebde2d51aacb88d3e?context=explore) | August 20, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.29` |
 | [EE-LTS-2.50.9.28](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.28/images/sha256-f33982c51a59b126aea9da9eef2cace0cd074411583ea896edc3f6db5b578a6b?context=explore) | August 19, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.28` |
@@ -29,7 +30,6 @@ Please find the latest LTS version here: <br/>
 | [EE-LTS-2.50.9.19](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.19/images/sha256-b62cb8d48bbab7a0b2bc92e251de6aba1f5b13a5ddd8e11e4b09f10d0eaf974f?context=explore) | July 24, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.19` |
 | [EE-LTS-2.50.9.18](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.18/images/sha256-f95c0d05a2d8b8bd3ab515e223fb04ca74a0d9a71e500cddc480e6513ac7aaf2?context=explore) | July 18, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.18` |
 | [EE-LTS-2.50.9.17](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.17/images/sha256-bf55f47ec955dcb62e93645582dadd60f7b20bec7e435a0921a9b47e03a0530b?context=explore) | July 12, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.17` |
-| [EE-LTS-2.50.9.16](https://hub.docker.com/layers/tooljet/tooljet/EE-LTS-2.50.9.16/images/sha256-89d86e778458f5dfc2c43f5221a584fd9b48d8dc590f2bded2f287ba9c0addd1?context=explore) | July 11, 2024 | `docker pull tooljet/tooljet:EE-LTS-2.50.9.16` |
 
 :::info
 Users are encouraged to upgrade to the latest LTS version to ensure they benefit from the latest improvements and maintain a secure and efficient environment. 


### PR DESCRIPTION
- Adds EE-LTS-2.50.9.31 tag to Choose Your ToolJet guide.