### PR TITLE
Fix marketplace build error

### DIFF
--- a/.github/workflows/maketplace-plugins-deploy.yml
+++ b/.github/workflows/maketplace-plugins-deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install and build dependencies
         run: |
-          cd marketplace && npm install && npm run build --workspaces
+          cd marketplace && npm install && npm run build 
         continue-on-error: true
       
       - name: Build marketplace plugins 

--- a/marketplace/package-lock.json
+++ b/marketplace/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "plugins/*"
       ],
+      "dependencies": {
+        "depd": "^2.0.0"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
@@ -10520,6 +10523,14 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/deprecation": {
       "version": "2.3.1",

--- a/marketplace/package.json
+++ b/marketplace/package.json
@@ -25,10 +25,12 @@
   },
   "scripts": {
     "start:watch": "lerna run watch --stream --parallel",
-    "build": "npm run build --workspaces",
+    "build": "lerna run build --stream --sort",
     "start:dev": "npm run build && npm run start:watch",
     "lint": "eslint .  '**/*.ts'",
     "format": "eslint . --fix '**/*.ts'"
   },
-  "dependencies": {}
+  "dependencies": {
+    "depd": "^2.0.0"
+  }
 }

--- a/marketplace/plugins/jira/package.json
+++ b/marketplace/plugins/jira/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/tooljet/tooljet#readme",
   "dependencies": {
-    "@tooljet-plugins/common": "file:../common",
+    "@tooljet-marketplace/common": "^1.0.0",
     "jira.js": "^4.0.1",
     "react": "^17.0.2"
   }

--- a/marketplace/plugins/sharepoint/package.json
+++ b/marketplace/plugins/sharepoint/package.json
@@ -16,11 +16,10 @@
     "watch": "ncc build lib/index.ts -o dist --watch"
   },
   "homepage": "https://github.com/tooljet/tooljet#readme",
-  "dependencies": {
-    "@tooljet-marketplace/common": "^1.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "typescript": "^4.7.4",
-    "@vercel/ncc": "^0.34.0"
+    "@vercel/ncc": "^0.34.0",
+    "@tooljet-marketplace/common": "^1.0.0"
   }
 }

--- a/marketplace/plugins/supabase/package.json
+++ b/marketplace/plugins/supabase/package.json
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/tooljet/tooljet#readme",
   "dependencies": {
-    "@supabase/supabase-js": "^2.41.1",
-    "@tooljet-marketplace/common": "^1.0.0"
+    "@supabase/supabase-js": "^2.41.1"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.34.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "@tooljet-marketplace/common": "^1.0.0"
   }
 }

--- a/marketplace/plugins/textract/package.json
+++ b/marketplace/plugins/textract/package.json
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/tooljet/tooljet#readme",
   "dependencies": {
-    "@aws-sdk/client-textract": "^3.321.1",
-    "@tooljet-marketplace/common": "^1.0.0"
+    "@aws-sdk/client-textract": "^3.321.1"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.34.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "@tooljet-marketplace/common": "^1.0.0"
   }
 }


### PR DESCRIPTION
Marketplace plugin build fails when the common folder is not built first.
This change uses lerna to streamline the build to have the dependencies built first.