### PR TITLE
#10927 docs: Updated documentation for range slider

### DIFF
--- a/docs/docs/widgets/range-slider.md
+++ b/docs/docs/widgets/range-slider.md
@@ -4,13 +4,13 @@ title: Range Slider
 ---
 # Range Slider
 
-The **Range Slider** widget is widely used across different UIs. One of the main purposes is to filter, explore all the related content and available in the control and settings options.
+The **Range Slider** component is widely used across different UIs. One of the main purposes is to filter, explore all the related content and available in the control and settings options.
 
 :::tip
 Range Sliders have "Two handles" option which allows user to select within a range.
 :::
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
@@ -18,12 +18,12 @@ Range Sliders have "Two handles" option which allows user to select within a ran
 |:------------ |:-------------|
 | Minimum value | Set the minimum value for the slider. This field accepts any numerical value. |
 | Maximum value | Set the maximum value for the slider. This field accepts any numerical value. |
-| Value | Set the default value when the widget loads. This can be used to pre-fill the value based on your data and requirements. |
+| Value | Set the default value when the component loads. This can be used to pre-fill the value based on your data and requirements. |
 | Two handles | The slider will now have 2 dragging handles. It is used to define a range of values versus a single given value. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -31,7 +31,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -41,29 +41,31 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
-## Layout
+## Devices
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
+| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Makes the component visible in desktop view.| You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile  | Makes the component visible in mobile view.  | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Styles
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/range-slider.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/range-slider.md
@@ -4,13 +4,13 @@ title: Range Slider
 ---
 # Range Slider
 
-The **Range Slider** widget is widely used across different UIs. One of the main purposes is to filter, explore all the related content and available in the control and settings options.
+The **Range Slider** component is widely used across different UIs. One of the main purposes is to filter, explore all the related content and available in the control and settings options.
 
 :::tip
 Range Sliders have "Two handles" option which allows user to select within a range.
 :::
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
@@ -18,12 +18,12 @@ Range Sliders have "Two handles" option which allows user to select within a ran
 |:------------ |:-------------|
 | Minimum value | Set the minimum value for the slider. This field accepts any numerical value. |
 | Maximum value | Set the maximum value for the slider. This field accepts any numerical value. |
-| Value | Set the default value when the widget loads. This can be used to pre-fill the value based on your data and requirements. |
+| Value | Set the default value when the component loads. This can be used to pre-fill the value based on your data and requirements. |
 | Two handles | The slider will now have 2 dragging handles. It is used to define a range of values versus a single given value. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -31,7 +31,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -41,29 +41,31 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
-## Layout
+## Devices
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
+| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Makes the component visible in desktop view. | Toggle on or off to display desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Makes the component visible in mobile view.  | Toggle on or off to display mobile view.  | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Styles
 


### PR DESCRIPTION
Description
Updated range-slider docs as mentioned in issue #10928

 - [x] Formatting updates (removed padding bottom, added separator)
 - [x] Content updates (changed widgets to components, changed content of the Layout table)
 - [x] Didn't change any existing link
 - [x]This PR solves #10927

Files on which changes are implemented -
Next - ToolJet/docs/docs/widgets/range-slider.md
Version 2.50.0 (LTS) - ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/range-slider.md

Let me know if I am missing something else. I followed references when updating the content and the table headers of the Layout (now devices) table. 