### PR TITLE
Fix: ToolJet database limit check API issue

### DIFF
--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -1474,5 +1474,6 @@ export const checkConditionsForRoute = (conditions, conditionsObj) => {
 };
 
 export const hasBuilderRole = (roleObj) => {
-  return roleObj.name === 'builder';
+  if (roleObj.name) return roleObj.name === 'builder';
+  return false;
 };

--- a/server/src/modules/casl/abilities/tooljet-db-ability.factory.ts
+++ b/server/src/modules/casl/abilities/tooljet-db-ability.factory.ts
@@ -42,7 +42,7 @@ export class TooljetDbAbilityFactory {
         ).isAdmin
       : false;
 
-    const isBuilder = await this.abilityService.isBuilder(user);
+    const isBuilder = !isEmpty(user) ? await this.abilityService.isBuilder(user) : false;
 
     if (isAdmin || isBuilder) {
       can(Action.CreateTable, 'all');


### PR DESCRIPTION
The ToolJet database user ability checking part had an issue. When checking if a user has a builder role, we were invoking a method without user details, which resulted in an undefined issue. This resulted in the failure of the API to check the limit of ToolJet database tables.