### PR TITLE
Fix: edit btn visible on app card in dark mode

### DIFF
--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -128,7 +128,7 @@ export default function AppCard({
                   reloadDocument
                 >
                   <button type="button" className="tj-primary-btn edit-button tj-text-xsm" data-cy="edit-button">
-                    <SolidIcon name="editrectangle" width="14" fill={darkMode ? '#11181C' : '#FDFDFE'} />
+                    <SolidIcon name="editrectangle" width="14" fill={darkMode ? '#FFFFFF' : '#FDFDFE'} />
                     &nbsp;{t('globals.edit', 'Edit')}
                   </button>
                 </Link>


### PR DESCRIPTION
Closes #11263

Fix screenshot :point_down: 

![dark-mode-edit-button-app-card-tooljet](https://github.com/user-attachments/assets/78765b4b-8616-4da0-be15-88de2ef06c00)
