### PR TITLE
[docs]: Fix documentation for container component

### DIFF
--- a/docs/docs/widgets/container.md
+++ b/docs/docs/widgets/container.md
@@ -4,7 +4,7 @@ title: Container
 ---
 # Container
 
-Containers are used to group widgets together. You can move the desired number of widgets inside a container to organize your app better.
+Containers are used to group components together. You can move the desired number of components inside a container to organize your app better.
 
 :::caution Restricted components
 In order to avoid excessively complex situations, certain components, namely **Calendar** and **Kanban**, are restricted from being placed within the Container component using drag-and-drop functionality.
@@ -14,7 +14,7 @@ If the builder attempts to add any of the aforementioned components inside the c
 `<Restricted component> cannot be used as a child component within the container.`
 :::
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Enabling Vertical Scroll on Container
 
@@ -22,17 +22,17 @@ To enable the vertical scroll on the container, drag and place any component to 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Loading State
 
-To activate the loader on the Container component, access its properties and dynamically adjust the **Loading State** property by clicking the **Fx** button. You can set it to either `{{true}}` or `{{false}}`.
+To activate the loader on the Container component, access its properties and dynamically adjust the **Loading State** property by clicking the **fx** button. You can set it to either `{{true}}` or `{{false}}`.
 
 For instance, if you wish to display the loader on the container when the query named `restapi1` is in progress, set the **Loading State** value to `{{queries.restapi1.isLoading}}`.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -40,7 +40,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -48,29 +48,31 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| Show on desktop | This property have toggle switch. If enabled, the Container widget will display in the desktop view else it will not appear. This is enabled by default.|
-| Show on mobile | This property have toggle switch. If enabled, the Container widget will display in the mobile view else it will not appear.|
+| Show on desktop | This property have toggle switch. If enabled, the Container component will display in the desktop view else it will not appear. This is enabled by default.|
+| Show on mobile | This property have toggle switch. If enabled, the Container component will display in the mobile view else it will not appear.|
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+---
+
+<div style={{paddingTop:'24px'}}>
 
 ## Styles
 
@@ -79,12 +81,12 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 | Background color |  Change the background color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
 | Border radius | Modifies the border radius of the container. The field expects only numerical value from `1` to `100`.| Default is `0` |
 | Border color |  Changes the border color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
-| Visibility | Controls the visibility of the widget. If `{{false}}` the widget will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}` |
-| Disable |  This property only accepts boolean values. If set to `{{true}}`, the widget will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| Visibility | Controls the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}` |
+| Disable |  This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
 
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having `fx` button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/docs/widgets/container.md
+++ b/docs/docs/widgets/container.md
@@ -2,7 +2,6 @@
 id: container
 title: Container
 ---
-# Container
 
 Containers are used to group components together. You can move the desired number of components inside a container to organize your app better.
 
@@ -55,7 +54,7 @@ There are currently no exposed variables for the component.
 
 A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
+Under the **General** accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
@@ -64,9 +63,9 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> |
-|:----------- |:----------- |
-| Show on desktop | This property have toggle switch. If enabled, the Container component will display in the desktop view else it will not appear. This is enabled by default.|
-| Show on mobile | This property have toggle switch. If enabled, the Container component will display in the mobile view else it will not appear.|
+|:----------- |:----------- | :-----------|
+| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on fx and entering a logical expression. |
+| Show on mobile | Makes the component visible in mobile view.| You can set it with the toggle button or dynamically configure the value by clicking on fx and entering a logical expression. |
 
 </div>
 
@@ -79,10 +78,10 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"100px"}}> Default Value </div> |
 |:----------- |:----------- |:---------|
 | Background color |  Change the background color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
-| Border radius | Modifies the border radius of the container. The field expects only numerical value from `1` to `100`.| Default is `0` |
-| Border color |  Changes the border color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
-| Visibility | Controls the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}` |
-| Disable |  This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| Border radius | Modifies the border radius of the container. The field expects only numerical values from `1` to `100`.| Default is `0`. |
+| Border color |  Change the border color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
+| Visibility | Controls the visibility of the component. If `{{false}}` the component will not be visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`. |
+| Disable |  This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}`. |
 
 
 :::info

--- a/docs/docs/widgets/container.md
+++ b/docs/docs/widgets/container.md
@@ -64,8 +64,8 @@ Under the **General** accordion, you can set the value in the string format. Now
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- | :-----------|
-| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on fx and entering a logical expression. |
-| Show on mobile | Makes the component visible in mobile view.| You can set it with the toggle button or dynamically configure the value by clicking on fx and entering a logical expression. |
+| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile | Makes the component visible in mobile view.| You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 

--- a/docs/docs/widgets/container.md
+++ b/docs/docs/widgets/container.md
@@ -86,7 +86,7 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 
 :::info
-Any property having `fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/container.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/container.md
@@ -4,7 +4,7 @@ title: Container
 ---
 # Container
 
