### PR TITLE
Fix: ensure proper text visibility in RichText and HTML widgets in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -5135,7 +5135,7 @@ div#driver-page-overlay {
   padding: 10px 5px 0 0;
   float: left;
   font-size: 14px;
-  color: $light-gray;
+  color: var(--slate-12);
 }
 
 .dynamic-form-row {

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -2253,6 +2253,7 @@ body {
   font-family: "Inconsolata", "Menlo", "Consolas", monospace;
   font-size: 16px;
   padding: 20px;
+  color: #0000009c;
 }
 
 .RichEditor-controls {


### PR DESCRIPTION
Fixes:

- Fixed an issue where text marked as code (`<code>...</code>`) was not visible in RichText Editor and HTML Widget in dark mode (white text on white background).
- Updated the styles to ensure proper contrast and readability.
- Tested the fix in ToolJet Cloud (Version 3.0.24-cloud-lts) to confirm proper visibility of code-marked text.

How to Test:

- Enable dark mode in ToolJet Cloud.
- Drag a RichText Editor or HTML Widget into the canvas.
- Type some text, select it, and format it as code using the <> button.
- Ensure that the text is clearly visible and properly styled.