### PR TITLE
Fix: GraphQL plugin appends an empty URL parameter (?=) to the endpoint.

### DIFF
--- a/plugins/packages/common/lib/utils.helper.ts
+++ b/plugins/packages/common/lib/utils.helper.ts
@@ -121,8 +121,11 @@ export const sanitizeSearchParams = (sourceOptions: any, queryOptions: any, hasD
   });
 
   if (!hasDataSource) return _urlParams;
+  const sanitisedUrlParamsFromSourceOptions = (sourceOptions.url_params || []).filter((o) => {
+    return o.some((e) => !isEmpty(e));
+  });
 
-  const urlParams = _urlParams.concat(sourceOptions.url_params || []);
+  const urlParams = _urlParams.concat(sanitisedUrlParamsFromSourceOptions || []);
   return urlParams;
 };
 


### PR DESCRIPTION
Problem:
In GraphQL plugin even when url parameters are not provided, empty parameters are appended in the endpoint ( ?= ).