### PR TITLE
fix: App dashboard left nav bar scroll issue

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -4527,7 +4527,21 @@ input[type="text"] {
  * Folder List
  */
 .folder-list {
-  overflow-y: auto;
+  overflow-y: scroll;
+  scrollbar-width: thin;
+  scrollbar-color: #888 transparent;  
+  &:hover {
+    &::-webkit-scrollbar {
+      display: block;
+      width: 5px;
+    }
+    &::-webkit-scrollbar-thumb {
+      background-color: #888;
+    }
+    &::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
+  }
 
   .list-group-transparent .list-group-item.active {
     color: $primary;


### PR DESCRIPTION
fixed [#9953](https://github.com/ToolJet/ToolJet/issues/9953) 

- added scrollbar for leftnav in chrome and safari only when the container is hovered.
This is how it looks

https://github.com/user-attachments/assets/71045e40-6d09-40e1-a82e-e430b4ccebcc

