### PR TITLE
[docs]: Fix documentation for Spinner Component

### DIFF
--- a/docs/docs/widgets/spinner.md
+++ b/docs/docs/widgets/spinner.md
@@ -4,9 +4,9 @@ title: Spinner
 ---
 # Spinner
 
-The **Spinner** widget can be used to provide a visual indication that an action is in progress by awaiting a change.
+The **Spinner** component can be used to provide a visual indication that an action is in progress by awaiting a change.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -14,7 +14,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -22,35 +22,37 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically change the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically change the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+---
+
+<div style={{paddingTop:'24px'}}>
 
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}>  Description </div> | 
 |:------------ |:-------------|
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
 | Color | Change the color of the Spinner by entering the `Hex color code` or choosing a color of your choice from the color-picker. |
 | Size | Change the size of the Spinner by selecting options from the dropdown. It has small and large sizes available. |
 

--- a/docs/docs/widgets/spinner.md
+++ b/docs/docs/widgets/spinner.md
@@ -39,8 +39,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically change the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically change the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically change the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically change the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 

--- a/docs/versioned_docs/version-2.5.0/widgets/spinner.md
+++ b/docs/versioned_docs/version-2.5.0/widgets/spinner.md
@@ -4,24 +4,24 @@ title: Spinner
 ---
 # Spinner
 
-Spinner widget can be used to provide a visual indication that an action is in progress by awaiting a change.
+Spinner component can be used to provide a visual indication that an action is in progress by awaiting a change.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/widgets/spinner/spinner.png" alt="ToolJet - Widget Reference - Spinner" />
+<img className="screenshot-full" src="/img/widgets/spinner/spinner.png" alt="ToolJet - Component Reference - Spinner" />
 
 </div>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/tooltip.png" alt="ToolJet - Widget Reference - Spinner" />
+<img className="screenshot-full" src="/img/tooltip.png" alt="ToolJet - Component Reference - Spinner" />
 
 </div>
 
@@ -29,16 +29,18 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 ### Show on desktop
 
-Toggle on or off to display the widget in desktop view. You can programmatically determine the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}`.
+Toggle on or off to display the component in desktop view. You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`.
 ### Show on mobile
 
-Toggle on or off to display the widget in mobile view. You can programmatically determine the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}`.
+Toggle on or off to display the component in mobile view. You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`.
+
+---
 
 ## Styles
 
 ### Visibility
 
-Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. By default, it's set to `{{true}}`.
+Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`.
 
 ### Color
 

--- a/docs/versioned_docs/version-2.5.0/widgets/spinner.md
+++ b/docs/versioned_docs/version-2.5.0/widgets/spinner.md
@@ -4,24 +4,24 @@ title: Spinner
 ---
 # Spinner
 
-Spinner component can be used to provide a visual indication that an action is in progress by awaiting a change.
+Spinner widget can be used to provide a visual indication that an action is in progress by awaiting a change.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/widgets/spinner/spinner.png" alt="ToolJet - Component Reference - Spinner" />
+<img className="screenshot-full" src="/img/widgets/spinner/spinner.png" alt="ToolJet - Widget Reference - Spinner" />
 
 </div>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/tooltip.png" alt="ToolJet - Component Reference - Spinner" />
+<img className="screenshot-full" src="/img/tooltip.png" alt="ToolJet - Widget Reference - Spinner" />
 
 </div>
 
@@ -29,18 +29,16 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 ### Show on desktop
 
-Toggle on or off to display the component in desktop view. You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`.
+Toggle on or off to display the widget in desktop view. You can programmatically determine the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}`.
 ### Show on mobile
 
-Toggle on or off to display the component in mobile view. You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`.
-
----
+Toggle on or off to display the widget in mobile view. You can programmatically determine the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}`.
 
 ## Styles
 
 ### Visibility
 
-Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`.
+Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. By default, it's set to `{{true}}`.
 
 ### Color
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/spinner.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/spinner.md
@@ -39,8 +39,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/spinner.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/spinner.md
@@ -4,9 +4,9 @@ title: Spinner
 ---
 # Spinner
 
-The **Spinner** widget can be used to provide a visual indication that an action is in progress by awaiting a change.
+The **Spinner** component can be used to provide a visual indication that an action is in progress by awaiting a change.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -14,7 +14,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -22,35 +22,37 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}`. |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}`. |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+---
+
+<div style={{paddingTop:'24px'}}>
 
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}>  Description </div> | 
 |:------------ |:-------------|
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
 | Color | Change the color of the Spinner by entering the `Hex color code` or choosing a color of your choice from the color-picker. |
 | Size | Change the size of the Spinner by selecting options from the dropdown. It has small and large sizes available. |
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/spinner.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/spinner.md
@@ -39,8 +39,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically change the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically change the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 


### PR DESCRIPTION
**Description**
Updated spinner docs as mentioned in issue #10926

 **Formatting updates** 
 - removed padding bottom
 - added separator above styles
 
 **Content updates** 
- changed widgets to components
- changed `Fx` to **fx**
 - Didn't change any existing link, but changed alt text in "version-2.50.0-LTS/widgets/spinner.md" -  Widget Reference -> Component Reference.
 
[X] This PR closes https://github.com/ToolJet/ToolJet/issues/10926

Files on which changes are implemented -
Next - ToolJet/docs/docs/widgets/spinner.md
Version 2.50.0 (LTS) - ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/spinner.md

Let me know if I am missing something else. I followed references when updating the content.