### PR TITLE
fixed casing with event name to title case - Pagination Component

### DIFF
--- a/frontend/src/Editor/WidgetManager/configs/pagination.js
+++ b/frontend/src/Editor/WidgetManager/configs/pagination.js
@@ -31,7 +31,7 @@ export const paginationConfig = {
   },
   validation: {},
   events: {
-    onPageChange: { displayName: 'On Page Change' },
+    onPageChange: { displayName: 'On page change' },
   },
   styles: {
     visibility: {


### PR DESCRIPTION
## What does this PR do?

This PR changes the casing of event name of the pagination component from "On Page Change" to "On page change"

Fixes #10946 

![image](https://github.com/user-attachments/assets/987e975a-54cf-4ef0-bb7c-64644db2beb5)