### PR TITLE
[docs]: Add env var for TJDB Bulk Upload

### DIFF
--- a/docs/docs/tooljet-db/tooljet-database.md
+++ b/docs/docs/tooljet-db/tooljet-database.md
@@ -47,7 +47,7 @@ Please make sure that DB_URI is given in the format `postgres://[USERNAME]:[PASS
 #### Additional ToolJet server configuration
 
 
-| <div style={{ width:"100px"}}> Variable </div>           | <div style={{ width:"100px"}}> Description </div>                                  |
+| <div style={{ width:"100px"}}> Variable </div>           | <div style={{ width:"100px"}}> Description </div>   |
 | ------------------ | -------------------------------------------- |
 | TOOLJET_DB         | Default value is `tooljet_db`                |
 | TOOLJET_DB_HOST    | database host                                |
@@ -56,6 +56,8 @@ Please make sure that DB_URI is given in the format `postgres://[USERNAME]:[PASS
 | TOOLJET_DB_PORT    | database port                                |
 | PGRST_JWT_SECRET   | JWT token client provided for authentication |
 | PGRST_HOST         | postgrest database host                      |
+| TOOLJET_DB_BULK_UPLOAD_MAX_ROWS | Maximum rows allowed to bulk upload. Default value is 1000 |
+| TOOLJET_DB_BULK_UPLOAD_MAX_CSV_FILE_SIZE_MB  | Maximum file size of CSV for bulk upload. Default value is 5 MB  |
 
 
 If you intend to make changes in the above configuration. Please refer [PostgREST configuration docs](https://postgrest.org/en/stable/configuration.html#environment-variables).

--- a/docs/versioned_docs/version-3.0.0-LTS/tooljet-db/tooljet-database.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/tooljet-db/tooljet-database.md
@@ -54,6 +54,8 @@ Please make sure that DB_URI is given in the format `postgres://[USERNAME]:[PASS
 | TOOLJET_DB_PORT    | database port                                |
 | PGRST_JWT_SECRET   | JWT token client provided for authentication |
 | PGRST_HOST         | postgrest database host                      |
+| TOOLJET_DB_BULK_UPLOAD_MAX_ROWS | Maximum rows allowed to bulk upload. Default value is 1000 |
+| TOOLJET_DB_BULK_UPLOAD_MAX_CSV_FILE_SIZE_MB  | Maximum file size of CSV for bulk upload. Default value is 5 MB  |
 
 
 If you intend to make changes in the above configuration. Please refer [PostgREST configuration docs](https://postgrest.org/en/stable/configuration.html#environment-variables).


### PR DESCRIPTION
Added newly introduced configurations for TJDB:

- `TOOLJET_DB_BULK_UPLOAD_MAX_ROWS` - Maximum rows allowed to upload. Default : 1000 rows
- `TOOLJET_DB_BULK_UPLOAD_MAX_CSV_FILE_SIZE_MB` - Maximum file size of CSV. Default: 5 mb