### PR TITLE
[docs]: Fix documentation for Star Rating component

### DIFF
--- a/docs/docs/widgets/star-rating.md
+++ b/docs/docs/widgets/star-rating.md
@@ -82,7 +82,7 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}>  Description </div> | <div style={{ width:"100px"}}> Default Value </div> |
 |:------------ |:-------------|:--------- |
-| Star Color | Display color of the star. `default: #ffb400` (color hex). Change color by providing `Hex color code` or choosing one from the picker. |  |
+| Star Color | Display color of the star. Change color by providing `Hex color code` or choosing one from the picker. | `default: #ffb400` (color hex). |
 | Label color | Change the color of label in component by providing `Hex color code` or choosing one from the picker. |  |
 | Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. | By default, it's set to `{{true}}`. |
 | Disable | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **fx** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}`. |

--- a/docs/docs/widgets/star-rating.md
+++ b/docs/docs/widgets/star-rating.md
@@ -15,7 +15,7 @@ The **Star Rating** component can be used to display as well as input ratings. T
 | Label | The text to be used as the label for the star rating. | This field expects a `String` value. |
 | Number of stars | Initial number of stars in the list on initial load. `default: 5`. | This field expects an integer value. |
 | Default no of selected stars | This property specifies the default count of stars that are selected on the initial load. `default: 5` (integer). | This field expects an integer value. |
-| Enable half star | Toggle `on` to allow selection of half stars. `default: false` (bool). | Click on **`fx`** to programmatically define the value `{{true}}` or `{{false}}`. |
+| Enable half star | Toggle `on` to allow selection of half stars. `default: false` (bool). | Click on **fx** to programmatically define the value `{{true}}` or `{{false}}`. |
 | Tooltips | This is used for displaying informative tooltips on each star, and it is mapped to the index of the star. | `default: []` (array of strings ). |
 
 </div>
@@ -48,7 +48,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 | <div style={{ width:"100px"}}> Variables  </div>  | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:--------- |
-| value | This variable holds the value whenever a rating is added on the component. The variable holds a numerical value. | Access the value dynamically using JS: `{{components.colorpicker1.selectedColorHex}}`|
+| value | This variable holds the value whenever a rating is added on the component. The variable holds a numerical value. | Access the value dynamically using JS: `{{components.colorpicker1.selectedColorHex}}`.|
 
 </div>
 
@@ -69,8 +69,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **`fx`** to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **`fx`** to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 
@@ -84,7 +84,7 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 |:------------ |:-------------|:--------- |
 | Star Color | Display color of the star. `default: #ffb400` (color hex). Change color by providing `Hex color code` or choosing one from the picker. |  |
 | Label color | Change the color of label in component by providing `Hex color code` or choosing one from the picker. |  |
-| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **`fx`** button next to it. If `{{false}}` the component will not be visible after the app is deployed. | By default, it's set to `{{true}}` |
-| Disable | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **`fx`** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. | By default, it's set to `{{true}}`. |
+| Disable | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **fx** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}`. |
 
 </div>

--- a/docs/docs/widgets/star-rating.md
+++ b/docs/docs/widgets/star-rating.md
@@ -4,9 +4,9 @@ title: Star Rating
 ---
 # Star Rating
 
-The **Star Rating** widget can be used to display as well as input ratings. The widget supports half stars, and the number of stars can be set too.
+The **Star Rating** component can be used to display as well as input ratings. The component supports half stars, and the number of stars can be set too.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
@@ -15,12 +15,12 @@ The **Star Rating** widget can be used to display as well as input ratings. The 
 | Label | The text to be used as the label for the star rating. | This field expects a `String` value. |
 | Number of stars | Initial number of stars in the list on initial load. `default: 5`. | This field expects an integer value. |
 | Default no of selected stars | This property specifies the default count of stars that are selected on the initial load. `default: 5` (integer). | This field expects an integer value. |
-| Enable half star | Toggle `on` to allow selection of half stars. `default: false` (bool). | Click on `Fx` to programmatically define the value `{{true}}` or `{{false}}`. |
+| Enable half star | Toggle `on` to allow selection of half stars. `default: false` (bool). | Click on **`fx`** to programmatically define the value `{{true}}` or `{{false}}`. |
 | Tooltips | This is used for displaying informative tooltips on each star, and it is mapped to the index of the star. | `default: []` (array of strings ). |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
 
@@ -34,7 +34,7 @@ Check [Action Reference](/docs/category/actions-reference) docs to get the detai
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -42,7 +42,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -52,37 +52,39 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **`fx`** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **`fx`** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}>  Description </div> | <div style={{ width:"100px"}}> Default Value </div> |
 |:------------ |:-------------|:--------- |
 | Star Color | Display color of the star. `default: #ffb400` (color hex). Change color by providing `Hex color code` or choosing one from the picker. |  |
-| Label color | Change the color of label in widget by providing `Hex color code` or choosing one from the picker. |  |
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. | By default, it's set to `{{true}}` |
-| Disable | This is `off` by default, toggle `on` the switch to lock the widget and make it non-functional. You can also programmatically set the value by clicking on the `Fx` button next to it. If set to `{{true}}`, the widget will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| Label color | Change the color of label in component by providing `Hex color code` or choosing one from the picker. |  |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **`fx`** button next to it. If `{{false}}` the component will not be visible after the app is deployed. | By default, it's set to `{{true}}` |
+| Disable | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **`fx`** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/star-rating.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/star-rating.md
@@ -82,7 +82,7 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}>  Description </div> | <div style={{ width:"100px"}}> Default Value </div> |
 |:------------ |:-------------|:--------- |
