### PR TITLE
[docs]: Fix documentation for Tree Select Component

### DIFF
--- a/docs/docs/widgets/tree-select.md
+++ b/docs/docs/widgets/tree-select.md
@@ -5,9 +5,9 @@ title: Tree Select
 
 # Tree Select
 
-The **Tree Select** widget is a group checkboxes in a TreeView which can be expanded or collapsed.
+The **Tree Select** component is a group checkboxes in a TreeView which can be expanded or collapsed.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Properties
 
@@ -86,7 +86,7 @@ Similar to checked values, expanded values is an array of values passed to expan
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Events
 
@@ -94,15 +94,15 @@ Similar to checked values, expanded values is an array of values passed to expan
 Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
 :::
 
-| <div style={{ width:"100px"}}> Event </div>     | <div style={{ width:"100px"}}> Description </div> |
-|:----------- |:----------- | 
-| On change | On check event is triggered whenever the checkbox value is changed (checked or unchecked). |
-| On check | On check event is triggered whenever the checkbox value is checked. |
-| On uncheck | On uncheck event is triggered whenever the checkbox value is unchecked. |
+| <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div>                                          |
+| :------------------------------------------ | :----------------------------------------------------------------------------------------- |
+| On change                                   | On check event is triggered whenever the checkbox value is changed (checked or unchecked). |
+| On check                                    | On check event is triggered whenever the checkbox value is checked.                        |
+| On uncheck                                  | On uncheck event is triggered whenever the checkbox value is unchecked.                    |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -110,43 +110,45 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Exposed Variables
 
-| <div style={{ width:"100px"}}> Variables  </div>  | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div>|
-|:----------- |:----------- |:-------|
-| checked | This variable holds the value of all the checked items on the Tree Select component. | Access the value dynamically using JS: `{{components.treeselect1.checked[1]}}`|
-| expanded | This variable holds the value of expanded items on the Tree Select component.|  Access the value dynamically using JS: `{{components.treeselect1.expanded[0]}}`|
-| checkedPathArray | This variable holds the path of the checked items in different arrays. | Access the value dynamically using JS: `{{components.treeselect1.checkedPathArray[1][1]}}`|
-| checkedPathStrings | This variable holds the path of the checked items in strings separated by a dash(-).| Access the value dynamically using JS: `{{components.treeselect1.checkedPathStrings[2]}}`|
+| <div style={{ width:"100px"}}> Variables </div> | <div style={{ width:"135px"}}> Description </div>                                    | <div style={{ width:"135px"}}> How To Access </div>                                        |
+| :---------------------------------------------- | :----------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
+| checked                                         | This variable holds the value of all the checked items on the Tree Select component. | Access the value dynamically using JS: `{{components.treeselect1.checked[1]}}`             |
+| expanded                                        | This variable holds the value of expanded items on the Tree Select component.        | Access the value dynamically using JS: `{{components.treeselect1.expanded[0]}}`            |
+| checkedPathArray                                | This variable holds the path of the checked items in different arrays.               | Access the value dynamically using JS: `{{components.treeselect1.checkedPathArray[1][1]}}` |
+| checkedPathStrings                              | This variable holds the path of the checked items in strings separated by a dash(-). | Access the value dynamically using JS: `{{components.treeselect1.checkedPathStrings[2]}}`  |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Layout
 
-|  <div style={{ width:"100px"}}> Layout </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"135px"}}> Expected Value </div>|
-|:----- |:---------  |:------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div>                                                            |
+| :------------------------------------------- | :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- |
+| Show on desktop                              | Toggle on or off to display desktop view.         | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile                               | Toggle on or off to display mobile view.          | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
+
+---
 
 ## Styles
 
