### PR TITLE
Override codemirror autocomplete's default filtering

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
@@ -53,7 +53,7 @@ const MultiLineCodeEditor = (props) => {
 
   const context = useContext(CodeHinterContext);
 
-  const { suggestionList } = createReferencesLookup(context, true);
+  const { suggestionList: paramList } = createReferencesLookup(context, true);
 
   const currentValueRef = useRef(initialValue);
 
@@ -139,6 +139,8 @@ const MultiLineCodeEditor = (props) => {
       hint: varName,
       type: 'variable',
     }));
+
+    const suggestionList = paramList.filter((paramSuggestion) => paramSuggestion.hint.includes(nearestSubstring));
 
     const suggestions = generateHints(
       [...localVariableSuggestions, ...JSLangHints, ...autoSuggestionList, ...suggestionList],
@@ -226,7 +228,7 @@ const MultiLineCodeEditor = (props) => {
   ]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const overRideFunction = React.useCallback((context) => autoCompleteExtensionConfig(context), []);
+  const overRideFunction = React.useCallback((context) => autoCompleteExtensionConfig(context), [paramList]);
   const { handleTogglePopupExapand, isOpen, setIsOpen, forceUpdate } = portalProps;
   let cyLabel = paramLabel ? paramLabel.toLowerCase().trim().replace(/\s+/g, '-') : props.cyLabel;
 

--- a/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
@@ -178,6 +178,7 @@ const MultiLineCodeEditor = (props) => {
     return {
       from: context.pos,
       options: [...suggestions],
+      filter: false,
     };
   }
 

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -6,7 +6,13 @@ import { useTranslation } from 'react-i18next';
 import { camelCase, isEmpty, noop } from 'lodash';
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
-import { autocompletion, completionKeymap, completionStatus, acceptCompletion } from '@codemirror/autocomplete';
+import {
+  autocompletion,
+  completionKeymap,
+  completionStatus,
+  acceptCompletion,
+  startCompletion,
+} from '@codemirror/autocomplete';
 import { defaultKeymap } from '@codemirror/commands';
 import { keymap } from '@codemirror/view';
 import FxButton from '../CodeBuilder/Elements/FxButton';
@@ -157,6 +163,7 @@ const EditorInput = ({
   disabled = false,
 }) => {
   const getSuggestions = useStore((state) => state.getSuggestions, shallow);
+  const [codeMirrorView, setCodeMirrorView] = useState(undefined);
   function autoCompleteExtensionConfig(context) {
     const hints = getSuggestions();
     let word = context.matchBefore(/\w*/);
@@ -314,6 +321,9 @@ const EditorInput = ({
       >
         <ErrorBoundary>
           <CodeMirror
+            onCreateEditor={(view) => {
+              setCodeMirrorView(view);
+            }}
             value={currentValue}
             placeholder={placeholder}
             height={showLineNumbers ? '400px' : '100%'}
@@ -344,6 +354,11 @@ const EditorInput = ({
             theme={theme}
             indentWithTab={false}
             readOnly={disabled}
+            onKeyDown={(event) => {
+              if (event.key === 'Backspace') {
+                startCompletion(codeMirrorView);
+              }
+            }}
           />
         </ErrorBoundary>
       </CodeHinter.Portal>

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -195,6 +195,7 @@ const EditorInput = ({
       from: word.from,
       options: completions,
       validFor: /^\{\{.*\}\}$/,
+      filter: false,
     };
   }
 

--- a/frontend/src/AppBuilder/CodeEditor/autocompleteExtensionConfig.js
+++ b/frontend/src/AppBuilder/CodeEditor/autocompleteExtensionConfig.js
@@ -156,35 +156,11 @@ export const generateHints = (hints, totalReferences = 1, input, searchText) => 
 function filterHintsByDepth(input, hints) {
   if (input === '') return hints;
 
-  const inputDepth = input.includes('.') ? input.split('.').length : 0;
+  const inputParts = input.split('.');
 
-  const filteredHints = hints.filter((cm) => {
-    const hintParts = cm.hint.split('.');
-
-    let shouldInclude =
-      (cm.hint.startsWith(input) && hintParts.length === inputDepth + 1) ||
-      (cm.hint.startsWith(input) && hintParts.length === inputDepth);
-
-    const shouldFuzzyMatch = !shouldInclude ? hintParts.length > inputDepth : false;
-
-    if (shouldFuzzyMatch) {
-      // fuzzy match
-      let matchedDepth = -1;
-      for (let i = 0; i < hintParts.length; i++) {
-        if (hintParts[i].includes(input)) {
-          matchedDepth = i;
-          break;
-        }
-      }
-
-      if (matchedDepth !== -1) {
-        shouldInclude = hintParts.length === matchedDepth + 1;
-      }
-    } else if (input.endsWith('.')) {
-      shouldInclude = cm.hint.startsWith(input) && hintParts.length === inputDepth;
-    }
-
-    return shouldInclude;
+  const filteredHints = hints.filter((hint) => {
+    const hintParts = hint.hint.split('.');
+    return hintParts.length <= inputParts.length + 1;
   });
 
   return filteredHints;

--- a/frontend/src/AppBuilder/CodeEditor/autocompleteExtensionConfig.js
+++ b/frontend/src/AppBuilder/CodeEditor/autocompleteExtensionConfig.js
@@ -163,8 +163,6 @@ export const generateHints = (hints, totalReferences = 1, input, searchText) => 
 };
 
 function filterHintsByDepth(input, hints) {
-  if (input === '') return hints;
-
   const inputParts = input.split('.');
   const inputDepth = inputParts.length + 1;
 

--- a/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
@@ -125,6 +125,7 @@ export const createResolvedSlice = (set, get) => ({
       'setVariables'
     );
     get().updateDependencyValues(`variables.${key}`);
+    get().checkAndSetTrueBuildSuggestionsFlag();
   },
 
   getVariable: (key, moduleId = 'canvas') => {
@@ -153,6 +154,7 @@ export const createResolvedSlice = (set, get) => ({
       'setPageVariable'
     );
     get().updateDependencyValues(`page.variables.${key}`);
+    get().checkAndSetTrueBuildSuggestionsFlag();
   },
 
   getPageVariable: (key, moduleId = 'canvas') => {


### PR DESCRIPTION
Related to #10617

This PR fixes the following items:

1. When there is a text input and a query, when the typed in value in one of the query fields is `{{components.textinput1.v}}`, it should show `value` as a a suggestion, but it does not. This PR solves it.
2. When there is a query called `runjs1`, in any property field of any component, type in `{{r}}` and the suggestions does not have `queries.runjs1` on them, this PR fixes that.

Implementation-wise, this PR overrides the default filtering logic of CodeMirror, and also removes the existing complex custom filtering function.

To QA: Please check if some existing behavior had been violated. 