### PR TITLE
Fix Documentation Formatting and Terminology in Icon Component

### DIFF
--- a/docs/docs/widgets/icon.md
+++ b/docs/docs/widgets/icon.md
@@ -3,53 +3,53 @@ id: icon
 title: Icon 
 ---
 
-An **Icon** widget can be used to add icons(sourced from icon library). It supports events like on hover and on click.
+An **Icon** component can be used to add icons (sourced from the icon library). It supports events like on hover and on click.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
 |  <div style={{ width:"100px"}}> Properties </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"135px"}}> Expected Value </div> |
 |:----------- |:----------- |:-------------- |
-| Icon | Use this to choose an icon form the list of available icons | You can also use the search bar in it to look for the icons | 
+| Icon | Use this to choose an icon from the list of available icons. You can also use the search bar in it to look for the icons. | 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
 
-To add an event, click on the Icon widget's configuration handle to open the widget properties on the components drawer on the right. Go to the **Events** section and click on **+ Add handler**.
+To add an event, click on the Icon component's configuration handle to open the component properties on the components drawer on the right. Go to the **Events** section and click on **+ Add handler**.
 
-The Icon widget supports the following events:
+The Icon component supports the following events:
 
 |  <div style={{ width:"100px"}}> Event </div> |  <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| On hover      | This event is triggered when the cursor is hovered over the icon|
-| On click      | This event is triggered when the icon is clicked |
+| On hover      | Triggers whenever the user hovers the cursor over the icon. |
+| On click      | Triggers whenever the user clicks on the icon. |
 
 Just like any other event on ToolJet, you can set multiple handlers for any of the above-mentioned events.
 
 :::info
-Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
+Check [Action Reference](/docs/category/actions-reference) docs to get detailed information about all the **Actions**.
 :::
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
-Following actions of the component can be controlled using the component specific actions(CSA):
+Following actions of the component can be controlled using the component-specific actions (CSA):
 
 | <div style={{ width:"100px"}}> Actions  </div>   | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:--------- |
 | setVisibility | You can toggle the visibility of the Icon component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.icon1.setVisibility(false)` |
-| click | You can trigger the click action on Icon component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.icon1.click()` |
+| click | You can trigger the click action on the Icon component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.icon1.click()` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -57,37 +57,39 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 
-<b>Tooltip:</b> Set a tooltip text to specify the information when the user moves the mouse pointer over the widget.
+<b>Tooltip:</b> Set a tooltip text to specify the information when the user moves the mouse pointer over the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:----------- |:----------- |:------------- |
-| Icon color |  You can change the color of the Icon widget by entering the Hex color code or choosing a color of your choice from the color picker. |
-| Visibility | This is to control the visibility of the widget. | If `{{false}}` the widget will not visible after the app is deployed. | It can only have boolean values i.e. either `{{true}}` or `{{false}}`. By default, it's set to `{{true}}`. |
-| Box shadow | This property adds a shadow to the widget. | You can use different values for box shadow property like offsets, blur, spread, and the color code. |
+| Icon color | You can change the color of the Icon component by entering the Hex color code or choosing a color of your choice from the color picker. |
+| Visibility | This is to control the visibility of the component. If `{{false}}`, the component will not be visible after the app is deployed. It can only have boolean values, i.e., either `{{true}}` or `{{false}}`. By default, it's set to `{{true}}`. |
+| Box shadow | This property adds a shadow to the component. You can use different values for the box shadow property like offsets, blur, spread, and the color code. |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/docs/widgets/link.md
+++ b/docs/docs/widgets/link.md
@@ -5,41 +5,42 @@ title: Link
 
 # Link
 
-The **Link** widget allows you to add a hyperlink and navigate to the external URL.
+The **Link** component allows you to add a hyperlink and navigate to the external URL.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
 | <div style={{ width:"100px"}}> Properties </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:----------- |:----------- |:-------------- |
 | Link target | This property sets the URL where the user needs to be taken on clicking the link | example: `https://dev.to/tooljet` or `{{queries.xyz.data.url}}` | 
-| Link text | This property sets the text for the Link widget  | example: `Click here` or `Open webpage` | 
+| Link text | This property sets the text for the Link component  | example: `Click here` or `Open webpage` | 
 | Target type | This property specifies the link to be opened in the same tab or new tab on clicking the link | Options: `New Tab` & `Same Tab` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
-To add an event to a link, click on the widget handle to open the widget properties on the right sidebar. Go to the **Events** section and click on **Add handler**.
+
+To add an event to a link, click on the component handle to open the component properties on the right sidebar. Go to the **Events** section and click on **Add handler**.
 
 |  <div style={{ width:"100px"}}> Event </div> |  <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| On click | **On Click** event is triggered when the link is clicked. Just like any other event on ToolJet, you can set multiple handlers for on click event. |
