### PR TITLE
[docs]: Fix relative links in documentation - 2

### DIFF
--- a/docs/docs/data-sources/airtable.md
+++ b/docs/docs/data-sources/airtable.md
@@ -9,7 +9,7 @@ ToolJet can connect to your **Airtable** account to read and write data.
 
 ## Connection
 
-To establish a connection with the **Airtable** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard.
+To establish a connection with the **Airtable** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Airtable:
 - **Personal Access Token**

--- a/docs/docs/data-sources/amazonses.md
+++ b/docs/docs/data-sources/amazonses.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Amazon SES account to send emails.
 
 ## Connection
 
-To establish a connection with the **Amazon SES** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the **Amazon SES** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to Amazon SES:
 

--- a/docs/docs/data-sources/appwrite.md
+++ b/docs/docs/data-sources/appwrite.md
@@ -9,7 +9,7 @@ ToolJet can connect to appwrite database to read/write data.
 
 ## Connection 
 
-To establish a connection with the Appwrite data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](https://docs.tooljet.com/docs/data-sources/overview)** page from the ToolJet dashboard.
+To establish a connection with the Appwrite data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Appwrite:
 - **Host (API endpoint)**
@@ -46,7 +46,7 @@ You should also set the scope for access to a particular resource. Learn more ab
 </div> 
 
 :::tip
-Query results can be transformed using Transformations. Read our **Transformation Documentation** [here](/docs/tutorial/transformations).
+Query results can be transformed using Transformations. Read our **Transformation Documentation** [here](../tutorial/transformations).
 :::
 
 </div>

--- a/docs/docs/data-sources/athena.md
+++ b/docs/docs/data-sources/athena.md
@@ -9,7 +9,7 @@ ToolJet can connect to **Amazon Athena** which is an interactive query service t
 
 ## Connection
 
-To establish a connection with the **Amazon Athena** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](https://docs.tooljet.com/docs/data-sources/overview)** page from the ToolJet dashboard and choose **Amazon Athena** as the data source.
+To establish a connection with the **Amazon Athena** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose **Amazon Athena** as the data source.
 
 ToolJet requires the following to connect to your Athena.
 

--- a/docs/docs/data-sources/azureblob.md
+++ b/docs/docs/data-sources/azureblob.md
@@ -7,7 +7,7 @@ ToolJet offers the capability to establish a connection with Azure Blob storage 
 
 ## Connection
 
-To establish a connection with the Azure Blob data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Azure Blob as the data source.
+To establish a connection with the Azure Blob data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Azure Blob as the data source.
 
 ToolJet requires the following to connect to your Azure Blob.
 - **Connection String**
@@ -28,7 +28,7 @@ ToolJet requires the following to connect to your Azure Blob.
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to trigger the query.
 
 :::tip
-Query results can be transformed using Transformation. For more information on transformations, please refer to our documentation at **[link](/docs/tutorial/transformations)**.
+Query results can be transformed using Transformation. For more information on transformations, please refer to our documentation at **[link](../tutorial/transformations)**.
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/docs/data-sources/baserow.md
+++ b/docs/docs/data-sources/baserow.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Baserow account to read and write data.
 
 ## Connection
 
-To establish a connection with the **Baserow** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the **Baserow** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to Baserow:
 

--- a/docs/docs/data-sources/bigquery.md
+++ b/docs/docs/data-sources/bigquery.md
@@ -9,7 +9,7 @@ ToolJet can connect to **BigQuery** databases to run BigQuery queries.
 
 ## Connection
 
-To establish a connection with the **BigQuery** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose BigQuery as the data source.
+To establish a connection with the **BigQuery** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose BigQuery as the data source.
 
 ToolJet requires the following to connect to your BigQuery:
 - **Private key**
@@ -58,7 +58,7 @@ How to get a Private key?
 </div>
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/docs/data-sources/clickhouse.md
+++ b/docs/docs/data-sources/clickhouse.md
@@ -11,7 +11,7 @@ ToolJet uses this [NodeJS](https://github.com/TimonKK/clickhouse) client for Cli
 
 ## Connection
 
-To establish a connection with the Clickhouse data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the Clickhouse data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your ClickHouse Database:
 

--- a/docs/docs/data-sources/cosmosdb.md
+++ b/docs/docs/data-sources/cosmosdb.md
@@ -7,7 +7,7 @@ ToolJet can connect to CosmosDB databases to read and write data.
 
 ## Connection
 
-To establish a connection with the CosmosDB data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the CosmosDB data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Cosmos DB.
 

--- a/docs/docs/data-sources/couchdb.md
+++ b/docs/docs/data-sources/couchdb.md
@@ -9,7 +9,7 @@ ToolJet can connect to CouchDB databases to read and write data.
 
 ## Connection
 
-To establish a connection with the CouchDB data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the CouchDB data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your CouchDB.
 - **Username**

--- a/docs/docs/data-sources/custom-js.md
+++ b/docs/docs/data-sources/custom-js.md
@@ -139,9 +139,9 @@ This ID will be longer than the one generated earlier, and it could look like "2
 
 :::tip Resources
 - You can also write custom JavaScript code to get the data from **External APIs** and manipulate the response for graphical representation. Here's the [tutorial](https://blog.tooljet.com/build-github-stars-history-app-in-5-minutes-using-low-code/) on how we used custom JavaScript code to build an app using GitHub API.
-- [Import external libraries](/docs/how-to/import-external-libraries-using-runjs) using RunJS.
-- [Intentionally Fail](docs/how-to/intentionally-fail-js-query) a RunJS query.
-- [Trigger query at specified intervals](/docs/how-to/run-query-at-specified-intervals) using RunJS.
+- [Import external libraries](../how-to/import-external-libraries-using-runjs) using RunJS.
+- [Intentionally Fail](../how-to/intentionally-fail-js-query) a RunJS query.
+- [Trigger query at specified intervals](../how-to/run-query-at-specified-intervals) using RunJS.
 :::
 
 </div>

--- a/docs/docs/data-sources/databricks.md
+++ b/docs/docs/data-sources/databricks.md
@@ -60,7 +60,7 @@ ToolJet's Databricks integration relies on a configuration form that supports th
 
 
 :::tip
-You can apply transformations to the query results. Refer to our transformations documentation for more information: [link](/docs/tutorial/transformations)
+You can apply transformations to the query results. Refer to our transformations documentation for more information: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/docs/data-sources/dynamodb.md
+++ b/docs/docs/data-sources/dynamodb.md
@@ -9,7 +9,7 @@ title: DynamoDB
 
 ## Connection
 
-To establish a connection with the **DynamoDB** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the **DynamoDB** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](./overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -67,7 +67,7 @@ To perform queries on **DynamoDB**, click on the **+ Add** button in the query m
 </div>
 
 :::tip
-You can apply transformations to the query results. Refer to our transformations documentation for more information: [link](/docs/tutorial/transformations)
+You can apply transformations to the query results. Refer to our transformations documentation for more information: [link](../tutorial/transformations)
 :::
 
 #### Supported Operations

--- a/docs/docs/data-sources/elasticsearch.md
+++ b/docs/docs/data-sources/elasticsearch.md
@@ -7,7 +7,7 @@ ToolJet allows you to connect to your Elasticsearch cluster to perform data read
 
 ## Connection
 
-To connect to an Elasticsearch data source in ToolJet, you can either click the **+ Add new data source** button on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page in the ToolJet dashboard.
+To connect to an Elasticsearch data source in ToolJet, you can either click the **+ Add new data source** button on the query panel or navigate to the **[Data Sources](./overview)** page in the ToolJet dashboard.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -38,7 +38,7 @@ ToolJet also supports SSL certificate-based connections:
 2. Choose the operation you want to perform on your Elasticsearch cluster.
 
 :::tip
-Query results can be transformed using transformations. Refer to our transformations documentation for more details: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Refer to our transformations documentation for more details: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/docs/data-sources/firestore.md
+++ b/docs/docs/data-sources/firestore.md
@@ -9,7 +9,7 @@ ToolJet can connect to **Cloud Firestore** databases to read and write data.
 
 ## Connection 
 
-To establish a connection with the **Cloud Firestore** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Cloud Firestore as the data source.
+To establish a connection with the **Cloud Firestore** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Cloud Firestore as the data source.
 
 ToolJet requires the following to connect to your BigQuery:
 - **Private key**
@@ -32,7 +32,7 @@ For generating a private key check out **[Firestore's official documentation](ht
 <img className="screenshot-full" src="/img/datasource-reference/firestore/firestore-query-v2.png" alt="firestore QUERY" />
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/docs/data-sources/gcs.md
+++ b/docs/docs/data-sources/gcs.md
@@ -9,7 +9,7 @@ ToolJet can connect to GCS buckets and perform various operation on them.
 
 ## Connection
 
-To establish a connection with the Google Cloud Storage data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the Google Cloud Storage data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to a GCS datasource:
 - **JSON Private Key** 
@@ -30,7 +30,7 @@ You can follow the [google documentation](https://cloud.google.com/docs/authenti
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to create and trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 #### Supported operations

--- a/docs/docs/data-sources/google.sheets.md
+++ b/docs/docs/data-sources/google.sheets.md
@@ -11,7 +11,7 @@ ToolJet has the capability to establish a connection with Google Sheet for both 
 
 If you decide to self-host ToolJet, there are a few additional steps you need to take:
 
-1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth--optional-) to configure the necessary settings.
+1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](../setup/env-vars#google-oauth--optional-) to configure the necessary settings.
 2. Assign the corresponding values obtained from the previous step to the following environment variables:
    - **GOOGLE_CLIENT_ID**
    - **GOOGLE_CLIENT_SECRET**
@@ -24,7 +24,7 @@ If you decide to self-host ToolJet, there are a few additional steps you need to
 
 ## Connection
 
-To establish a connection with the Google Sheet datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the Google Sheet datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ### Authorization Scopes
 

--- a/docs/docs/data-sources/graphql.md
+++ b/docs/docs/data-sources/graphql.md
@@ -9,7 +9,7 @@ ToolJet can establish connections with GraphQL endpoints, enabling the execution
 
 ## Connection
 
-To establish a connection with the GraphQL global datasource, you can either click on the **+ Add new global datasource** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the GraphQL global datasource, you can either click on the **+ Add new global datasource** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -63,7 +63,7 @@ ToolJet requires the following to connect to a GraphQL datasource:
 ```
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/docs/data-sources/grpc.md
+++ b/docs/docs/data-sources/grpc.md
@@ -15,7 +15,7 @@ Only self-hosted deployments will have access to a gRPC datasource that is capab
 
 ### Step 1: Upgrade ToolJet to the Version 2.5 or Above
 
-Find instructions on how to do this in the setup guides located here: [ToolJet Setup](/docs/setup/).
+Find instructions on how to do this in the setup guides located here: [ToolJet Setup](../setup/).
 
 ### Step 2: Add Proto Files
 
@@ -46,7 +46,7 @@ docker-compose up -d
 
 ## Querying gRPC
 
-After setting up your proto files, you should be able to establish a connection to gRPC by going to the [global datasource](/docs/data-sources/overview) page.
+After setting up your proto files, you should be able to establish a connection to gRPC by going to the [Data Sources](./overview) page.
 
 ### Connect the gRPC Datasource
 

--- a/docs/docs/data-sources/mailgun.md
+++ b/docs/docs/data-sources/mailgun.md
@@ -13,7 +13,7 @@ The Mailgun API Datasource supports for interaction with the mail endpoint of th
 
 ## Connection
 
-To establish a connection with the **Mailgun** data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the **Mailgun** data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Mailgun:
 - **API key**

--- a/docs/docs/data-sources/mariadb.md
+++ b/docs/docs/data-sources/mariadb.md
@@ -9,7 +9,7 @@ ToolJet can connect to both self-hosted and cloud-based MariaDB servers to read 
 
 ## Connection
 
-To establish a connection with the MariaDB global datasource, you can either click on the **+ Add new global datasource** button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MariaDB global datasource, you can either click on the **+ Add new global datasource** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 **ToolJet requires the following connection details to connect to MariaDB:**
 
@@ -41,7 +41,7 @@ Once you have connected to the MariaDB datasource, follow these steps to write q
 4. Click **Preview** to view the data returned from the query or click **Run** to execute the query.
 
 :::tip
-Query results can be transformed using Transformation. For more information on transformations, please refer to our documentation at **[link](/docs/tutorial/transformations)**.
+Query results can be transformed using Transformation. For more information on transformations, please refer to our documentation at **[link](../tutorial/transformations)**.
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/docs/data-sources/minio.md
+++ b/docs/docs/data-sources/minio.md
@@ -9,7 +9,7 @@ ToolJet can connect to minio and perform various operation on them.
 
 ## Connection
 
-To establish a connection with the MinIo data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the MinIo data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your DynamoDB:
 
@@ -34,7 +34,7 @@ ToolJet requires the following to connect to your DynamoDB:
 <img className="screenshot-full" src="/img/datasource-reference/minio/minio-query.png" alt="miniIo query" />
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/docs/data-sources/mongodb.md
+++ b/docs/docs/data-sources/mongodb.md
@@ -9,7 +9,7 @@ ToolJet can connect to MongoDB to read and write data.
 
 ## Manual Connection
 
-To establish a manual connection with the **MongoDB** data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a manual connection with the **MongoDB** data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -60,7 +60,7 @@ For example: `mongodb+srv://tooljettest:dummypassword@cluster0.urul7.mongodb.net
 <img className="screenshot-full" src="/img/datasource-reference/mongo-db/mo-query.png" alt="ToolJet - Mongo query"/>
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 <div style={{paddingTop:'24px'}}>

--- a/docs/docs/data-sources/mssql.md
+++ b/docs/docs/data-sources/mssql.md
@@ -9,7 +9,7 @@ ToolJet can connect to MS SQL Server & Azure SQL databases to read and write dat
 
 ## Connection
 
-To establish a connection with the MS SQL Server data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the MS SQL Server data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -37,7 +37,7 @@ ToolJet requires the following to connect to your PostgreSQL database.
 1. Click on **+ Add** button of the query manager at the bottom panel of the editor.
 2. Select the database added in the previous step as the data source.
 
-Once the SQL data source is added, you can create queries to read and write data to the database. You can create queries from the **[Query Panel](/docs/app-builder/query-panel#query-manager)** located at the bottom panel of the app builder.
+Once the SQL data source is added, you can create queries to read and write data to the database. You can create queries from the **[Query Panel](../app-builder/query-panel#query-manager)** located at the bottom panel of the app builder.
 
 ### SQL Mode
 
@@ -93,7 +93,7 @@ GUI mode can be used to query MS SQL Server / Azure SQL Databases without writin
 <img className="screenshot-full" src="/img/datasource-reference/mssql/gui mode.png" alt="ToolJet mssql gui mode"/>
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/docs/data-sources/mysql.md
+++ b/docs/docs/data-sources/mysql.md
@@ -9,7 +9,7 @@ ToolJet can connect to MySQL databases to read and write data.
 
 ## Connection
 
-To establish a connection with the MySQL data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MySQL data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -60,7 +60,7 @@ If you are using **Socket** as the connection type, you will need to provide the
 1. Click on **+ Add** button of the query manager at the bottom panel of the editor.
 2. Select the database added in the previous step as the data source. 
 
-Once the MySQL data source is added, you can create queries to read and write data to the database. You can create queries from the **[Query Panel](/docs/app-builder/query-panel#query-manager)** located at the bottom panel of the app builder.
+Once the MySQL data source is added, you can create queries to read and write data to the database. You can create queries from the **[Query Panel](../app-builder/query-panel#query-manager)** located at the bottom panel of the app builder.
 
 ### SQL Mode
 
@@ -127,7 +127,7 @@ GUI mode can be used to query MySQL database without writing queries.
 </div>
 
 :::tip
-Query results can be transformed using transformations. Learn more about transformations [here](/docs/tutorial/transformations).
+Query results can be transformed using transformations. Learn more about transformations [here](../tutorial/transformations).
 :::
 
 </div>

--- a/docs/docs/data-sources/n8n.md
+++ b/docs/docs/data-sources/n8n.md
@@ -9,7 +9,7 @@ ToolJet can trigger n8n workflows using webhook URLs. Please refer [this](https:
 
 ## Connection
 
-To establish a connection with the n8n data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the n8n data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 Webhooks in n8n can be configured to operate with or without **Authentication**. If no authentication is required, select `None` as the **Authentication type**. For webhooks that require authentication, choose the appropriate method from the dropdown and provide the corresponding credentials.
 

--- a/docs/docs/data-sources/notion.md
+++ b/docs/docs/data-sources/notion.md
@@ -9,7 +9,7 @@ ToolJet can connect to a Notion workspace to do operations on notion pages, data
 
 ## Connection
 
-To establish a connection with the Notion data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the Notion data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 For integrating Notion with ToolJet we will need the API token. The API token can be generated from your Notion workspace settings. Read the official Notion docs for [Creating an internal integration with notion API](https://www.notion.so/help/create-integrations-with-the-notion-api).
 

--- a/docs/docs/data-sources/openapi.md
+++ b/docs/docs/data-sources/openapi.md
@@ -9,7 +9,7 @@ OpenAPI is a specification for designing and documenting RESTful APIs. Using Ope
 
 ## Connection
 
-To establish a connection with the OpenAPI datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the OpenAPI datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](./overview)** page through the ToolJet dashboard.
 
 Connections are created based on OpenAPI specifications. The available authentication methods currently supported are Basic Auth, API Key, Bearer Token, and OAuth 2.0. It is also possible to use specifications that require multiple authentications. Learn more [here](https://swagger.io/docs/specification/authentication/).
 

--- a/docs/docs/data-sources/oracledb.md
+++ b/docs/docs/data-sources/oracledb.md
@@ -9,7 +9,7 @@ ToolJet can connect to Oracle databases to read and write data.
 
 ## Connection
 
-To establish a connection with the OracleDB datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the OracleDB datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to a OracleDB datasource:
 
@@ -64,8 +64,8 @@ The instant client version affects which Oracle Database versions you can connec
 
 ## Supported Operations
 
-- **[SQL mode](/docs/data-sources/oracledb#sql-mode)**
-- **[GUI mode](/docs/data-sources/oracledb#gui-mode)**
+- **[SQL mode](#sql-mode)**
+- **[GUI mode](#gui-mode)**
 
 <img className="screenshot-full" src="/img/datasource-reference/oracledb/operations.png" alt="ToolJet - Data source - OracleDB" style={{marginBottom:'15px'}}/>
 
@@ -107,7 +107,7 @@ GUI mode can be used to query Oracle database without writing queries.
 <img className="screenshot-full" src="/img/datasource-reference/oracledb/gui.png" alt="ToolJet - Data source - OracleDB" style={{marginBottom:'15px'}}/>
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/docs/data-sources/overview.md
+++ b/docs/docs/data-sources/overview.md
@@ -38,7 +38,7 @@ Data Source page is available only on **ToolJet version 2.3.0 and above**.
 
 3. Once the data source is added, you'll be required to input the configuration details for establishing a connection.
 
-  ***Note: For paid plans, configuration entry and saving are necessary to enable availability across [multiple environments](/docs/release-management/multi-environment/).***
+  ***Note: For paid plans, configuration entry and saving are necessary to enable availability across [multiple environments](../release-management/multi-environment/).***
 
   <div style={{textAlign: 'center'}}>
   
@@ -65,10 +65,10 @@ Data Source page is available only on **ToolJet version 2.3.0 and above**.
 ## Default data sources
 
 By default, 4 data sources will be available on every app on ToolJet:
-- **[ToolJet Database](/docs/tooljet-db/tooljet-database/)**
-- **[RestAPI](/docs/data-sources/restapi/)**
-- **[Run JavaScript Query](/docs/data-sources/run-js/)**
-- **[Run Python Query](/docs/data-sources/run-py/)**
+- **[ToolJet Database](../tooljet-db/tooljet-database/)**
+- **[RestAPI](./restapi/)**
+- **[Run JavaScript Query](./run-js/)**
+- **[Run Python Query](./run-py/)**
 
 <div style={{textAlign: 'center'}}>
 
@@ -78,7 +78,7 @@ By default, 4 data sources will be available on every app on ToolJet:
 
 ## User Permissions
 
-Changing the **Permissions** for Data Sources is a privilege reserved for **Admins** and **[Super Admins](/docs/Enterprise/superadmin)** within the workspace.
+Changing the **Permissions** for Data Sources is a privilege reserved for **Admins** and **[Super Admins](../Enterprise/superadmin)** within the workspace.
 
 To configure these permissions, navigate to **Workspace Settings** -> **Groups Settings**. Admins and Super Admins have the authority to assign the following permissions to user groups:
 

--- a/docs/docs/data-sources/postgresql.md
+++ b/docs/docs/data-sources/postgresql.md
@@ -9,7 +9,7 @@ ToolJet has the capability to connect to PostgreSQL databases for data retrieval
 
 ## Establishing a Connection
 
-To establish a connection with the PostgreSQL data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose PostgreSQL as the data source.
+To establish a connection with the PostgreSQL data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose PostgreSQL as the data source.
 
 ToolJet offers two connection types to connect to your PostgreSQL database:
 
@@ -106,8 +106,8 @@ Choose the GUI mode from the dropdown and select the operation **Bulk update usi
 ```
 
 :::tip
-- You can apply transformations to the query results. Refer to our transformations documentation for more details: **[Transformation Tutorial](/docs/tutorial/transformations)**
-- Check out this how-to guide on **[bulk updating multiple rows](/docs/how-to/bulk-update-multiple-rows)** from a table component.
+- You can apply transformations to the query results. Refer to our transformations documentation for more details: **[Transformation Tutorial](../tutorial/transformations)**
+- Check out this how-to guide on **[bulk updating multiple rows](../how-to/bulk-update-multiple-rows)** from a table component.
 :::
 
 </div>

--- a/docs/docs/data-sources/redis.md
+++ b/docs/docs/data-sources/redis.md
@@ -9,7 +9,7 @@ ToolJet enables you to execute Redis commands on your Redis instances.
 
 ## Connecting to Redis
 
-To establish a connection with the Redis data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Redis as the data source.
+To establish a connection with the Redis data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Redis as the data source.
 
 <img className="screenshot-full" src="/img/datasource-reference/redis/connect-v2.png" alt="Redis Connection" style={{marginBottom:'15px'}} />
 

--- a/docs/docs/data-sources/rethinkdb.md
+++ b/docs/docs/data-sources/rethinkdb.md
@@ -10,7 +10,7 @@ ToolJet can connect to RethinkDB databases to read and write data. For more info
 
 ## Connection
 
-To establish a connection with the RethinkDB data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the RethinkDB data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to a RethinkDB data source:
 

--- a/docs/docs/data-sources/run-py.md
+++ b/docs/docs/data-sources/run-py.md
@@ -29,11 +29,11 @@ p1 = Person(tj_globals.currentUser.firstName, 36)
 components.text1.setText(p1.myfunc())
 ```
 
-4. The above code has a function `myfunc` which returns a string and we are using a **[Component Specific Action](/docs/tooljet-concepts/component-specific-actions)** to set the Text Component's value from the Python query. 
+4. The above code has a function `myfunc` which returns a string and we are using a **[Component Specific Action](../tooljet-concepts/component-specific-actions)** to set the Text Component's value from the Python query. 
 
 :::tip
 - As of now, Run Python code only supports the [Python standard library](https://docs.python.org/3/library/).
-- Check **[RunPy Limitations](/docs/contributing-guide/troubleshooting/runpy-limitations)** to go through the limitations with using Python code
+- Check **[RunPy Limitations](../contributing-guide/troubleshooting/runpy-limitations)** to go through the limitations with using Python code
 :::
 
 </div>

--- a/docs/docs/data-sources/s3.md
+++ b/docs/docs/data-sources/s3.md
@@ -9,7 +9,7 @@ ToolJet can connect to **Amazon S3** buckets and perform various operations on t
 
 ## Connection
 
-To establish a connection with the **Amazon S3** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard.
+To establish a connection with the **Amazon S3** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard.
 
 ToolJet supports connecting to AWS S3 using **IAM Access Keys**, **AWS Instance Credentials** or **AWS ARN Role**. 
 
@@ -37,7 +37,7 @@ If you are using **AWS ARN Role**, you will need to provide the following detail
 <img className="screenshot-full" src="/img/datasource-reference/aws-s3/arnnew.png" alt="aws s3 modal" />
 
 :::tip
-You can now connect to **[different S3 Hosts using custom endpoints](/docs/how-to/s3-custom-endpoints)**.
+You can now connect to **[different S3 Hosts using custom endpoints](../how-to/s3-custom-endpoints)**.
 :::
 
 </div>
@@ -54,7 +54,7 @@ You can now connect to **[different S3 Hosts using custom endpoints](/docs/how-t
 <img className="screenshot-full" src="/img/datasource-reference/aws-s3/operations3.png" alt="aws s3 query" />
 
 :::info
-Query results can be transformed using transformations. Read our [transformations documentation](/docs/tutorial/transformations).
+Query results can be transformed using transformations. Read our [transformations documentation](../tutorial/transformations).
 :::
 
 </div>

--- a/docs/docs/data-sources/saphana.md
+++ b/docs/docs/data-sources/saphana.md
@@ -9,7 +9,7 @@ ToolJet can connect to SAP HANA databases to read and write data.
 
 ## Connection
 
-To establish a connection with the SAP HANA datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the SAP HANA datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your SAP HANA database:
 
@@ -42,6 +42,7 @@ select * from PRODUCTS
 ```
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
+
 </div>

--- a/docs/docs/data-sources/sendgrid.md
+++ b/docs/docs/data-sources/sendgrid.md
@@ -9,7 +9,7 @@ ToolJet can connect to your SendGrid account to send emails.
 
 ## Connection
 
-To establish a connection with the SendGrid datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the SendGrid datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your SendGrid database:
 - **SendGrid API key**

--- a/docs/docs/data-sources/slack.md
+++ b/docs/docs/data-sources/slack.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Slack workspace to send messages.
 
 ## Connection
 
-To establish a connection with the **Slack** datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the **Slack** datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 <img className="screenshot-full" src="/img/datasource-reference/slack/connect-v2.png" alt="Slack datasource: ToolJet"/>
 

--- a/docs/docs/data-sources/smtp.md
+++ b/docs/docs/data-sources/smtp.md
@@ -9,7 +9,7 @@ The SMTP datasource facilitates the connection between ToolJet applications and 
 
 ## Connection
 
-To establish a connection with the SMTP data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard and choose SMTP as the data source.
+To establish a connection with the SMTP data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard and choose SMTP as the data source.
 
 ToolJet requires the following to connect to SMTP server:
 

--- a/docs/docs/data-sources/snowflake.md
+++ b/docs/docs/data-sources/snowflake.md
@@ -9,7 +9,7 @@ ToolJet can connect to Snowflake databases to read and write data.
 
 ## Connection
 
-To establish a connection with the Snowflake data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard and choose Snowflake as the data source.
+To establish a connection with the Snowflake data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard and choose Snowflake as the data source.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -47,7 +47,7 @@ select * from "SNOWFLAKE_SAMPLE_DATA"."WEATHER"."DAILY_14_TOTAL" limit 10;
 ```
 
 :::tip
-Query results can be transformed using transformations. Read our [transformations](/docs/tutorial/transformations) documentation to learn more.
+Query results can be transformed using transformations. Read our [transformations](../tutorial/transformations) documentation to learn more.
 :::
 
 </div>

--- a/docs/docs/data-sources/stripe.md
+++ b/docs/docs/data-sources/stripe.md
@@ -13,7 +13,7 @@ Check out the **[Stripe Refund App tutorial](https://blog.tooljet.com/build-a-st
 
 ## Connection
 
-To establish a connection with the Stripe data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard and choose Stripe as the data source.
+To establish a connection with the Stripe data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard and choose Stripe as the data source.
 
 ToolJet requires the following to connect to Stripe datasource.
 - **Stripe API key**
@@ -36,7 +36,7 @@ You can get the Stripe API key from the dashboard of your Stripe account. Go to 
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/docs/data-sources/twilio.md
+++ b/docs/docs/data-sources/twilio.md
@@ -9,7 +9,7 @@ ToolJet can connect to Twilio account to send sms.
 
 ## Connection
 
-To establish a connection with the Twilio data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Twilio as the data source.
+To establish a connection with the Twilio data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Twilio as the data source.
 
 ToolJet requires the following to connect to Twilio:
 - **Auth Token**

--- a/docs/docs/data-sources/typesense.md
+++ b/docs/docs/data-sources/typesense.md
@@ -9,7 +9,7 @@ ToolJet can connect to your TypeSense deployment to read and write data.
 
 ## Connection 
 
-To establish a connection with the Typesense data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Typesense as the data source.
+To establish a connection with the Typesense data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Typesense as the data source.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -35,7 +35,7 @@ ToolJet requires the following to connect to TypeSense deployment:
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/docs/data-sources/woocommerce.md
+++ b/docs/docs/data-sources/woocommerce.md
@@ -9,7 +9,7 @@ ToolJet can connect to WooCommerce databases to read and write data.
 
 ## Connection
 
-To establish a connection with the WooCommerce data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose WooCommerce as the data source.
+To establish a connection with the WooCommerce data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose WooCommerce as the data source.
 
 ToolJet requires the following to connect to WooCommerce
 - **Host**
@@ -34,7 +34,7 @@ NOTE: For generating keys visit admin dashboard of woocommerce , more info: http
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/docs/data-sources/zendesk.md
+++ b/docs/docs/data-sources/zendesk.md
@@ -9,7 +9,7 @@ ToolJet can connect to Zendesk APIs to read and write data using OAuth 2.0, whic
 
 ## Connection 
 
-To establish a connection with the Zendesk data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Zendesk as the data source.
+To establish a connection with the Zendesk data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Zendesk as the data source.
 
 ToolJet connects to your Zendesk app using :
 - **Zendesk Sub-domain**

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/airtable.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/airtable.md
@@ -9,7 +9,7 @@ ToolJet can connect to your **Airtable** account to read and write data.
 
 ## Connection
 
-To establish a connection with the **Airtable** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard.
+To establish a connection with the **Airtable** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Airtable:
 - **Personal Access Token**

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/amazonses.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/amazonses.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Amazon SES account to send emails.
 
 ## Connection
 
-To establish a connection with the **Amazon SES** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the **Amazon SES** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to Amazon SES:
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/appwrite.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/appwrite.md
@@ -9,7 +9,7 @@ ToolJet can connect to appwrite database to read/write data.
 
 ## Connection 
 
-To establish a connection with the Appwrite data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard.
+To establish a connection with the Appwrite data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Appwrite:
 - **Host (API endpoint)**
@@ -46,7 +46,7 @@ You should also set the scope for access to a particular resource. Learn more ab
 </div> 
 
 :::tip
-Query results can be transformed using Transformations. Read our **Transformation Documentation** [here](/docs/tutorial/transformations).
+Query results can be transformed using Transformations. Read our **Transformation Documentation** [here](../tutorial/transformations).
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/athena.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/athena.md
@@ -9,7 +9,7 @@ ToolJet can connect to **Amazon Athena** which is an interactive query service t
 
 ## Connection
 
-To establish a connection with the **Amazon Athena** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](https://docs.tooljet.com/docs/data-sources/overview)** page from the ToolJet dashboard and choose **Amazon Athena** as the data source.
+To establish a connection with the **Amazon Athena** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose **Amazon Athena** as the data source.
 
 ToolJet requires the following to connect to your Athena.
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/azureblob.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/azureblob.md
@@ -7,7 +7,7 @@ ToolJet offers the capability to establish a connection with Azure Blob storage 
 
 ## Connection
 
-To establish a connection with the Azure Blob data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Azure Blob as the data source.
+To establish a connection with the Azure Blob data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Azure Blob as the data source.
 
 ToolJet requires the following to connect to your Azure Blob.
 - **Connection String**
@@ -28,7 +28,7 @@ ToolJet requires the following to connect to your Azure Blob.
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to trigger the query.
 
 :::tip
-Query results can be transformed using Transformation. For more information on transformations, please refer to our documentation at **[link](/docs/tutorial/transformations)**.
+Query results can be transformed using Transformation. For more information on transformations, please refer to our documentation at **[link](../tutorial/transformations)**.
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/baserow.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/baserow.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Baserow account to read and write data.
 
 ## Connection
 
-To establish a connection with the **Baserow** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the **Baserow** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to Baserow:
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/bigquery.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/bigquery.md
@@ -9,7 +9,7 @@ ToolJet can connect to **BigQuery** databases to run BigQuery queries.
 
 ## Connection
 
-To establish a connection with the **BigQuery** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose BigQuery as the data source.
+To establish a connection with the **BigQuery** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose BigQuery as the data source.
 
 ToolJet requires the following to connect to your BigQuery:
 - **Private key**
@@ -58,7 +58,7 @@ How to get a Private key?
 </div>
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/clickhouse.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/clickhouse.md
@@ -11,7 +11,7 @@ ToolJet uses this [NodeJS](https://github.com/TimonKK/clickhouse) client for Cli
 
 ## Connection
 
-To establish a connection with the Clickhouse data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the Clickhouse data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your ClickHouse Database:
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/cosmosdb.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/cosmosdb.md
@@ -7,7 +7,7 @@ ToolJet can connect to CosmosDB databases to read and write data.
 
 ## Connection
 
-To establish a connection with the CosmosDB data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the CosmosDB data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Cosmos DB.
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/couchdb.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/couchdb.md
@@ -9,7 +9,7 @@ ToolJet can connect to CouchDB databases to read and write data.
 
 ## Connection
 
-To establish a connection with the CouchDB data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the CouchDB data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your CouchDB.
 - **Username**

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/custom-js.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/custom-js.md
@@ -139,9 +139,9 @@ This ID will be longer than the one generated earlier, and it could look like "2
 
 :::tip Resources
 - You can also write custom JavaScript code to get the data from **External APIs** and manipulate the response for graphical representation. Here's the [tutorial](https://blog.tooljet.com/build-github-stars-history-app-in-5-minutes-using-low-code/) on how we used custom JavaScript code to build an app using GitHub API.
-- [Import external libraries](/docs/how-to/import-external-libraries-using-runjs) using RunJS.
-- [Intentionally Fail](docs/how-to/intentionally-fail-js-query) a RunJS query.
-- [Trigger query at specified intervals](/docs/how-to/run-query-at-specified-intervals) using RunJS.
+- [Import external libraries](../how-to/import-external-libraries-using-runjs) using RunJS.
+- [Intentionally Fail](../how-to/intentionally-fail-js-query) a RunJS query.
+- [Trigger query at specified intervals](../how-to/run-query-at-specified-intervals) using RunJS.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/databricks.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/databricks.md
@@ -60,7 +60,7 @@ ToolJet's Databricks integration relies on a configuration form that supports th
 
 
 :::tip
-You can apply transformations to the query results. Refer to our transformations documentation for more information: [link](/docs/tutorial/transformations)
+You can apply transformations to the query results. Refer to our transformations documentation for more information: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/dynamodb.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/dynamodb.md
@@ -9,7 +9,7 @@ title: DynamoDB
 
 ## Connection
 
-To establish a connection with the **DynamoDB** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the **DynamoDB** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](./overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -67,7 +67,7 @@ To perform queries on **DynamoDB**, click on the **+ Add** button in the query m
 </div>
 
 :::tip
-You can apply transformations to the query results. Refer to our transformations documentation for more information: [link](/docs/tutorial/transformations)
+You can apply transformations to the query results. Refer to our transformations documentation for more information: [link](../tutorial/transformations)
 :::
 
 #### Supported Operations

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/elasticsearch.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/elasticsearch.md
@@ -6,7 +6,7 @@ title: Elasticsearch
 ToolJet can connect to your Elasticsearch cluster to read and write data.
 
 ## Connection 
-To establish a connection with the ElasticSearch data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the ElasticSearch data source, you can either click on the **+ Add new data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -35,7 +35,7 @@ Elastic search data source is also providing an option for connecting services w
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to create and trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 #### Supported Operations

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/firestore.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/firestore.md
@@ -9,7 +9,7 @@ ToolJet can connect to **Cloud Firestore** databases to read and write data.
 
 ## Connection 
 
-To establish a connection with the **Cloud Firestore** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Cloud Firestore as the data source.
+To establish a connection with the **Cloud Firestore** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Cloud Firestore as the data source.
 
 ToolJet requires the following to connect to your BigQuery:
 - **Private key**
@@ -32,7 +32,7 @@ For generating a private key check out **[Firestore's official documentation](ht
 <img className="screenshot-full" src="/img/datasource-reference/firestore/firestore-query-v2.png" alt="firestore QUERY" />
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/gcs.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/gcs.md
@@ -9,7 +9,7 @@ ToolJet can connect to GCS buckets and perform various operation on them.
 
 ## Connection
 
-To establish a connection with the Google Cloud Storage data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the Google Cloud Storage data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to a GCS datasource:
 - **JSON Private Key** 
@@ -30,7 +30,7 @@ You can follow the [google documentation](https://cloud.google.com/docs/authenti
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to create and trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 #### Supported operations

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/google.sheets.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/google.sheets.md
@@ -24,7 +24,7 @@ If you decide to self-host ToolJet, there are a few additional steps you need to
 
 ## Connection
 
-To establish a connection with the Google Sheet datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the Google Sheet datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ### Authorization Scopes
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/graphql.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/graphql.md
@@ -9,7 +9,7 @@ ToolJet can establish connections with GraphQL endpoints, enabling the execution
 
 ## Connection
 
-To establish a connection with the GraphQL global datasource, you can either click on the **+ Add new global datasource** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the GraphQL global datasource, you can either click on the **+ Add new global datasource** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -63,7 +63,7 @@ ToolJet requires the following to connect to a GraphQL datasource:
 ```
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/grpc.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/grpc.md
@@ -15,7 +15,7 @@ Only self-hosted deployments will have access to a gRPC datasource that is capab
 
 ### Step 1: Upgrade ToolJet to the Version 2.5 or Above
 
-Find instructions on how to do this in the setup guides located here: [ToolJet Setup](/docs/setup/).
+Find instructions on how to do this in the setup guides located here: [ToolJet Setup](../setup/).
 
 ### Step 2: Add Proto Files
 
@@ -46,7 +46,7 @@ docker-compose up -d
 
 ## Querying gRPC
 
-After setting up your proto files, you should be able to establish a connection to gRPC by going to the [global datasource](/docs/data-sources/overview) page.
+After setting up your proto files, you should be able to establish a connection to gRPC by going to the [Data Sources](./overview) page.
 
 ### Connect the gRPC Datasource
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/mailgun.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/mailgun.md
@@ -13,7 +13,7 @@ The Mailgun API Datasource supports for interaction with the mail endpoint of th
 
 ## Connection
 
-To establish a connection with the **Mailgun** data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the **Mailgun** data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your Mailgun:
 - **API key**

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/mariadb.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/mariadb.md
@@ -9,7 +9,7 @@ ToolJet can connect to both self-hosted and cloud-based MariaDB servers to read 
 
 ## Connection
 
-To establish a connection with the MariaDB global datasource, you can either click on the **+ Add new global datasource** button located on the query panel or navigate to the **[Global Datasources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MariaDB global datasource, you can either click on the **+ Add new global datasource** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 **ToolJet requires the following connection details to connect to MariaDB:**
 
@@ -41,7 +41,7 @@ Once you have connected to the MariaDB datasource, follow these steps to write q
 4. Click **Preview** to view the data returned from the query or click **Run** to execute the query.
 
 :::tip
-Query results can be transformed using Transformation. For more information on transformations, please refer to our documentation at **[link](/docs/tutorial/transformations)**.
+Query results can be transformed using Transformation. For more information on transformations, please refer to our documentation at **[link](../tutorial/transformations)**.
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/minio.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/minio.md
@@ -9,7 +9,7 @@ ToolJet can connect to minio and perform various operation on them.
 
 ## Connection
 
-To establish a connection with the MiniIo data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the MiniIo data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 ToolJet requires the following to connect to your DynamoDB:
 
@@ -35,7 +35,7 @@ ToolJet requires the following to connect to your DynamoDB:
 <img className="screenshot-full" src="/img/datasource-reference/minio/minio-query.png" alt="miniIo query" />
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/mongodb.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/mongodb.md
@@ -9,7 +9,7 @@ ToolJet can connect to MongoDB to read and write data.
 
 ## Manual Connection
 
-To establish a manual connection with the **MongoDB** data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a manual connection with the **MongoDB** data source, click on the **+ Add new data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -60,7 +60,7 @@ For example: `mongodb+srv://tooljettest:dummypassword@cluster0.urul7.mongodb.net
 <img className="screenshot-full" src="/img/datasource-reference/mongo-db/mo-query.png" alt="ToolJet - Mongo query"/>
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 <div style={{paddingTop:'24px'}}>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/mssql.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/mssql.md
@@ -9,7 +9,7 @@ ToolJet can connect to MS SQL Server & Azure SQL databases to read and write dat
 
 ## Connection
 
-To establish a connection with the MS SQL Server data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the MS SQL Server data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -37,7 +37,7 @@ ToolJet requires the following to connect to your PostgreSQL database.
 1. Click on **+ Add** button of the query manager at the bottom panel of the editor.
 2. Select the database added in the previous step as the data source. 
 
-Once the SQL data source is added, you can create queries to read and write data to the database. You can create queries from the **[Query Panel](/docs/app-builder/query-panel#query-manager)** located at the bottom panel of the app builder.
+Once the SQL data source is added, you can create queries to read and write data to the database. You can create queries from the **[Query Panel](../app-builder/query-panel#query-manager)** located at the bottom panel of the app builder.
 
 ### SQL Mode
 
@@ -72,7 +72,7 @@ GUI mode can be used to query MS SQL Server / Azure SQL Databases without writin
 <img className="screenshot-full" src="/img/datasource-reference/mssql/gui mode.png" alt="ToolJet mssql gui mode"/>
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: [link](/docs/tutorial/transformations)
+Query results can be transformed using transformations. Read our transformations documentation to see how: [link](../tutorial/transformations)
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/mysql.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/mysql.md
@@ -9,7 +9,7 @@ ToolJet can connect to MySQL databases to read and write data.
 
 ## Connection
 
-To establish a connection with the MySQL data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the MySQL data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 <div style={{textAlign: 'center'}}>
 
@@ -56,7 +56,7 @@ If you are using **Socket** as the connection type, you will need to provide the
 1. Click on **+ Add** button of the query manager at the bottom panel of the editor.
 2. Select the database added in the previous step as the data source. 
 
-Once the MySQL data source is added, you can create queries to read and write data to the database. You can create queries from the **[Query Panel](/docs/app-builder/query-panel#query-manager)** located at the bottom panel of the app builder.
+Once the MySQL data source is added, you can create queries to read and write data to the database. You can create queries from the **[Query Panel](../app-builder/query-panel#query-manager)** located at the bottom panel of the app builder.
 
 ### SQL Mode
 
@@ -101,7 +101,7 @@ GUI mode can be used to query MySQL database without writing queries.
 </div>
 
 :::tip
-Query results can be transformed using transformations. Learn more about transformations [here](/docs/tutorial/transformations).
+Query results can be transformed using transformations. Learn more about transformations [here](../tutorial/transformations).
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/n8n.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/n8n.md
@@ -9,7 +9,7 @@ ToolJet can trigger n8n workflows using webhook URLs. Please refer [this](https:
 
 ## Connection
 
-To establish a connection with the n8n data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the n8n data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 Webhooks in n8n can be configured to operate with or without **Authentication**. If no authentication is required, select `None` as the **Authentication type**. For webhooks that require authentication, choose the appropriate method from the dropdown and provide the corresponding credentials.
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/notion.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/notion.md
@@ -9,7 +9,7 @@ ToolJet can connect to a Notion workspace to do operations on notion pages, data
 
 ## Connection
 
-To establish a connection with the Notion data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](https://docs.tooljet.com/docs/data-sources/overview) page from the ToolJet dashboard.
+To establish a connection with the Notion data source, click on the **+ Add new Data source** button located on the query panel or navigate to the [Data Sources](./overview) page from the ToolJet dashboard.
 
 For integrating Notion with ToolJet we will need the API token. The API token can be generated from your Notion workspace settings. Read the official Notion docs for [Creating an internal integration with notion API](https://www.notion.so/help/create-integrations-with-the-notion-api).
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/openapi.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/openapi.md
@@ -9,7 +9,7 @@ OpenAPI is a specification for designing and documenting RESTful APIs. Using Ope
 
 ## Connection
 
-To establish a connection with the OpenAPI datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the OpenAPI datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](./overview)** page through the ToolJet dashboard.
 
 Connections are created based on OpenAPI specifications. The available authentication methods currently supported are Basic Auth, API Key, Bearer Token, and OAuth 2.0. It is also possible to use specifications that require multiple authentications. Learn more [here](https://swagger.io/docs/specification/authentication/).
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/oracledb.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/oracledb.md
@@ -9,7 +9,7 @@ ToolJet can connect to Oracle databases to read and write data.
 
 ## Connection
 
-To establish a connection with the OracleDB datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the OracleDB datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to a OracleDB datasource:
 
@@ -64,8 +64,8 @@ The instant client version affects which Oracle Database versions you can connec
 
 ## Supported Operations
 
-- **[SQL mode](/docs/data-sources/oracledb#sql-mode)**
-- **[GUI mode](/docs/data-sources/oracledb#gui-mode)**
+- **[SQL mode](#sql-mode)**
+- **[GUI mode](#gui-mode)**
 
 <img className="screenshot-full" src="/img/datasource-reference/oracledb/operations.png" alt="ToolJet - Data source - OracleDB" style={{marginBottom:'15px'}}/>
 
@@ -107,7 +107,7 @@ GUI mode can be used to query Oracle database without writing queries.
 <img className="screenshot-full" src="/img/datasource-reference/oracledb/gui.png" alt="ToolJet - Data source - OracleDB" style={{marginBottom:'15px'}}/>
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/overview.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/overview.md
@@ -38,7 +38,7 @@ Data Source page is available only on **ToolJet version 2.3.0 and above**.
 
 3. Once the data source is added, you'll be required to input the configuration details for establishing a connection.
 
-  ***Note: For paid plans, configuration entry and saving are necessary to enable availability across [multiple environments](/docs/release-management/multi-environment/).***
+  ***Note: For paid plans, configuration entry and saving are necessary to enable availability across [multiple environments](../release-management/multi-environment/).***
 
   <div style={{textAlign: 'center'}}>
   
@@ -65,10 +65,10 @@ Data Source page is available only on **ToolJet version 2.3.0 and above**.
 ## Default data sources
 
 By default, 4 data sources will be available on every app on ToolJet:
-- **[ToolJet Database](/docs/tooljet-db/tooljet-database/)**
-- **[RestAPI](/docs/data-sources/restapi/)**
-- **[Run JavaScript Query](/docs/data-sources/run-js/)**
-- **[Run Python Query](/docs/data-sources/run-py/)**
+- **[ToolJet Database](../tooljet-db/tooljet-database/)**
+- **[RestAPI](./restapi/)**
+- **[Run JavaScript Query](./run-js/)**
+- **[Run Python Query](./run-py/)**
 
 <div style={{textAlign: 'center'}}>
 
@@ -78,7 +78,7 @@ By default, 4 data sources will be available on every app on ToolJet:
 
 ## User Permissions
 
-Changing the **Permissions** for Data Sources is a privilege reserved for **Admins** and **[Super Admins](/docs/Enterprise/superadmin)** within the workspace.
+Changing the **Permissions** for Data Sources is a privilege reserved for **Admins** and **[Super Admins](../Enterprise/superadmin)** within the workspace.
 
 To configure these permissions, navigate to **Workspace Settings** -> **Groups Settings**. Admins and Super Admins have the authority to assign the following permissions to user groups:
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/postgresql.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/postgresql.md
@@ -9,7 +9,7 @@ ToolJet has the capability to connect to PostgreSQL databases for data retrieval
 
 ## Establishing a Connection
 
-To establish a connection with the PostgreSQL data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose PostgreSQL as the data source.
+To establish a connection with the PostgreSQL data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose PostgreSQL as the data source.
 
 ToolJet requires the following information to connect to your PostgreSQL database:
 
@@ -73,8 +73,8 @@ Choose the GUI mode from the dropdown and select the operation **Bulk update usi
 ```
 
 :::tip
-- You can apply transformations to the query results. Refer to our transformations documentation for more details: **[Transformation Tutorial](/docs/tutorial/transformations)**
-- Check out this how-to guide on **[bulk updating multiple rows](/docs/how-to/bulk-update-multiple-rows)** from a table component.
+- You can apply transformations to the query results. Refer to our transformations documentation for more details: **[Transformation Tutorial](../tutorial/transformations)**
+- Check out this how-to guide on **[bulk updating multiple rows](../how-to/bulk-update-multiple-rows)** from a table component.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/redis.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/redis.md
@@ -9,7 +9,7 @@ ToolJet enables you to execute Redis commands on your Redis instances.
 
 ## Connecting to Redis
 
-To establish a connection with the Redis data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Redis as the data source.
+To establish a connection with the Redis data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Redis as the data source.
 
 <img className="screenshot-full" src="/img/datasource-reference/redis/connect-v2.png" alt="Redis Connection" style={{marginBottom:'15px'}} />
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/restapi.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/restapi.md
@@ -9,7 +9,7 @@ ToolJet can establish a connection with any available REST API endpoint and crea
 
 ## Connection
 
-To establish a connection with the REST API data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the REST API data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 <img className="screenshot-full" src="/img/datasource-reference/rest-api/restconnect.gif" alt="ToolJet - Data source - REST API" style={{marginBottom:'15px'}}/>
 
@@ -41,7 +41,7 @@ Once you have connected to the REST API data source, follow these steps to write
 4. Click **Preview** to view the data returned from the query or click **Run** to execute the query.
 
 :::tip
-Query results can be transformed using the **[Transformations](/docs/how-to/transformations)** feature.
+Query results can be transformed using the **[Transformations](../tutorial/transformations)** feature.
 :::
 
 ToolJet supports the following REST HTTP methods 
@@ -163,7 +163,7 @@ You can also use JS methods like **map** to load data on components like **dropd
 
 </details>
 
-Read the guide on **[loading base64 data](/docs/how-to/loading-image-pdf-from-db)**
+Read the guide on **[loading base64 data](../how-to/loading-image-pdf-from-db)**
 
 <img className="screenshot-full" src="/img/datasource-reference/rest-api/base64.png" alt="ToolJet - Data source - REST API" />
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/rethinkdb.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/rethinkdb.md
@@ -10,7 +10,7 @@ ToolJet can connect to RethinkDB databases to read and write data. For more info
 
 ## Connection
 
-To establish a connection with the RethinkDB data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the RethinkDB data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to a RethinkDB data source:
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/run-py.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/run-py.md
@@ -29,11 +29,11 @@ p1 = Person(tj_globals.currentUser.firstName, 36)
 components.text1.setText(p1.myfunc())
 ```
 
-4. The above code has a function `myfunc` which returns a string and we are using a **[Component Specific Action](/docs/tooljet-concepts/component-specific-actions)** to set the Text Component's value from the Python query. 
+4. The above code has a function `myfunc` which returns a string and we are using a **[Component Specific Action](../tooljet-concepts/component-specific-actions)** to set the Text Component's value from the Python query. 
 
 :::tip
 - As of now, Run Python code only supports the [Python standard library](https://docs.python.org/3/library/).
-- Check **[RunPy Limitations](/docs/contributing-guide/troubleshooting/runpy-limitations)** to go through the limitations with using Python code
+- Check **[RunPy Limitations](../contributing-guide/troubleshooting/runpy-limitations)** to go through the limitations with using Python code
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/s3.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/s3.md
@@ -9,7 +9,7 @@ ToolJet can connect to **Amazon S3** buckets and perform various operations on t
 
 ## Connection
 
-To establish a connection with the **Amazon S3** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard.
+To establish a connection with the **Amazon S3** data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard.
 
 ToolJet supports connecting to AWS S3 using **IAM Access Keys**, **AWS Instance Credentials** or **AWS ARN Role**. 
 
@@ -37,7 +37,7 @@ If you are using **AWS ARN Role**, you will need to provide the following detail
 <img className="screenshot-full" src="/img/datasource-reference/aws-s3/arnnew.png" alt="aws s3 modal" />
 
 :::tip
-You can now connect to **[different S3 Hosts using custom endpoints](/docs/how-to/s3-custom-endpoints)**.
+You can now connect to **[different S3 Hosts using custom endpoints](../how-to/s3-custom-endpoints)**.
 :::
 
 </div>
@@ -54,7 +54,7 @@ You can now connect to **[different S3 Hosts using custom endpoints](/docs/how-t
 <img className="screenshot-full" src="/img/datasource-reference/aws-s3/operations3.png" alt="aws s3 query" />
 
 :::info
-Query results can be transformed using transformations. Read our [transformations documentation](/docs/tutorial/transformations).
+Query results can be transformed using transformations. Read our [transformations documentation](../tutorial/transformations).
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/saphana.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/saphana.md
@@ -9,7 +9,7 @@ ToolJet can connect to SAP HANA databases to read and write data.
 
 ## Connection
 
-To establish a connection with the SAP HANA datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the SAP HANA datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your SAP HANA database:
 
@@ -42,6 +42,7 @@ select * from PRODUCTS
 ```
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
+
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/sendgrid.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/sendgrid.md
@@ -9,7 +9,7 @@ ToolJet can connect to your SendGrid account to send emails.
 
 ## Connection
 
-To establish a connection with the SendGrid datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the SendGrid datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 ToolJet requires the following to connect to your SendGrid database:
 - **SendGrid API key**

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/slack.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/slack.md
@@ -9,7 +9,7 @@ ToolJet can connect to your Slack workspace to send messages.
 
 ## Connection
 
-To establish a connection with the **Slack** datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page through the ToolJet dashboard.
+To establish a connection with the **Slack** datasource, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page through the ToolJet dashboard.
 
 <img className="screenshot-full" src="/img/datasource-reference/slack/connect-v2.png" alt="Slack datasource: ToolJet"/>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/smtp.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/smtp.md
@@ -9,7 +9,7 @@ The SMTP datasource facilitates the connection between ToolJet applications and 
 
 ## Connection
 
-To establish a connection with the SMTP data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard and choose SMTP as the data source.
+To establish a connection with the SMTP data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard and choose SMTP as the data source.
 
 ToolJet requires the following to connect to SMTP server:
 

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/snowflake.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/snowflake.md
@@ -9,7 +9,7 @@ ToolJet can connect to Snowflake databases to read and write data.
 
 ## Connection
 
-To establish a connection with the Snowflake data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard and choose Snowflake as the data source.
+To establish a connection with the Snowflake data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard and choose Snowflake as the data source.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -47,7 +47,7 @@ select * from "SNOWFLAKE_SAMPLE_DATA"."WEATHER"."DAILY_14_TOTAL" limit 10;
 ```
 
 :::tip
-Query results can be transformed using transformations. Read our [transformations](/docs/tutorial/transformations) documentation to learn more.
+Query results can be transformed using transformations. Read our [transformations](../tutorial/transformations) documentation to learn more.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/stripe.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/stripe.md
@@ -13,7 +13,7 @@ Check out the **[Stripe Refund App tutorial](https://blog.tooljet.com/build-a-st
 
 ## Connection
 
-To establish a connection with the Stripe data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview/)** page from the ToolJet dashboard and choose Stripe as the data source.
+To establish a connection with the Stripe data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview/)** page from the ToolJet dashboard and choose Stripe as the data source.
 
 ToolJet requires the following to connect to Stripe datasource.
 - **Stripe API key**
@@ -36,7 +36,7 @@ You can get the Stripe API key from the dashboard of your Stripe account. Go to 
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/twilio.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/twilio.md
@@ -9,7 +9,7 @@ ToolJet can connect to Twilio account to send sms.
 
 ## Connection
 
-To establish a connection with the Twilio data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Twilio as the data source.
+To establish a connection with the Twilio data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Twilio as the data source.
 
 ToolJet requires the following to connect to Twilio:
 - **Auth Token**

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/typesense.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/typesense.md
@@ -9,7 +9,7 @@ ToolJet can connect to your TypeSense deployment to read and write data.
 
 ## Connection 
 
-To establish a connection with the Typesense data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Typesense as the data source.
+To establish a connection with the Typesense data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Typesense as the data source.
 
 :::info
 Please make sure the **Host/IP** of the database is accessible from your VPC if you have self-hosted ToolJet. If you are using ToolJet cloud, please **whitelist** our IP.
@@ -35,7 +35,7 @@ ToolJet requires the following to connect to TypeSense deployment:
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/woocommerce.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/woocommerce.md
@@ -9,7 +9,7 @@ ToolJet can connect to WooCommerce databases to read and write data.
 
 ## Connection
 
-To establish a connection with the WooCommerce data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose WooCommerce as the data source.
+To establish a connection with the WooCommerce data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose WooCommerce as the data source.
 
 ToolJet requires the following to connect to WooCommerce
 - **Host**
@@ -34,7 +34,7 @@ NOTE: For generating keys visit admin dashboard of woocommerce , more info: http
 4. Click on the **Preview** button to preview the output or Click on the **Run** button to trigger the query.
 
 :::tip
-Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](/docs/tutorial/transformations)**
+Query results can be transformed using transformations. Read our transformations documentation to see how: **[link](../tutorial/transformations)**
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/zendesk.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/zendesk.md
@@ -9,7 +9,7 @@ ToolJet can connect to Zendesk APIs to read and write data using OAuth 2.0, whic
 
 ## Connection 
 
-To establish a connection with the Zendesk data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](/docs/data-sources/overview)** page from the ToolJet dashboard and choose Zendesk as the data source.
+To establish a connection with the Zendesk data source, you can either click on the **+ Add new Data source** button located on the query panel or navigate to the **[Data Sources](./overview)** page from the ToolJet dashboard and choose Zendesk as the data source.
 
 ToolJet connects to your Zendesk app using :
 - **Zendesk Sub-domain**


### PR DESCRIPTION
Fix all the relative links by removing duplicate path segments, and making them version-aware.
This PR consist updates in following folder:
- data-sources