### PR TITLE
[docs]: Fix the command format in the testing

### DIFF
--- a/docs/docs/contributing-guide/testing.md
+++ b/docs/docs/contributing-guide/testing.md
@@ -13,44 +13,49 @@ Follow the steps below to setup and run the test specifications using Cypress. W
   ```
 
 ## Running Tests
+
 #### Headed mode
+
 - To run cypress in **headed** mode, run the following command:
   ```bash
   npm run cy:open
   ```
 - In **headed** mode, the user will be able to choose the test specs from the test runner:
   <div style={{textAlign: 'center'}}>
-  
+
   <img className="screenshot-full" src="/img/testing/headed.png" alt="Cypress headed mode" />
-  
+
   </div>
 
 #### Headless mode
 
 - To run cypress in **headless** mode, run the following command:
-  ```bash
- npm run cy:run
- ```
 
-- For running specific spec in headless mode, run for specific spec 
+  ```bash
+  npm run cy:run
+  ```
+
+- For running specific spec in headless mode, run for specific spec
+
   ```bash
   npm run cy:run --  --spec "cypress/e2e/dashboard/multi-workspace/manageSSO.cy.js
   ```
 
   <div style={{textAlign: 'center'}}>
-  
+
   <img className="screenshot-full" src="/img/testing/headless.png" alt="Cypress headless mode" />
-  
+
   </div>
 
   :::caution
   If some test specs need the environment variables, the user can pass them similar to the following command:
+
   ```bash
   npm run cy:open -- --env='{"pg_host":"localhost","pg_user":"postgres", "pg_password":"postgres"}'
   ```
+
   or the user can add env-vars in the **cypress.config.js** file
   :::
-
 
 :::info
 Check all the Cypress commands [here](https://docs.cypress.io/guides/guides/command-line#Commands)

--- a/docs/docs/contributing-guide/testing.md
+++ b/docs/docs/contributing-guide/testing.md
@@ -35,8 +35,8 @@ Follow the steps below to setup and run the test specifications using Cypress. W
   npm run cy:run
   ```
 
-- For running specific spec in headless mode, run for specific spec
-
+- To run a specific spec in headless mode, run the following command:
+  
   ```bash
   npm run cy:run --  --spec "cypress/e2e/dashboard/multi-workspace/manageSSO.cy.js
   ```

--- a/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/testing.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/testing.md
@@ -13,44 +13,49 @@ Follow the steps below to setup and run the test specifications using Cypress. W
   ```
 
 ## Running Tests
+
 #### Headed mode
+
 - To run cypress in **headed** mode, run the following command:
   ```bash
   npm run cy:open
   ```
 - In **headed** mode, the user will be able to choose the test specs from the test runner:
   <div style={{textAlign: 'center'}}>
-  
+
   <img className="screenshot-full" src="/img/testing/headed.png" alt="Cypress headed mode" />
-  
+
   </div>
 
 #### Headless mode
 
 - To run cypress in **headless** mode, run the following command:
-  ```bash
- npm run cy:run
- ```
 
-- For running specific spec in headless mode, run for specific spec 
+  ```bash
+  npm run cy:run
+  ```
+
+- For running specific spec in headless mode, run for specific spec
+
   ```bash
   npm run cy:run --  --spec "cypress/e2e/dashboard/multi-workspace/manageSSO.cy.js
   ```
 
   <div style={{textAlign: 'center'}}>
-  
+
   <img className="screenshot-full" src="/img/testing/headless.png" alt="Cypress headless mode" />
-  
+
   </div>
 
   :::caution
   If some test specs need the environment variables, the user can pass them similar to the following command:
+
   ```bash
   npm run cy:open -- --env='{"pg_host":"localhost","pg_user":"postgres", "pg_password":"postgres"}'
   ```
+
   or the user can add env-vars in the **cypress.config.js** file
   :::
-
 
 :::info
 Check all the Cypress commands [here](https://docs.cypress.io/guides/guides/command-line#Commands)

--- a/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/testing.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/testing.md
@@ -35,8 +35,8 @@ Follow the steps below to setup and run the test specifications using Cypress. W
   npm run cy:run
   ```
 
-- For running specific spec in headless mode, run for specific spec
-
+- To run a specific spec in headless mode, run the following command:
+  
   ```bash
   npm run cy:run --  --spec "cypress/e2e/dashboard/multi-workspace/manageSSO.cy.js
   ```

--- a/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/testing.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/testing.md
@@ -13,44 +13,49 @@ Follow the steps below to setup and run the test specifications using Cypress. W
   ```
 
 ## Running Tests
+
 #### Headed mode
+
 - To run cypress in **headed** mode, run the following command:
   ```bash
   npm run cy:open
   ```
 - In **headed** mode, the user will be able to choose the test specs from the test runner:
   <div style={{textAlign: 'center'}}>
-  
+
   <img className="screenshot-full" src="/img/testing/headed.png" alt="Cypress headed mode" />
-  
+
   </div>
 
 #### Headless mode
 
 - To run cypress in **headless** mode, run the following command:
-  ```bash
- npm run cy:run
- ```
 
-- For running specific spec in headless mode, run for specific spec 
+  ```bash
+  npm run cy:run
+  ```
+
+- For running specific spec in headless mode, run for specific spec
+
   ```bash
   npm run cy:run --  --spec "cypress/e2e/dashboard/multi-workspace/manageSSO.cy.js
   ```
 
   <div style={{textAlign: 'center'}}>
-  
+
   <img className="screenshot-full" src="/img/testing/headless.png" alt="Cypress headless mode" />
-  
+
   </div>
 
   :::caution
   If some test specs need the environment variables, the user can pass them similar to the following command:
+
   ```bash
   npm run cy:open -- --env='{"pg_host":"localhost","pg_user":"postgres", "pg_password":"postgres"}'
   ```
+
   or the user can add env-vars in the **cypress.config.js** file
   :::
-
 
 :::info
 Check all the Cypress commands [here](https://docs.cypress.io/guides/guides/command-line#Commands)

--- a/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/testing.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/testing.md
@@ -35,7 +35,7 @@ Follow the steps below to setup and run the test specifications using Cypress. W
   npm run cy:run
   ```
 
-- For running specific spec in headless mode, run for specific spec
+- To run a specific spec in headless mode, run the following command:
 
   ```bash
   npm run cy:run --  --spec "cypress/e2e/dashboard/multi-workspace/manageSSO.cy.js


### PR DESCRIPTION
**Description:**

This PR fixes the formatting issue in the ToolJet documentation related to the command 'npm run cy:run' in the testing guide. Currently, the command is not properly displayed within a command box.

**Changes:**

**Files:** 
**Next** - ToolJet/docs/docs/contributing-guide/testing.md
**Version 2.50.0 (LTS)** - ToolJet/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/testing.md
**Version 3.0.0 (LTS)** - ToolJet/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/testing.md

**Changes made:** Placed the command 'npm run cy:run' inside the code block.

**Before**
![before](https://github.com/user-attachments/assets/bc35f245-c45c-4ae0-a5eb-1f29b57ef044)

**After**
![after](https://github.com/user-attachments/assets/fa4b3d45-55d1-48bd-9151-f9b07c6b60c2)



