### PR TITLE
Bug: 11418 - Fix for Can create workspace with empty name

### DIFF
--- a/frontend/src/_components/OrganizationManager/CreateOrganization.jsx
+++ b/frontend/src/_components/OrganizationManager/CreateOrganization.jsx
@@ -93,19 +93,20 @@ export const CreateOrganization = ({ showCreateOrg, setShowCreateOrg }) => {
       }
     }
 
-    const disabled = !error?.status;
     const updatedValue = {
       value,
       error: error?.errorMsg,
     };
+    const trimmedValue = updatedValue?.value?.trim();
+    const disabled = !error?.status || !trimmedValue?.length;
 
     if (field === 'slug') {
       setSlug(updatedValue);
       setSlugDisabled(disabled);
       setSlugProgress(false);
     }
-    if (field === 'name') {
-      setName(updatedValue);
+    if (field === 'name') { 
+      setName(trimmedValue);
       setNameDisabled(disabled);
       setWorkspaceNameProgress(false);
     }


### PR DESCRIPTION
Disabled button if blank workspace name is entered i.e only spaces entered.

Trimmed input value and applied check if the trimmed value has a length.

Video:
https://github.com/user-attachments/assets/b84cc3a3-c49d-4acc-8099-facf1e6751d9

