### PR TITLE
[docs]: Fix documentation for Divider Component

### DIFF
--- a/docs/docs/widgets/divider.md
+++ b/docs/docs/widgets/divider.md
@@ -2,11 +2,12 @@
 id: divider
 title: Divider
 ---
+
 # Divider
 
-**Divider** widget is used to add separator between components. 
+**Divider** component is used to add separator between components.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -14,7 +15,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed variables
 
@@ -22,40 +23,42 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
+
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
-
-| <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> |
-|:----------- |:----------- |
-| Show on Desktop |  This property have toggle switch. If enabled, the divider will display in the desktop view else it will not appear. |
-| Show on Mobile |  This property have toggle switch. If enabled, the divider will display in the mobile view else it will not appear. |
+| <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div>                                                                   |
+| :------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| Show on Desktop                              | This property have toggle switch. If enabled, the divider will display in the desktop view else it will not appear. |
+| Show on Mobile                               | This property have toggle switch. If enabled, the divider will display in the mobile view else it will not appear.  |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Styles
 
-| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div> |
-| ----------- | ----------- |
-| Divider Color |  It is used to set the color of the divider. Use hex code to set the background color. |
-| Visibility |  This property is used to set the visibility of the divider. The property accepts Boolean value. |
+| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                               |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Divider Color                               | It is used to set the color of the divider. Use hex code to set the background color.           |
+| Visibility                                  | This property is used to set the visibility of the divider. The property accepts Boolean value. |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/docs/widgets/divider.md
+++ b/docs/docs/widgets/divider.md
@@ -3,9 +3,7 @@ id: divider
 title: Divider
 ---
 
-# Divider
-
-**Divider** component is used to add separator between components.
+The **Divider** component is used to add a separator between components.
 
 <div style={{paddingTop:'24px'}}>
 
@@ -39,10 +37,10 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 ## Layout
 
-| <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div>                                                                   |
-| :------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
-| Show on Desktop                              | This property have toggle switch. If enabled, the divider will display in the desktop view else it will not appear. |
-| Show on Mobile                               | This property have toggle switch. If enabled, the divider will display in the mobile view else it will not appear.  |
+| <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div>    | Expected Value                                                  |
+| :------------------------------------------- | :----------------------------------------------------| :-------------------------------------------------------------- |
+| Show on Desktop                              | Makes the component visible in desktop view.         | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on Mobile                               | Makes the component visible in mobile view.          | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md
@@ -9,8 +9,6 @@ title: Divider
 
 <div style={{paddingTop:'24px'}}>
 
----
-
 ## Component Specific Actions (CSA)
 
 There are currently no CSA (Component-Specific Actions) implemented to regulate or control the component.
@@ -19,8 +17,6 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 <div style={{paddingTop:'24px'}}>
 
----
-
 ## Exposed variables
 
 There are currently no exposed variables for the component.
@@ -28,8 +24,6 @@ There are currently no exposed variables for the component.
 </div>
 
 <div style={{paddingTop:'24px'}}>
-
----
 
 ## General
 
@@ -43,8 +37,6 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 <div style={{paddingTop:'24px'}}>
 
----
-
 ## Layout
 
 | <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div>                                                                   |
@@ -55,8 +47,6 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 </div>
 
 <div style={{paddingTop:'24px'}}>
-
----
 
 ## Styles
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md
@@ -48,6 +48,8 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 <div style={{paddingTop:'24px'}}>
 
+---
+
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                               |

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md
@@ -3,9 +3,7 @@ id: divider
 title: Divider
 ---
 
-# Divider
-
-**Divider** component is used to add separator between components.
+The **Divider** component is used to add a separator between components.
 
 <div style={{paddingTop:'24px'}}>
 
@@ -39,10 +37,11 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 ## Layout
 
-| <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div>                                                                   |
-| :------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
-| Show on Desktop                              | This property have toggle switch. If enabled, the divider will display in the desktop view else it will not appear. |
-| Show on Mobile                               | This property have toggle switch. If enabled, the divider will display in the mobile view else it will not appear.  |
+| <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div>    | Expected Value                                                  |
+| :------------------------------------------- | :----------------------------------------------------| :-------------------------------------------------------------- |
+| Show on Desktop                              | Makes the component visible in desktop view.         | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on Mobile                               | Makes the component visible in mobile view.          | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+
 
 </div>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md
@@ -2,11 +2,14 @@
 id: divider
 title: Divider
 ---
+
 # Divider
 
-**Divider** widget is used to add separator between components. 
+**Divider** component is used to add separator between components.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Component Specific Actions (CSA)
 
@@ -14,7 +17,9 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Exposed variables
 
@@ -22,40 +27,46 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## General
+
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Layout
 
-
-| <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> |
-|:----------- |:----------- |
-| Show on Desktop |  This property have toggle switch. If enabled, the divider will display in the desktop view else it will not appear. |
-| Show on Mobile |  This property have toggle switch. If enabled, the divider will display in the mobile view else it will not appear. |
+| <div style={{ width:"135px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div>                                                                   |
+| :------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| Show on Desktop                              | This property have toggle switch. If enabled, the divider will display in the desktop view else it will not appear. |
+| Show on Mobile                               | This property have toggle switch. If enabled, the divider will display in the mobile view else it will not appear.  |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
+
+---
 
 ## Styles
 
-| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div> |
-| ----------- | ----------- |
-| Divider Color |  It is used to set the color of the divider. Use hex code to set the background color. |
-| Visibility |  This property is used to set the visibility of the divider. The property accepts Boolean value. |
+| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                               |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Divider Color                               | It is used to set the color of the divider. Use hex code to set the background color.           |
+| Visibility                                  | This property is used to set the visibility of the divider. The property accepts Boolean value. |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>


### PR DESCRIPTION
@PriteshKiri, This pull request addresses the formatting and content updates as per  #10977.

**The following files were changed:**

1. **Next**: `ToolJet/docs/docs/widgets/divider.md`
2. **Version 2.50.0 (LTS)**: `ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/divider.md`

## Changes Made

- [x] Replaced "Fx" with **fx** (lowercase and bold) throughout the documentation.
- [x] Updated all occurrences of the word "widget" to "component".
- [x] Removed `24px` padding-bottom for all `h2` headers.
- [x] Ensured that the wrapper div for the `h2` headers and the subsequent section only has a `padding-top` of `24px` without any `padding-bottom`.
- [x] Added a divider before the "Styles" section reference in both files.
- [x] Formatted the markdown files using a markdown linter for better readability and scalability.


Lemme know if there are any questions or further adjustments needed.