### PR TITLE
chore: Exposes CSAs for Container widget

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/DefaultComponent.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/DefaultComponent.jsx
@@ -12,6 +12,7 @@ import { shallow } from 'zustand/shallow';
 
 const SHOW_ADDITIONAL_ACTIONS = [
   'Text',
+  'Container',
   'TextInput',
   'NumberInput',
   'PasswordInput',

--- a/frontend/src/AppBuilder/WidgetManager/widgets/container.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/container.js
@@ -20,6 +20,22 @@ export const containerConfig = {
         defaultValue: false,
       },
     },
+    visibility: {
+      type: 'toggle',
+      displayName: 'Visibility',
+      validation: {
+        schema: { type: 'boolean' },
+        defaultValue: true,
+      },
+    },
+    disabledState: {
+      type: 'toggle',
+      displayName: 'Disable',
+      validation: {
+        schema: { type: 'boolean' },
+      },
+      defaultValue: false,
+    },
   },
   events: {},
   styles: {
@@ -50,24 +66,29 @@ export const containerConfig = {
         defaultValue: '#fff',
       },
     },
-    visibility: {
-      type: 'toggle',
-      displayName: 'Visibility',
-      validation: {
-        schema: { type: 'boolean' },
-        defaultValue: true,
-      },
-    },
-    disabledState: {
-      type: 'toggle',
-      displayName: 'Disable',
-      validation: {
-        schema: { type: 'boolean' },
-      },
-      defaultValue: false,
-    },
   },
