### PR TITLE
feat(Docker): Enable debugging in docker containers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,30 @@
             "cwd": "${workspaceRoot}/server",
             "console": "integratedTerminal",
             "protocol": "inspector"
+        },
+        {
+            "name": "Docker Debug Client",
+            "request": "launch",
+            "type": "chrome",
+            "preLaunchTask": "docker-compose: debug:client",
+            "url": "http://127.0.0.1:8082",
+            "webRoot": "${workspaceFolder}/frontend",
+            "skipFiles": ["<node_internals>/**"]
+        },
+        {
+            "name": "Docker Debug Server",
+            "request": "launch",
+            "type": "docker",
+            "platform": "node",
+            "preLaunchTask": "docker-compose: debug:server",
+            "removeContainerAfterDebug": true,
+            "node": {
+                "port": 9229,
+                "localRoot": "${workspaceRoot}/server",
+                "remoteRoot": "/app/server",
+                "sourceMaps": true,
+                "skipFiles": ["<node_internals>/**"]
+            },
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,37 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "docker-compose",
+      "label": "docker-compose: debug:client",
+      "dockerCompose": {
+        "up": {
+          "detached": true,
+          "services": [
+            "client"
+          ]
+        },
+        "files": [
+          "${workspaceFolder}/docker-compose.yaml",
+          "${workspaceFolder}/docker-compose-debug.yaml"
+        ]
+      }
+    },
+    {
+      "type": "docker-compose",
+      "label": "docker-compose: debug:server",
+      "dockerCompose": {
+        "up": {
+          "detached": true,
+          "services": [
+            "server"
+          ]
+        },
+        "files": [
+          "${workspaceFolder}/docker-compose.yaml",
+          "${workspaceFolder}/docker-compose-debug.yaml"
+        ]
+      }
+    }
+  ]
+}

--- a/docker-compose-debug.yaml
+++ b/docker-compose-debug.yaml
@@ -1,0 +1,7 @@
+version: "3"
+
+services:
+  server:
+    ports:
+      - 9229:9229
+    command: npm run --prefix server start:debug -- --debug 0.0.0.0:9229


### PR DESCRIPTION
This PR addresses #10813 by adding `VSCode` debugging configurations for both the client and server within the Docker environment. It introduces an extension to the `launch.json` setup for debugging via Chrome (client) and Node (server), as well as Docker Compose tasks for starting each service in detached mode. Additionally, a `docker-compose-debug.yaml` file has been created to expose the necessary ports and enable seamless debugging.