### PR TITLE
chore: Set modal as the selected widget when clicked

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Modal.jsx
+++ b/frontend/src/AppBuilder/Widgets/Modal.jsx
@@ -289,8 +289,19 @@ const Component = ({ children, ...restProps }) => {
   } = restProps['modalProps'];
 
   const setSelectedComponentAsModal = useStore((state) => state.setSelectedComponentAsModal, shallow);
+
+  // When the modal body is clicked capture it and use the callback to set the selected component as modal
+  const handleModalBodyClick = (event) => {
+    const clickedComponentId = event.target.getAttribute('component-id');
+
+    // Check if the clicked element is part of the modal canvas & same widget with id
+    if (id === clickedComponentId) {
+      setSelectedComponentAsModal(id);
+    }
+  };
+
   return (
-    <BootstrapModal {...restProps}>
+    <BootstrapModal {...restProps} onClick={handleModalBodyClick}>
       {showConfigHandler && (
         <ConfigHandle
           id={id}


### PR DESCRIPTION
**Changes made**
- Adds listener for modal body to listen for clicks, will set the selected component if id of component & clicked part of the modal

Fixes - [#11155](https://github.com/ToolJet/ToolJet/issues/11155)