### PR TITLE
feat: Qdrant plugin

### DIFF
--- a/marketplace/package-lock.json
+++ b/marketplace/package-lock.json
@@ -3903,6 +3903,78 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.4.tgz",
+      "integrity": "sha512-NBhrxEWnFh0FxeA0d//YP95lRFsSx2TNLEUQg4/W+5f/BMxcCjgOOIT24iD+ZB/tZw057j44DaIxja7w4XMrhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "dev": true,
@@ -4477,6 +4549,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@lerna/child-process": {
@@ -6201,6 +6283,82 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@pinecone-database/pinecone": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-3.0.3.tgz",
+      "integrity": "sha512-0cAG0d/6knVZgVyXM1II4qG3dyOepLuAQsCXTOJomdA7iQxf+/Om9mq9Cw4QObr56oZ+lqtptlw5qz0BQaBX2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "encoding": "^0.1.13"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@sigstore/protobuf-specs": {
       "version": "0.1.0",
       "dev": true,
@@ -6903,10 +7061,6 @@
       "resolved": "plugins/engagespot",
       "link": true
     },
-    "node_modules/@tooljet-marketplace/gemini": {
-      "resolved": "plugins/gemini",
-      "link": true
-    },
     "node_modules/@tooljet-marketplace/github": {
       "resolved": "plugins/github",
       "link": true
@@ -6919,6 +7073,10 @@
       "resolved": "plugins/openai",
       "link": true
     },
+    "node_modules/@tooljet-marketplace/pinecone": {
+      "resolved": "plugins/pinecone",
+      "link": true
+    },
     "node_modules/@tooljet-marketplace/plivo": {
       "resolved": "plugins/plivo",
       "link": true
@@ -6929,6 +7087,10 @@
     },
     "node_modules/@tooljet-marketplace/portkey": {
       "resolved": "plugins/portkey",
+      "link": true
+    },
+    "node_modules/@tooljet-marketplace/qdrant": {
+      "resolved": "plugins/qdrant",
       "link": true
     },
     "node_modules/@tooljet-marketplace/s3": {
@@ -9061,7 +9223,6 @@
     "node_modules/encoding": {
       "version": "0.1.13",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -9069,7 +9230,6 @@
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -9132,7 +9292,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9837,7 +9996,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -12712,6 +12870,12 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "license": "MIT"
@@ -12769,6 +12933,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -14331,18 +14501,38 @@
       }
     },
     "node_modules/openai": {
-      "version": "3.2.1",
-      "license": "MIT",
+      "version": "4.76.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.76.0.tgz",
+      "integrity": "sha512-QBGIetjX1C9xDp5XGa/3mPnfKI9BgAe2xHQX6PmO98wuW9qQaurBaumcYptQWc9LHZZq7cH/Y1Rjnsr6uUDdVw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^0.26.0",
-        "form-data": "^4.0.0"
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
-    "node_modules/openai/node_modules/axios": {
-      "version": "0.26.1",
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.67",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.67.tgz",
+      "integrity": "sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/optionator": {
@@ -15278,6 +15468,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/protocols": {
       "version": "2.0.1",
       "dev": true,
@@ -15761,7 +15975,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17194,7 +17407,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -17336,7 +17548,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -17435,6 +17646,7 @@
     "plugins/gemini": {
       "name": "@tooljet-marketplace/gemini",
       "version": "1.0.0",
+      "extraneous": true,
       "dependencies": {
         "@tooljet-marketplace/common": "^1.0.0",
         "portkey-ai": "^1.3.1"
@@ -17473,7 +17685,20 @@
       "version": "1.0.0",
       "dependencies": {
         "@tooljet-marketplace/common": "^1.0.0",
-        "openai": "^3.2.1"
+        "openai": "^4.56.0"
+      },
+      "devDependencies": {
+        "@vercel/ncc": "^0.34.0",
+        "typescript": "^4.7.4"
+      }
+    },
+    "plugins/pinecone": {
+      "name": "@tooljet-marketplace/pinecone",
+      "version": "1.0.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.2",
+        "@pinecone-database/pinecone": "^3.0.3",
+        "@tooljet-marketplace/common": "^1.0.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.34.0",
@@ -17510,6 +17735,17 @@
       "dependencies": {
         "@tooljet-marketplace/common": "^1.0.0",
         "portkey-ai": "^1.3.1"
+      },
+      "devDependencies": {
+        "@vercel/ncc": "^0.34.0",
+        "typescript": "^4.7.4"
+      }
+    },
+    "plugins/qdrant": {
+      "name": "@tooljet-marketplace/qdrant",
+      "version": "1.0.0",
+      "dependencies": {
+        "@tooljet-marketplace/common": "^1.0.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.34.0",
@@ -20508,6 +20744,57 @@
       "version": "1.1.3",
       "dev": true
     },
+    "@grpc/grpc-js": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.4.tgz",
+      "integrity": "sha512-NBhrxEWnFh0FxeA0d//YP95lRFsSx2TNLEUQg4/W+5f/BMxcCjgOOIT24iD+ZB/tZw057j44DaIxja7w4XMrhg==",
+      "requires": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      }
+    },
+    "@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "dev": true,
@@ -20936,6 +21223,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
     },
     "@lerna/child-process": {
       "version": "6.6.1",
@@ -22097,6 +22389,68 @@
         "node-gyp-build": "^4.3.0"
       }
     },
+    "@pinecone-database/pinecone": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-3.0.3.tgz",
+      "integrity": "sha512-0cAG0d/6knVZgVyXM1II4qG3dyOepLuAQsCXTOJomdA7iQxf+/Om9mq9Cw4QObr56oZ+lqtptlw5qz0BQaBX2Q==",
+      "requires": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "@sigstore/protobuf-specs": {
       "version": "0.1.0",
       "dev": true
@@ -22677,15 +23031,6 @@
         "typescript": "^4.7.4"
       }
     },