-Containers are used to group widgets together. You can move the desired number of widgets inside a container to organize your app better.
+Containers are used to group components together. You can move the desired number of components inside a container to organize your app better.
 
 :::caution Restricted components
 In order to avoid excessively complex situations, certain components, namely **Calendar** and **Kanban**, are restricted from being placed within the Container component using drag-and-drop functionality.
@@ -14,7 +14,7 @@ If the builder attempts to add any of the aforementioned components inside the c
 `<Restricted component> cannot be used as a child component within the container.`
 :::
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Enabling Vertical Scroll on Container
 
@@ -22,17 +22,17 @@ To enable the vertical scroll on the container, drag and place any component to 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Loading State
 
-To activate the loader on the Container component, access its properties and dynamically adjust the **Loading State** property by clicking the **Fx** button. You can set it to either `{{true}}` or `{{false}}`.
+To activate the loader on the Container component, access its properties and dynamically adjust the **Loading State** property by clicking the **fx** button. You can set it to either `{{true}}` or `{{false}}`.
 
 For instance, if you wish to display the loader on the container when the query named `restapi1` is in progress, set the **Loading State** value to `{{queries.restapi1.isLoading}}`.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -40,7 +40,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -48,29 +48,31 @@ There are currently no exposed variables for the component.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## General
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| Show on desktop | This property have toggle switch. If enabled, the Container widget will display in the desktop view else it will not appear. This is enabled by default.|
-| Show on mobile | This property have toggle switch. If enabled, the Container widget will display in the mobile view else it will not appear.|
+| Show on desktop | This property have toggle switch. If enabled, the Container component will display in the desktop view else it will not appear. This is enabled by default.|
+| Show on mobile | This property have toggle switch. If enabled, the Container component will display in the mobile view else it will not appear.|
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+---
+
+<div style={{paddingTop:'24px'}}>
 
 ## Styles
 
@@ -79,12 +81,12 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 | Background color |  Change the background color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
 | Border radius | Modifies the border radius of the container. The field expects only numerical value from `1` to `100`.| Default is `0` |
 | Border color |  Changes the border color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
-| Visibility | Controls the visibility of the widget. If `{{false}}` the widget will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}` |
-| Disable |  This property only accepts boolean values. If set to `{{true}}`, the widget will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| Visibility | Controls the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}` |
+| Disable |  This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
 
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having `fx` button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/container.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/container.md
@@ -2,7 +2,6 @@
 id: container
 title: Container
 ---
-# Container
 
 Containers are used to group components together. You can move the desired number of components inside a container to organize your app better.
 
@@ -55,7 +54,7 @@ There are currently no exposed variables for the component.
 
 A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
+Under the **General** accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 </div>
 
@@ -64,9 +63,9 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> |
-|:----------- |:----------- |
-| Show on desktop | This property have toggle switch. If enabled, the Container component will display in the desktop view else it will not appear. This is enabled by default.|
-| Show on mobile | This property have toggle switch. If enabled, the Container component will display in the mobile view else it will not appear.|
+|:----------- |:----------- | :-----------|
+| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on fx and entering a logical expression. |
+| Show on mobile | Makes the component visible in mobile view.| You can set it with the toggle button or dynamically configure the value by clicking on fx and entering a logical expression. |
 
 </div>
 
@@ -79,10 +78,10 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"100px"}}> Default Value </div> |
 |:----------- |:----------- |:---------|
 | Background color |  Change the background color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
-| Border radius | Modifies the border radius of the container. The field expects only numerical value from `1` to `100`.| Default is `0` |
-| Border color |  Changes the border color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
-| Visibility | Controls the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}` |
-| Disable |  This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| Border radius | Modifies the border radius of the container. The field expects only numerical values from `1` to `100`.| Default is `0`. |
+| Border color |  Change the border color of the Container by entering the `Hex color code` or choosing a color of your choice from the color picker. | |
+| Visibility | Controls the visibility of the component. If `{{false}}` the component will not be visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`. |
+| Disable |  This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}`. |
 
 
 :::info

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/container.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/container.md
@@ -64,8 +64,8 @@ Under the **General** accordion, you can set the value in the string format. Now
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- | :-----------|
-| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on fx and entering a logical expression. |
-| Show on mobile | Makes the component visible in mobile view.| You can set it with the toggle button or dynamically configure the value by clicking on fx and entering a logical expression. |
+| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile | Makes the component visible in mobile view.| You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/container.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/container.md
@@ -86,7 +86,7 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 
 :::info
-Any property having `fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>


### PR DESCRIPTION
- Replaced "Fx" and "Fx" with "fx" wherever applicable.
- For each h2 (created using ##), removed 24px padding-bottom.
- Replaced the word "widget" with "component" wherever applicable.
- Added a divider before the "Styles" section.