### PR TITLE
#4318 SQL Server with encryption fails

### DIFF
--- a/plugins/packages/mssql/lib/index.ts
+++ b/plugins/packages/mssql/lib/index.ts
@@ -16,8 +16,8 @@ const recognizedBooleans = {
   no: false,
 };
 
-function interpretValue(value: string): string | boolean {
-  return recognizedBooleans[value.toLowerCase()] ?? value;
+function interpretValue(value: string): string | boolean | number {
+  return recognizedBooleans[value.toLowerCase()] ?? (!isNaN(Number.parseInt(value)) ? Number.parseInt(value) : value);
 }
 
 export default class MssqlQueryService implements QueryService {

--- a/plugins/packages/mssql/lib/manifest.json
+++ b/plugins/packages/mssql/lib/manifest.json
@@ -30,6 +30,9 @@
       "password": {
         "type": "string",
         "encrypted": true
+      },
+      "connection_options": {
+        "type": "array"
       }
     }
   },
@@ -93,8 +96,13 @@
       "type": "password",
       "description": "Enter password"
     },
+    "connection_options": {
+      "label": "Connection Options",
+      "key": "connection_options",
+      "type": "react-component-headers"
+    },
     "azure": {
-      "label": "Azure",
+      "label": "Azure (set 'encrypt' to true)",
       "key": "azure",
       "type": "toggle",
       "description": "Toggle for azure"

--- a/plugins/packages/mssql/lib/types.ts
+++ b/plugins/packages/mssql/lib/types.ts
@@ -5,6 +5,7 @@ export type SourceOptions = {
   port: string;
   username: string;
   password: string;
+  connection_options: string[][];
   azure: boolean;
 };
 export type QueryOptions = {


### PR DESCRIPTION
The angle of attack: some SQL Server providers require specific connection parameters; therefore, inspired by the PostgreSQL data source configurator, I've added key-value pairs that are further translated to parameters. 

If the parameter's value is `true`, `false`, `yes`, or `no`, then the type of the value is assumed to be a boolean. If the parameter's value can be parsed as an `integer,` the type is `number`.