-  exposedVariables: {},
+  exposedVariables: {
+    isVisible: true,
+    isDisabled: false,
+    isLoading: false,
+  },
+  actions: [
+    {
+      handle: 'setVisibility',
+      displayName: 'Set visibility',
+      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+    {
+      handle: 'setDisable',
+      displayName: 'Set disable',
+      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+    {
+      handle: 'setLoading',
+      displayName: 'Set loading',
+      params: [{ handle: 'loading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+  ],
   definition: {
     others: {
       showOnDesktop: { value: '{{true}}' },
@@ -76,14 +97,14 @@ export const containerConfig = {
     properties: {
       visible: { value: '{{true}}' },
       loadingState: { value: `{{false}}` },
+      visibility: { value: '{{true}}' },
+      disabledState: { value: '{{false}}' },
     },
     events: [],
     styles: {
       backgroundColor: { value: '#fff' },
       borderRadius: { value: '4' },
       borderColor: { value: '#fff' },
-      visibility: { value: '{{true}}' },
-      disabledState: { value: '{{false}}' },
     },
   },
 };

--- a/frontend/src/AppBuilder/WidgetManager/widgets/container.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/container.js
@@ -84,12 +84,12 @@ export const containerConfig = {
     {
       handle: 'setDisable',
       displayName: 'Set disable',
-      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+      params: [{ handle: 'setDisable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
     },
     {
       handle: 'setLoading',
       displayName: 'Set loading',
-      params: [{ handle: 'loading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+      params: [{ handle: 'setLoading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
     },
   ],
   definition: {

--- a/frontend/src/AppBuilder/WidgetManager/widgets/container.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/container.js
@@ -15,6 +15,7 @@ export const containerConfig = {
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
+      section: 'additionalActions',
       validation: {
         schema: { type: 'boolean' },
         defaultValue: false,
@@ -23,6 +24,7 @@ export const containerConfig = {
     visibility: {
       type: 'toggle',
       displayName: 'Visibility',
+      section: 'additionalActions',
       validation: {
         schema: { type: 'boolean' },
         defaultValue: true,
@@ -31,10 +33,11 @@ export const containerConfig = {
     disabledState: {
       type: 'toggle',
       displayName: 'Disable',
+      section: 'additionalActions',
       validation: {
         schema: { type: 'boolean' },
+        defaultValue: false,
       },
-      defaultValue: false,
     },
   },
   events: {},
@@ -95,7 +98,6 @@ export const containerConfig = {
       showOnMobile: { value: '{{false}}' },
     },
     properties: {
-      visible: { value: '{{true}}' },
       loadingState: { value: `{{false}}` },
       visibility: { value: '{{true}}' },
       disabledState: { value: '{{false}}' },

--- a/frontend/src/AppBuilder/Widgets/Container.jsx
+++ b/frontend/src/AppBuilder/Widgets/Container.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { Container as ContainerComponent } from '@/AppBuilder/AppCanvas/Container';
 import Spinner from '@/_ui/Spinner';
 import { useExposeState } from '@/AppBuilder/_hooks/useExposeVariables';
@@ -13,16 +13,12 @@ export const Container = ({
   setExposedVariables,
   setExposedVariable,
 }) => {
-  const renderCount = useRef(0);
-  renderCount.current += 1;
-
-  console.log(`Container has re-rendered ${renderCount.current} times`);
-  const { disabledState, borderRadius, borderColor, boxShadow } = styles;
+  const { borderRadius, borderColor, boxShadow } = styles;
 
   const { isDisabled, isVisible, isLoading } = useExposeState(
     properties.loadingState,
-    properties.visible,
-    disabledState,
+    properties.visibility,
+    properties.disabledState,
     setExposedVariables,
     setExposedVariable
   );

--- a/frontend/src/AppBuilder/Widgets/Container.jsx
+++ b/frontend/src/AppBuilder/Widgets/Container.jsx
@@ -1,9 +1,88 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { Container as ContainerComponent } from '@/AppBuilder/AppCanvas/Container';
 import Spinner from '@/_ui/Spinner';
 
-export const Container = ({ id, properties, styles, darkMode, height, width }) => {
-  const { visibility, disabledState, borderRadius, borderColor, boxShadow } = styles;
+export const Container = ({
+  id,
+  properties,
+  styles,
+  darkMode,
+  height,
+  width,
+  setExposedVariables,
+  setExposedVariable,
+}) => {
+  const { disabledState, borderRadius, borderColor, boxShadow } = styles;
+
+  const [isDisabled, setDisable] = useState(disabledState || properties.loadingState);
+  const [isVisible, setVisibility] = useState(properties.visible);
+  const [isLoading, setLoading] = useState(properties.loadingState);
+
+  useEffect(() => {
+    isDisabled !== disabledState && setDisable(disabledState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disabledState]);
+
+  useEffect(() => {
+    isVisible !== properties.visible && setVisibility(properties.visible);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [properties.visible]);
+
+  useEffect(() => {
+    isLoading !== properties.loadingState && setLoading(properties.loadingState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [properties.loadingState]);
+
+  const exposedVariables = {
+    setDisable: async (value) => setDisable(value),
+    setVisibility: async (value) => setVisibility(value),
+    setLoading: async (value) => setLoading(value),
+  };
+
+  useEffect(() => {
+    setExposedVariables(exposedVariables);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDisabled]);
+
+  useEffect(() => {
+    setExposedVariable('setLoading', async function (loading) {
+      setLoading(loading);
+      setExposedVariable('isLoading', loading);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [properties.loadingState]);
+
+  useEffect(() => {
+    setExposedVariable('setVisibility', async function (state) {
+      setVisibility(state);
+      setExposedVariable('isVisible', state);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [properties.visible]);
+
+  useEffect(() => {
+    setExposedVariable('setDisable', async function (disable) {
+      setDisable(disable);
+      setExposedVariable('isDisabled', disable);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disabledState]);
+
+  useEffect(() => {
+    setExposedVariable('isLoading', isLoading);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading]);
+
+  useEffect(() => {
+    setExposedVariable('isVisible', isVisible);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isVisible]);
+
+  useEffect(() => {
+    setExposedVariable('isDisabled', isDisabled);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDisabled]);
+
   const bgColor = useMemo(() => {
     return {
       backgroundColor:
@@ -16,19 +95,19 @@ export const Container = ({ id, properties, styles, darkMode, height, width }) =
     borderRadius: borderRadius ? parseFloat(borderRadius) : 0,
     border: `1px solid ${borderColor}`,
     height,
-    display: visibility ? 'flex' : 'none',
+    display: isVisible ? 'flex' : 'none',
     overflow: 'hidden auto',
     position: 'relative',
     boxShadow,
   };
   return (
     <div
-      className={`jet-container ${properties.loadingState && 'jet-container-loading'}`}
+      className={`jet-container ${isLoading && 'jet-container-loading'}`}
       id={id}
-      data-disabled={disabledState}
+      data-disabled={isDisabled}
       style={computedStyles}
     >
-      {properties.loadingState ? (
+      {isLoading ? (
         <Spinner />
       ) : (
         <ContainerComponent id={id} styles={bgColor} canvasHeight={height} canvasWidth={width} darkMode={darkMode} />

--- a/frontend/src/AppBuilder/Widgets/Container.jsx
+++ b/frontend/src/AppBuilder/Widgets/Container.jsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { Container as ContainerComponent } from '@/AppBuilder/AppCanvas/Container';
 import Spinner from '@/_ui/Spinner';
+import { useExposeState } from '@/AppBuilder/_hooks/useExposeVariables';
 
 export const Container = ({
   id,
@@ -12,76 +13,19 @@ export const Container = ({
   setExposedVariables,
   setExposedVariable,
 }) => {
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+
+  console.log(`Container has re-rendered ${renderCount.current} times`);
   const { disabledState, borderRadius, borderColor, boxShadow } = styles;
 
-  const [isDisabled, setDisable] = useState(disabledState || properties.loadingState);
-  const [isVisible, setVisibility] = useState(properties.visible);
-  const [isLoading, setLoading] = useState(properties.loadingState);
-
-  useEffect(() => {
-    isDisabled !== disabledState && setDisable(disabledState);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [disabledState]);
-
-  useEffect(() => {
-    isVisible !== properties.visible && setVisibility(properties.visible);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [properties.visible]);
-
-  useEffect(() => {
-    isLoading !== properties.loadingState && setLoading(properties.loadingState);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [properties.loadingState]);
-
-  const exposedVariables = {
-    setDisable: async (value) => setDisable(value),
-    setVisibility: async (value) => setVisibility(value),
-    setLoading: async (value) => setLoading(value),
-  };
-
-  useEffect(() => {
-    setExposedVariables(exposedVariables);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDisabled]);
-
-  useEffect(() => {
-    setExposedVariable('setLoading', async function (loading) {
-      setLoading(loading);
-      setExposedVariable('isLoading', loading);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [properties.loadingState]);
-
-  useEffect(() => {
-    setExposedVariable('setVisibility', async function (state) {
-      setVisibility(state);
-      setExposedVariable('isVisible', state);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [properties.visible]);
-
-  useEffect(() => {
-    setExposedVariable('setDisable', async function (disable) {
-      setDisable(disable);
-      setExposedVariable('isDisabled', disable);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [disabledState]);
-
-  useEffect(() => {
-    setExposedVariable('isLoading', isLoading);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading]);
-
-  useEffect(() => {
-    setExposedVariable('isVisible', isVisible);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isVisible]);
-
-  useEffect(() => {
-    setExposedVariable('isDisabled', isDisabled);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDisabled]);
+  const { isDisabled, isVisible, isLoading } = useExposeState(
+    properties.loadingState,
+    properties.visible,
+    disabledState,
+    setExposedVariables,
+    setExposedVariable
+  );
 
   const bgColor = useMemo(() => {
     return {

--- a/frontend/src/AppBuilder/_hooks/useExposeVariables.js
+++ b/frontend/src/AppBuilder/_hooks/useExposeVariables.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 
 export const useExposeState = (loadingState, visibleState, disabledState, setExposedVariables, setExposedVariable) => {
-  const [isDisabled, setDisable] = useState(loadingState || disabledState);
+  const [isDisabled, setDisable] = useState(disabledState || false);
   const [isVisible, setVisibility] = useState(visibleState || true);
   const [isLoading, setLoading] = useState(loadingState || false);
 

--- a/frontend/src/AppBuilder/_hooks/useExposeVariables.js
+++ b/frontend/src/AppBuilder/_hooks/useExposeVariables.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 
 export const useExposeState = (loadingState, visibleState, disabledState, setExposedVariables, setExposedVariable) => {
   const [isDisabled, setDisable] = useState(disabledState || false);

--- a/frontend/src/AppBuilder/_hooks/useExposeVariables.js
+++ b/frontend/src/AppBuilder/_hooks/useExposeVariables.js
@@ -5,95 +5,47 @@ export const useExposeState = (loadingState, visibleState, disabledState, setExp
   const [isVisible, setVisibility] = useState(visibleState || true);
   const [isLoading, setLoading] = useState(loadingState || false);
 
-  // Wrapping state update functions with useCallback prevent rerenders
-  const setDisableIfChangedWithSideEffect = useCallback(
-    (newValue) => {
-      setDisable((prev) => {
-        if (prev !== newValue) {
-          setExposedVariable('isDisabled', newValue);
-          return newValue;
-        }
-        return prev;
-      });
-    },
-    [setExposedVariable]
-  );
-
-  const setVisibilityIfChangedWithSideEffect = useCallback(
-    (newValue) => {
-      setVisibility((prev) => {
-        if (prev !== newValue) {
-          setExposedVariable('isVisible', newValue);
-          return newValue;
-        }
-        return prev;
-      });
-    },
-    [setExposedVariable]
-  );
-
-  const setLoadingIfChangedWithSideEffect = useCallback(
-    (newValue) => {
-      setLoading((prev) => {
-        if (prev !== newValue) {
-          setExposedVariable('isLoading', newValue);
-          return newValue;
-        }
-        return prev;
-      });
-    },
-    [setExposedVariable]
-  );
-
-  // Effect to conditionally update states with side effects
+  // Effect to conditionally update state from properties passed to widget
   useEffect(() => {
     setDisable(disabledState);
-    setExposedVariable('isDisabled', disabledState);
-  }, [disabledState, setDisable, setExposedVariable]);
+  }, [disabledState]);
 
   useEffect(() => {
     setVisibility(visibleState);
-    setExposedVariable('isVisible', visibleState);
-  }, [visibleState, setVisibility, setExposedVariable]);
+  }, [visibleState]);
 
   useEffect(() => {
     setLoading(loadingState);
-    setExposedVariable('isLoading', loadingState);
-  }, [loadingState, setLoading, setExposedVariable]);
+  }, [loadingState]);
 
-  useEffect(() => {
-    setDisableIfChangedWithSideEffect(disabledState);
-    setVisibilityIfChangedWithSideEffect(visibleState);
-    setLoadingIfChangedWithSideEffect(loadingState);
-  }, [
-    loadingState,
-    visibleState,
-    disabledState,
-    setDisableIfChangedWithSideEffect,
-    setVisibilityIfChangedWithSideEffect,
-    setLoadingIfChangedWithSideEffect,
-  ]);
-
-  // exposed variables with state and async setters
+  // exposed variables with state and async setters, happens on first time load
   useEffect(() => {
     setExposedVariables({
-      setDisable: async (value) => setDisableIfChangedWithSideEffect(value),
-      setVisibility: async (value) => setVisibilityIfChangedWithSideEffect(value),
-      setLoading: async (value) => setLoadingIfChangedWithSideEffect(value),
+      setDisable: async (value) => setDisable(value),
+      setVisibility: async (value) => setVisibility(value),
+      setLoading: async (value) => setLoading(value),
     });
-  }, [
-    setExposedVariables,
-    setDisableIfChangedWithSideEffect,
-    setVisibilityIfChangedWithSideEffect,
-    setLoadingIfChangedWithSideEffect,
-  ]);
+  }, [setExposedVariables]);
+
+  //Side effect to state variables, these will run after the state is set and the values will be exposed
+  useEffect(() => {
+    setExposedVariable('isDisabled', isDisabled);
+  }, [isDisabled, setExposedVariable]);
+
+  useEffect(() => {
+    setExposedVariable('isVisible', isVisible);
+  }, [isVisible, setExposedVariable]);
+
+  useEffect(() => {
+    setExposedVariable('isLoading', isLoading);
+  }, [isLoading, setExposedVariable]);
 
   return {
     isDisabled,
-    setDisable: setDisableIfChangedWithSideEffect,
+    setDisable,
     isVisible,
-    setVisibility: setVisibilityIfChangedWithSideEffect,
+    setVisibility,
     isLoading,
-    setLoading: setLoadingIfChangedWithSideEffect,
+    setLoading,
   };
 };

--- a/frontend/src/AppBuilder/_hooks/useExposeVariables.js
+++ b/frontend/src/AppBuilder/_hooks/useExposeVariables.js
@@ -1,0 +1,99 @@
+import { useEffect, useState, useCallback } from 'react';
+
+export const useExposeState = (loadingState, visibleState, disabledState, setExposedVariables, setExposedVariable) => {
+  const [isDisabled, setDisable] = useState(loadingState || disabledState);
+  const [isVisible, setVisibility] = useState(visibleState || true);
+  const [isLoading, setLoading] = useState(loadingState || false);
+
+  // Wrapping state update functions with useCallback prevent rerenders
+  const setDisableIfChangedWithSideEffect = useCallback(
+    (newValue) => {
+      setDisable((prev) => {
+        if (prev !== newValue) {
+          setExposedVariable('isDisabled', newValue);
+          return newValue;
+        }
+        return prev;
+      });
+    },
+    [setExposedVariable]
+  );
+
+  const setVisibilityIfChangedWithSideEffect = useCallback(
+    (newValue) => {
+      setVisibility((prev) => {
+        if (prev !== newValue) {
+          setExposedVariable('isVisible', newValue);
+          return newValue;
+        }
+        return prev;
+      });
+    },
+    [setExposedVariable]
+  );
+
+  const setLoadingIfChangedWithSideEffect = useCallback(
+    (newValue) => {
+      setLoading((prev) => {
+        if (prev !== newValue) {
+          setExposedVariable('isLoading', newValue);
+          return newValue;
+        }
+        return prev;
+      });
+    },
+    [setExposedVariable]
+  );
+
+  // Effect to conditionally update states with side effects
+  useEffect(() => {
+    setDisable(disabledState);
+    setExposedVariable('isDisabled', disabledState);
+  }, [disabledState, setDisable, setExposedVariable]);
+
+  useEffect(() => {
+    setVisibility(visibleState);
+    setExposedVariable('isVisible', visibleState);
+  }, [visibleState, setVisibility, setExposedVariable]);
+
+  useEffect(() => {
+    setLoading(loadingState);
+    setExposedVariable('isLoading', loadingState);
+  }, [loadingState, setLoading, setExposedVariable]);
+
+  useEffect(() => {
+    setDisableIfChangedWithSideEffect(disabledState);
+    setVisibilityIfChangedWithSideEffect(visibleState);
+    setLoadingIfChangedWithSideEffect(loadingState);
+  }, [
+    loadingState,
+    visibleState,
+    disabledState,
+    setDisableIfChangedWithSideEffect,
+    setVisibilityIfChangedWithSideEffect,
+    setLoadingIfChangedWithSideEffect,
+  ]);
+
+  // exposed variables with state and async setters
+  useEffect(() => {
+    setExposedVariables({
+      setDisable: async (value) => setDisableIfChangedWithSideEffect(value),
+      setVisibility: async (value) => setVisibilityIfChangedWithSideEffect(value),
+      setLoading: async (value) => setLoadingIfChangedWithSideEffect(value),
+    });
+  }, [
+    setExposedVariables,
+    setDisableIfChangedWithSideEffect,
+    setVisibilityIfChangedWithSideEffect,
+    setLoadingIfChangedWithSideEffect,
+  ]);
+
+  return {
+    isDisabled,
+    setDisable: setDisableIfChangedWithSideEffect,
+    isVisible,
+    setVisibility: setVisibilityIfChangedWithSideEffect,
+    isLoading,
+    setLoading: setLoadingIfChangedWithSideEffect,
+  };
+};

--- a/frontend/src/Editor/WidgetManager/configs/container.js
+++ b/frontend/src/Editor/WidgetManager/configs/container.js
@@ -79,17 +79,17 @@ export const containerConfig = {
     {
       handle: 'setVisibility',
       displayName: 'Set visibility',
-      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+      params: [{ handle: 'setVisibility', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
     },
     {
-      handle: 'setDisable',
+      handle: 'setLoading',
       displayName: 'Set disable',
-      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+      params: [{ handle: 'setLoading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
     },
     {
       handle: 'setLoading',
       displayName: 'Set loading',
-      params: [{ handle: 'loading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+      params: [{ handle: 'setLoading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
     },
   ],
   definition: {

--- a/frontend/src/Editor/WidgetManager/configs/container.js
+++ b/frontend/src/Editor/WidgetManager/configs/container.js
@@ -67,7 +67,28 @@ export const containerConfig = {
       defaultValue: false,
     },
   },
-  exposedVariables: {},
+  exposedVariables: {
+    isVisible: true,
+    isDisabled: false,
+    isLoading: false,
+  },
+  actions: [
+    {
+      handle: 'setVisibility',
+      displayName: 'Set visibility',
+      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+    {
+      handle: 'setDisable',
+      displayName: 'Set disable',
+      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+    {
+      handle: 'setLoading',
+      displayName: 'Set loading',
+      params: [{ handle: 'loading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+  ],
   definition: {
     others: {
       showOnDesktop: { value: '{{true}}' },

--- a/frontend/src/Editor/WidgetManager/configs/container.js
+++ b/frontend/src/Editor/WidgetManager/configs/container.js
@@ -15,6 +15,25 @@ export const containerConfig = {
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
+      section: 'additionalActions',
+      validation: {
+        schema: { type: 'boolean' },
+        defaultValue: false,
+      },
+    },
+    visibility: {
+      type: 'toggle',
+      displayName: 'Visibility',
+      section: 'additionalActions',
+      validation: {
+        schema: { type: 'boolean' },
+        defaultValue: true,
+      },
+    },
+    disabledState: {
+      type: 'toggle',
+      section: 'additionalActions',
+      displayName: 'Disable',
       validation: {
         schema: { type: 'boolean' },
         defaultValue: false,
@@ -50,22 +69,6 @@ export const containerConfig = {
         defaultValue: '#fff',
       },
     },
-    visibility: {
-      type: 'toggle',
-      displayName: 'Visibility',
-      validation: {
-        schema: { type: 'boolean' },
-        defaultValue: true,
-      },
-    },
-    disabledState: {
-      type: 'toggle',
-      displayName: 'Disable',
-      validation: {
-        schema: { type: 'boolean' },
-      },
-      defaultValue: false,
-    },
   },
   exposedVariables: {
     isVisible: true,
@@ -95,8 +98,9 @@ export const containerConfig = {
       showOnMobile: { value: '{{false}}' },
     },
     properties: {
-      visible: { value: '{{true}}' },
       loadingState: { value: `{{false}}` },
+      visibility: { value: '{{true}}' },
+      disabledState: { value: '{{false}}' },
     },
     events: [],
     styles: {

--- a/server/src/helpers/widget-config/container.js
+++ b/server/src/helpers/widget-config/container.js
@@ -20,6 +20,22 @@ export const containerConfig = {
         defaultValue: false,
       },
     },
+    visibility: {
+      type: 'toggle',
+      displayName: 'Visibility',
+      validation: {
+        schema: { type: 'boolean' },
+        defaultValue: true,
+      },
+    },
+    disabledState: {
+      type: 'toggle',
+      displayName: 'Disable',
+      validation: {
+        schema: { type: 'boolean' },
+      },
+      defaultValue: false,
+    },
   },
   events: {},
   styles: {
@@ -50,40 +66,44 @@ export const containerConfig = {
         defaultValue: '#fff',
       },
     },
-    visibility: {
-      type: 'toggle',
-      displayName: 'Visibility',
-      validation: {
-        schema: { type: 'boolean' },
-        defaultValue: true,
-      },
-    },
-    disabledState: {
-      type: 'toggle',
-      displayName: 'Disable',
-      validation: {
-        schema: { type: 'boolean' },
-      },
-      defaultValue: false,
-    },
   },
-  exposedVariables: {},
+  exposedVariables: {
+    isVisible: true,
+    isDisabled: false,
+    isLoading: false,
+  },
+  actions: [
+    {
+      handle: 'setVisibility',
+      displayName: 'Set visibility',
+      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+    {
+      handle: 'setDisable',
+      displayName: 'Set disable',
+      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+    {
+      handle: 'setLoading',
+      displayName: 'Set loading',
+      params: [{ handle: 'loading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+    },
+  ],
   definition: {
     others: {
       showOnDesktop: { value: '{{true}}' },
       showOnMobile: { value: '{{false}}' },
     },
     properties: {
-      visible: { value: '{{true}}' },
       loadingState: { value: `{{false}}` },
+      visibility: { value: '{{true}}' },
+      disabledState: { value: '{{false}}' },
     },
     events: [],
     styles: {
       backgroundColor: { value: '#fff' },
       borderRadius: { value: '4' },
       borderColor: { value: '#fff' },
-      visibility: { value: '{{true}}' },
-      disabledState: { value: '{{false}}' },
     },
   },
 };

--- a/server/src/helpers/widget-config/container.js
+++ b/server/src/helpers/widget-config/container.js
@@ -79,17 +79,17 @@ export const containerConfig = {
     {
       handle: 'setVisibility',
       displayName: 'Set visibility',
-      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+      params: [{ handle: 'setVisibility', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
     },
     {
       handle: 'setDisable',
       displayName: 'Set disable',
-      params: [{ handle: 'disable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+      params: [{ handle: 'setDisable', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
     },
     {
       handle: 'setLoading',
       displayName: 'Set loading',
-      params: [{ handle: 'loading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
+      params: [{ handle: 'setLoading', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],
     },
   ],
   definition: {

--- a/server/src/helpers/widget-config/container.js
+++ b/server/src/helpers/widget-config/container.js
@@ -15,6 +15,7 @@ export const containerConfig = {
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
+      section: 'additionalActions',
       validation: {
         schema: { type: 'boolean' },
         defaultValue: false,
@@ -23,6 +24,7 @@ export const containerConfig = {
     visibility: {
       type: 'toggle',
       displayName: 'Visibility',
+      section: 'additionalActions',
       validation: {
         schema: { type: 'boolean' },
         defaultValue: true,
@@ -31,10 +33,11 @@ export const containerConfig = {
     disabledState: {
       type: 'toggle',
       displayName: 'Disable',
+      section: 'additionalActions',
       validation: {
         schema: { type: 'boolean' },
+        defaultValue: false,
       },
-      defaultValue: false,
     },
   },
   events: {},


### PR DESCRIPTION
**Changes made**
- Added state variables to keep track of the loading, disabled and  visibility
- Publishes the attributes through setExposedVariable, setExposedVariables

<img width="643" alt="image" src="https://github.com/user-attachments/assets/42ae84e1-6b18-496b-b4c2-0639bb3efa5c">

Issue: #11147 

Note: Reset Container is not implemented 