### PR TITLE
Add ToolJet Logo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<div align="center">
+    <img src="frontend/assets/images/Logomark-dark-mode.svg" width="200" alt="ToolJet logo">
+</div>
+
+<h1 align="center">Build and Deploy Internal Tools with Ease</h1> 
+
+
 ToolJet is an **open-source low-code framework** to build and deploy internal tools with minimal engineering effort. ToolJet's drag-and-drop frontend builder allows you to create complex, responsive frontends within minutes. Additionally, you can integrate various data sources, including databases like PostgreSQL, MongoDB, and Elasticsearch; API endpoints with OpenAPI spec and OAuth2 support; SaaS tools such as Stripe, Slack, Google Sheets, Airtable, and Notion; as well as object storage services like S3, GCS, and Minio, to fetch and write data.
 
  :star: If you find ToolJet useful, please consider giving us a star on GitHub! Your support helps us continue to innovate and deliver exciting features.


### PR DESCRIPTION
This PR adds the ToolJet logo to the README.md file, enhancing the project's visual appeal and brand identity. 

The logo is displayed prominently to represent ToolJet as an open-source low-code framework for building and deploying internal tools.