### PR TITLE
[docs] : Updated the documentation for the Steps component

### DIFF
--- a/docs/docs/widgets/steps.md
+++ b/docs/docs/widgets/steps.md
@@ -78,14 +78,16 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 <div style={{paddingTop:'24px'}}>
 
-## Layout
+## Devices
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
+| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile  | Makes the component visible in mobile view.  | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
+
+---
 
 <div style={{paddingTop:'24px'}}>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/steps.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/steps.md
@@ -79,14 +79,16 @@ Under the <b>General</b> accordion, you can set the value in the string format. 
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-## Layout
+## Devices
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
+| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile  | Makes the component visible in mobile view.  | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
+
+---
 
 <div style={{paddingTop:'24px' }}>
 


### PR DESCRIPTION
- Updated title from Layout to Devices
- Updated name of first column from Layout to Property
- Updated contents of Description and Expected Value Columns
- Added a full stop at the end of sentence in Description column
- Added a divider before the styles section

Made these changes for following files:
ToolJet/docs/docs/widgets/steps.md
ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/steps.md
fixes #11119 