-|  <div style={{ width:"100px"}}> Style </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"100px"}}> Default Value </div>|
-|:----- |:---------  |:------------- |
-| Text color | Change the color of the text in the widget by providig the `Hex color code` or choosing a color from the picker. |  |
-| Checkbox color | Change the color of the toggle switch in the widget by providig the `Hex color code` or choosing a color from the picker. |  |
-| Visibility | This is to control the visibility of the widget. If `{{false}}` the widget will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`. |
-| Disable | This property only accepts boolean values. If set to `{{true}}`, the widget will be locked and becomes non-functional. | By default, its value is set to `{{false}}`. |
+| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                                                                                                                                   | <div style={{ width:"100px"}}> Default Value </div> |
+| :------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
+| Text color                                  | Change the color of the text in the component by providig the `Hex color code` or choosing a color from the picker.                                                                                 |                                                     |
+| Checkbox color                              | Change the color of the toggle switch in the component by providig the `Hex color code` or choosing a color from the picker.                                                                        |                                                     |
+| Visibility                                  | This is to control the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`.                 |
+| Disable                                     | This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional.                                                                           | By default, its value is set to `{{false}}`.        |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/docs/widgets/tree-select.md
+++ b/docs/docs/widgets/tree-select.md
@@ -7,7 +7,7 @@ title: Tree Select
 
 The **Tree Select** component is a group checkboxes in a TreeView which can be expanded or collapsed.
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
@@ -86,7 +86,7 @@ Similar to checked values, expanded values is an array of values passed to expan
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
 
@@ -102,7 +102,7 @@ Check [Action Reference](/docs/category/actions-reference) docs to get the detai
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -110,7 +110,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -123,7 +123,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
@@ -134,7 +134,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ---
 

--- a/docs/docs/widgets/tree-select.md
+++ b/docs/docs/widgets/tree-select.md
@@ -94,11 +94,11 @@ Similar to checked values, expanded values is an array of values passed to expan
 Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
 :::
 
-| <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div>                                          |
-| :------------------------------------------ | :----------------------------------------------------------------------------------------- |
-| On change                                   | On check event is triggered whenever the checkbox value is changed (checked or unchecked). |
-| On check                                    | On check event is triggered whenever the checkbox value is checked.                        |
-| On uncheck                                  | On uncheck event is triggered whenever the checkbox value is unchecked.                    |
+| <div style={{ width:"100px"}}> Event </div>     | <div style={{ width:"100px"}}> Description </div> |
+|:----------- |:----------- | 
+| On change | On check event is triggered whenever the checkbox value is changed (checked or unchecked). |
+| On check | On check event is triggered whenever the checkbox value is checked. |
+| On uncheck | On uncheck event is triggered whenever the checkbox value is unchecked. |
 
 </div>
 
@@ -114,12 +114,12 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 ## Exposed Variables
 
-| <div style={{ width:"100px"}}> Variables </div> | <div style={{ width:"135px"}}> Description </div>                                    | <div style={{ width:"135px"}}> How To Access </div>                                        |
-| :---------------------------------------------- | :----------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
-| checked                                         | This variable holds the value of all the checked items on the Tree Select component. | Access the value dynamically using JS: `{{components.treeselect1.checked[1]}}`             |
-| expanded                                        | This variable holds the value of expanded items on the Tree Select component.        | Access the value dynamically using JS: `{{components.treeselect1.expanded[0]}}`            |
-| checkedPathArray                                | This variable holds the path of the checked items in different arrays.               | Access the value dynamically using JS: `{{components.treeselect1.checkedPathArray[1][1]}}` |
-| checkedPathStrings                              | This variable holds the path of the checked items in strings separated by a dash(-). | Access the value dynamically using JS: `{{components.treeselect1.checkedPathStrings[2]}}`  |
+| <div style={{ width:"100px"}}> Variables  </div>  | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div>|
+|:----------- |:----------- |:-------|
+| checked | This variable holds the value of all the checked items on the Tree Select component. | Access the value dynamically using JS: `{{components.treeselect1.checked[1]}}`|
+| expanded | This variable holds the value of expanded items on the Tree Select component.|  Access the value dynamically using JS: `{{components.treeselect1.expanded[0]}}`|
+| checkedPathArray | This variable holds the path of the checked items in different arrays. | Access the value dynamically using JS: `{{components.treeselect1.checkedPathArray[1][1]}}`|
+| checkedPathStrings | This variable holds the path of the checked items in strings separated by a dash(-).| Access the value dynamically using JS: `{{components.treeselect1.checkedPathStrings[2]}}`|
 
 </div>
 
@@ -127,10 +127,10 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 ## Layout
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div>                                                            |
-| :------------------------------------------- | :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- |
-| Show on desktop                              | Toggle on or off to display desktop view.         | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
-| Show on mobile                               | Toggle on or off to display mobile view.          | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+|  <div style={{ width:"100px"}}> Layout </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"135px"}}> Expected Value </div>|
+|:----- |:---------  |:------------- |
+| Show on desktop  | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile | Toggle on or off to display mobile view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
@@ -140,12 +140,12 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 ## Styles
 
-| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                                                                                                                                   | <div style={{ width:"100px"}}> Default Value </div> |
-| :------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
-| Text color                                  | Change the color of the text in the component by providig the `Hex color code` or choosing a color from the picker.                                                                                 |                                                     |
-| Checkbox color                              | Change the color of the toggle switch in the component by providig the `Hex color code` or choosing a color from the picker.                                                                        |                                                     |
-| Visibility                                  | This is to control the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`.                 |
-| Disable                                     | This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional.                                                                           | By default, its value is set to `{{false}}`.        |
+|  <div style={{ width:"100px"}}> Style </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"100px"}}> Default Value </div>|
+|:----- |:---------  |:------------- |
+| Text color  | Change the color of the text in the component by providig the `Hex color code` or choosing a color from the picker. |     |
+| Checkbox color | Change the color of the toggle switch in the component by providig the `Hex color code` or choosing a color from the picker. |   |
+| Visibility  | This is to control the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`.  |
+| Disable   | This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional.  | By default, its value is set to `{{false}}`.|
 
 :::info
 Any property having **fx** button next to its field can be **programmatically configured**.

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/tree-select.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/tree-select.md
@@ -5,9 +5,9 @@ title: Tree Select
 
 # Tree Select
 
-The **Tree Select** widget is a group checkboxes in a TreeView which can be expanded or collapsed.
+The **Tree Select** component is a group checkboxes in a TreeView which can be expanded or collapsed.
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Properties
 
@@ -86,7 +86,7 @@ Similar to checked values, expanded values is an array of values passed to expan
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Events
 
@@ -94,15 +94,15 @@ Similar to checked values, expanded values is an array of values passed to expan
 Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
 :::
 
-| <div style={{ width:"100px"}}> Event </div>     | <div style={{ width:"100px"}}> Description </div> |
-|:----------- |:----------- | 
-| On change | On check event is triggered whenever the checkbox value is changed (checked or unchecked). |
-| On check | On check event is triggered whenever the checkbox value is checked. |
-| On uncheck | On uncheck event is triggered whenever the checkbox value is unchecked. |
+| <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div>                                          |
+| :------------------------------------------ | :----------------------------------------------------------------------------------------- |
+| On change                                   | On check event is triggered whenever the checkbox value is changed (checked or unchecked). |
+| On check                                    | On check event is triggered whenever the checkbox value is checked.                        |
+| On uncheck                                  | On uncheck event is triggered whenever the checkbox value is unchecked.                    |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -110,43 +110,45 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Exposed Variables
 
-| <div style={{ width:"100px"}}> Variables  </div>  | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div>|
-|:----------- |:----------- |:-------|
-| checked | This variable holds the value of all the checked items on the Tree Select component. | Access the value dynamically using JS: `{{components.treeselect1.checked[1]}}`|
-| expanded | This variable holds the value of expanded items on the Tree Select component.|  Access the value dynamically using JS: `{{components.treeselect1.expanded[0]}}`|
-| checkedPathArray | This variable holds the path of the checked items in different arrays. | Access the value dynamically using JS: `{{components.treeselect1.checkedPathArray[1][1]}}`|
-| checkedPathStrings | This variable holds the path of the checked items in strings separated by a dash(-).| Access the value dynamically using JS: `{{components.treeselect1.checkedPathStrings[2]}}`|
+| <div style={{ width:"100px"}}> Variables </div> | <div style={{ width:"135px"}}> Description </div>                                    | <div style={{ width:"135px"}}> How To Access </div>                                        |
+| :---------------------------------------------- | :----------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
+| checked                                         | This variable holds the value of all the checked items on the Tree Select component. | Access the value dynamically using JS: `{{components.treeselect1.checked[1]}}`             |
+| expanded                                        | This variable holds the value of expanded items on the Tree Select component.        | Access the value dynamically using JS: `{{components.treeselect1.expanded[0]}}`            |
+| checkedPathArray                                | This variable holds the path of the checked items in different arrays.               | Access the value dynamically using JS: `{{components.treeselect1.checkedPathArray[1][1]}}` |
+| checkedPathStrings                              | This variable holds the path of the checked items in strings separated by a dash(-). | Access the value dynamically using JS: `{{components.treeselect1.checkedPathStrings[2]}}`  |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
 
 ## Layout
 
