### PR TITLE
[docs]: Fix relative links in documentation - 7

### DIFF
--- a/docs/docs/tooljet-concepts/access-values.md
+++ b/docs/docs/tooljet-concepts/access-values.md
@@ -4,7 +4,7 @@ title: Access Values
 ---
 
 
-In ToolJet, double curly braces `{{}}` can be used to retrieve data returned by queries, access values related to components and pass custom code. You can see the list of all accessible values in the **[Inspector](/docs/how-to/use-inspector/)** tab in the left sidebar. 
+In ToolJet, double curly braces `{{}}` can be used to retrieve data returned by queries, access values related to components and pass custom code. You can see the list of all accessible values in the **[Inspector](../how-to/use-inspector/)** tab in the left sidebar. 
 
 <div class="video-container">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/hMzkNaHMFr0?si=s5WeHv2hY6rBrvE_&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/docs/tooljet-concepts/actions.md
+++ b/docs/docs/tooljet-concepts/actions.md
@@ -24,8 +24,8 @@ ToolJet supports a variety of actions. For instance, Show alert action displays 
 
 ## Ways to Configure Actions
 
-Actions can be triggered in response to various events, such as button presses or successful query executions. To set up actions, you can establish a **[new event](/docs/tooljet-concepts/what-are-events/)** within the configuration settings of any component or query. Alternatively, for more dynamic interactions, you can utilize a **[RunJS query](/docs/how-to/run-actions-from-runjs/)**. This approach enables action triggering based on user interactions or even at designated time intervals.
+Actions can be triggered in response to various events, such as button presses or successful query executions. To set up actions, you can establish a **[new event](../tooljet-concepts/what-are-events/)** within the configuration settings of any component or query. Alternatively, for more dynamic interactions, you can utilize a **[RunJS query](../how-to/run-actions-from-runjs/)**. This approach enables action triggering based on user interactions or even at designated time intervals.
 
 </div>
 
-Checkout all the available actions under the **[Actions Reference](/docs/actions/show-alert)** dropdown for more information.
+Checkout all the available actions under the **[Actions Reference](../actions/show-alert)** dropdown for more information.

--- a/docs/docs/tooljet-concepts/component-specific-actions.md
+++ b/docs/docs/tooljet-concepts/component-specific-actions.md
@@ -9,4 +9,4 @@ Component Specific Actions are specialized actions that are unique to each compo
     <iframe width="560" height="315" src="https://www.youtube.com/embed/_x8-1UON3QY?si=9NUA1Y2eGV5x8Bg2&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-Read more about how you can utilize Component Specific Actions **[here](/docs/actions/control-component/)**.
+Read more about how you can utilize Component Specific Actions **[here](../actions/control-component/)**.

--- a/docs/docs/tooljet-concepts/components.md
+++ b/docs/docs/tooljet-concepts/components.md
@@ -37,7 +37,7 @@ In ToolJet, components can be easily connected to various data sources like data
 
 ## Custom Components
 
-ToolJet allows for the creation of custom components using React. This feature is invaluable for developers who require functionalities beyond the 45+ built-in components that ToolJet offers. To create a custom component, you can drag and drop a **[Custom Component](/docs/widgets/custom-component/)** on the canvas and configure its data and code. 
+ToolJet allows for the creation of custom components using React. This feature is invaluable for developers who require functionalities beyond the 45+ built-in components that ToolJet offers. To create a custom component, you can drag and drop a **[Custom Component](../widgets/custom-component/)** on the canvas and configure its data and code. 
 
 <div style={{textAlign: 'center'}}>
     <img className="screenshot-full" src="/img/tooljet-concepts/what-are-components/custom-components.png" alt="Custom Components" />
@@ -47,5 +47,5 @@ By incorporating custom React components, you can significantly extend the capab
 </div>
 
 
-To explore the full list of components in ToolJet, go through the **[Component Library](/docs/widgets/bounded-box)**.
+To explore the full list of components in ToolJet, go through the **[Component Library](../widgets/bounded-box)**.
 

--- a/docs/docs/tooljet-concepts/data-sources.md
+++ b/docs/docs/tooljet-concepts/data-sources.md
@@ -33,4 +33,4 @@ Adding a new data source is as easy as filling out a form; users can click on th
 
 </div>
 
-To see a full list of compatible data sources and their set up details, checkout the **[Datasource Catalog](/docs/data-sources/overview)**.
+To see a full list of compatible data sources and their set up details, checkout the **[Datasource Catalog](../data-sources/overview)**.

--- a/docs/docs/tooljet-concepts/inspector.md
+++ b/docs/docs/tooljet-concepts/inspector.md
@@ -22,4 +22,4 @@ The Inspector panel is divided into six main sections: **Queries, Components, Gl
 
 </div>
 
