### PR TITLE
[Docs] Fix typos and improve documentation for ToolJet CLI

### DIFF
--- a/docs/docs/app-builder/toolbar.md
+++ b/docs/docs/app-builder/toolbar.md
@@ -13,7 +13,7 @@ To modify the app name, click on the application name on the left side of the to
     <img className="screenshot-full" src="/img/v2-beta/app-builder/toolbar/appnamenew-v2.png" alt="App Builder: App Name"/>
 </div>
 
-### Desktop or Mobile layout
+### Desktop or Mobile Layout
 
 Toggle between Mobile and Desktop views directly from the topbar to switch the canvas mode.
 
@@ -61,7 +61,7 @@ Learn more about multi-environment configuration **[here](/docs/release-manageme
 
 ### Version Manager
 
-You can manage application versions through the Version Manager. You can use this dropdown to edit a version name or adding/removing versions.
+You can manage application versions through the Version Manager. You can use this dropdown to edit a version name or add or remove versions.
 
 :::tip
 Versioning is also helpful when working with **[multiple environments](/docs/release-management/multi-environment/)** like development, staging and production.
@@ -72,10 +72,10 @@ Versioning is also helpful when working with **[multiple environments](/docs/rel
 </div>
 
 
-### Gitsync
-The `Gitsync` icon next to the versions dropdown allows you to sync your application with your GitHub repository.
+### GitSync
+The `GitSync` icon next to the versions dropdown allows you to sync your application with your GitHub repository.
 
-Read more about Gitsync **[here](/docs/gitsync)**. 
+Read more about GitSync **[here](/docs/gitsync)**. 
 ### Undo or Redo
 
 You can Undo or Redo any action performed on the canvas using the Undo and Redo buttons. 
@@ -108,7 +108,7 @@ The Preview button allows you to view the current app version in a new tab, faci
 
 ### Release
 
-Use the Release button on the right to publish the current app version. The Release button, used to publish the current app version, becomes visible only in the Production environment, ensuring that only finalized versions are made public.
+Use the Release button on the right to publish the current app version. The Release button is used to publish the current app version, becomes visible only in the Production environment, ensuring that only finalized versions are made public.
 
 :::caution
 ToolJet will block editing of the Released version of an app and will display a prompt to create a new version to make the changes. This is to prevent accidentally pushing an unfinished app to the live version.

--- a/docs/docs/setup/docker.md
+++ b/docs/docs/setup/docker.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 Follow the steps below to deploy ToolJet on a server using Docker Compose. ToolJet requires a PostgreSQL database to store applications definitions, (encrypted) credentials for datasources and user authentication data.
 
 :::info
-If you rather want to try out ToolJet on your local machine with Docker, you can follow the steps [here](/docs/setup/try-tooljet/).
+If you would rather want to try out ToolJet on your local machine with Docker, you can follow the steps [here](/docs/setup/try-tooljet/).
 :::
 
 *If you have any questions feel free to join our [Slack Community](https://tooljet.com/slack) or send us an email at hello@tooljet.com.*
@@ -24,14 +24,14 @@ Install docker and docker-compose on the server.
 ### Deployment options
 
 There are two options to deploy ToolJet using Docker Compose:
-1. **With in-built PostgreSQL database (recommended)**. This setup uses the official Docker image of PostgreSQL.
+1. **with built-in PostgreSQL database (recommended)**. This setup uses the official Docker image of PostgreSQL.
 2.   **With external PostgreSQL database**. This setup is recommended if you want to use a managed PostgreSQL service such as AWS RDS or Google Cloud SQL.
 
 Confused about which setup to select? Feel free to ask the community via Slack: https://tooljet.com/slack.
 
 
 <Tabs>
-  <TabItem value="with-in-built-postgres" label="With in-built PostgreSQL" default>
+  <TabItem value="with-in-built-postgres" label="with built-in PostgreSQL" default>
 
   1. Download our production docker-compose file into the server.
   ```bash
@@ -48,7 +48,7 @@ Confused about which setup to select? Feel free to ask the community via Slack: 
   mv .env.internal.example .env && ./internal.sh
   ```
 
-  `internal.sh` helps to generate the basic .env variables such as the LOCKBOX_MASTER_KEY, SECRET_KEY_BASE, and the password for postgreSQL database.
+  `internal.sh` helps to generate the basic .env variables such as the LOCKBOX_MASTER_KEY, SECRET_KEY_BASE, and the password for PostgreSQL database.
 
   3. To start the docker container, use the following command:
 
@@ -56,7 +56,7 @@ Confused about which setup to select? Feel free to ask the community via Slack: 
   docker-compose up -d
   ```
 
-  4. **(Optional)** `TOOLJET_HOST` environment variable can either be the public ipv4 address of your server or a custom domain that you want to use. Which can be modified in the .env file.
+  4. **(Optional)** `TOOLJET_HOST` environment variable can either be the public IPv4 address of your server or a custom domain that you want to use. Which can be modified in the .env file.
 
   Also, for setting up additional environment variables in the .env file, please check our documentation on [environment variable](/docs/setup/env-vars)
 
@@ -69,7 +69,7 @@ Confused about which setup to select? Feel free to ask the community via Slack: 
   :::info
   i. Please make sure that `TOOLJET_HOST` starts with either `http://` or `https://`
 
-  ii. Setup docker to run without root privileges by following the instructions written here https://docs.docker.com/engine/install/linux-postinstall/
+  ii. set up Docker to run without root privileges by following the instructions written here https://docs.docker.com/engine/install/linux-postinstall/
 
   iii. If you're running on a linux server, `docker` might need sudo permissions. In that case you can either run:
   `sudo docker-compose up -d`
@@ -107,7 +107,7 @@ curl -LO https://tooljet-deployments.s3.us-west-1.amazonaws.com/docker/backup-re
 
   3. Create `.env` file in the current directory (where the docker-compose.yaml file is downloaded as in step 1):
 
-  Kindly set the postgresql database credentials according to your external database. Please enter the database details with the help of the bash as shown below.
+  Kindly set the PostgreSQL database credentials according to your external database. Please enter the database details with the help of the bash as shown below.
 
   <div style={{textAlign: 'center'}}>
 
@@ -127,7 +127,7 @@ curl -LO https://tooljet-deployments.s3.us-west-1.amazonaws.com/docker/backup-re
   docker-compose up -d
   ```
 
-  5. **(Optional)** `TOOLJET_HOST` environment variable can either be the public ipv4 address of your server or a custom domain that you want to use. Which can be modified in the .env file.
+  5. **(Optional)** `TOOLJET_HOST` environment variable can either be the public IPv4 address of your server or a custom domain that you want to use. Which can be modified in the .env file.
 
   Also, for setting up additional environment variables in the .env file, please check our documentation on [environment variable](/docs/setup/env-vars)
 
@@ -140,12 +140,12 @@ curl -LO https://tooljet-deployments.s3.us-west-1.amazonaws.com/docker/backup-re
   :::info
   i. Please make sure that `TOOLJET_HOST` starts with either `http://` or `https://`
 
-  ii. If there are self signed HTTPS endpoints that ToolJet needs to connect to, please make sure that `NODE_EXTRA_CA_CERTS` environment variable is set to the absolute path containing the certificates.
+  ii. If there are self-signed HTTPS endpoints that ToolJet needs to connect to, please make sure that `NODE_EXTRA_CA_CERTS` environment variable is set to the absolute path containing the certificates.
 
   iii. If you're running a linux server, `docker` might need sudo permissions. In that case you can either run:
   `sudo docker-compose up -d`
 
-  iv. Setup docker to run without root privileges by following the instructions written here https://docs.docker.com/engine/install/linux-postinstall/
+  iv. set up Docker to run without root privileges by following the instructions written here https://docs.docker.com/engine/install/linux-postinstall/
 :::
 
 </TabItem>
@@ -154,7 +154,7 @@ curl -LO https://tooljet-deployments.s3.us-west-1.amazonaws.com/docker/backup-re
 
 ## Upgrading to the Latest LTS Version
 
-New LTS versions are released every 3-5 months with an end-of-life of atleast 18 months. To check the latest LTS version, visit the [ToolJet Docker Hub](https://hub.docker.com/r/tooljet/tooljet/tags) page. The LTS tags follow a naming convention with the prefix `LTS-` followed by the version number, for example `tooljet/tooljet:EE-LTS-latest`.
+New LTS versions are released every 3-5 months with an end-of-life of at least 18 months. To check the latest LTS version, visit the [ToolJet Docker Hub](https://hub.docker.com/r/tooljet/tooljet/tags) page. The LTS tags follow a naming convention with the prefix `LTS-` followed by the version number, for example `tooljet/tooljet:EE-LTS-latest`.
 
 If this is a new installation of the application, you may start directly with the latest version. This guide is not required for new installations.
 

--- a/docs/docs/setup/kubernetes.md
+++ b/docs/docs/setup/kubernetes.md
@@ -6,17 +6,17 @@ title: Kubernetes
 # Deploying ToolJet on Kubernetes
 
 :::info
-You should setup a PostgreSQL database manually to be used by ToolJet.
+You should set up a PostgreSQL database manually to be used by ToolJet.
 :::
 
 *If you have any questions feel free to join our [Slack Community](https://tooljet.com/slack) or send us an email at hello@tooljet.com.*
 
 Follow the steps below to deploy ToolJet on a Kubernetes cluster.
 
-1. Setup a PostgreSQL database
-   ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not have plans to support other databases such as MySQL.
+1. set up a PostgreSQL database
+   ToolJet uses a PostgreSQL database as the persistent storage for storing data related to users and apps. We do not have plans to support other databases such as MySQL.
 
-2. Create a Kubernetes secret with name `server`. For the minimal setup, ToolJet requires `pg_host`, `pg_db`, `pg_user`, `pg_password`, `secret_key_base` & `lockbox_key` keys in the secret.
+2. Create a Kubernetes secret with name `server`. For the minimal set up, ToolJet requires `pg_host`, `pg_db`, `pg_user`, `pg_password`, `secret_key_base` & `lockbox_key` keys in the secret.
 
    Read **[environment variables reference](/docs/setup/env-vars)**
 


### PR DESCRIPTION
- Corrected typos and grammar inconsistencies in the ToolJet CLI documentation.  
- Enhanced clarity by rephrasing some sections for better understanding.  
- Updated command descriptions and formatting for consistent style.  

These changes improve readability and accuracy. Requesting a merge as these corrections are important for maintaining quality documentation.