### PR TITLE
Feature: Add TLS settings for redis plugin (LTS 3.0)

### DIFF
--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -19608,7 +19608,7 @@
     },
     "packages/redis": {
       "name": "@tooljet-plugins/redis",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@tooljet-plugins/common": "file:../common",
         "ioredis": "^4.28.5",

--- a/plugins/packages/redis/lib/index.ts
+++ b/plugins/packages/redis/lib/index.ts
@@ -1,6 +1,7 @@
 import { ConnectionTestResult, QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
 import Redis from 'ioredis';
 import { SourceOptions, QueryOptions } from './types';
+import { ConnectionOptions } from 'tls';
 
 export default class RedisQueryService implements QueryService {
   async run(sourceOptions: SourceOptions, queryOptions: QueryOptions, dataSourceId: string): Promise<QueryResult> {
@@ -24,7 +25,12 @@ export default class RedisQueryService implements QueryService {
 
   async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
     const client = await this.getConnection(sourceOptions);
-    await client.ping();
+    try {
+      await client.ping();
+    } catch (err) {
+      client.disconnect();
+      throw new QueryError('Connection could not be established', err.message, {});
+    }
 
     return {
       status: 'ok',
@@ -36,8 +42,26 @@ export default class RedisQueryService implements QueryService {
     const host = sourceOptions.host;
     const password = sourceOptions.password;
     const port = sourceOptions.port;
+    let tls: ConnectionOptions = undefined;
 
-    const client = new Redis(port, host, { maxRetriesPerRequest: 1, username, password });
-    return client;
+    if (sourceOptions.tls_enabled) {
+      tls = {};
+      tls.rejectUnauthorized = (sourceOptions.tls_certificate ?? 'none') != 'none';
+      if (sourceOptions.tls_certificate === 'ca_certificate') {
+        tls.ca = sourceOptions.ca_cert;
+      }
+      if (sourceOptions.tls_certificate === 'client_certificate') {
+        tls.ca = sourceOptions.ca_cert;
+        tls.key = sourceOptions.client_key;
+        tls.cert = sourceOptions.client_cert;
+      }
+    }
+
+    return new Redis(port, host, {
+      maxRetriesPerRequest: 1,
+      username,
+      password,
+      tls: tls,
+    });
   }
 }

--- a/plugins/packages/redis/lib/manifest.json
+++ b/plugins/packages/redis/lib/manifest.json
@@ -24,6 +24,15 @@
       "password": {
         "type": "string",
         "encrypted": true
+      },
+      "ca_cert": {
+        "encrypted": true
+      },
+      "client_key": {
+        "encrypted": true
+      },
+      "client_cert": {
+        "encrypted": true
       }
     }
   },
@@ -39,32 +48,98 @@
     },
     "password": {
       "value": ""
+    },
+    "tls_enabled": {
+      "value": false
+    },
+    "tls_certificate": {
+      "value": "none"
     }
   },
   "properties": {
-    "host": {
-      "label": "Host",
-      "key": "host",
-      "type": "text",
-      "description": "Enter host"
+    "tls_certificate": {
+      "label": "TLS Certificate",
+      "key": "tls_certificate",
+      "type": "dropdown-component-flip",
+      "description": "Single select dropdown for choosing certificates",
+      "list": [
+        {
+          "value": "ca_certificate",
+          "name": "CA certificate"
+        },
+        {
+          "value": "client_certificate",
+          "name": "Client certificate"
+        },
+        {
+          "value": "none",
+          "name": "None"
+        }
+      ],
+      "commonFields": {
+        "host": {
+          "label": "Host",
+          "key": "host",
+          "type": "text",
+          "description": "Enter host"
+        },
+        "port": {
+          "label": "Port",
+          "key": "port",
+          "type": "text",
+          "description": "Enter port"
+        },
+        "username": {
+          "label": "Username",
+          "key": "username",
+          "type": "text",
+          "description": "Enter username"
+        },
+        "password": {
+          "label": "Password",
+          "key": "password",
+          "type": "password",
+          "description": "Enter password"
+        },
+        "tls_enabled": {
+          "label": "TLS",
+          "key": "tls_enabled",
+          "type": "toggle",
+          "description": "Toggle for TLS"
+        }
+      }
     },
-    "port": {
-      "label": "Port",
-      "key": "port",
-      "type": "text",
-      "description": "Enter port"
+    "ca_certificate": {
+      "ca_cert": {
+        "label": "CA Cert",
+        "key": "ca_cert",
+        "type": "textarea",
+        "encrypted": true,
+        "description": "Enter ca certificate"
+      }
     },
-    "username": {
-      "label": "Username",
-      "key": "username",
-      "type": "text",
-      "description": "Enter username"
-    },
-    "password": {
-      "label": "Password",
-      "key": "password",
-      "type": "password",
-      "description": "Enter password"
+    "client_certificate": {
+      "client_key": {
+        "label": "Client Key",
+        "key": "client_key",
+        "type": "textarea",
+        "encrypted": true,
+        "description": "Enter client key"
+      },
+      "client_cert": {
+        "label": "Client Cert",
+        "key": "client_cert",
+        "type": "textarea",
+        "encrypted": true,
+        "description": "Enter client certificate"
+      },
+      "ca_cert": {
+        "label": "CA Cert",
+        "key": "ca_cert",
+        "type": "textarea",
+        "encrypted": true,
+        "description": "Enter ca certificate"
+      }
     }
   },
   "required": [

--- a/plugins/packages/redis/lib/types.ts
+++ b/plugins/packages/redis/lib/types.ts
@@ -3,6 +3,11 @@ export type SourceOptions = {
   port: string;
   username: string;
   password: string;
+  tls_enabled: boolean;
+  tls_certificate: string;
+  ca_cert: string;
+  client_cert: string;
+  client_key: string;
 };
 export type QueryOptions = {
   operation: string;

--- a/plugins/packages/redis/package.json
+++ b/plugins/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tooljet-plugins/redis",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "directories": {


### PR DESCRIPTION
* Change the code to use IsEmpty from common library

* Add certification section for redis plugin

* Remove connection options

* Change self_signed certificate to ca_certificate

* Handle execption and close connection when pinging redis