### PR TITLE
[docs]: Fix documentation for color picker component

### DIFF
--- a/docs/docs/widgets/color-picker.md
+++ b/docs/docs/widgets/color-picker.md
@@ -97,7 +97,7 @@ Any property having **fx** button next to its field can be **programmatically co
 - Let's start by creating a new app and then dragging the Color Picker component onto the canvas.
 - Click on the Color Picker component, a picker pop-up will appear, one can select desired color from the picker.
 - In order to close the appeared picker pop-up, one need's to move away mouse from the picker pop-up and picker pop-up will fade away.
-- In the Inspector, inside component, look for colorpicker, where one can get respective hex, rgb and rgba color
+- In the Inspector, inside component, look for colorpicker, where one can get respective hex, rgb and rgba color.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/docs/widgets/color-picker.md
+++ b/docs/docs/widgets/color-picker.md
@@ -101,7 +101,7 @@ Any property having **fx** button next to its field can be **programmatically co
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/widgets/color-picker/colorpickerinspector-v2.png" alt="ToolJet - component Reference - Color Picker" />
+<img className="screenshot-full" src="/img/widgets/color-picker/colorpickerinspector-v2.png" alt="ToolJet - Component Reference - Color Picker" />
 
 </div>
 

--- a/docs/docs/widgets/color-picker.md
+++ b/docs/docs/widgets/color-picker.md
@@ -3,19 +3,17 @@ id: color-picker
 title: Color Picker
 ---
 
-# Color Picker
+**Color Picker** component is used to select the desired color from the color picker.
 
-**Color Picker** widget is used to select the desired color from the color picker
-
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
 ### Default color
 
-The data needs to be an valid hex color
+The data needs to be an valid hex color.
 
-- One can change default color either from color picker or using `fx` (need to provide only respective hex value)
+- One can change default color either from color picker or using **fx** (need to provide only respective hex value).
 
 **Example:**
 
@@ -26,19 +24,17 @@ Invalid Color : #0000, "black" , rgb(0,0,0) ,
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
 
-To add an event to a color-picker component, click on the widget handle to open the widget properties on the right sidebar. Go to the **Events** section and click on **+ Add handler**.
-
 | <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| On change | On change event is triggered when the color is changed on the color-picker|
+| On change | Triggers whenever the color is changed on the color-picker.|
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -46,44 +42,46 @@ The following actions of the component can be controlled using component specifi
 
 | <div style={{ width:"100px"}}> Actions  </div>   | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:----------- |
-| setColor | Set a color on the color component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.colorpicker1.setColor('#64A07A')` |
+| setColor | Set a color on the color component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.colorpicker1.setColor('#64A07A')`. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
 | <div style={{ width:"100px"}}> Variables </div> | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:---------- |
-| selectedColorHex | Gets updated with HEX color code whenever a user selects a color from the color picker.| Access the value dynamically using JS: `{{components.colorpicker1.selectedColorHex}}`|
-| selectedColorRGB | Gets updated with RGB color code whenever a user selects a color from the color picker. | Access the value dynamically using JS: `{{components.colorpicker1.selectedColorRGB}}`|
-| selectedColorRGBA | Gets updated with RGBA color code whenever a user selects a color from the color picker.| Access the value dynamically using JS: `{{components.colorpicker1.selectedColorRGBA}}`|
+| selectedColorHex | Gets updated with HEX color code whenever a user selects a color from the color picker.| Access the value dynamically using JS: `{{components.colorpicker1.selectedColorHex}}`.|
+| selectedColorRGB | Gets updated with RGB color code whenever a user selects a color from the color picker. | Access the value dynamically using JS: `{{components.colorpicker1.selectedColorRGB}}`.|
+| selectedColorRGBA | Gets updated with RGBA color code whenever a user selects a color from the color picker.| Access the value dynamically using JS: `{{components.colorpicker1.selectedColorRGBA}}`.|
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value  </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | Programmatically determine the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | Programmatically determinine the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | Programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | Programmatically determinine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+----
+
+<div style={{paddingTop:'24px'}}>
 
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description    </div>                                                                                                                                                                                                                                          | <div style={{ width:"135px"}}> Expected Value </div> |
 |:---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |:---------- |
-| Visibility | Toggle on or off to control the visibility of the widget.| Programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not visible after the app is deployed. By default, it's set to `{{true}}` |
+| Visibility | Toggle on or off to control the visibility of the component.| Programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Actions
 
@@ -92,18 +90,18 @@ The following actions of the component can be controlled using component specifi
 | setColor | Set the  color. | `color` eg - `#ffffff` |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 **Example: Selecting/changing color from the color picker and getting respective hex, rgb and rgba value of selected color**
-- Let's start by creating a new app and then dragging the Color Picker  widget onto the canvas.
-- Click on the Color Picker widget, a picker pop-up will appear, one can select desired color from the picker.
+- Let's start by creating a new app and then dragging the Color Picker component onto the canvas.
+- Click on the Color Picker component, a picker pop-up will appear, one can select desired color from the picker.
 - In order to close the appeared picker pop-up, one need's to move away mouse from the picker pop-up and picker pop-up will fade away.
 - In the Inspector, inside component, look for colorpicker, where one can get respective hex, rgb and rgba color
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/widgets/color-picker/colorpickerinspector-v2.png" alt="ToolJet - Widget Reference - Color Picker" />
+<img className="screenshot-full" src="/img/widgets/color-picker/colorpickerinspector-v2.png" alt="ToolJet - component Reference - Color Picker" />
 
 </div>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/color-picker.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/color-picker.md
@@ -97,7 +97,7 @@ Any property having **fx** button next to its field can be **programmatically co
 - Let's start by creating a new app and then dragging the Color Picker component onto the canvas.
 - Click on the Color Picker component, a picker pop-up will appear, one can select desired color from the picker.
 - In order to close the appeared picker pop-up, one need's to move away mouse from the picker pop-up and picker pop-up will fade away.
