### PR TITLE
#fixes Refactor InviteUsersForm component to support dark mode

### DIFF
--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -32,6 +32,8 @@ function InviteUsersForm({
 
   const hiddenFileInput = useRef(null);
 
+  const darkmode = localStorage.getItem('darkMode') === 'true';
+
   useEffect(() => {
     if (currentEditingUser && groups.length) {
       const { first_name, last_name, email, groups: addedToGroups } = currentEditingUser;
@@ -131,7 +133,11 @@ function InviteUsersForm({
                     onClick={() => setActiveTab(1)}
                     data-cy="button-invite-with-email"
                   >
-                    <SolidIcon name="mail" width="14" fill={activeTab == 1 ? '#11181C' : '#687076'} />
+                    <SolidIcon
+                      name="mail"
+                      width="14"
+                      fill={activeTab == 1 ? (darkmode ? '#FFFFFF' : '#11181C') : darkmode ? '#AAAAAA' : '#687076'}
+                    />
                     <span> Invite with email</span>
                   </button>
                   <button
@@ -139,7 +145,11 @@ function InviteUsersForm({
                     onClick={() => setActiveTab(2)}
                     data-cy="button-upload-csv-file"
                   >
-                    <SolidIcon name="fileupload" width="14" fill={activeTab == 2 ? '#11181C' : '#687076'} />
+                    <SolidIcon
+                      name="fileupload"
+                      width="14"
+                      fill={activeTab == 2 ? (darkmode ? '#FFFFFF' : '#11181C') : darkmode ? '#AAAAAA' : '#687076'}
+                    />
                     <span>Upload CSV file</span>
                   </button>
                 </div>

--- a/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
+++ b/frontend/src/ManageOrgUsers/InviteUsersForm.jsx
@@ -102,6 +102,12 @@ function InviteUsersForm({
   };
 
   const isEditing = userDrawerMode === USER_DRAWER_MODES.EDIT;
+  let fillColor;
+  if (activeTab == 1) {
+    fillColor = darkmode ? '#FFFFFF' : '#11181C';
+  } else {
+    fillColor = darkmode ? '#AAAAAA' : '#687076';
+  }
 
   return (
     <div>
@@ -133,11 +139,7 @@ function InviteUsersForm({
                     onClick={() => setActiveTab(1)}
                     data-cy="button-invite-with-email"
                   >
-                    <SolidIcon
-                      name="mail"
-                      width="14"
-                      fill={activeTab == 1 ? (darkmode ? '#FFFFFF' : '#11181C') : darkmode ? '#AAAAAA' : '#687076'}
-                    />
+                    <SolidIcon name="mail" width="14" fill={fillColor} />
                     <span> Invite with email</span>
                   </button>
                   <button
@@ -145,11 +147,7 @@ function InviteUsersForm({
                     onClick={() => setActiveTab(2)}
                     data-cy="button-upload-csv-file"
                   >
-                    <SolidIcon
-                      name="fileupload"
-                      width="14"
-                      fill={activeTab == 2 ? (darkmode ? '#FFFFFF' : '#11181C') : darkmode ? '#AAAAAA' : '#687076'}
-                    />
+                    <SolidIcon name="fileupload" width="14" fill={fillColor} />
                     <span>Upload CSV file</span>
                   </button>
                 </div>


### PR DESCRIPTION
fixes #10868
This pull request introduces a small but important change to the `InviteUsersForm` component in the `frontend/src/ManageOrgUsers/InviteUsersForm.jsx` file. The change adds support for dark mode to improve the user interface based on the user's preference.

Improvements to UI based on dark mode:

* [`frontend/src/ManageOrgUsers/InviteUsersForm.jsx`](diffhunk://#diff-904a31bb9b80f04c7763dac76b415b87eaf4612d7b7efa2d84f8cd4639699d59R35-R36): Added a `darkmode` constant that checks the user's dark mode preference from `localStorage`.
* [`frontend/src/ManageOrgUsers/InviteUsersForm.jsx`](diffhunk://#diff-904a31bb9b80f04c7763dac76b415b87eaf4612d7b7efa2d84f8cd4639699d59L134-R152): Updated the `SolidIcon` components to adjust their `fill` color based on the `darkmode` state, ensuring proper visibility in both light and dark modes.

**Attachments**
![WhatsApp Image 2024-10-03 at 12 03 57 PM (1)](https://github.com/user-attachments/assets/8bcbb101-01b1-4ed6-bb86-08056b12bb03)
![WhatsApp Image 2024-10-03 at 12 03 57 PM](https://github.com/user-attachments/assets/8672bcf8-a34f-4f48-9db6-2d7554fa778e)