-To learn more about the Inspector option in the sidebar, go through this **[how-to](/docs/how-to/use-inspector)** guide. 
+To learn more about the Inspector option in the sidebar, go through this **[how-to](../how-to/use-inspector)** guide. 

--- a/docs/docs/tooljet-concepts/pages.md
+++ b/docs/docs/tooljet-concepts/pages.md
@@ -27,4 +27,4 @@ ToolJet's Pages panel also includes advanced features like Page Handle, which is
 
 </div>
 
-To understand each functionality associated with Pages, read this **[document](/docs/tutorial/pages/)**.
+To understand each functionality associated with Pages, read this **[document](../tutorial/pages/)**.

--- a/docs/docs/tooljet-concepts/permissions.md
+++ b/docs/docs/tooljet-concepts/permissions.md
@@ -24,4 +24,4 @@ To secure your applications in ToolJet, you can leverage Groups and Permissions.
 
 </div>
 
-Read more about managing users and groups **[here](/docs/tutorial/manage-users-groups/)**.
+Read more about managing users and groups **[here](../tutorial/manage-users-groups/)**.

--- a/docs/docs/tooljet-concepts/queries.md
+++ b/docs/docs/tooljet-concepts/queries.md
@@ -37,4 +37,4 @@ Queries run when triggered by app events, such as clicking a button. They can fe
 
 </div>
 
-Learn more about queries in this **[detailed guide](/docs/app-builder/query-panel/)** for Query Panel. 
+Learn more about queries in this **[detailed guide](../app-builder/query-panel/)** for Query Panel. 

--- a/docs/docs/tooljet-concepts/run-js.md
+++ b/docs/docs/tooljet-concepts/run-js.md
@@ -29,7 +29,7 @@ Run JavaScript code also supports advanced functionalities such as setting and u
 
 To learn more about Run JavaScript code, go through the below list of documents:
 
