### PR TITLE
[docs]: Fix documentation for Statistics Component

### DIFF
--- a/docs/docs/widgets/statistics.md
+++ b/docs/docs/widgets/statistics.md
@@ -5,7 +5,7 @@ title: Statistics
 
 # Statistics
 
-**Statistics** help us understand and summarize data in a clear and simple way. By using tools like graphs, charts, and averages, statistics allow us to see patterns, compare information, and make sense of numbers. Whether it's for research, business, or everyday decisions, statistics turn raw data into useful insights, making complex information easier to understand and act on.
+**Statistics** can be used to display different statistical information.
 
 <div style={{paddingTop:'24px'}}>
 

--- a/docs/docs/widgets/statistics.md
+++ b/docs/docs/widgets/statistics.md
@@ -15,11 +15,11 @@ title: Statistics
 |:------------ |:-------------|
 | Primary value label | This property lets you add and remove primary value label. | 
 | Primary value | This property lets you add and remove primary value, the actual amount can be represented here. |
-| Hide secondary value | This property lets you show/hide the secondary value from the statistics component. By default, this property is disabled. Toggle it on to hide the secondary value, you can also click on the `fx` button next to it to dynamically set the value to `{{true}}` or `{{false}}`. |
+| Hide secondary value | This property lets you show/hide the secondary value from the statistics component. By default, this property is disabled. Toggle it on to hide the secondary value, you can also click on the **fx** button next to it to dynamically set the value to `{{true}}` or `{{false}}`. |
 | Secondary value label | This property lets you add and remove secondary value label. |
 | Secondary value | This property lets you add and remove secondary value, the change in value can be represented here. |
 | Secondary sign display | This property lets you add and secondary sign either positive or negative,can be used to represent positive(increase) or negative(decrease) movement. Default value is positive. |
-| Loading state | Loading state can be used to show a spinner on the statistics. Loading state is commonly used with `isLoading` property of the queries to show a loading status while a query is being run. Switch the toggle **On** or click on `fx` to programmatically set the value `{{true}}` or `{{false}}`. |
+| Loading state | Loading state can be used to show a spinner on the statistics. Loading state is commonly used with `isLoading` property of the queries to show a loading status while a query is being run. Switch the toggle **On** or click on **fx** to programmatically set the value `{{true}}` or `{{false}}`. |
 
 </div>
 
@@ -56,8 +56,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
@@ -73,10 +73,10 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 | Primary text colour | You can change the primary text color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Secondary label colour | You can change the secondary label color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Secondary text colour | You can change the secondary text color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
-| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the `fx` button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 :::info
-Any property having `fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/docs/widgets/statistics.md
+++ b/docs/docs/widgets/statistics.md
@@ -56,8 +56,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 

--- a/docs/docs/widgets/statistics.md
+++ b/docs/docs/widgets/statistics.md
@@ -5,9 +5,9 @@ title: Statistics
 
 # Statistics
 
-**Statistics** can be used to display different statistical information.
+**Statistics** help us understand and summarize data in a clear and simple way. By using tools like graphs, charts, and averages, statistics allow us to see patterns, compare information, and make sense of numbers. Whether it's for research, business, or everyday decisions, statistics turn raw data into useful insights, making complex information easier to understand and act on.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
@@ -15,7 +15,7 @@ title: Statistics
 |:------------ |:-------------|
 | Primary value label | This property lets you add and remove primary value label. | 
 | Primary value | This property lets you add and remove primary value, the actual amount can be represented here. |
-| Hide secondary value | This property lets you show/hide the secondary value from the statistics component. By default, this property is disabled. Toggle it on to hide the secondary value, you can also click on the `Fx` button next to it to dynamically set the value to `{{true}}` or `{{false}}`. |
+| Hide secondary value | This property lets you show/hide the secondary value from the statistics component. By default, this property is disabled. Toggle it on to hide the secondary value, you can also click on the `fx` button next to it to dynamically set the value to `{{true}}` or `{{false}}`. |
 | Secondary value label | This property lets you add and remove secondary value label. |
 | Secondary value | This property lets you add and remove secondary value, the change in value can be represented here. |
 | Secondary sign display | This property lets you add and secondary sign either positive or negative,can be used to represent positive(increase) or negative(decrease) movement. Default value is positive. |
@@ -23,7 +23,7 @@ title: Statistics
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -31,7 +31,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -39,29 +39,31 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `fx` to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `fx` to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+--- 
 
 ## Styles
 
@@ -71,10 +73,10 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 | Primary text colour | You can change the primary text color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Secondary label colour | You can change the secondary label color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Secondary text colour | You can change the secondary text color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the `fx` button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having `fx` button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/statistics.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/statistics.md
@@ -5,7 +5,7 @@ title: Statistics
 
 # Statistics
 
-**Statistics** help us understand and summarize data in a clear and simple way. By using tools like graphs, charts, and averages, statistics allow us to see patterns, compare information, and make sense of numbers. Whether it's for research, business, or everyday decisions, statistics turn raw data into useful insights, making complex information easier to understand and act on.
+**Statistics** can be used to display different statistical information.
 
 <div style={{paddingTop:'24px'}}>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/statistics.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/statistics.md
@@ -15,11 +15,11 @@ title: Statistics
 |:------------ |:-------------|
 | Primary value label | This property lets you add and remove primary value label. | 
 | Primary value | This property lets you add and remove primary value, the actual amount can be represented here. |
-| Hide secondary value | This property lets you show/hide the secondary value from the statistics component. By default, this property is disabled. Toggle it on to hide the secondary value, you can also click on the `fx` button next to it to dynamically set the value to `{{true}}` or `{{false}}`. |
+| Hide secondary value | This property lets you show/hide the secondary value from the statistics component. By default, this property is disabled. Toggle it on to hide the secondary value, you can also click on the **fx** button next to it to dynamically set the value to `{{true}}` or `{{false}}`. |
 | Secondary value label | This property lets you add and remove secondary value label. |
 | Secondary value | This property lets you add and remove secondary value, the change in value can be represented here. |
 | Secondary sign display | This property lets you add and secondary sign either positive or negative,can be used to represent positive(increase) or negative(decrease) movement. Default value is positive. |
-| Loading state | Loading state can be used to show a spinner on the statistics. Loading state is commonly used with `isLoading` property of the queries to show a loading status while a query is being run. Switch the toggle **On** or click on `fx` to programmatically set the value `{{true}}` or `{{false}}`. |
+| Loading state | Loading state can be used to show a spinner on the statistics. Loading state is commonly used with `isLoading` property of the queries to show a loading status while a query is being run. Switch the toggle **On** or click on **fx** to programmatically set the value `{{true}}` or `{{false}}`. |
 
 </div>
 
@@ -56,8 +56,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
@@ -73,10 +73,10 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 | Primary text colour | You can change the primary text color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Secondary label colour | You can change the secondary label color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Secondary text colour | You can change the secondary text color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
-| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the `fx` button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 :::info
-Any property having `fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/statistics.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/statistics.md
@@ -56,8 +56,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/statistics.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/statistics.md
@@ -5,9 +5,9 @@ title: Statistics
 
 # Statistics
 
