### PR TITLE
Incorrect code-hinter header text

### DIFF
--- a/frontend/src/Editor/QueryManager/Components/SuccessNotificationInputs.jsx
+++ b/frontend/src/Editor/QueryManager/Components/SuccessNotificationInputs.jsx
@@ -20,6 +20,7 @@ export default function SuccessNotificationInputs({ currentState, options, darkM
             onChange={(value) => optionchanged('successMessage', value)}
             placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}
             cyLabel={'success-message'}
+            componentName={'Success Message'}
           />
         </div>
       </div>


### PR DESCRIPTION
What is the issue?
Currently, when the code hinter is expanded, the header text is shown as Editor instead it should display the name of the property from where the code hinter is expanded.

How to reproduce the issue?
Open ToolJet app builder
Create a RunJS query
Scroll down the query editor and toggle on the show notification on success?
On Success Message input box, expand the code hinter by clicking on the icon on the right of the input box
Once the code-hinter pops-up, check the header text

Changes:
1. Pass the component name in the prop

Fixes : https://github.com/ToolJet/ToolJet/issues/6655