-    "@tooljet-marketplace/gemini": {
-      "version": "file:plugins/gemini",
-      "requires": {
-        "@tooljet-marketplace/common": "^1.0.0",
-        "@vercel/ncc": "^0.34.0",
-        "portkey-ai": "^1.3.1",
-        "typescript": "^4.7.4"
-      }
-    },
     "@tooljet-marketplace/github": {
       "version": "file:plugins/github",
       "requires": {
@@ -22709,7 +23054,17 @@
       "requires": {
         "@tooljet-marketplace/common": "^1.0.0",
         "@vercel/ncc": "^0.34.0",
-        "openai": "^3.2.1",
+        "openai": "^4.56.0",
+        "typescript": "^4.7.4"
+      }
+    },
+    "@tooljet-marketplace/pinecone": {
+      "version": "file:plugins/pinecone",
+      "requires": {
+        "@grpc/grpc-js": "^1.12.2",
+        "@pinecone-database/pinecone": "^3.0.3",
+        "@tooljet-marketplace/common": "^1.0.0",
+        "@vercel/ncc": "^0.34.0",
         "typescript": "^4.7.4"
       }
     },
@@ -22737,6 +23092,14 @@
         "@tooljet-marketplace/common": "^1.0.0",
         "@vercel/ncc": "^0.34.0",
         "portkey-ai": "^1.3.1",
+        "typescript": "^4.7.4"
+      }
+    },
+    "@tooljet-marketplace/qdrant": {
+      "version": "file:plugins/qdrant",
+      "requires": {
+        "@tooljet-marketplace/common": "^1.0.0",
+        "@vercel/ncc": "^0.34.0",
         "typescript": "^4.7.4"
       }
     },
@@ -24164,14 +24527,12 @@
     },
     "encoding": {
       "version": "0.1.13",
-      "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
       "dependencies": {
         "iconv-lite": {
           "version": "0.6.3",
-          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -24214,8 +24575,7 @@
     "escalade": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "dev": true
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -24655,8 +25015,7 @@
       "peer": true
     },
     "get-caller-file": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "get-intrinsic": {
       "version": "1.2.0",
@@ -26639,6 +26998,11 @@
     "lodash": {
       "version": "4.17.21"
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "lodash.includes": {
       "version": "4.3.0"
     },
@@ -26679,6 +27043,11 @@
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
       }
+    },
+    "long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -27732,16 +28101,25 @@
       }
     },
     "openai": {
-      "version": "3.2.1",
+      "version": "4.76.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.76.0.tgz",
+      "integrity": "sha512-QBGIetjX1C9xDp5XGa/3mPnfKI9BgAe2xHQX6PmO98wuW9qQaurBaumcYptQWc9LHZZq7cH/Y1Rjnsr6uUDdVw==",
       "requires": {
-        "axios": "^0.26.0",
-        "form-data": "^4.0.0"
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.26.1",
+        "@types/node": {
+          "version": "18.19.67",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.67.tgz",
+          "integrity": "sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==",
           "requires": {
-            "follow-redirects": "^1.14.8"
+            "undici-types": "~5.26.4"
           }
         }
       }
@@ -28359,6 +28737,25 @@
       "version": "1.2.4",
       "dev": true
     },
