### PR TITLE
Fix: Datasource text not visible in light theme #10743

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -5135,7 +5135,7 @@ div#driver-page-overlay {
   padding: 10px 5px 0 0;
   float: left;
   font-size: 14px;
-  color: $light-gray;
+  color: var(--slate-12);
 }
 
 .dynamic-form-row {


### PR DESCRIPTION
This PR fixes issue #10743 by ensuring that the text under the dropdown in the n8n datasource is visible when using the light theme.