### PR TITLE
#10612 removed the CSS style with Static overriding style

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -4457,11 +4457,6 @@ input[type="text"] {
     background-color: var(--base);
   }
 
-  .input-icon .form-control:not(:first-child),
-  .input-icon .form-select:not(:last-child) {
-    padding-left: 28px !important;
-  }
-
   input:focus {
     width: 200px;
     background-color: var(--base);


### PR DESCRIPTION
## Expected Behavior

There should be some space between the search icon and the placeholder text to improve visual clarity.

## Current Behavior

The search icon and placeholder text appear stacked with minimal space between them, leading to a cluttered appearance.

## Steps to Reproduce

Create an account.
Navigate to /my-workspace/data-sources.
Observe the search bar for data sources.
Screenshots

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/e34e46f9-fd50-4df7-9418-f7ab757288d1">


<img width="1469" alt="image" src="https://github.com/user-attachments/assets/19668027-8de9-48c1-9f47-02a394af0deb">

## Solution
A static style for child of the element was added, removing the same worked to get style back.

Note : Open for the discussion.