-**Statistics** can be used to display different statistical information.
+**Statistics** help us understand and summarize data in a clear and simple way. By using tools like graphs, charts, and averages, statistics allow us to see patterns, compare information, and make sense of numbers. Whether it's for research, business, or everyday decisions, statistics turn raw data into useful insights, making complex information easier to understand and act on.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
@@ -15,7 +15,7 @@ title: Statistics
 |:------------ |:-------------|
 | Primary value label | This property lets you add and remove primary value label. | 
 | Primary value | This property lets you add and remove primary value, the actual amount can be represented here. |
-| Hide secondary value | This property lets you show/hide the secondary value from the statistics component. By default, this property is disabled. Toggle it on to hide the secondary value, you can also click on the `Fx` button next to it to dynamically set the value to `{{true}}` or `{{false}}`. |
+| Hide secondary value | This property lets you show/hide the secondary value from the statistics component. By default, this property is disabled. Toggle it on to hide the secondary value, you can also click on the `fx` button next to it to dynamically set the value to `{{true}}` or `{{false}}`. |
 | Secondary value label | This property lets you add and remove secondary value label. |
 | Secondary value | This property lets you add and remove secondary value, the change in value can be represented here. |
 | Secondary sign display | This property lets you add and secondary sign either positive or negative,can be used to represent positive(increase) or negative(decrease) movement. Default value is positive. |
@@ -23,7 +23,7 @@ title: Statistics
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -31,7 +31,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -39,29 +39,31 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `fx` to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `fx` to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+--- 
 
 ## Styles
 
@@ -71,10 +73,10 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 | Primary text colour | You can change the primary text color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Secondary label colour | You can change the secondary label color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Secondary text colour | You can change the secondary text color of the primary label by entering the Hex color code or choosing a color of your choice from the color picker. |
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the `fx` button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having `fx` button next to its field can be **programmatically configured**.
 :::
 
 </div>


### PR DESCRIPTION
This PR addresses the following changes in the documentation for the Statistics component:

Formatting updates:

Replaced "Fx" with "fx" wherever applicable.
Removed 24px padding-bottom for all h2 headers, ensuring only 24px padding-top remains in the wrapping div.

Content updates:

Enhanced the introduction with a more descriptive summary.
Replaced the term "widget" with "component" throughout the documentation (excluding URLs).
Added a divider before the "Styles" section for better content structure.