-- In the Inspector, inside component, look for colorpicker, where one can get respective hex, rgb and rgba color
+- In the Inspector, inside component, look for colorpicker, where one can get respective hex, rgb and rgba color.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/color-picker.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/color-picker.md
@@ -101,7 +101,7 @@ Any property having **fx** button next to its field can be **programmatically co
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/widgets/color-picker/colorpickerinspector-v2.png" alt="ToolJet - component Reference - Color Picker" />
+<img className="screenshot-full" src="/img/widgets/color-picker/colorpickerinspector-v2.png" alt="ToolJet - Component Reference - Color Picker" />
 
 </div>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/color-picker.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/color-picker.md
@@ -3,19 +3,17 @@ id: color-picker
 title: Color Picker
 ---
 
-# Color Picker
+**Color Picker** component is used to select the desired color from the color picker.
 
-**Color Picker** widget is used to select the desired color from the color picker
-
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
 ### Default color
 
-The data needs to be an valid hex color
+The data needs to be an valid hex color.
 
-- One can change default color either from color picker or using `fx` (need to provide only respective hex value)
+- One can change default color either from color picker or using **fx** (need to provide only respective hex value).
 
 **Example:**
 
@@ -26,19 +24,17 @@ Invalid Color : #0000, "black" , rgb(0,0,0) ,
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
 
-To add an event to a color-picker component, click on the widget handle to open the widget properties on the right sidebar. Go to the **Events** section and click on **+ Add handler**.
-
 | <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| On change | On change event is triggered when the color is changed on the color-picker|
+| On change | Triggers whenever the color is changed on the color-picker.|
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -46,44 +42,46 @@ The following actions of the component can be controlled using component specifi
 
 | <div style={{ width:"100px"}}> Actions  </div>   | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:----------- |
-| setColor | Set a color on the color component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.colorpicker1.setColor('#64A07A')` |
+| setColor | Set a color on the color component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.colorpicker1.setColor('#64A07A')`. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
 | <div style={{ width:"100px"}}> Variables </div> | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:---------- |
-| selectedColorHex | Gets updated with HEX color code whenever a user selects a color from the color picker.| Access the value dynamically using JS: `{{components.colorpicker1.selectedColorHex}}`|
-| selectedColorRGB | Gets updated with RGB color code whenever a user selects a color from the color picker. | Access the value dynamically using JS: `{{components.colorpicker1.selectedColorRGB}}`|
-| selectedColorRGBA | Gets updated with RGBA color code whenever a user selects a color from the color picker.| Access the value dynamically using JS: `{{components.colorpicker1.selectedColorRGBA}}`|
+| selectedColorHex | Gets updated with HEX color code whenever a user selects a color from the color picker.| Access the value dynamically using JS: `{{components.colorpicker1.selectedColorHex}}`.|
+| selectedColorRGB | Gets updated with RGB color code whenever a user selects a color from the color picker. | Access the value dynamically using JS: `{{components.colorpicker1.selectedColorRGB}}`.|
+| selectedColorRGBA | Gets updated with RGBA color code whenever a user selects a color from the color picker.| Access the value dynamically using JS: `{{components.colorpicker1.selectedColorRGBA}}`.|
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
 | <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value  </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | Programmatically determine the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | Programmatically determinine the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| Show on desktop | Toggle on or off to display desktop view. | Programmatically determine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on mobile  | Toggle on or off to display mobile view.  | Programmatically determinine the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+----
+
+<div style={{paddingTop:'24px'}}>
 
 ## Styles
 
 | <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description    </div>                                                                                                                                                                                                                                          | <div style={{ width:"135px"}}> Expected Value </div> |
 |:---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |:---------- |
-| Visibility | Toggle on or off to control the visibility of the widget.| Programmatically change its value by clicking on the `Fx` button next to it. If `{{false}}` the widget will not visible after the app is deployed. By default, it's set to `{{true}}` |
+| Visibility | Toggle on or off to control the visibility of the component.| Programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Actions
 
@@ -92,18 +90,18 @@ The following actions of the component can be controlled using component specifi
 | setColor | Set the  color. | `color` eg - `#ffffff` |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 **Example: Selecting/changing color from the color picker and getting respective hex, rgb and rgba value of selected color**
-- Let's start by creating a new app and then dragging the Color Picker  widget onto the canvas.
-- Click on the Color Picker widget, a picker pop-up will appear, one can select desired color from the picker.
+- Let's start by creating a new app and then dragging the Color Picker component onto the canvas.
+- Click on the Color Picker component, a picker pop-up will appear, one can select desired color from the picker.
 - In order to close the appeared picker pop-up, one need's to move away mouse from the picker pop-up and picker pop-up will fade away.
 - In the Inspector, inside component, look for colorpicker, where one can get respective hex, rgb and rgba color
 
 <div style={{textAlign: 'center'}}>
 
-<img className="screenshot-full" src="/img/widgets/color-picker/colorpickerinspector-v2.png" alt="ToolJet - Widget Reference - Color Picker" />
+<img className="screenshot-full" src="/img/widgets/color-picker/colorpickerinspector-v2.png" alt="ToolJet - component Reference - Color Picker" />
 
 </div>
 


### PR DESCRIPTION
Files affected:
Next - ToolJet/docs/docs/widgets/color-picker.md
Version 2.50.0 (LTS) - ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/color-picker.md

Made the following changes:
- Replace `Fx` with **fx** wherever applicable.
- removed paddingBottom
- Replaced widget with component
- Updated the events table as mentioned in the issue
- Added a divider before the style section
- Added full stop wherever necessary

This PR will close #11017  