### PR TITLE
[hotfix]: Expose proper default value on radiobutton component

### DIFF
--- a/frontend/src/Editor/Components/RadioButton.jsx
+++ b/frontend/src/Editor/Components/RadioButton.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 export const RadioButton = function RadioButton({
@@ -12,8 +12,8 @@ export const RadioButton = function RadioButton({
   darkMode,
   dataCy,
 }) {
-  const isInitialRender = useRef(true);
   const { label, value, values, display_values } = properties;
+
   const { visibility, disabledState, activeColor, boxShadow } = styles;
   const textColor = darkMode && styles.textColor === '#000' ? '#fff' : styles.textColor;
   const [checkedValue, setValue] = useState(() => value);
@@ -38,12 +38,6 @@ export const RadioButton = function RadioButton({
   }
 
   useEffect(() => {
-    if (isInitialRender.current) return;
-    setExposedVariable('value', value);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
     const exposedVariables = {
       value: value,
       selectOption: async function (option) {
@@ -51,9 +45,8 @@ export const RadioButton = function RadioButton({
       },
     };
     setExposedVariables(exposedVariables);
-    isInitialRender.current = false;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [value]);
 
   return (
     <div


### PR DESCRIPTION
When the query data (`query.queryName.data.isVisible`) is attached to the radio button, it exposes the incorrect value. The issue is fixed in this PR