### PR TITLE
Bug: 11342 - Edit Version Modal: Save CTA Disable Fix

### DIFF
--- a/frontend/src/Editor/AppVersionsManager/EditVersionModal.jsx
+++ b/frontend/src/Editor/AppVersionsManager/EditVersionModal.jsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import { useEnvironmentsAndVersionsStore } from '@/_stores/environmentsAndVersionsStore';
 import AlertDialog from '@/_ui/AlertDialog';
+import React, { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
-import { useEnvironmentsAndVersionsStore } from '@/_stores/environmentsAndVersionsStore';
 
 export const EditVersion = ({ appId, setShowEditAppVersion, showEditAppVersion }) => {
   const [isEditingVersion, setIsEditingVersion] = useState(false);
@@ -87,6 +87,7 @@ export const EditVersion = ({ appId, setShowEditAppVersion, showEditAppVersion }
               {t('globals.cancel', 'Cancel')}
             </button>
             <button
+              disabled={!versionName}
               className={`btn btn-primary ${isEditingVersion ? 'btn-loading' : ''}`}
               data-cy="save-button"
               type="submit"

--- a/frontend/src/Editor/AppVersionsManager/EditVersionModal.jsx
+++ b/frontend/src/Editor/AppVersionsManager/EditVersionModal.jsx
@@ -87,7 +87,7 @@ export const EditVersion = ({ appId, setShowEditAppVersion, showEditAppVersion }
               {t('globals.cancel', 'Cancel')}
             </button>
             <button
-              disabled={!versionName}
+              disabled={!versionName || versionName === editingVersion?.name}
               className={`btn btn-primary ${isEditingVersion ? 'btn-loading' : ''}`}
               data-cy="save-button"
               type="submit"


### PR DESCRIPTION
Disabled Save CTA if no versionName is present in the versionName input field in Edit Version modal.

Refer below screen recording.

Video: 
https://github.com/user-attachments/assets/eb3c9c89-f854-4cd3-8cce-186791438042

