### PR TITLE
Hotfix: Support for pagination in GitHub plugin

### DIFF
--- a/marketplace/plugins/github/lib/operations.json
+++ b/marketplace/plugins/github/lib/operations.json
@@ -110,6 +110,28 @@
             "name": "All"
           }
         ]
+      },
+      "page_size": {
+        "label": "Page size",
+        "key": "page_size",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "description": "Enter number of issues per page",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins",
+        "placeholder": "Enter number of issues per page"
+      },
+      "page": {
+        "label": "Page",
+        "key": "page",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "description": "Enter page number",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins",
+        "placeholder": "Enter page number"
       }
     },
     "get_repo_pull_requests": {
@@ -155,6 +177,28 @@
             "name": "All"
           }
         ]
+      },
+      "page_size": {
+        "label": "Page size",
+        "key": "page_size",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "description": "Enter number of pull requests per page",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins",
+        "placeholder": "Enter number of pull requests per page"
+      },
+      "page": {
+        "label": "Page",
+        "key": "page",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "description": "Enter page number",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins",
+        "placeholder": "Enter page number"
       }
     }
   }

--- a/marketplace/plugins/github/lib/operations.json
+++ b/marketplace/plugins/github/lib/operations.json
@@ -120,10 +120,10 @@
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Enter number of issues per page"
+        "placeholder": "Default is 30"
       },
       "page": {
-        "label": "Page",
+        "label": "Page number",
         "key": "page",
         "type": "codehinter",
         "lineNumbers": false,
@@ -131,7 +131,7 @@
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Enter page number"
+        "placeholder": "Default is 1"
       }
     },
     "get_repo_pull_requests": {
@@ -187,10 +187,10 @@
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Enter number of pull requests per page"
+        "placeholder": "Default is 30"
       },
       "page": {
-        "label": "Page",
+        "label": "Page number",
         "key": "page",
         "type": "codehinter",
         "lineNumbers": false,
@@ -198,7 +198,7 @@
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Enter page number"
+        "placeholder": "Default is 1"
       }
     }
   }

--- a/marketplace/plugins/github/lib/operations.json
+++ b/marketplace/plugins/github/lib/operations.json
@@ -120,7 +120,7 @@
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Default is 30"
+        "placeholder": "Enter number of issues per page. Default is 30"
       },
       "page": {
         "label": "Page number",
@@ -131,7 +131,7 @@
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Default is 1"
+        "placeholder": "Enter page number. Default is 1"
       }
     },
     "get_repo_pull_requests": {
@@ -187,7 +187,7 @@
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Default is 30"
+        "placeholder": "Enter number of pull requests per page. Default is 30"
       },
       "page": {
         "label": "Page number",
@@ -198,7 +198,7 @@
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Default is 1"
+        "placeholder": "Enter page number. Default is 1"
       }
     }
   }

--- a/marketplace/plugins/github/lib/query_operations.ts
+++ b/marketplace/plugins/github/lib/query_operations.ts
@@ -16,12 +16,29 @@ export async function getRepo(octokit: Octokit, options: QueryOptions): Promise<
   return data;
 }
 
+function validateNumber(customErrorMessage, optionKey, value, min, max = undefined) {
+  const parsedValue = parseInt(value, 10);
+  if (isNaN(parsedValue) || value < min || (max !== undefined && value > max)) {
+    throw new Error(`Invalid ${optionKey}: ${customErrorMessage}`);
+  }
+  return true;
+}
+
 export async function getRepoIssues(octokit: Octokit, options: QueryOptions): Promise<object> {
   const { data } = await octokit.request('GET /repos/{owner}/{repo}/issues', {
     owner: options.owner,
     repo: options.repo,
     state: options.state || 'all',
+    ...(options.page &&
+      validateNumber('The value must be greater than 1.', 'page', options.page, 1) && {
+        page: parseInt(options.page, 10),
+      }),
+    ...(options.page_size &&
+      validateNumber('The value must be in the range of 1 to 100', 'page size', options.page_size, 1, 100) && {
+        per_page: parseInt(options.page_size, 10),
+      }),
   });
+
   return data;
 }
 
@@ -30,6 +47,15 @@ export async function getRepoPullRequests(octokit: Octokit, options: QueryOption
     owner: options.owner,
     repo: options.repo,
     state: options.state || 'all',
+    ...(options.page &&
+      validateNumber('The value must be greater than 1.', 'page', options.page, 1) && {
+        page: parseInt(options.page, 10),
+      }),
+    ...(options.page_size &&
+      validateNumber('The value must be in the range of 1 to 100', 'page size', options.page_size, 1, 100) && {
+        per_page: parseInt(options.page_size, 10),
+      }),
   });
+
   return data;
 }

--- a/marketplace/plugins/github/lib/types.ts
+++ b/marketplace/plugins/github/lib/types.ts
@@ -9,6 +9,8 @@ export type QueryOptions = {
   repo?: string;
   owner?: string;
   state?: 'open' | 'closed' | 'all';
+  page_size?: string;
+  page?: string;
 };
 
 export enum Operation {


### PR DESCRIPTION
Problem:

1. The page size for **listing issues** and **pull requests** in the repository is set to _30_, and the page is _1,_ as per the GitHub plugin's default settings. Editing the pagination fields cannot be done.

Solution
1. The GitHub plugin now offers the possibility of editing page and page size in the operation **list issues** and **pull request list** in the repository.