-- **[Use Axios in RunJS](/docs/how-to/use-axios-in-runjs/)**
-- **[Run Actions From RunJS](/docs/how-to/run-actions-from-runjs/)**
-- **[Import External Libraries Using RunJS](/docs/how-to/import-external-libraries-using-runjs/)**
-- **[Access a User's Location Using RunJS](/docs/how-to/access-users-location/)**
+- **[Use Axios in RunJS](../how-to/use-axios-in-runjs/)**
+- **[Run Actions From RunJS](../how-to/run-actions-from-runjs/)**
+- **[Import External Libraries Using RunJS](../how-to/import-external-libraries-using-runjs/)**
+- **[Access a User's Location Using RunJS](../how-to/access-users-location/)**

--- a/docs/docs/tooljet-concepts/styling-components.md
+++ b/docs/docs/tooljet-concepts/styling-components.md
@@ -27,7 +27,7 @@ By injecting **Custom CSS**, users can easily override default styles, offering 
 
 </div>
 
-Continue reading about Custom CSS **[here](/docs/app-builder/customstyles/)**.
+Continue reading about Custom CSS **[here](../app-builder/customstyles/)**.
 
 
 

--- a/docs/docs/tooljet-concepts/super-admin.md
+++ b/docs/docs/tooljet-concepts/super-admin.md
@@ -8,4 +8,4 @@ The Super Admin in ToolJet plays a critical role in managing the instance by hav
 ## Advanced Control and Customization
 Beyond regular management tasks, Super Admins can implement more intricate settings like white labeling, enabling multiplayer editing, and managing instance licenses. They also have the power to restrict personal workspace creation for users, ensuring tighter control over the workspace environment. These advanced capabilities underscore the Super Admin's pivotal role in overseeing the comprehensive management and customization of the ToolJet instance.
 
-Read more about super admins **[here](/docs/enterprise/superadmin/)**.
+Read more about super admins **[here](../enterprise/superadmin/)**.

--- a/docs/docs/tooljet-concepts/variables.md
+++ b/docs/docs/tooljet-concepts/variables.md
@@ -51,7 +51,7 @@ Together, these variable management functions and types provide a robust framewo
 
 To learn more about different types of variables and their usage, go through the below links:
 
-**[Setting and unsetting variables and page variables](/docs/how-to/run-actions-from-runjs)** <br/>
-**[Exposed variables](/docs/tooljet-concepts/exposed-variables)** <br/>
-**[Environment variables](/docs/setup/env-vars/)** <br/>
-**[Workspace variables](/docs/org-management/workspaces/workspace-variables/)**
+**[Setting and unsetting variables and page variables](../how-to/run-actions-from-runjs)** <br/>
+**[Exposed variables](../tooljet-concepts/exposed-variables)** <br/>
+**[Environment variables](../setup/env-vars/)** <br/>
+**[Workspace variables](../org-management/workspaces/workspace-variables/)**

--- a/docs/docs/tooljet-concepts/workspace-constants.md
+++ b/docs/docs/tooljet-concepts/workspace-constants.md
@@ -42,4 +42,4 @@ The syntax for using constants is straightforward:
 
 </div>
 
-For a deep-dive into workspace constants and secrets, including how to create and manage them, go through **[this](/docs/org-management/workspaces/workspace_constants/)** documentation.
+For a deep-dive into workspace constants and secrets, including how to create and manage them, go through **[this](../org-management/workspaces/workspace_constants/)** documentation.

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/access-values.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/access-values.md
@@ -4,7 +4,7 @@ title: Access Values
 ---
 
 
-In ToolJet, double curly braces `{{}}` can be used to retrieve data returned by queries, access values related to components and pass custom code. You can see the list of all accessible values in the **[Inspector](/docs/how-to/use-inspector/)** tab in the left sidebar. 
+In ToolJet, double curly braces `{{}}` can be used to retrieve data returned by queries, access values related to components and pass custom code. You can see the list of all accessible values in the **[Inspector](../how-to/use-inspector/)** tab in the left sidebar. 
 
 <div class="video-container">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/hMzkNaHMFr0?si=s5WeHv2hY6rBrvE_&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/actions.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/actions.md
@@ -24,8 +24,8 @@ ToolJet supports a variety of actions. For instance, Show alert action displays 
 
 ## Ways to Configure Actions
 
-Actions can be triggered in response to various events, such as button presses or successful query executions. To set up actions, you can establish a **[new event](/docs/tooljet-concepts/what-are-events/)** within the configuration settings of any component or query. Alternatively, for more dynamic interactions, you can utilize a **[RunJS query](/docs/how-to/run-actions-from-runjs/)**. This approach enables action triggering based on user interactions or even at designated time intervals.
+Actions can be triggered in response to various events, such as button presses or successful query executions. To set up actions, you can establish a **[new event](../tooljet-concepts/what-are-events/)** within the configuration settings of any component or query. Alternatively, for more dynamic interactions, you can utilize a **[RunJS query](../how-to/run-actions-from-runjs/)**. This approach enables action triggering based on user interactions or even at designated time intervals.
 
 </div>
 
-Checkout all the available actions under the **[Actions Reference](/docs/actions/show-alert)** dropdown for more information.
+Checkout all the available actions under the **[Actions Reference](../actions/show-alert)** dropdown for more information.

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/component-specific-actions.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/component-specific-actions.md
@@ -9,4 +9,4 @@ Component Specific Actions are specialized actions that are unique to each compo
     <iframe width="560" height="315" src="https://www.youtube.com/embed/_x8-1UON3QY?si=9NUA1Y2eGV5x8Bg2&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-Read more about how you can utilize Component Specific Actions **[here](/docs/actions/control-component/)**.
+Read more about how you can utilize Component Specific Actions **[here](../actions/control-component/)**.

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/components.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/components.md
@@ -38,7 +38,7 @@ In ToolJet, components can be easily connected to various data sources like data
 
 ## Custom Components
 
-ToolJet allows for the creation of custom components using React. This feature is invaluable for developers who require functionalities beyond the 45+ built-in components that ToolJet offers. To create a custom component, you can drag and drop a **[Custom Component](/docs/widgets/custom-component/)** on the canvas and configure its data and code. 
+ToolJet allows for the creation of custom components using React. This feature is invaluable for developers who require functionalities beyond the 45+ built-in components that ToolJet offers. To create a custom component, you can drag and drop a **[Custom Component](../widgets/custom-component/)** on the canvas and configure its data and code. 
 
 <div style={{textAlign: 'center'}}>
     <img className="screenshot-full" src="/img/tooljet-concepts/what-are-components/custom-components.png" alt="Custom Components" />
@@ -48,7 +48,7 @@ By incorporating custom React components, you can significantly extend the capab
 </div>
 
 
-To explore the full list of components in ToolJet, go through the **[Component Library](/docs/widgets/bounded-box)**.
+To explore the full list of components in ToolJet, go through the **[Component Library](../widgets/bounded-box)**.
 
 
 

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/data-sources.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/data-sources.md
@@ -33,7 +33,7 @@ Adding a new data source is as easy as filling out a form; users can click on th
 
 </div>
 
-To see a full list of compatible data sources and their set up details, checkout the **[Datasource Catalog](/docs/data-sources/overview)**.
+To see a full list of compatible data sources and their set up details, checkout the **[Datasource Catalog](../data-sources/overview)**.
 
 
 

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/inspector.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/inspector.md
@@ -20,4 +20,4 @@ The Inspector panel is divided into six main sections: **Queries, Components, Gl
 
 </div>
 
-To learn more about the Inspector option in the sidebar, go through this **[how-to](/docs/how-to/use-inspector)** guide. 
+To learn more about the Inspector option in the sidebar, go through this **[how-to](../how-to/use-inspector)** guide. 

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/pages.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/pages.md
@@ -27,4 +27,4 @@ ToolJet's Pages panel also includes advanced features like Page Handle, which is
 
 </div>
 
-To understand each functionality associated with Pages, read this **[document](/docs/tutorial/pages/)**.
+To understand each functionality associated with Pages, read this **[document](../tutorial/pages/)**.

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/permissions.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/permissions.md
@@ -23,4 +23,4 @@ To secure your applications in ToolJet, you can leverage Groups and Permissions.
 
 </div>
 
-Read more about managing users and groups **[here](/docs/tutorial/manage-users-groups/)**.
+Read more about managing users and groups **[here](../tutorial/manage-users-groups/)**.

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/queries.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/queries.md
@@ -37,4 +37,4 @@ Queries run when triggered by app events, such as clicking a button. They can fe
 
 </div>
 
-Learn more about queries in this **[detailed guide](/docs/app-builder/query-panel/)** for Query Panel. 
+Learn more about queries in this **[detailed guide](../app-builder/query-panel/)** for Query Panel. 

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/run-js.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/run-js.md
@@ -29,7 +29,7 @@ Run JavaScript code also supports advanced functionalities such as setting and u
 
 To learn more about Run JavaScript code, go through the below list of documents:
 
-- **[Use Axios in RunJS](/docs/how-to/use-axios-in-runjs/)**
-- **[Run Actions From RunJS](/docs/how-to/run-actions-from-runjs/)**
-- **[Import External Libraries Using RunJS](/docs/how-to/import-external-libraries-using-runjs/)**
-- **[Access a User's Location Using RunJS](/docs/how-to/access-users-location/)**
+- **[Use Axios in RunJS](../how-to/use-axios-in-runjs/)**
+- **[Run Actions From RunJS](../how-to/run-actions-from-runjs/)**
+- **[Import External Libraries Using RunJS](../how-to/import-external-libraries-using-runjs/)**
+- **[Access a User's Location Using RunJS](../how-to/access-users-location/)**

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/styling-components.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/styling-components.md
@@ -27,5 +27,5 @@ By injecting **Custom CSS**, users can easily override default styles, offering 
 
 </div>
 
-Continue reading about Custom CSS **[here](/docs/app-builder/customstyles/)**.
+Continue reading about Custom CSS **[here](../app-builder/customstyles/)**.
 

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/super-admin.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/super-admin.md
@@ -8,4 +8,4 @@ The Super Admin in ToolJet plays a critical role in managing the instance by hav
 ## Advanced Control and Customization
 Beyond regular management tasks, Super Admins can implement more intricate settings like white labeling, enabling multiplayer editing, and managing instance licenses. They also have the power to restrict personal workspace creation for users, ensuring tighter control over the workspace environment. These advanced capabilities underscore the Super Admin's pivotal role in overseeing the comprehensive management and customization of the ToolJet instance.
 
-Read more about super admins **[here](/docs/enterprise/superadmin/)**.
+Read more about super admins **[here](../enterprise/superadmin/)**.

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/variables.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/variables.md
@@ -51,7 +51,7 @@ Together, these variable management functions and types provide a robust framewo
 
 To learn more about different types of variables and their usage, go through the below links:
 
-**[Setting and unsetting variables and page variables](/docs/how-to/run-actions-from-runjs)** <br/>
-**[Exposed variables](/docs/tooljet-concepts/exposed-variables)** <br/>
-**[Environment variables](/docs/setup/env-vars/)** <br/>
-**[Workspace variables](/docs/org-management/workspaces/workspace-variables/)**
+**[Setting and unsetting variables and page variables](../how-to/run-actions-from-runjs)** <br/>
+**[Exposed variables](../tooljet-concepts/exposed-variables)** <br/>
+**[Environment variables](../setup/env-vars/)** <br/>
+**[Workspace variables](../org-management/workspaces/workspace-variables/)**

--- a/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/workspace-constants.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/tooljet-concepts/workspace-constants.md
@@ -26,4 +26,4 @@ Access to creating, updating, or deleting Workspace Constants is restricted to A
 
 </div>
 
-For a deep-dive in workspace constants, go through **[this](/docs/org-management/workspaces/workspace_constants/)** documentation.
+For a deep-dive in workspace constants, go through **[this](../org-management/workspaces/workspace_constants/)** documentation.


### PR DESCRIPTION
Fix all the relative links by removing duplicate path segments, and making them version-aware.
This PR consist updates in following folder:
- tooljet-concepts