### PR TITLE
fix: standardize app visibility toggle messages

### DIFF
--- a/frontend/src/Editor/Header/RightTopHeaderButtons/ManageAppUsers.jsx
+++ b/frontend/src/Editor/Header/RightTopHeaderButtons/ManageAppUsers.jsx
@@ -102,9 +102,9 @@ class ManageAppUsersComponent extends React.Component {
         });
 
         if (newState) {
-          toast('Application is now public.');
+          toast('App is now public');
         } else {
-          toast('Application visibility set to private');
+          toast('App is now private');
         }
       })
       .catch((error) => {


### PR DESCRIPTION
Fixes #11552

Standardized snackbar messages for app visibility toggle:
- Changed "Application is now public." to "App is now public"
- Changed "Application visibility set to private" to "App is now private"

![image](https://github.com/user-attachments/assets/6f32b73d-965e-4d6f-beec-39d0cabef812)