-|  <div style={{ width:"100px"}}> Layout </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"135px"}}> Expected Value </div>|
-|:----- |:---------  |:------------- |
-| Show on desktop | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
-| Show on mobile  | Toggle on or off to display mobile view.  | You can programmatically determining the value by clicking on `Fx` to set the value `{{true}}` or `{{false}}` |
+| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div>                                                            |
+| :------------------------------------------- | :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- |
+| Show on desktop                              | Toggle on or off to display desktop view.         | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile                               | Toggle on or off to display mobile view.          | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
+<div style={{padding-top:'24px'}}>
+
+---
 
 ## Styles
 
-|  <div style={{ width:"100px"}}> Style </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"100px"}}> Default Value </div>|
-|:----- |:---------  |:------------- |
-| Text color | Change the color of the text in the widget by providig the `Hex color code` or choosing a color from the picker. |  |
-| Checkbox color | Change the color of the toggle switch in the widget by providig the `Hex color code` or choosing a color from the picker. |  |
-| Visibility | This is to control the visibility of the widget. If `{{false}}` the widget will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`. |
-| Disable | This property only accepts boolean values. If set to `{{true}}`, the widget will be locked and becomes non-functional. | By default, its value is set to `{{false}}`. |
+| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                                                                                                                                   | <div style={{ width:"100px"}}> Default Value </div> |
+| :------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
+| Text color                                  | Change the color of the text in the component by providig the `Hex color code` or choosing a color from the picker.                                                                                 |                                                     |
+| Checkbox color                              | Change the color of the toggle switch in the component by providig the `Hex color code` or choosing a color from the picker.                                                                        |                                                     |
+| Visibility                                  | This is to control the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`.                 |
+| Disable                                     | This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional.                                                                           | By default, its value is set to `{{false}}`.        |
 
 :::info
-Any property having `Fx` button next to its field can be **programmatically configured**.
+Any property having **fx** button next to its field can be **programmatically configured**.
 :::
 
 </div>

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/tree-select.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/tree-select.md
@@ -7,7 +7,7 @@ title: Tree Select
 
 The **Tree Select** component is a group checkboxes in a TreeView which can be expanded or collapsed.
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Properties
 
@@ -86,7 +86,7 @@ Similar to checked values, expanded values is an array of values passed to expan
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Events
 
@@ -102,7 +102,7 @@ Check [Action Reference](/docs/category/actions-reference) docs to get the detai
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Component Specific Actions (CSA)
 
@@ -110,7 +110,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Exposed Variables
 
@@ -123,7 +123,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ## Layout
 
@@ -134,7 +134,7 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 </div>
 
-<div style={{padding-top:'24px'}}>
+<div style={{paddingTop:'24px'}}>
 
 ---
 

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/tree-select.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/tree-select.md
@@ -94,11 +94,11 @@ Similar to checked values, expanded values is an array of values passed to expan
 Check [Action Reference](/docs/category/actions-reference) docs to get the detailed information about all the **Actions**.
 :::
 
-| <div style={{ width:"100px"}}> Event </div> | <div style={{ width:"100px"}}> Description </div>                                          |
-| :------------------------------------------ | :----------------------------------------------------------------------------------------- |
-| On change                                   | On check event is triggered whenever the checkbox value is changed (checked or unchecked). |
-| On check                                    | On check event is triggered whenever the checkbox value is checked.                        |
-| On uncheck                                  | On uncheck event is triggered whenever the checkbox value is unchecked.                    |
+| <div style={{ width:"100px"}}> Event </div>     | <div style={{ width:"100px"}}> Description </div> |
+|:----------- |:----------- | 
+| On change | On check event is triggered whenever the checkbox value is changed (checked or unchecked). |
+| On check | On check event is triggered whenever the checkbox value is checked. |
+| On uncheck | On uncheck event is triggered whenever the checkbox value is unchecked. |
 
 </div>
 
@@ -114,12 +114,12 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 ## Exposed Variables
 
