### PR TITLE
fix: Adds vertical scroll to tab component

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Tabs.jsx
+++ b/frontend/src/AppBuilder/Widgets/Tabs.jsx
@@ -117,6 +117,7 @@ export const Tabs = function Tabs({
           position: 'absolute',
           top: parsedHideTabs ? '0px' : '41px',
           width: '100%',
+          overflowY: 'auto',
         }}
       >
         <SubContainer


### PR DESCRIPTION
Adds Vertical scroll to tab component when the dropped component height is larger than tab container height.

Fixes - [#11274](https://github.com/ToolJet/ToolJet/issues/11274)