### PR TITLE
Fix: #11669 (Remove Cursor Display in Dropdown Selection Box)

### DIFF
--- a/cypress-tests/cypress/constants/texts/dataSource.js
+++ b/cypress-tests/cypress/constants/texts/dataSource.js
@@ -12,11 +12,11 @@ export const dataSourceText = {
   labelHost: "Host",
   labelPort: "Port",
   labelSSL: "SSL",
-  labelDbName: "Database Name",
+  labelDbName: "Database name",
   labelUserName: "Username",
   labelPassword: "Password",
   label: "Encrypted",
-  sslCertificate: "SSL Certificate",
+  sslCertificate: "SSL certificate",
   whiteListIpText:
     "Please white-list our IP address if the data source is not publicly accessible",
   textCopy: "Copy",


### PR DESCRIPTION
###Description:
This PR resolves an issue in the ToolJet UI where the cursor appears in the selection box of the dropdown menu, making it resemble a text input field. The update ensures the dropdown behaves as expected, providing a more intuitive user experience.