### PR TITLE
[docs]: Fix documentation for Radio Button Component

### DIFF
--- a/docs/docs/widgets/radio-button.md
+++ b/docs/docs/widgets/radio-button.md
@@ -2,32 +2,33 @@
 id: radio-button
 title: Radio Button
 ---
+
 # Radio Button
 
-The **Radio Button** widget can be used to select one option from a group of options.
+The **Radio Button** component can be used to select one option from a group of options.
 
 :::tip
 Radio Buttons are preferred when the list of options is less than six, and all the options can be displayed at once.
 :::
 
 :::info
-For more than six options, consider using **[Dropdown](/docs/widgets/dropdown)** widget.
+For more than six options, consider using **[Dropdown](/docs/widgets/dropdown)** component.
 :::
 
 ## Properties
 
-| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"150px"}}> Description </div> | 
-|:------------ |:-------------|
-| Label | The text is to be used as the label for the radio button. This field expects a `String` value. |
-| Default value | The value of the default option. |
-| Option values | List of values for different items/options. Refer your query data with dynamic variables `{{queries.datasource.data.map(item => item.value)}}` or populate it with sample values `{{[true, false]}}`. |
-| Option labels | List of labels for different items/options. Refer your query data with dynamic variables `{{queries.datasource.data.map(item => item.label)}}` or populate it with sample values `{{["yes", "no"]}}`. |
+| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"150px"}}> Description </div>                                                                                                                                                     |
+| :--------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Label                                          | The text is to be used as the label for the radio button. This field expects a `String` value.                                                                                                        |
+| Default value                                  | The value of the default option.                                                                                                                                                                      |
+| Option values                                  | List of values for different items/options. Refer your query data with dynamic variables `{{queries.datasource.data.map(item => item.value)}}` or populate it with sample values `{{[true, false]}}`. |
+| Option labels                                  | List of labels for different items/options. Refer your query data with dynamic variables `{{queries.datasource.data.map(item => item.label)}}` or populate it with sample values `{{["yes", "no"]}}`. |
 
 ## Event
 
 | <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div> |
-|:------------------|:---------------------|
-| On select | This event is triggered when an option is clicked. |
+| :------------------------------------------ | :------------------------------------------------ |
+| On select                                   | Triggers whenever the user clicks an option.      |
 
 :::info
 Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
@@ -37,33 +38,36 @@ Check [Action Reference](/docs/category/actions-reference) docs to get the detai
 
 The following actions of the component can be controlled using component specific actions(CSA):
 
-| <div style={{ width:"100px"}}> Actions  </div> |<div style={{ width:"135px"}}>  Description </div> | <div style={{ width:"135px"}}> How To Access </div>
-|:----------- |:----------- |:------- |
-| selectOption | Select an option from the radio buttons via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as: `await components.radiobutton1.selectOption('one')` |
+| <div style={{ width:"100px"}}> Actions </div> | <div style={{ width:"135px"}}> Description </div>                                                 | <div style={{ width:"135px"}}> How To Access </div>                                                                     |
+| :-------------------------------------------- | :------------------------------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------- |
+| selectOption                                  | Select an option from the radio buttons via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as: `await components.radiobutton1.selectOption('one')` |
 
 ## Exposed Variables
 
 There are currently no exposed variables for the component.
 
 ## General
+
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 ## Layout
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
-|:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div>                                                            |
+| :------------------------------------------- | :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- |
+| Show on desktop                              | Toggle on or off to display desktop view.         | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile                               | Toggle on or off to display mobile view.          | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+
+---
 
 ## Styles
 
-| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}>  Description </div> | <div style={{ width:"100px"}}> Default Value </div> |
-|:------------ |:-------------|:--------- |
-| Text color | Change the color of the text in the widget by providing the `Hex color code` or by choosing the color of your choice from the color picker. |  |
-| Active color | Change the color of active radio button by providing the `Hex color code` or by choosing the color of your choice from the color picker. |  |
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. | By default, it's set to `{{true}}` |
-| Disable | This is `off` by default, toggle `on` the switch to lock the widget and make it non-functional. You can also programmatically set the value by clicking on the `Fx` button next to it. If set to `{{true}}`, the widget will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                                                                                                                                                                                                          | <div style={{ width:"100px"}}> Default Value </div> |
+| :------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
+| Text color                                  | Change the color of the text in the component by providing the `Hex color code` or by choosing the color of your choice from the color picker.                                                                                                                             |                                                     |
+| Active color                                | Change the color of active radio button by providing the `Hex color code` or by choosing the color of your choice from the color picker.                                                                                                                                   |                                                     |
+| Visibility                                  | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed.                                            | By default, it's set to `{{true}}`                  |
+| Disable                                     | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **fx** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}`         |

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/radio-button.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/radio-button.md
@@ -2,32 +2,33 @@
 id: radio-button
 title: Radio Button
 ---
+
 # Radio Button
 
-The **Radio Button** widget can be used to select one option from a group of options.
+The **Radio Button** component can be used to select one option from a group of options.
 
 :::tip
 Radio Buttons are preferred when the list of options is less than six, and all the options can be displayed at once.
 :::
 
 :::info
-For more than six options, consider using **[Dropdown](/docs/widgets/dropdown)** widget.
+For more than six options, consider using **[Dropdown](/docs/widgets/dropdown)** component.
 :::
 
 ## Properties
 
-| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"150px"}}> Description </div> | 
-|:------------ |:-------------|
-| Label | The text is to be used as the label for the radio button. This field expects a `String` value. |
-| Default value | The value of the default option. |
-| Option values | List of values for different items/options. Refer your query data with dynamic variables `{{queries.datasource.data.map(item => item.value)}}` or populate it with sample values `{{[true, false]}}`. |
-| Option labels | List of labels for different items/options. Refer your query data with dynamic variables `{{queries.datasource.data.map(item => item.label)}}` or populate it with sample values `{{["yes", "no"]}}`. |
+| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"150px"}}> Description </div>                                                                                                                                                     |
+| :--------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Label                                          | The text is to be used as the label for the radio button. This field expects a `String` value.                                                                                                        |
+| Default value                                  | The value of the default option.                                                                                                                                                                      |
+| Option values                                  | List of values for different items/options. Refer your query data with dynamic variables `{{queries.datasource.data.map(item => item.value)}}` or populate it with sample values `{{[true, false]}}`. |
+| Option labels                                  | List of labels for different items/options. Refer your query data with dynamic variables `{{queries.datasource.data.map(item => item.label)}}` or populate it with sample values `{{["yes", "no"]}}`. |
 
 ## Event
 
 | <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div> |
-|:------------------|:---------------------|
-| On select | This event is triggered when an option is clicked. |
+| :------------------------------------------ | :------------------------------------------------ |
+| On select                                   | Triggers whenever the user clicks an option.      |
 
 :::info
 Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
@@ -37,33 +38,36 @@ Check [Action Reference](/docs/category/actions-reference) docs to get the detai
 
 The following actions of the component can be controlled using component specific actions(CSA):
 
-| <div style={{ width:"100px"}}> Actions  </div> |<div style={{ width:"135px"}}>  Description </div> | <div style={{ width:"135px"}}> How To Access </div>
-|:----------- |:----------- |:------- |
-| selectOption | Select an option from the radio buttons via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as: `await components.radiobutton1.selectOption('one')` |
+| <div style={{ width:"100px"}}> Actions </div> | <div style={{ width:"135px"}}> Description </div>                                                 | <div style={{ width:"135px"}}> How To Access </div>                                                                     |
+| :-------------------------------------------- | :------------------------------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------- |
+| selectOption                                  | Select an option from the radio buttons via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as: `await components.radiobutton1.selectOption('one')` |
 
 ## Exposed Variables
 
 There are currently no exposed variables for the component.
 
 ## General
+
 ### Tooltip
 
-A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the widget.
+A Tooltip is often used to specify extra information about something when the user hovers the mouse pointer over the component.
 
-Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the widget will display the string as the tooltip.
+Under the <b>General</b> accordion, you can set the value in the string format. Now hovering over the component will display the string as the tooltip.
 
 ## Layout
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
-|:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div>                                                            |
+| :------------------------------------------- | :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- |
+| Show on desktop                              | Toggle on or off to display desktop view.         | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile                               | Toggle on or off to display mobile view.          | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+
+---
 
 ## Styles
 
-| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}>  Description </div> | <div style={{ width:"100px"}}> Default Value </div> |
-|:------------ |:-------------|:--------- |
-| Text color | Change the color of the text in the widget by providing the `Hex color code` or by choosing the color of your choice from the color picker. |  |
-| Active color | Change the color of active radio button by providing the `Hex color code` or by choosing the color of your choice from the color picker. |  |
-| Visibility | Toggle on or off to control the visibility of the widget. You can programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not be visible after the app is deployed. | By default, it's set to `{{true}}` |
-| Disable | This is `off` by default, toggle `on` the switch to lock the widget and make it non-functional. You can also programmatically set the value by clicking on the `Fx` button next to it. If set to `{{true}}`, the widget will be locked and becomes non-functional. | By default, its value is set to `{{false}}` |
+| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                                                                                                                                                                                                          | <div style={{ width:"100px"}}> Default Value </div> |
+| :------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
+| Text color                                  | Change the color of the text in the component by providing the `Hex color code` or by choosing the color of your choice from the color picker.                                                                                                                             |                                                     |
+| Active color                                | Change the color of active radio button by providing the `Hex color code` or by choosing the color of your choice from the color picker.                                                                                                                                   |                                                     |
+| Visibility                                  | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not be visible after the app is deployed.                                            | By default, it's set to `{{true}}`                  |
+| Disable                                     | This is `off` by default, toggle `on` the switch to lock the component and make it non-functional. You can also programmatically set the value by clicking on the **fx** button next to it. If set to `{{true}}`, the component will be locked and becomes non-functional. | By default, its value is set to `{{false}}`         |


### PR DESCRIPTION
### Pull Request Summary

**Formatting Updates:**

- Replaced **"fx"** with **fx** wherever applicable (removed backticks and bold formatting).
- For each `h2` (created using `##`), removed 24px padding-bottom. The wrapping `div` for the `h2` headers and the section below now only has a `padding-top` of 24px and no `padding-bottom`.

**Content Updates:**

- Replaced the word **"widget"** with **"component"** wherever applicable (URLs remain unchanged).
  
**Event Table:**

- Updated the content in the **"Description"** of the **"On select"** event to reference (please check the sentence structure from the given reference; the rest remains unchanged).
- Added a full stop at the end of the sentence in the **"Description"** column.
- Added a divider before the **"Styles"** section.

### Affected Files
- `ToolJet/docs/docs/widgets/radio-button.md`
- `ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/radio-button.md`

![Screenshot 2024-10-24 054954](https://github.com/user-attachments/assets/bc207c54-6b35-4870-9516-e538f85578c5)


### Issue Type
Documentation bug

### Documentation URL
[Radio Button Documentation](https://docs.tooljet.com/docs/widgets/radio-button)

### Additional Notes
If any other changes need to be made, please let me know!

### Code of Conduct
- [x] I agree to follow the ToolJet Code of Conduct.

will close #11063