-| Star Color | Display color of the star. `default: #ffb400` (color hex). Change color by providing `Hex color code` or choosing one from the picker. |  |
+| Star Color | Display color of the star. Change color by providing `Hex color code` or choosing one from the picker. | `default: #ffb400` (color hex). |
 | Label color | Change the color of label in component by providing `Hex color code` or choosing one from the picker. |  |
 | Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. | By default, it's set to `{{true}}`. |
 | Disable | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **fx** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}`. |

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/star-rating.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/star-rating.md
@@ -15,7 +15,7 @@ The **Star Rating** component can be used to display as well as input ratings. T
 | Label | The text to be used as the label for the star rating. | This field expects a `String` value. |
 | Number of stars | Initial number of stars in the list on initial load. `default: 5`. | This field expects an integer value. |
 | Default no of selected stars | This property specifies the default count of stars that are selected on the initial load. `default: 5` (integer). | This field expects an integer value. |
-| Enable half star | Toggle `on` to allow selection of half stars. `default: false` (bool). | Click on **`fx`** to programmatically define the value `{{true}}` or `{{false}}`. |
+| Enable half star | Toggle `on` to allow selection of half stars. `default: false` (bool). | Click on **fx** to programmatically define the value `{{true}}` or `{{false}}`. |
 | Tooltips | This is used for displaying informative tooltips on each star, and it is mapped to the index of the star. | `default: []` (array of strings ). |
 
 </div>
@@ -48,7 +48,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 | <div style={{ width:"100px"}}> Variables  </div>  | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:--------- |
-| value | This variable holds the value whenever a rating is added on the component. The variable holds a numerical value. | Access the value dynamically using JS: `{{components.colorpicker1.selectedColorHex}}`|
+| value | This variable holds the value whenever a rating is added on the component. The variable holds a numerical value. | Access the value dynamically using JS: `{{components.colorpicker1.selectedColorHex}}`.|
 
 </div>
 
@@ -69,8 +69,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **`fx`** to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **`fx`** to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 
@@ -84,7 +84,7 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 |:------------ |:-------------|:--------- |
 | Star Color | Display color of the star. `default: #ffb400` (color hex). Change color by providing `Hex color code` or choosing one from the picker. |  |
 | Label color | Change the color of label in component by providing `Hex color code` or choosing one from the picker. |  |
-| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **`fx`** button next to it. If `{{false}}` the component will not be visible after the app is deployed. | By default, it's set to `{{true}}` |
-| Disable | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **`fx`** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. | By default, it's set to `{{true}}`. |
+| Disable | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **fx** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}`. |
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/star-rating.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/star-rating.md
@@ -4,9 +4,9 @@ title: Star Rating
 ---
 # Star Rating
 
-The **Star Rating** widget can be used to display as well as input ratings. The widget supports half stars, and the number of stars can be set too.
+The **Star Rating** component can be used to display as well as input ratings. The component supports half stars, and the number of stars can be set too.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
@@ -15,12 +15,12 @@ The **Star Rating** widget can be used to display as well as input ratings. The 
 | Label | The text to be used as the label for the star rating. | This field expects a `String` value. |
 | Number of stars | Initial number of stars in the list on initial load. `default: 5`. | This field expects an integer value. |
 | Default no of selected stars | This property specifies the default count of stars that are selected on the initial load. `default: 5` (integer). | This field expects an integer value. |
-| Enable half star | Toggle `on` to allow selection of half stars. `default: false` (bool). | Click on `Fx` to programmatically define the value `{{true}}` or `{{false}}`. |
+| Enable half star | Toggle `on` to allow selection of half stars. `default: false` (bool). | Click on **`fx`** to programmatically define the value `{{true}}` or `{{false}}`. |
 | Tooltips | This is used for displaying informative tooltips on each star, and it is mapped to the index of the star. | `default: []` (array of strings ). |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
 
@@ -34,7 +34,7 @@ Check [Action Reference](/docs/category/actions-reference) docs to get the detai
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -42,7 +42,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -52,37 +52,39 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **`fx`** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **`fx`** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}>  Description </div> | <div style={{ width:"100px"}}> Default Value </div> |
 |:------------ |:-------------|:--------- |
 | Star Color | Display color of the star. `default: #ffb400` (color hex). Change color by providing `Hex color code` or choosing one from the picker. |  |
-| Label color | Change the color of label in widget by providing `Hex color code` or choosing one from the picker. |  |
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. | By default, it's set to `{{true}}` |
-| Disable | This is `off` by default, toggle `on` the switch to lock the widget and make it non-functional. You can also programmatically set the value by clicking on the `Fx` button next to it. If set to `{{true}}`, the widget will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| Label color | Change the color of label in component by providing `Hex color code` or choosing one from the picker. |  |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **`fx`** button next to it. If `{{false}}` the component will not be visible after the app is deployed. | By default, it's set to `{{true}}` |
+| Disable | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **`fx`** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
 
 </div>


### PR DESCRIPTION
I have made the following changes:
- Replaced "Fx" with "fx"(made the fx lowercase and bold)
- Removed padding bottom from all the `div` that wraps up the h2 headers and the section below the header
- Replaced the word "widget" with "component" (except URL's)
- Added the divider before "Styles" section.

I have made all these changes in both the asked files.

Issue: #10925 