-| On hover | **On Hover** event is triggered when the link is hovered. Just like any other event on ToolJet, you can set multiple handlers for on click event. |
+| On click | **On Click** event is triggered when the link is clicked. Just like any other event on ToolJet, you can set multiple handlers for the on-click event. |
+| On hover | **On Hover** event is triggered when the link is hovered. Just like any other event on ToolJet, you can set multiple handlers for the hover event. |
 
 :::info
-Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
+Check [Action Reference](/docs/category/actions-reference) docs to get detailed information about all the **Actions**.
 :::
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
-Following actions of link component can be controlled using the component specific actions(CSA):
+Following actions of the link component can be controlled using the component-specific actions (CSA):
 
 | <div style={{ width:"100px"}}> Actions  </div>   | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:------------ |
@@ -47,7 +48,7 @@ Following actions of link component can be controlled using the component specif
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -55,41 +56,42 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
+
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in string format. Now, hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+---
 
 ## Styles
 
 | <div style={{ width:"100px"}}> Style  </div>    | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- | 
 | Text color |  You can change the background color of the text by entering the Hex color code or choosing a color of your choice from the color picker. |
-| Text size | By default, the text size is set to 14. You can enter any value from 1-100 to set custom text size. |
+| Text size | By default, the text size is set to 14. You can enter any value from 1-100 to set a custom text size. |
 | Underline | You can change the underline of the text in the following ways: **on-hover (default), never, always** |
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not visible after the app is deployed. By default, it's set to `{{true}}`. |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}`, the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having the **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/icon.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/icon.md
@@ -3,7 +3,7 @@ id: icon
 title: Icon 
 ---
 
-An **Icon** widget can be used to add icons(sourced from icon library). It supports events like on hover and on click.
+An **Icon** component can be used to add icons sourced from the icon library. It supports events like on hover and on click.
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
@@ -11,27 +11,27 @@ An **Icon** widget can be used to add icons(sourced from icon library). It suppo
 
 |  <div style={{ width:"100px"}}> Properties </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"135px"}}> Expected Value </div> |
 |:----------- |:----------- |:-------------- |
-| Icon | Use this to choose an icon form the list of available icons | You can also use the search bar in it to look for the icons | 
+| Icon | Use this to choose an icon from the list of available icons. | You can also use the search bar in it to look for the icons. | 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
 
-To add an event, click on the Icon widget's configuration handle to open the widget properties on the components drawer on the right. Go to the **Events** section and click on **+ Add handler**.
+To add an event, click on the Icon component's configuration handle to open the component properties on the components drawer on the right. Go to the **Events** section and click on **+ Add handler**.
 
-The Icon widget supports the following events:
+The Icon component supports the following events:
 
 |  <div style={{ width:"100px"}}> Event </div> |  <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| On hover      | This event is triggered when the cursor is hovered over the icon|
-| On click      | This event is triggered when the icon is clicked |
+| On hover      | Triggers whenever the user hovers the cursor over the icon. |
+| On click      | Triggers whenever the user clicks on the icon. |
 
 Just like any other event on ToolJet, you can set multiple handlers for any of the above-mentioned events.
 
 :::info
-Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
+Check [Action Reference](/docs/category/actions-reference) docs to get detailed information about all the **Actions**.
 :::
 
 </div>
@@ -40,12 +40,12 @@ Check [Action Reference](/docs/category/actions-reference) docs to get the detai
 
 ## Component Specific Actions (CSA)
 
