### PR TITLE
Making CE and Basic Plan logic same for environments

### DIFF
--- a/server/src/helpers/edition.helper.ts
+++ b/server/src/helpers/edition.helper.ts
@@ -1,0 +1,56 @@
+import { DataSource } from 'typeorm';
+import { getTooljetEdition } from './utils.helper';
+import { INestApplication } from '@nestjs/common';
+import { Metadata } from '@entities/metadata.entity';
+
+const EDITION_PRIORITY = {
+  ce: 0,
+  ee: 1,
+  cloud: 2,
+};
+
+export function getEditionPriority(edition: string): number {
+  return EDITION_PRIORITY[edition?.toLowerCase()] ?? -1;
+}
+
+export function isEditionDowngrade(currentEdition: string, newEdition: string): boolean {
+  if (!currentEdition || !newEdition) return false;
+  return getEditionPriority(currentEdition) > getEditionPriority(newEdition);
+}
+
+export async function validateEdition(app: INestApplication) {
+  if (process.env.NODE_ENV === 'production') return;
+
+  const dataSource = app.get(DataSource);
+  const metadataRepository = dataSource.getRepository(Metadata);
+  const editionMetadata = (await metadataRepository.find())?.[0];
+
+  const currentEdition = getTooljetEdition();
+  const savedEdition = editionMetadata?.data?.edition;
+
+  if (savedEdition) {
+    if (isEditionDowngrade(savedEdition, currentEdition)) {
+      console.error(
+        `Cannot downgrade from ${savedEdition} to ${currentEdition}. Please use an equal or higher edition or reset the database.`
+      );
+      await app.close();
+      process.exit(0);
+    }
+    // change edition
+    if (savedEdition !== currentEdition) {
+      await metadataRepository.update(
+        { id: editionMetadata.id },
+        { data: { ...editionMetadata.data, edition: currentEdition } }
+      );
+    }
+  } else if (editionMetadata) {
+    await metadataRepository.update(
+      { id: editionMetadata.id },
+      { data: { ...editionMetadata.data, edition: currentEdition } }
+    );
+  } else {
+    await metadataRepository.save({
+      data: { edition: currentEdition },
+    });
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -27,6 +27,7 @@ import { GuardValidator } from '@modules/app/validators/feature-guard.validator'
 import { ILicenseUtilService } from '@modules/licensing/interfaces/IUtilService';
 import { ITemporalService } from '@modules/workflows/interfaces/ITemporalService';
 import { getTooljetEdition } from '@helpers/utils.helper';
+import { validateEdition } from '@helpers/edition.helper';
 
 let appContext: INestApplicationContext = undefined;
 
@@ -147,6 +148,9 @@ async function bootstrap() {
     bufferLogs: true,
     abortOnError: false,
   });
+
+  // Get DataSource from the app
+  await validateEdition(app);
 
   globalThis.TOOLJET_VERSION = `${fs.readFileSync('./.version', 'utf8').trim()}-${getTooljetEdition()}`;
   process.env['RELEASE_VERSION'] = globalThis.TOOLJET_VERSION;

--- a/server/src/modules/app-environments/interfaces/IService.ts
+++ b/server/src/modules/app-environments/interfaces/IService.ts
@@ -2,6 +2,7 @@ import { AppEnvironment } from 'src/entities/app_environments.entity';
 import { AppVersion } from 'src/entities/app_version.entity';
 import { AppEnvironmentActionParametersDto } from '../dto';
 import { IAppEnvironmentResponse } from './IAppEnvironmentResponse';
+import { EntityManager } from 'typeorm';
 
 export interface IAppEnvironmentService {
   init(editingVersionId: string, organizationId: string): Promise<IAppEnvironmentResponse>;
@@ -10,7 +11,13 @@ export interface IAppEnvironmentService {
     action: string,
     actionParameters: AppEnvironmentActionParametersDto
   ): Promise<any>;
-  get(organizationId: string, id?: string, priorityCheck?: boolean, licenseCheck?: boolean): Promise<AppEnvironment>;
+  get(
+    organizationId: string,
+    id?: string,
+    priorityCheck?: boolean,
+    licenseCheck?: boolean,
+    manager?: EntityManager
+  ): Promise<AppEnvironment>;
   create(organizationId: string, name: string, isDefault?: boolean, priority?: number): Promise<AppEnvironment>;
   update(id: string, name: string, organizationId: string): Promise<any>;
   getAll(organizationId: string, appId?: string): Promise<AppEnvironment[]>;

--- a/server/src/modules/app-environments/interfaces/IUtilService.ts
+++ b/server/src/modules/app-environments/interfaces/IUtilService.ts
@@ -1,8 +1,8 @@
-import { EntityManager, DeleteResult } from 'typeorm';
+import { EntityManager } from 'typeorm';
 import { AppEnvironment } from 'src/entities/app_environments.entity';
-import { OrgEnvironmentConstantValue } from 'src/entities/org_environment_constant_values.entity';
 import { DataSourceOptions } from '@entities/data_source_options.entity';
-import { OrganizationConstantType } from '@modules/organization-constants/constants';
+import { IAppEnvironmentResponse } from './IAppEnvironmentResponse';
+import { AppVersion } from '@entities/app_version.entity';
 
 export interface IAppEnvironmentUtilService {
   getByPriority(organizationId: string, ASC?: boolean, manager?: EntityManager): Promise<AppEnvironment>;
@@ -27,4 +27,10 @@ export interface IAppEnvironmentUtilService {
   ): Promise<AppEnvironment>;
   getAll(organizationId: string, appId?: string, manager?: EntityManager): Promise<AppEnvironment[]>;
   getOptions(dataSourceId: string, organizationId: string, environmentId?: string): Promise<DataSourceOptions>;
+  init(
+    editorVersion: Partial<AppVersion>,
+    organizationId: string,
+    isMultiEnvironmentEnabled: boolean,
+    manager?: EntityManager
+  ): Promise<IAppEnvironmentResponse>;
 }

--- a/server/src/modules/organization-constants/controller.ts
+++ b/server/src/modules/organization-constants/controller.ts
@@ -43,8 +43,12 @@ export class OrganizationConstantController implements IOrganizationConstantCont
   @Get(':app_slug')
   @InitFeature(FEATURE_KEY.GET_FROM_APP)
   async getConstantsFromApp(@User() user, @Query('environmentId') environmentId) {
-    const result = await this.organizationConstantsService.allEnvironmentConstants(user.organizationId);
-    return { constants: {} };
+    const result = await this.organizationConstantsService.getConstantsForEnvironment(
+      user.organizationId,
+      environmentId,
+      OrganizationConstantType.GLOBAL
+    );
+    return { constants: result };
   }
 
   @UseGuards(JwtAuthGuard, FeatureAbilityGuard)

--- a/server/src/modules/organization-constants/interfaces/IService.ts
+++ b/server/src/modules/organization-constants/interfaces/IService.ts
@@ -22,7 +22,8 @@ export interface IOrganizationConstantsService {
   update(
     constantId: string,
     organizationId: string,
-    params: UpdateOrganizationConstantDto
+    params: UpdateOrganizationConstantDto,
+    isMultiEnvEnabled?: boolean
   ): Promise<OrganizationConstant>;
   delete(constantId: string, organizationId: string, environmentId?: string): Promise<DeleteResult>;
 }

--- a/server/src/modules/organization-constants/interfaces/IService.ts
+++ b/server/src/modules/organization-constants/interfaces/IService.ts
@@ -16,7 +16,8 @@ export interface IOrganizationConstantsService {
   ): Promise<OrganizationConstant[]>;
   create(
     organizationConstant: CreateOrganizationConstantDto,
-    organizationId: string
+    organizationId: string,
+    isMultiEnvEnabled?: boolean
   ): Promise<OrganizationConstant | []>;
   update(
     constantId: string,


### PR DESCRIPTION
**Changes**
1. Making CE and Basic Plan logic same for environments
2. Previously, we were automatically upgrading to production when the user released a version. Now, it will only map to the corresponding environment.
3. Added a edition downgrade checker