### PR TITLE
[docs]: Update V3 Migration Guide

### DIFF
--- a/docs/docs/setup/upgrade-to-v3.md
+++ b/docs/docs/setup/upgrade-to-v3.md
@@ -21,14 +21,7 @@ Before attempting to upgrade to the ToolJet 3.0:
 - **Application Review**: Check your apps for breaking and deprecated features listed in this guide.
 - **Test Environment**: Only attempt upgrade in a testing environment first.
 
-To upgrade, update your Docker image to:
-
-```bash
-tooljet/tooljet:v3.0.0-ee-lts
-```
-:::warning
-This is a beta release. Test thoroughly in a non-production environment first.
-:::
+To upgrade, checkout the latest docker image **[here](/docs/setup/choose-your-tooljet)**.
 
 ## Breaking Changes
 

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/upgrade-to-v3.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/upgrade-to-v3.md
@@ -21,14 +21,7 @@ Before attempting to upgrade to the ToolJet 3.0:
 - **Application Review**: Check your apps for breaking and deprecated features listed in this guide.
 - **Test Environment**: Only attempt upgrade in a testing environment first.
 
-To upgrade, update your Docker image to:
-
-```bash
-tooljet/tooljet:v3.0.0-ee-lts
-```
-:::warning
-This is a beta release. Test thoroughly in a non-production environment first.
-:::
+To upgrade, checkout the latest docker image **[here](/docs/setup/choose-your-tooljet)**.
 
 ## Breaking Changes
 


### PR DESCRIPTION
1. Removed Beta Warning.
2. Link to Choose Your ToolJet Docs for latest docker image.