-| <div style={{ width:"100px"}}> Variables </div> | <div style={{ width:"135px"}}> Description </div>                                    | <div style={{ width:"135px"}}> How To Access </div>                                        |
-| :---------------------------------------------- | :----------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
-| checked                                         | This variable holds the value of all the checked items on the Tree Select component. | Access the value dynamically using JS: `{{components.treeselect1.checked[1]}}`             |
-| expanded                                        | This variable holds the value of expanded items on the Tree Select component.        | Access the value dynamically using JS: `{{components.treeselect1.expanded[0]}}`            |
-| checkedPathArray                                | This variable holds the path of the checked items in different arrays.               | Access the value dynamically using JS: `{{components.treeselect1.checkedPathArray[1][1]}}` |
-| checkedPathStrings                              | This variable holds the path of the checked items in strings separated by a dash(-). | Access the value dynamically using JS: `{{components.treeselect1.checkedPathStrings[2]}}`  |
+| <div style={{ width:"100px"}}> Variables  </div>  | <div style={{ width:"135px"}}> Description </div> | <div style={{ width:"135px"}}> How To Access </div>|
+|:----------- |:----------- |:-------|
+| checked | This variable holds the value of all the checked items on the Tree Select component. | Access the value dynamically using JS: `{{components.treeselect1.checked[1]}}`|
+| expanded | This variable holds the value of expanded items on the Tree Select component.|  Access the value dynamically using JS: `{{components.treeselect1.expanded[0]}}`|
+| checkedPathArray | This variable holds the path of the checked items in different arrays. | Access the value dynamically using JS: `{{components.treeselect1.checkedPathArray[1][1]}}`|
+| checkedPathStrings | This variable holds the path of the checked items in strings separated by a dash(-).| Access the value dynamically using JS: `{{components.treeselect1.checkedPathStrings[2]}}`|
 
 </div>
 
@@ -127,10 +127,10 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 ## Layout
 
-| <div style={{ width:"100px"}}> Layout </div> | <div style={{ width:"100px"}}> Description </div> | <div style={{ width:"135px"}}> Expected Value </div>                                                            |
-| :------------------------------------------- | :------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------- |
-| Show on desktop                              | Toggle on or off to display desktop view.         | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
-| Show on mobile                               | Toggle on or off to display mobile view.          | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+|  <div style={{ width:"100px"}}> Layout </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"135px"}}> Expected Value </div>|
+|:----- |:---------  |:------------- |
+| Show on desktop  | Toggle on or off to display desktop view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
+| Show on mobile | Toggle on or off to display mobile view. | You can programmatically determining the value by clicking on **fx** to set the value `{{true}}` or `{{false}}` |
 
 </div>
 
@@ -140,12 +140,12 @@ There are currently no CSA (Component-Specific Actions) implemented to regulate 
 
 ## Styles
 
-| <div style={{ width:"100px"}}> Style </div> | <div style={{ width:"100px"}}> Description </div>                                                                                                                                                   | <div style={{ width:"100px"}}> Default Value </div> |
-| :------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------- |
-| Text color                                  | Change the color of the text in the component by providig the `Hex color code` or choosing a color from the picker.                                                                                 |                                                     |
-| Checkbox color                              | Change the color of the toggle switch in the component by providig the `Hex color code` or choosing a color from the picker.                                                                        |                                                     |
-| Visibility                                  | This is to control the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`.                 |
-| Disable                                     | This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional.                                                                           | By default, its value is set to `{{false}}`.        |
+|  <div style={{ width:"100px"}}> Style </div> |  <div style={{ width:"100px"}}> Description </div> |  <div style={{ width:"100px"}}> Default Value </div>|
+|:----- |:---------  |:------------- |
+| Text color  | Change the color of the text in the component by providig the `Hex color code` or choosing a color from the picker. |     |
+| Checkbox color | Change the color of the toggle switch in the component by providig the `Hex color code` or choosing a color from the picker. |   |
+| Visibility  | This is to control the visibility of the component. If `{{false}}` the component will not visible after the app is deployed. It can only have boolean values i.e. either `{{true}}` or `{{false}}`. | By default, it's set to `{{true}}`.  |
+| Disable   | This property only accepts boolean values. If set to `{{true}}`, the component will be locked and becomes non-functional.  | By default, its value is set to `{{false}}`.|
 
 :::info
 Any property having **fx** button next to its field can be **programmatically configured**.


### PR DESCRIPTION
**Description**

1. Formatting Updates:

- Replaced "Fx" with fx (lowercase, bold) throughout the documentation.
- Removed padding-bottom: 24px from the div elements wrapping h2 headers; retained padding-top: 24px.

2. Content Updates:

- Replaced the term "widget" with "component" where applicable (URLs remain unchanged).
- Added a divider before the "Styles" section.

3. Files Updated:

- Next - ToolJet/docs/docs/widgets/tree-select.md
- Version 2.50.0 (LTS) - ToolJet/docs/versioned_docs/version-2.50.0-LTS/widgets/tree-select.md

will close #11058




