### PR TITLE
Fix: viewer, sidebar and pages bugs

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
@@ -38,6 +38,7 @@ export const AppCanvas = ({ moduleId, appId, isViewerSidebarPinned }) => {
   const setIsComponentLayoutReady = useStore((state) => state.setIsComponentLayoutReady, shallow);
   const canvasMaxWidth = useAppCanvasMaxWidth({ mode: currentMode });
   const editorMarginLeft = useSidebarMargin(canvasContainerRef);
+  const isPagesSidebarHidden = useStore((state) => state.getPagesSidebarVisibility('canvas'), shallow);
   const pageSwitchInProgress = useStore((state) => state.pageSwitchInProgress);
   const setPageSwitchInProgress = useStore((state) => state.setPageSwitchInProgress);
   useEffect(() => {
@@ -60,6 +61,8 @@ export const AppCanvas = ({ moduleId, appId, isViewerSidebarPinned }) => {
 
   return (
     <div className={cx(`main main-editor-canvas`, {})} id="main-editor-canvas" onMouseUp={handleCanvasContainerMouseUp}>
+      {creationMode === 'GIT' && <FreezeVersionInfo info={'Apps imported from git repository cannot be edited'} />}
+      {creationMode !== 'GIT' && <FreezeVersionInfo hide={currentMode !== 'edit'} />}
       <div
         ref={canvasContainerRef}
         className={cx(
@@ -69,12 +72,12 @@ export const AppCanvas = ({ moduleId, appId, isViewerSidebarPinned }) => {
         )}
         style={{
           // transform: `scale(1)`,
-          borderLeft: editorMarginLeft + 'px solid',
+          borderLeft: currentMode === 'edit' && editorMarginLeft + 'px solid',
           height: currentMode === 'edit' ? canvasContainerHeight : '100%',
           backgroundColor: canvasBgColor,
           // background: !isAppDarkMode ? '#EBEBEF' : '#2E3035',
           marginLeft:
-            isViewerSidebarPinned && currentLayout !== 'mobile' && currentMode !== 'edit'
+            isViewerSidebarPinned && !isPagesSidebarHidden && currentLayout !== 'mobile' && currentMode !== 'edit'
               ? pageSidebarStyle === 'icon'
                 ? '65px'
                 : '210px'
@@ -88,8 +91,6 @@ export const AppCanvas = ({ moduleId, appId, isViewerSidebarPinned }) => {
           className={`app-${appId}`}
         >
           <AutoComputeMobileLayoutAlert currentLayout={currentLayout} darkMode={isAppDarkMode} />
-          {creationMode === 'GIT' && <FreezeVersionInfo info={'Apps imported from git repository cannot be edited'} />}
-          {creationMode !== 'GIT' && <FreezeVersionInfo hide={currentMode !== 'edit'} />}
           <DeleteWidgetConfirmation darkMode={isAppDarkMode} />
           <HotkeyProvider mode={currentMode} canvasMaxWidth={canvasMaxWidth} currentLayout={currentLayout}>
             {environmentLoadingState !== 'loading' && (

--- a/frontend/src/AppBuilder/LeftSidebar/LeftSidebar.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/LeftSidebar.jsx
@@ -62,8 +62,9 @@ export const LeftSidebar = ({ darkMode = false, switchDarkMode }) => {
   };
 
   useEffect(() => {
-    setPopoverContentHeight(((window.innerHeight - queryPanelHeight - 45) / window.innerHeight) * 100);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setPopoverContentHeight(
+      ((window.innerHeight - (queryPanelHeight == 0 ? 40 : queryPanelHeight) - 45) / window.innerHeight) * 100
+    ); // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queryPanelHeight]);
 
   const renderPopoverContent = () => {

--- a/frontend/src/AppBuilder/LeftSidebar/PageMenu/IconSelector.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/PageMenu/IconSelector.jsx
@@ -70,7 +70,7 @@ export default function IconSelector({ iconName, iconColor, pageId }) {
   };
 
   // eslint-disable-next-line import/namespace
-  const IconElement = Icons?.[iconName] ?? Icons?.['IconHome2'];
+  const IconElement = Icons?.[iconName] ?? Icons?.['IconFileDescription'];
 
   return (
     <OverlayTrigger

--- a/frontend/src/AppBuilder/LeftSidebar/PageMenu/PageHandlerMenu.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/PageMenu/PageHandlerMenu.jsx
@@ -1,7 +1,6 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import React from 'react';
 import { Overlay, Popover } from 'react-bootstrap';
 import { Button } from '@/_ui/LeftSidebar';
-import { shallow } from 'zustand/shallow';
 import useStore from '@/AppBuilder/_stores/store';
 
 export const PageHandlerMenu = ({ darkMode }) => {
@@ -57,7 +56,7 @@ export const PageHandlerMenu = ({ darkMode }) => {
 
   return (
     <Overlay
-      placement="auto"
+      placement="right"
       target={targetContainer}
       show={showMenu}
       rootClose
@@ -228,8 +227,8 @@ const Field = ({ id, text, iconSrc, customClass = '', closeMenu, disabled = fals
   const handleOnClick = (e) => {
     e.preventDefault();
     e.stopPropagation();
-    closeMenu();
     callback(id);
+    closeMenu();
   };
 
   return (

--- a/frontend/src/AppBuilder/LeftSidebar/PageMenu/PageMenuItem.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/PageMenu/PageMenuItem.jsx
@@ -47,8 +47,9 @@ export const PageMenuItem = withRouter(
 
     const isEditingPage = editingPage?.id === page?.id;
     const icon = () => {
+      const iconName = isHomePage && !page.icon ? 'IconHome2' : page.icon;
       if (!isDisabled && !isHidden) {
-        return <IconSelector iconColor={computedStyles?.icon?.color} iconName={page.icon} pageId={page.id} />;
+        return <IconSelector iconColor={computedStyles?.icon?.color} iconName={iconName} pageId={page.id} />;
       }
       if (isDisabled || (isDisabled && isHidden)) {
         return (
@@ -136,8 +137,21 @@ export const PageMenuItem = withRouter(
       setCurrentPageHandle(page.handle);
     }, [currentPageId, page.id, page.handle, switchPage, setCurrentPageHandle]);
 
+    const handlePageMenuSettings = useCallback(
+      (event) => {
+        event.stopPropagation();
+        openPageEditPopover(page, popoverRef);
+      },
+      [popoverRef.current, page]
+    );
+
     return (
-      <div onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+      <div
+        ref={popoverRef}
+        id={`edit-popover-${page.id}`}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
         {editingPageName && editingPage?.id === page?.id ? (
           <>
             <RenameInput
@@ -160,9 +174,9 @@ export const PageMenuItem = withRouter(
             >
               <div className="left">
                 {icon()}
-                <div style={{ ...computedStyles?.text }} className="page-name">
-                  <OverflowTooltip>{page.name}</OverflowTooltip>
-                </div>
+                <OverflowTooltip childrenClassName="page-name" style={{ ...computedStyles?.text }}>
+                  {page.name}
+                </OverflowTooltip>
                 <span
                   style={{
                     marginLeft: '8px',
@@ -188,10 +202,7 @@ export const PageMenuItem = withRouter(
                       }),
                     }}
                     className="edit-page-overlay-toggle"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      openPageEditPopover(page, popoverRef);
-                    }}
+                    onClick={handlePageMenuSettings}
                   >
                     <SolidIcon width="20" dataCy={`page-menu`} name="morevertical" />
                   </button>
@@ -200,15 +211,6 @@ export const PageMenuItem = withRouter(
             </div>
           </>
         )}
-        <div
-          id={`edit-popover-${page.id}`}
-          style={{
-            position: 'absolute',
-            right: 0,
-            top: 0,
-          }}
-          ref={popoverRef}
-        ></div>
       </div>
     );
   })

--- a/frontend/src/AppBuilder/Viewer/MobileHeader.jsx
+++ b/frontend/src/AppBuilder/Viewer/MobileHeader.jsx
@@ -88,7 +88,7 @@ const MobileHeader = ({
     );
   };
 
-  if (!showHeader) {
+  if (!showHeader && isVersionReleased) {
     return <>{showViewerNavigation ? _renderMobileNavigationMenu() : _renderDarkModeBtn()}</>;
   }
 

--- a/frontend/src/AppBuilder/Viewer/Viewer.jsx
+++ b/frontend/src/AppBuilder/Viewer/Viewer.jsx
@@ -63,8 +63,8 @@ export const Viewer = ({ id: appId, darkMode, moduleId = 'canvas', switchDarkMod
     }),
     shallow
   );
-  const getCurrentPageComponents = useStore((state) => state.getCurrentPageComponents, shallow);
-  const currentPageComponents = useMemo(() => getCurrentPageComponents(), [getCurrentPageComponents]);
+  const getCurrentPageComponents = useStore((state) => state.getCurrentPageComponents(), shallow);
+  const currentPageComponents = useMemo(() => getCurrentPageComponents, [getCurrentPageComponents]);
   const changeDarkMode = useStore((state) => state.changeDarkMode);
   const isPagesSidebarHidden = useStore((state) => state.getPagesSidebarVisibility('canvas'), shallow);
   const canvasBgColor = useStore((state) => state.getCanvasBackgroundColor('canvas', darkMode), shallow);
@@ -200,6 +200,7 @@ export const Viewer = ({ id: appId, darkMode, moduleId = 'canvas', switchDarkMod
                                 maxWidth: isMobilePreviewMode ? '450px' : computeCanvasMaxWidth(),
                                 margin: 0,
                                 padding: 0,
+                                position: 'relative',
                               }}
                             >
                               {currentLayout === 'mobile' && isMobilePreviewMode && (

--- a/frontend/src/AppBuilder/Viewer/ViewerSidebarNavigation.jsx
+++ b/frontend/src/AppBuilder/Viewer/ViewerSidebarNavigation.jsx
@@ -7,6 +7,7 @@ import FolderList from '@/_ui/FolderList/FolderList';
 import { ButtonSolid } from '@/_ui/AppButton/AppButton';
 import useStore from '@/AppBuilder/_stores/store';
 import { APP_HEADER_HEIGHT } from '../AppCanvas/appCanvasConstants';
+import OverflowTooltip from '@/_components/OverflowTooltip';
 
 export const ViewerSidebarNavigation = ({
   isMobileDevice,
@@ -21,6 +22,7 @@ export const ViewerSidebarNavigation = ({
   const { definition: { styles = {}, properties = {} } = {} } = useStore((state) => state.pageSettings) || {};
   const selectedVersionName = useStore((state) => state.selectedVersion?.name);
   const selectedEnvironmentName = useStore((state) => state.selectedEnvironment?.name);
+  const homePageId = useStore((state) => state.app.homePageId);
 
   if (isMobileDevice) {
     return null;
@@ -127,8 +129,10 @@ export const ViewerSidebarNavigation = ({
         ></ButtonSolid>
         <div className={cx('page-handler-wrapper', { 'dark-theme': darkMode })}>
           {pages.map((page) => {
+            const isHomePage = page.id === homePageId;
+            const iconName = isHomePage && !page.icon ? 'IconHome2' : page.icon;
             // eslint-disable-next-line import/namespace
-            const IconElement = Icons?.[page.icon] ?? Icons?.['IconHome2'];
+            const IconElement = Icons?.[iconName] ?? Icons?.['IconFileDescription'];
             return page.hidden || page.disabled ? null : (
               <FolderList
                 key={page.handle}
@@ -139,8 +143,10 @@ export const ViewerSidebarNavigation = ({
                 darkMode={darkMode}
               >
                 {!labelStyle?.label?.hidden && (
-                  <span data-cy={`pages-name-${String(page?.name).toLowerCase()}`} className="mx-2 text-wrap page-name">
-                    {_.truncate(page?.name, { length: 18 })}
+                  <span data-cy={`pages-name-${String(page?.name).toLowerCase()}`}>
+                    <OverflowTooltip style={{ width: '110px' }} childrenClassName={'mx-2 page-name'}>
+                      {page.name}
+                    </OverflowTooltip>
                   </span>
                 )}
               </FolderList>

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -193,8 +193,7 @@ const useAppData = (appId, moduleId, mode = 'edit', { environmentId, versionId }
       );
 
       setPages(pages, moduleId);
-      setPageSettings(deepCamelCase(appData?.editing_version?.page_settings));
-
+      setPageSettings(deepCamelCase(appData?.editing_version?.page_settings ?? appData?.page_settings));
       // set starting page as homepage initially
       let startingPage = appData.pages.find((page) => page.id === homePageId);
 

--- a/frontend/src/AppBuilder/_stores/slices/pageMenuSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/pageMenuSlice.js
@@ -111,8 +111,8 @@ export const createPageMenuSlice = (set, get) => {
       set((state) => {
         state.editingPage = page;
         if (ref) {
-          state.showEditingPopover = true;
           state.popoverTargetId = ref?.current?.id;
+          state.showEditingPopover = true;
         }
       }),
 

--- a/frontend/src/_components/SortableList/SortableList.jsx
+++ b/frontend/src/_components/SortableList/SortableList.jsx
@@ -10,10 +10,10 @@ export function SortableList({ items, onChange, renderItem }) {
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { delay: 150 },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
     })
+    // useSensor(KeyboardSensor, {
+    //   coordinateGetter: sortableKeyboardCoordinates,
+    // })
   );
 
   const shouldFreeze = useStore((state) => state.isVersionReleased || state.isEditorFreezed);

--- a/frontend/src/_styles/components.scss
+++ b/frontend/src/_styles/components.scss
@@ -123,7 +123,6 @@ $btn-dark-color: #FFFFFF;
 
 
 .page-selector-panel-body {
-  height: 100%;
   padding: 12px 16px;
   border-right: 1px solid #DFE3E6;
 

--- a/frontend/src/_styles/pages-sidebar.scss
+++ b/frontend/src/_styles/pages-sidebar.scss
@@ -12,7 +12,7 @@
     }
 
     .page-name {
-        font-size: 14px;
+        font-size: 12px;
     }
 
     .navigation-area {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -12693,7 +12693,7 @@ color: var(--text-default);
   position: absolute;
   display: flex;
   justify-content: center;
-  top: 55px;
+  top: 65px;
 
   .released-version-popup-cover {
     width: 250px;

--- a/server/src/services/app_import_export.service.ts
+++ b/server/src/services/app_import_export.service.ts
@@ -1260,6 +1260,23 @@ export class AppImportExportService {
     return appResourceMappings;
   }
 
+  createViewerNavigationVisibilityForImportedApp(newVersion: AppVersion, importedVersion: AppVersion) {
+    let pageSettings = {};
+    if (newVersion.pageSettings) {
+      pageSettings = { ...importedVersion.pageSettings };
+    } else {
+      pageSettings = {
+        properties: {
+          disableMenu: {
+            value: `{{${!importedVersion.showViewerNavigation}}}`,
+            fxActive: false,
+          },
+        },
+      };
+    }
+    return pageSettings;
+  }
+
   async createAppVersionsForImportedApp(
     manager: EntityManager,
     user: User,
@@ -1300,7 +1317,7 @@ export class AppImportExportService {
         version.showViewerNavigation = appVersion.showViewerNavigation;
         version.homePageId = appVersion.homePageId;
         version.globalSettings = appVersion.globalSettings;
-        version.pageSettings = appVersion.pageSettings;
+        version.pageSettings = this.createViewerNavigationVisibilityForImportedApp(version, appVersion);
       } else {
         version.showViewerNavigation = appVersion.definition?.showViewerNavigation || true;
         version.homePageId = appVersion.definition?.homePageId;
@@ -1318,7 +1335,7 @@ export class AppImportExportService {
           };
         } else {
           version.globalSettings = appVersion.definition?.globalSettings;
-          version.pageSettings = appVersion.definition?.pageSettings;
+          version.pageSettings = this.createViewerNavigationVisibilityForImportedApp(version, appVersion);
         }
       }
 


### PR DESCRIPTION
- Fix page default icons
- Fix left side margin on Viewer when editor sidebar is pinned
- Make released version banner info static relative to editor for released apps
- Fix sidebar height when query panel is collapsed
- Fix placement of page handler menu when clicked on more options
- Add overflow tooltips to page name on viewer and editor
- Fix mobile header to show preview settings when `hide header` is enabled on released apps
- Fix scrollable height on viewer 
- Fix page settings not being accounted in released apps
- Fix rename page input not accepting `space` in name
- Fix older imported apps not having values for Viewer Navigation when Disable Menu is set to true