### PR TITLE
[docs]: Fix documentation for the Link Component

### DIFF
--- a/docs/docs/widgets/link.md
+++ b/docs/docs/widgets/link.md
@@ -23,8 +23,8 @@ The **Link** component allows you to add a hyperlink and navigate to the externa
 
 |  <div style={{ width:"100px"}}> Event </div> |  <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| On click | **On Click** event is triggered when the link is clicked. Just like any other event on ToolJet, you can set multiple handlers for on click event. |
-| On hover | **On Hover** event is triggered when the link is hovered. Just like any other event on ToolJet, you can set multiple handlers for on click event. |
+| On click | Triggered when the link is clicked. |
+| On hover | Triggered when the cursor hovers over the link. |
 
 :::info
 Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
@@ -40,7 +40,7 @@ The following actions of the link component can be controlled using the componen
 
 | <div style={{ width:"100px"}}> Actions  </div>   | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:------------ |
-| click | You can trigger the click action of the Link component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.link1.click()`. |
+| click | Triggers click action of the link component. | Employ a RunJS query to execute component-specific actions such as `await components.link1.click()` or trigger it using an event. |
 
 </div>
 
@@ -65,12 +65,12 @@ Under the **General** accordion, you can set the value in the string format. Now
 
 <div style={{paddingTop:'24px'}}>
 
-## Layout
+## Devices
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
+| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on desktop | Toggles the component's visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile  | Toggles the component's visible in mobile view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 

--- a/docs/docs/widgets/link.md
+++ b/docs/docs/widgets/link.md
@@ -11,9 +11,9 @@ The **Link** component allows you to add a hyperlink and navigate to the externa
 
 | <div style={{ width:"100px"}}> Properties </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:----------- |:----------- |:-------------- |
-| Link target | This property sets the URL where the user needs to be taken on clicking the link. | example: `https://dev.to/tooljet` or `{{queries.xyz.data.url}}` | 
-| Link text | This property sets the text for the Link component.  | example: **Click here** or **Open webpage** | 
-| Target type | This property specifies the link to be opened in the same tab or new tab on clicking the link. | Options: **New Tab** & **Same Tab** |
+| Link target | This property sets the URL where the user needs to be taken on clicking the link. | example: `https://dev.to/tooljet` or `{{queries.xyz.data.url}}`. | 
+| Link text | This property sets the text for the Link component.  | example: **Click here** or **Open webpage**. | 
+| Target type | This property specifies the link to be opened in the same tab or new tab on clicking the link. | Options: **New Tab** & **Same Tab**. |
 
 </div>
 
@@ -69,8 +69,8 @@ Under the **General** accordion, you can set the value in the string format. Now
 
 | <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggles the component's visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
-| Show on mobile  | Toggles the component's visible in mobile view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile  | Makes the component visible in mobile view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 
@@ -84,7 +84,7 @@ Under the **General** accordion, you can set the value in the string format. Now
 |:----------- |:----------- | 
 | Text color |  You can change the background color of the text by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Text size | By default, the text size is set to 14. You can enter any value from 1-100 to set a custom text size. |
-| Underline | You can change the underline of the text in the following ways: **on-hover (default), never, always** |
+| Underline | You can change the underline of the text in the following ways: **on-hover (default), never, always**. |
 | Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 :::info

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/link.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/link.md
@@ -23,8 +23,8 @@ The **Link** component allows you to add a hyperlink and navigate to the externa
 
 |  <div style={{ width:"100px"}}> Event </div> |  <div style={{ width:"100px"}}> Description </div> |
 |:----------- |:----------- |
-| On click | **On Click** event is triggered when the link is clicked. Just like any other event on ToolJet, you can set multiple handlers for on click event. |
-| On hover | **On Hover** event is triggered when the link is hovered. Just like any other event on ToolJet, you can set multiple handlers for on click event. |
+| On click | Triggered when the link is clicked. |
+| On hover | Triggered when the cursor hovers over the link. |
 
 :::info
 Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
@@ -40,7 +40,7 @@ The following actions of the link component can be controlled using the componen
 
 | <div style={{ width:"100px"}}> Actions  </div>   | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div> |
 |:----------- |:----------- |:------------ |
-| click | You can trigger the click action of the Link component via a component-specific action within any event handler. | Employ a RunJS query to execute component-specific actions such as `await components.link1.click()`. |
+| click | Triggers click action of the link component. | Employ a RunJS query to execute component-specific actions such as `await components.link1.click()` or trigger it using an event. |
 
 </div>
 
@@ -65,12 +65,12 @@ Under the **General** accordion, you can set the value in the string format. Now
 
 <div style={{paddingTop:'24px'}}>
 
-## Layout
+## Devices
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
+| <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}`. |
+| Show on desktop | Toggles the component's visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile  | Toggles the component's visible in mobile view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/link.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/link.md
@@ -11,9 +11,9 @@ The **Link** component allows you to add a hyperlink and navigate to the externa
 
 | <div style={{ width:"100px"}}> Properties </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:----------- |:----------- |:-------------- |
-| Link target | This property sets the URL where the user needs to be taken on clicking the link. | example: `https://dev.to/tooljet` or `{{queries.xyz.data.url}}` | 
-| Link text | This property sets the text for the Link component.  | example: **Click here** or **Open webpage** | 
-| Target type | This property specifies the link to be opened in the same tab or new tab on clicking the link. | Options: **New Tab** & **Same Tab** |
+| Link target | This property sets the URL where the user needs to be taken on clicking the link. | example: `https://dev.to/tooljet` or `{{queries.xyz.data.url}}`. | 
+| Link text | This property sets the text for the Link component.  | example: **Click here** or **Open webpage**. | 
+| Target type | This property specifies the link to be opened in the same tab or new tab on clicking the link. | Options: **New Tab** & **Same Tab**. |
 
 </div>
 
@@ -69,8 +69,8 @@ Under the **General** accordion, you can set the value in the string format. Now
 
 | <div style={{ width:"100px"}}> Property </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div> |
 |:--------------- |:----------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
-| Show on desktop | Toggles the component's visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
-| Show on mobile  | Toggles the component's visible in mobile view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on desktop | Makes the component visible in desktop view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
+| Show on mobile  | Makes the component visible in mobile view. | You can set it with the toggle button or dynamically configure the value by clicking on **fx** and entering a logical expression. |
 
 </div>
 
@@ -84,7 +84,7 @@ Under the **General** accordion, you can set the value in the string format. Now
 |:----------- |:----------- | 
 | Text color |  You can change the background color of the text by entering the Hex color code or choosing a color of your choice from the color picker. |
 | Text size | By default, the text size is set to 14. You can enter any value from 1-100 to set a custom text size. |
-| Underline | You can change the underline of the text in the following ways: **on-hover (default), never, always** |
+| Underline | You can change the underline of the text in the following ways: **on-hover (default), never, always**. |
 | Visibility | Toggle on or off to control the visibility of the component. You can programmatically change its value by clicking on the **fx** button next to it. If `{{false}}` the component will not visible after the app is deployed. By default, it's set to `{{true}}`. |
 
 :::info


### PR DESCRIPTION
Will close #11123

- Update ToolJet/docs/docs/widgets/link.md
- Update ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/link.md

Changes Made as per the issue
- Updated "Description" in Events table for on click and on hover events.
- Updated "Description" and "How to Access" columns for the click action in "Component Specific Actions (CSA)".
- Updated Layout table title and column names as well as the Description and Expected Value columns.