### PR TITLE
Add Model-Specific Size Validation and Update Size Parameter Placeholders for Image Generation

### DIFF
--- a/marketplace/plugins/openai/lib/operations.json
+++ b/marketplace/plugins/openai/lib/operations.json
@@ -276,7 +276,7 @@
 					"key": "size",
 					"type": "codehinter",
 					"description": "Enter image size in pixels (e.g., 1024x1024)",
-					"placeholder": "By default 1024x1024 sized image will be generated",
+                    "placeholder": "1024x1024, 1792x1024 or 1024x1792. By default 1024x1024 sized image is generated",
 					"width": "320px",
 					"height": "36px"
     			}
@@ -294,7 +294,7 @@
 					"key": "size",
 					"type": "codehinter",
 					"description": "Enter image size in pixels (e.g., 1024x1024)",
-					"placeholder": "By default 1024x1024 sized image will be generated",
+                    "placeholder": "256x256, 512x512 or 1024x1024. By default 1024x1024 sized image is generated",
 					"width": "320px",
 					"height": "36px"
     			}


### PR DESCRIPTION
This PR introduces two key changes related to the image generation functionality:
1. Fixes issue #10686 
2. **Placeholder Update in operations.json:**
   - Updated the size parameter placeholder to reflect valid options based on the selected model (DALL-E 2 or DALL-E 3).
   - For DALL-E 3, the valid sizes are 1024x1024, 1792x1024, and 1024x1792, with the default set to 1024x1024.
   - For DALL-E 2, the valid sizes are 256x256, 512x512, and 1024x1024, with the default set to 1024x1024.

3. **Code Update in query_operations.ts:**
   - Added logic to enforce model-specific size validation during image generation.
   - Introduced a utility function that validates and applies the correct size based on whether the model is DALL-E 2 or DALL-E 3.
   - Ensures that any invalid or undefined size defaults to 1024x1024 for both models.

These changes ensure the correct usage of size parameters for different models, enhancing the robustness of the image generation functionality.