+    "protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      }
+    },
     "protocols": {
       "version": "2.0.1",
       "dev": true
@@ -28674,8 +29071,7 @@
       }
     },
     "require-directory": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "resolve": {
       "version": "1.22.1",
@@ -29588,7 +29984,6 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -29677,8 +30072,7 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.8",
-      "dev": true
+      "version": "5.0.8"
     },
     "yallist": {
       "version": "4.0.0"

--- a/marketplace/package-lock.json
+++ b/marketplace/package-lock.json
@@ -3898,6 +3898,14 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "dev": true,
@@ -6358,6 +6366,37 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@qdrant/js-client-rest": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.12.0.tgz",
+      "integrity": "sha512-H8VokZq2DYe9yfKG3c7xPNR+Oc5ZvwMUtPEr1wUO4xVi9w5P89MScJaCc9UW8mS5AR+/Y1h2t1YjSxBFPIYT2Q==",
+      "dependencies": {
+        "@qdrant/openapi-typescript-fetch": "1.2.6",
+        "@sevinf/maybe": "0.5.0",
+        "undici": "~5.28.4"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@qdrant/openapi-typescript-fetch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
+      "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/@sevinf/maybe": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@sevinf/maybe/-/maybe-0.5.0.tgz",
+      "integrity": "sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg=="
     },
     "node_modules/@sigstore/protobuf-specs": {
       "version": "0.1.0",
@@ -17053,6 +17092,17 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -17745,6 +17795,7 @@
       "name": "@tooljet-marketplace/qdrant",
       "version": "1.0.0",
       "dependencies": {
+        "@qdrant/js-client-rest": "^1.12.0",
         "@tooljet-marketplace/common": "^1.0.0"
       },
       "devDependencies": {
@@ -20740,6 +20791,11 @@
       "version": "8.37.0",
       "dev": true
     },
+    "@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "dev": true
@@ -22451,6 +22507,26 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@qdrant/js-client-rest": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.12.0.tgz",
+      "integrity": "sha512-H8VokZq2DYe9yfKG3c7xPNR+Oc5ZvwMUtPEr1wUO4xVi9w5P89MScJaCc9UW8mS5AR+/Y1h2t1YjSxBFPIYT2Q==",
+      "requires": {
+        "@qdrant/openapi-typescript-fetch": "1.2.6",
+        "@sevinf/maybe": "0.5.0",
+        "undici": "~5.28.4"
+      }
+    },
+    "@qdrant/openapi-typescript-fetch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
+      "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA=="
+    },
+    "@sevinf/maybe": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@sevinf/maybe/-/maybe-0.5.0.tgz",
+      "integrity": "sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg=="
+    },
     "@sigstore/protobuf-specs": {
       "version": "0.1.0",
       "dev": true
@@ -23098,6 +23174,7 @@
     "@tooljet-marketplace/qdrant": {
       "version": "file:plugins/qdrant",
       "requires": {
+        "@qdrant/js-client-rest": "^1.12.0",
         "@tooljet-marketplace/common": "^1.0.0",
         "@vercel/ncc": "^0.34.0",
         "typescript": "^4.7.4"
@@ -29741,6 +29818,14 @@
       "version": "3.17.4",
       "dev": true,
       "optional": true
+    },
+    "undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
+      }
     },
     "undici-types": {
       "version": "5.26.5",

--- a/marketplace/plugins/qdrant/.gitignore
+++ b/marketplace/plugins/qdrant/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+lib/*.d.*
+lib/*.js
+lib/*.js.map
+dist/*

--- a/marketplace/plugins/qdrant/README.md
+++ b/marketplace/plugins/qdrant/README.md
@@ -1,0 +1,4 @@
+
+# Qdrant
+
+Documentation on: https://docs.tooljet.com/docs/data-sources/qdrant

--- a/marketplace/plugins/qdrant/__tests__/index.js
+++ b/marketplace/plugins/qdrant/__tests__/index.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const qdrant = require('../lib');
-
-describe('qdrant', () => {
-    it.todo('needs tests');
-});

--- a/marketplace/plugins/qdrant/__tests__/index.js
+++ b/marketplace/plugins/qdrant/__tests__/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const qdrant = require('../lib');
+
+describe('qdrant', () => {
+    it.todo('needs tests');
+});

--- a/marketplace/plugins/qdrant/lib/icon.svg
+++ b/marketplace/plugins/qdrant/lib/icon.svg
@@ -1,0 +1,22 @@
+<svg width="49" height="56" viewBox="0 0 49 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4688_32465)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M38.4886 51.4767L37.3719 20.6899L35.3496 12.5732L48.848 14.0022V51.2437L40.6024 56.0026L38.4886 51.4767Z" fill="#24386C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M48.8468 14L40.6011 18.7622L23.5851 15.0296L3.66794 23.139L0.349609 14L12.4719 7L24.5979 0L36.7206 7L48.8468 14Z" fill="#7589BE"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0.349609 13.9994L8.59528 18.7616L13.3751 32.9769L29.5141 45.89L24.5983 55.9994L12.4723 48.999L0.349609 41.999V13.9994Z" fill="#B2BFE8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M30.0662 38.4209L24.5996 46.4799V56.0006L32.3566 51.525L36.3534 45.5569" fill="#24386C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M24.6021 36.9622L16.8418 23.5262L18.5133 19.0731L24.8677 15.9922L32.3557 23.5265L24.6021 36.9622Z" fill="#7589BE"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.8428 23.5254L24.5997 28.001V36.9595L17.4256 37.2682L13.0859 31.727L16.8428 23.5254Z" fill="#B2BFE8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M24.5996 27.9996L32.3566 23.5244L37.6358 32.3147L31.2472 37.5931L24.5996 36.9585V27.9996Z" fill="#24386C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M32.3553 51.524L40.601 56V18.7622L32.5978 14.1433L24.5983 9.52441L16.5952 14.1433L8.5957 18.7622V37.2411L16.5952 41.86L24.5983 46.4793L32.3553 41.9996V51.524ZM32.3553 32.4789L24.5983 36.9582L16.8414 32.4789V23.524L24.5983 19.0448L32.3553 23.524V32.4789Z" fill="#DC244C"/>
+<path d="M24.6033 46.4828V36.9606L16.8867 32.5195V42.0259L24.6033 46.4828Z" fill="url(#paint0_linear_4688_32465)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_4688_32465" x1="23.1805" y1="38.7809" x2="15.4911" y2="38.7809" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF3364"/>
+<stop offset="1" stop-color="#C91540" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_4688_32465">
+<rect width="48.3" height="56" fill="white" transform="translate(0.349609)"/>
+</clipPath>
+</defs>
+</svg>

--- a/marketplace/plugins/qdrant/lib/index.ts
+++ b/marketplace/plugins/qdrant/lib/index.ts
@@ -4,7 +4,7 @@ import { QdrantClient } from '@qdrant/js-client-rest';
 import { deletePoints, getCollectionInfo, getPoints, listCollections, queryPoints, upsertPoints } from './operations';
 
 export default class Qdrant implements QueryService {
-  async run(sourceOptions: SourceOptions, queryOptions: QueryOptions, dataSourceId: string): Promise<QueryResult> {
+  async run(sourceOptions: SourceOptions, queryOptions: QueryOptions): Promise<QueryResult> {
     const operation = queryOptions.operation;
     const qdrant = await this.getConnection(sourceOptions);
     let result = {};

--- a/marketplace/plugins/qdrant/lib/index.ts
+++ b/marketplace/plugins/qdrant/lib/index.ts
@@ -1,0 +1,75 @@
+import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-marketplace/common';
+import { SourceOptions, QueryOptions, Operation } from './types';
+import { QdrantClient } from '@qdrant/js-client-rest';
+import { deletePoints, getCollectionInfo, getPoints, listCollections, queryPoints, upsertPoints } from './operations';
+
+export default class Qdrant implements QueryService {
+  async run(sourceOptions: SourceOptions, queryOptions: QueryOptions, dataSourceId: string): Promise<QueryResult> {
+    const operation = queryOptions.operation;
+    const qdrant = await this.getConnection(sourceOptions);
+    let result = {};
+
+    try {
+      switch (operation) {
+        case Operation.GetCollectionInfo:
+          result = await getCollectionInfo(qdrant, queryOptions);
+          break;
+        case Operation.ListCollections:
+          result = await listCollections(qdrant, queryOptions);
+          break;
+        case Operation.GetPoints:
+          result = await getPoints(qdrant, queryOptions);
+          break;
+        case Operation.UpsertPoints:
+          result = await upsertPoints(qdrant, queryOptions);
+          break;
+        case Operation.DeletePoints:
+          result = await deletePoints(qdrant, queryOptions);
+          break;
+        case Operation.QueryPoints:
+          result = await queryPoints(qdrant, queryOptions);
+          break;
+        default:
+          throw new QueryError('Query could not be completed', 'Invalid operation', {});
+      }
+    } catch (error) {
+      throw new QueryError('Query could not be completed', error?.message, {});
+    }
+
+    return {
+      status: 'ok',
+      data: result,
+    };
+  }
+  async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
+    const qdrant = await this.getConnection(sourceOptions);
+
+    try {
+      await qdrant.getCollections();
+      console.log('Connection successful.');
+      return { status: 'ok' };
+    } catch (error) {
+      console.error('Connection could not be established:', error.message);
+      throw new QueryError('Connection could not be established', error?.message, {});
+    }
+  }
+
+  async getConnection(sourceOptions: SourceOptions): Promise<QdrantClient> {
+    const { apiKey, url } = sourceOptions;
+
+    if (!url) {
+      throw new QueryError('URL missing', 'No Qdrant URL provided in source options', {});
+    }
+
+    return new QdrantClient({
+      url,
+      apiKey,
+    });
+  }
+
+  private parseJSON(json?: string): object {
+    if (!json) return {};
+
+    return JSON.parse(json);
+  }
+}

--- a/marketplace/plugins/qdrant/lib/manifest.json
+++ b/marketplace/plugins/qdrant/lib/manifest.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/manifest.schema.json",
+  "title": "Qdrant datasource",
+  "description": "A schema defining Qdrant datasource",
+  "type": "api",
+  "source": {
+    "name": "Qdrant",
+    "kind": "qdrant",
+    "exposedVariables": {
+      "isLoading": false,
+      "data": {},
+      "rawData": {}
+    },
+    "options": {
+      "url": {
+        "type": "string",
+        "encrypted": false
+      },
+      "apiKey": {
+        "type": "string",
+        "encrypted": true
+      }
+    }
+  },
+  "defaults": {},
+  "properties": {
+    "url": {
+      "label": "Qdrant URL",
+      "key": "url",
+      "type": "text",
+      "description": "Enter your Qdrant URL.",
+      "helpText": "<a href='https://qdrant.tech/documentation/quickstart-cloud/#authenticate-via-sdks' target='_blank' rel='noreferrer'>REST URL</a> to authenticate the requests of the Qdrant instance."
+    },
+    "apiKey": {
+      "label": "API Key",
+      "key": "apiKey",
+      "type": "password",
+      "description": "Enter your Qdrant API key",
+      "helpText": "An <a href='https://qdrant.tech/documentation/quickstart-cloud/#setup-a-qdrant-cloud-cluster' target='_blank' rel='noreferrer'>API key</a> to authenticate the requests."
+    }
+  },
+  "required": [
+    "url"
+  ]
+}

--- a/marketplace/plugins/qdrant/lib/operations.json
+++ b/marketplace/plugins/qdrant/lib/operations.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/operations.schema.json",
+  "title": "Qdrant Datasource",
+  "description": "A schema defining Qdrant datasource",
+  "type": "api",
+  "defaults": {},
+  "properties": {
+    "operation": {
+      "label": "Operation",
+      "key": "operation",
+      "type": "dropdown-component-flip",
+      "description": "Select an operation",
+      "list": [
+        {
+          "value": "get_collection_info",
+          "name": "Get Collection Info"
+        },
+        {
+          "value": "list_collections",
+          "name": "List Collections"
+        },
+        {
+          "value": "get_points",
+          "name": "Get Points"
+        },
+        {
+          "value": "upsert_points",
+          "name": "Upsert Points"
+        },
+        {
+          "value": "delete_points",
+          "name": "Delete Points"
+        },
+        {
+          "value": "query_points",
+          "name": "Query Points"
+        }
+      ]
+    },
+    "get_collection_info": {
+      "collectionName": {
+        "label": "Collection Name",
+        "key": "collectionName",
+        "type": "codehinter",
+        "description": "Enter the collection name.",
+        "placeholder": "example-collection",
+        "height": "36px"
+      }
+    },
+    "list_collections": {},
+    "get_points": {
+      "collectionName": {
+        "label": "Collection Name",
+        "key": "collectionName",
+        "type": "codehinter",
+        "description": "Enter the collection name.",
+        "placeholder": "example-collection",
+        "height": "36px"
+      },
+      "ids": {
+        "label": "IDs",
+        "key": "ids",
+        "type": "codehinter",
+        "description": "Enter point IDs as JSON array",
+        "placeholder": "[\"792defdc-e3f9-49aa-b7b2-ddebcdbdc2a6\", 23]",
+        "height": "36px"
+      }
+    },
+    "upsert_points": {
+      "collectionName": {
+        "label": "Collection Name",
+        "key": "collectionName",
+        "type": "codehinter",
+        "description": "Enter the collection name.",
+        "placeholder": "example-collection",
+        "height": "36px"
+      },
+      "points": {
+        "label": "Points",
+        "key": "points",
+        "type": "codehinter",
+        "description": "Enter points as JSON array",
+        "placeholder": "[{\"id\":1,\"payload\":{\"color\":\"red\"},\"vector\":[0.9,0.1,0.1]}]",
+        "height": "36px"
+      }
+    },
+    "delete_points": {
+      "collectionName": {
+        "label": "Collection Name",
+        "key": "collectionName",
+        "type": "codehinter",
+        "description": "Enter the collection name.",
+        "placeholder": "example-collection",
+        "height": "36px"
+      },
+      "ids": {
+        "label": "IDs",
+        "key": "id",
+        "type": "codehinter",
+        "description": "Enter point IDs as JSON array",
+        "placeholder": "[\"845d6b75-38f6-4af7-bffa-b1fd46131ab5\", 23]",
+        "height": "36px"
+      },
+      "filter": {
+        "label": "Filter",
+        "key": "filter",
+        "type": "codehinter",
+        "description": "Enter a filter query in JSON format",
+        "placeholder": "{\"must\":[{\"key\":\"color\",\"match\":{\"value\":\"red\"}}]}",
+        "height": "150px"
+      }
+    },
+    "query_points": {
+      "collectionName": {
+        "label": "Collection Name",
+        "key": "collectionName",
+        "type": "codehinter",
+        "description": "Enter the collection name.",
+        "placeholder": "example-collection",
+        "height": "36px"
+      },
+      "limit": {
+        "label": "Limit",
+        "key": "limit",
+        "type": "codehinter",
+        "description": "Enter the number of results to return.",
+        "placeholder": "3",
+        "height": "36px"
+      },
+      "filter": {
+        "label": "Filter",
+        "key": "filter",
+        "type": "codehinter",
+        "description": "Enter a filter query in JSON format.",
+        "placeholder": "{\"must\":[{\"key\":\"color\",\"match\":{\"value\":\"red\"}}]}",
+        "height": "150px"
+      },
+      "withVectors": {
+        "label": "With Vectors",
+        "key": "withVectors",
+        "type": "codehinter",
+        "description": "Whether to return vector values.",
+        "placeholder": "true (false by default)",
+        "height": "36px"
+      },
+      "withPayload": {
+        "label": "Include metadata",
+        "key": "withPayload",
+        "type": "codehinter",
+        "description": "Whether to return payload values.",
+        "placeholder": "true (false by default)",
+        "height": "36px"
+      },
+      "query": {
+        "label": "Query",
+        "key": "query",
+        "type": "codehinter",
+        "description": "Enter the query in JSON.",
+        "placeholder": "[0.2, 0.1, 0.9, 0.79]",
+        "height": "36px"
+      }
+    }
+  }
+}

--- a/marketplace/plugins/qdrant/lib/operations.ts
+++ b/marketplace/plugins/qdrant/lib/operations.ts
@@ -8,22 +8,12 @@ export async function getCollectionInfo(qdrant: QdrantClient, options: QueryOpti
     throw new Error('Collection name is required');
   }
 
-  try {
-    return await qdrant.getCollection(collectionName);
-  } catch (error) {
-    console.error('Error fetching collection info:', error);
-    throw new Error(error?.message || 'An unexpected error occurred');
-  }
+  return await qdrant.getCollection(collectionName);
 }
 
-export async function listCollections(qdrant: QdrantClient): Promise<any> {
-  try {
-    const collections = (await qdrant.getCollections()).collections;
-    return collections.map((c) => c.name);
-  } catch (error) {
-    console.error('Error listing collections:', error);
-    throw new Error(error?.message || 'An unexpected error occurred');
-  }
+export async function listCollections(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
+  const collections = (await qdrant.getCollections()).collections;
+  return collections.map((c) => c.name);
 }
 
 export async function getPoints(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
@@ -33,17 +23,13 @@ export async function getPoints(qdrant: QdrantClient, options: QueryOptions): Pr
     throw new Error('Collection name is required');
   }
 
-  try {
-    const points = await qdrant.retrieve(collectionName, {
-      ids: JSON.parse(ids),
-      with_payload: true,
-      with_vector: true,
-    });
+  const points = await qdrant.retrieve(collectionName, {
+    ids: JSON.parse(ids),
+    with_payload: true,
+    with_vector: true,
+  });
 
-    return points;
-  } catch (error) {
-    throw new Error(error?.message || 'An unexpected error occurred');
-  }
+  return points;
 }
 
 export async function upsertPoints(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
@@ -53,14 +39,11 @@ export async function upsertPoints(qdrant: QdrantClient, options: QueryOptions):
     throw new Error('Collection name is required');
   }
 
-  try {
-    const response = await qdrant.upsert(collectionName, {
-      points: JSON.parse(points),
-    });
-    return response.status;
-  } catch (error) {
-    throw new Error(error?.message || 'An unexpected error occurred');
-  }
+  const response = await qdrant.upsert(collectionName, {
+    points: JSON.parse(points),
+    wait: true
+  });
+  return response.status;
 }
 
 export async function deletePoints(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
@@ -70,36 +53,31 @@ export async function deletePoints(qdrant: QdrantClient, options: QueryOptions):
     throw new Error('Collection name is required');
   }
 
-  try {
-    const response = await qdrant.delete(collectionName, {
-      filter: filter ? JSON.parse(filter) : undefined,
-      points: ids ? JSON.parse(ids) : undefined,
-    });
+  const response = await qdrant.delete(collectionName, {
+    filter: filter ? JSON.parse(filter) : undefined,
+    points: ids ? JSON.parse(ids) : undefined,
+    wait: true
+  });
 
-    return response.status;
-  } catch (error) {
-    throw new Error(error?.message || 'An unexpected error occurred');
-  }
+  return response.status;
 }
 
 export async function queryPoints(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
   const { collectionName, query, filter, limit, withPayload, withVectors } = options;
 
+  console.log("OPTIONS ARE " + JSON.stringify(options));
+
   if (!collectionName) {
     throw new Error('Collection name is required');
   }
 
-  try {
-    const response = await qdrant.query(collectionName, {
-      query: JSON.parse(query),
-      filter: JSON.parse(filter),
-      limit: JSON.parse(limit),
-      with_payload: withPayload.toLowerCase() === 'true',
-      with_vector: withVectors.toLowerCase() === 'true',
-    });
+  const response = await qdrant.query(collectionName, {
+    query: query ? JSON.parse(query) : null,
+    filter: filter ? JSON.parse(filter) : {},
+    limit: limit ? JSON.parse(limit) : 10,
+    with_payload: withPayload.toLowerCase() === 'true',
+    with_vector: withVectors.toLowerCase() == 'true',
+  });
 
-    return response.points;
-  } catch (error) {
-    throw new Error(error?.message);
-  }
+  return response.points;
 }

--- a/marketplace/plugins/qdrant/lib/operations.ts
+++ b/marketplace/plugins/qdrant/lib/operations.ts
@@ -16,7 +16,7 @@ export async function getCollectionInfo(qdrant: QdrantClient, options: QueryOpti
   }
 }
 
-export async function listCollections(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
+export async function listCollections(qdrant: QdrantClient): Promise<any> {
   try {
     const collections = (await qdrant.getCollections()).collections;
     return collections.map((c) => c.name);
@@ -95,11 +95,11 @@ export async function queryPoints(qdrant: QdrantClient, options: QueryOptions): 
       filter: JSON.parse(filter),
       limit: JSON.parse(limit),
       with_payload: withPayload.toLowerCase() === 'true',
-      with_vector: withVectors.toLowerCase() == 'true',
+      with_vector: withVectors.toLowerCase() === 'true',
     });
 
     return response.points;
   } catch (error) {
-    throw new Error(error.message);
+    throw new Error(error?.message);
   }
 }

--- a/marketplace/plugins/qdrant/lib/operations.ts
+++ b/marketplace/plugins/qdrant/lib/operations.ts
@@ -1,0 +1,105 @@
+import { QueryOptions } from './types';
+import { QdrantClient } from '@qdrant/js-client-rest';
+
+export async function getCollectionInfo(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
+  const { collectionName } = options;
+
+  if (!collectionName) {
+    throw new Error('Collection name is required');
+  }
+
+  try {
+    return await qdrant.getCollection(collectionName);
+  } catch (error) {
+    console.error('Error fetching collection info:', error);
+    throw new Error(error?.message || 'An unexpected error occurred');
+  }
+}
+
+export async function listCollections(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
+  try {
+    const collections = (await qdrant.getCollections()).collections;
+    return collections.map((c) => c.name);
+  } catch (error) {
+    console.error('Error listing collections:', error);
+    throw new Error(error?.message || 'An unexpected error occurred');
+  }
+}
+
+export async function getPoints(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
+  const { collectionName, ids } = options;
+
+  if (!collectionName) {
+    throw new Error('Collection name is required');
+  }
+
+  try {
+    const points = await qdrant.retrieve(collectionName, {
+      ids: JSON.parse(ids),
+      with_payload: true,
+      with_vector: true,
+    });
+
+    return points;
+  } catch (error) {
+    throw new Error(error?.message || 'An unexpected error occurred');
+  }
+}
+
+export async function upsertPoints(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
+  const { collectionName, points } = options;
+
+  if (!collectionName) {
+    throw new Error('Collection name is required');
+  }
+
+  try {
+    const response = await qdrant.upsert(collectionName, {
+      points: JSON.parse(points),
+    });
+    return response.status;
+  } catch (error) {
+    throw new Error(error?.message || 'An unexpected error occurred');
+  }
+}
+
+export async function deletePoints(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
+  const { collectionName, ids, filter } = options;
+
+  if (!collectionName) {
+    throw new Error('Collection name is required');
+  }
+
+  try {
+    const response = await qdrant.delete(collectionName, {
+      filter: filter ? JSON.parse(filter) : undefined,
+      points: ids ? JSON.parse(ids) : undefined,
+    });
+
+    return response.status;
+  } catch (error) {
+    throw new Error(error?.message || 'An unexpected error occurred');
+  }
+}
+
+export async function queryPoints(qdrant: QdrantClient, options: QueryOptions): Promise<any> {
+  const { collectionName, query, filter, limit, withPayload, withVectors } = options;
+
+  if (!collectionName) {
+    throw new Error('Collection name is required');
+  }
+
+  try {
+    const response = await qdrant.query(collectionName, {
+      query: JSON.parse(query),
+      filter: JSON.parse(filter),
+      limit: JSON.parse(limit),
+      with_payload: withPayload.toLowerCase() === 'true',
+      with_vector: withVectors.toLowerCase() == 'true',
+    });
+
+    return response.points;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}

--- a/marketplace/plugins/qdrant/lib/types.ts
+++ b/marketplace/plugins/qdrant/lib/types.ts
@@ -1,0 +1,26 @@
+export type SourceOptions = {
+  apiKey: string;
+  url: string;
+};
+
+export type QueryOptions = {
+  operation: Operation;
+  collectionName: string;
+  ids?: string;
+  points?: string;
+  id?: string;
+  filter?: string;
+  limit?: string;
+  withPayload?: string;
+  withVectors?: string;
+  query?: string;
+};
+
+export enum Operation {
+  GetCollectionInfo = 'get_collection_info',
+  ListCollections = 'list_collections',
+  GetPoints = 'get_points',
+  UpsertPoints = 'upsert_points',
+  DeletePoints = 'delete_points',
+  QueryPoints = 'query_points',
+}

--- a/marketplace/plugins/qdrant/package.json
+++ b/marketplace/plugins/qdrant/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tooljet-marketplace/qdrant",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "build": "ncc build lib/index.ts -o dist",
+    "watch": "ncc build lib/index.ts -o dist --watch"
+  },
+  "homepage": "https://github.com/tooljet/tooljet#readme",
+  "dependencies": {
+    "@tooljet-marketplace/common": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.7.4",
+    "@vercel/ncc": "^0.34.0"
+  }
+}

--- a/marketplace/plugins/qdrant/package.json
+++ b/marketplace/plugins/qdrant/package.json
@@ -17,10 +17,11 @@
   },
   "homepage": "https://github.com/tooljet/tooljet#readme",
   "dependencies": {
+    "@qdrant/js-client-rest": "^1.12.0",
     "@tooljet-marketplace/common": "^1.0.0"
   },
   "devDependencies": {
-    "typescript": "^4.7.4",
-    "@vercel/ncc": "^0.34.0"
+    "@vercel/ncc": "^0.34.0",
+    "typescript": "^4.7.4"
   }
 }

--- a/marketplace/plugins/qdrant/tsconfig.json
+++ b/marketplace/plugins/qdrant/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "lib"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -724,12 +724,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1051,9 +1051,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1160,9 +1160,9 @@
       "dev": true
     },
     "node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "dependencies": {
         "jake": "^10.8.5"
@@ -1552,9 +1552,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/server/src/assets/marketplace/plugins.json
+++ b/server/src/assets/marketplace/plugins.json
@@ -105,8 +105,8 @@
     "timestamp": "Mon, 28 Oct 2024 08:08:28 GMT"
   },
   {
-    "name": "qdrant",
-    "description": "api plugin from qdrant",
+    "name": "Qdrant",
+    "description": "Plugin for Qdrant APIs",
     "version": "1.0.0",
     "id": "qdrant",
     "author": "Tooljet",

--- a/server/src/assets/marketplace/plugins.json
+++ b/server/src/assets/marketplace/plugins.json
@@ -103,5 +103,13 @@
     "id": "pinecone",
     "author": "Tooljet",
     "timestamp": "Mon, 28 Oct 2024 08:08:28 GMT"
+  },
+  {
+    "name": "qdrant",
+    "description": "api plugin from qdrant",
+    "version": "1.0.0",
+    "id": "qdrant",
+    "author": "Tooljet",
+    "timestamp": "Tue, 10 Dec 2024 02:11:32 GMT"
   }
 ]


### PR DESCRIPTION
## Description

This PR adds a new plugin to interface with Qdrant - https://qdrant.tech/

## To use with Qdrant cloud

- Create a free cluster as described in https://qdrant.tech/documentation/quickstart-cloud/
- Set the credentials as follows.

<img width="1276" alt="Screenshot 2025-01-17 at 12 10 24 PM" src="https://github.com/user-attachments/assets/4948c499-7e12-4eb6-9cb4-8bac5faec1c3" />

## To use with local Qdrant

```bash
docker run -p 6333:6333 qdrant/qdrant
```

NOTE to use 127.0.0.1 instead of localhost.

<img width="1277" alt="Screenshot 2025-01-17 at 12 07 11 PM" src="https://github.com/user-attachments/assets/6c78f0c2-1992-40d1-bd05-0f5901719175" />

You should then be able to query using the plugin.

<img width="1020" alt="Screenshot 2025-01-17 at 12 11 24 PM" src="https://github.com/user-attachments/assets/977bf923-067c-44b5-951a-3e44999483d0" />