-Following actions of the component can be controlled using the component specific actions(CSA):
+Following actions of the component can be controlled using the component-specific actions (CSA):
 
 | <div style={{ width:"100px"}}> Actions  </div>   | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:--------- |
 | setVisibility | You can toggle the visibility of the Icon component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.icon1.setVisibility(false)` |
-| click | You can trigger the click action on Icon component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.icon1.click()` |
+| click | You can trigger the click action on the Icon component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.icon1.click()` |
 
 </div>
 
@@ -61,7 +61,7 @@ There are currently no exposed variables for the component.
 
 ## General
 
-<b>Tooltip:</b> Set a tooltip text to specify the information when the user moves the mouse pointer over the widget.
+<b>Tooltip:</b> Set a tooltip text to specify the information when the user moves the mouse pointer over the component.
 
 </div>
 
@@ -71,23 +71,25 @@ There are currently no exposed variables for the component.
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
+---
+
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:----------- |:----------- |:------------- |
-| Icon color |  You can change the color of the Icon widget by entering the Hex color code or choosing a color of your choice from the color picker. |
-| Visibility | This is to control the visibility of the widget. | If `{{false}}` the widget will not visible after the app is deployed. | It can only have boolean values i.e. either `{{true}}` or `{{false}}`. By default, it's set to `{{true}}`. |
-| Box shadow | This property adds a shadow to the widget. | You can use different values for box shadow property like offsets, blur, spread, and the color code. |
+| Icon color |  You can change the color of the Icon component by entering the Hex color code or choosing a color of your choice from the color picker. |
+| Visibility | This is to control the visibility of the component. | If `{{false}}` the component will not be visible after the app is deployed. It can only have boolean values i.e., either `{{true}}` or `{{false}}`. By default, it's set to `{{true}}`. |
+| Box shadow | This property adds a shadow to the component. | You can use different values for the box shadow property like offsets, blur, spread, and the color code. |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/link.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/link.md
@@ -5,49 +5,50 @@ title: Link
 
 # Link
 
-The **Link** widget allows you to add a hyperlink and navigate to the external URL.
+The **Link** component allows you to add a hyperlink and navigate to an external URL.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
 | <div style={{ width:"100px"}}> Properties </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:----------- |:----------- |:-------------- |
 | Link target | This property sets the URL where the user needs to be taken on clicking the link | example: `https://dev.to/tooljet` or `{{queries.xyz.data.url}}` | 
-| Link text | This property sets the text for the Link widget  | example: `Click here` or `Open webpage` | 
+| Link text | This property sets the text for the Link component | example: `Click here` or `Open webpage` | 
 | Target type | This property specifies the link to be opened in the same tab or new tab on clicking the link | Options: `New Tab` & `Same Tab` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
-To add an event to a link, click on the widget handle to open the widget properties on the right sidebar. Go to the **Events** section and click on **Add handler**.
 
-|  <div style={{ width:"100px"}}> Event </div> |  <div style={{ width:"100px"}}> Description </div> |
+To add an event to a link, click on the component handle to open the component properties on the right sidebar. Go to the **Events** section and click on **Add handler**.
+
+| <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| On click | **On Click** event is triggered when the link is clicked. Just like any other event on ToolJet, you can set multiple handlers for on click event. |
-| On hover | **On Hover** event is triggered when the link is hovered. Just like any other event on ToolJet, you can set multiple handlers for on click event. |
+| On click | **On Click** event is triggered when the link is clicked. Just like any other event on ToolJet, you can set multiple handlers for the on-click event. |
+| On hover | **On Hover** event is triggered when the link is hovered. Just like any other event on ToolJet, you can set multiple handlers for the hover event. |
 
 :::info
-Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
+Check [Action Reference](/docs/category/actions-reference) docs to get detailed information about all the **Actions**.
 :::
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
-Following actions of link component can be controlled using the component specific actions(CSA):
+Following actions of the link component can be controlled using the component-specific actions (CSA):
 
-| <div style={{ width:"100px"}}> Actions  </div>   | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
+| <div style={{ width:"100px"}}> Actions </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:------------ |
 | click | You can trigger the click action of the Link component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.link1.click()` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -55,41 +56,42 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
+
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in string format. Now, hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+---
 
 ## Styles
 
-| <div style={{ width:"100px"}}> Style  </div>    | <div style={{ width:"100px"}}> Description </div> |
+| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- | 
-| Text color |  You can change the background color of the text by entering the Hex color code or choosing a color of your choice from the color picker. |
-| Text size | By default, the text size is set to 14. You can enter any value from 1-100 to set custom text size. |
+| Text color | You can change the background color of the text by entering the Hex color code or choosing a color of your choice from the color picker. |
+| Text size | By default, the text size is set to 14. You can enter any value from 1-100 to set a custom text size. |
 | Underline | You can change the underline of the text in the following ways: **on-hover (default), never, always** |
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not visible after the app is deployed. By default, it's set to `{{true}}`. |
+| Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}`, the component will not be visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having the **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>


### PR DESCRIPTION
PR Description
This PR fixes the issue: #10972 

Summary of Changes:

- Replaced "Fx" with "fx" (lowercase and bold) across the document.
- Removed 24px padding-bottom from h2 headers, retaining only 24px padding-top.
- Updated the word "widget" to "component" throughout the documentation.
- Removed the description below the "Events" heading.
- Updated the descriptions for "On hover" and "On click" events for better clarity.
- Added a divider before the "Styles" section.
- 
Affected Files:

- ToolJet/docs/docs/widgets/icon.md
- ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/icon.md