### PR TITLE
Fix: Custom Component runQuery parameter not working

### DIFF
--- a/frontend/src/Editor/Components/CustomComponent/CustomComponent.jsx
+++ b/frontend/src/Editor/Components/CustomComponent/CustomComponent.jsx
@@ -42,7 +42,7 @@ export const CustomComponent = (props) => {
             setCustomProps({ ...customPropRef.current, ...e.data.updatedObj });
           } else if (e.data.message === 'RUN_QUERY') {
             const options = {
-              parameters: e.data.parameters,
+              parameters: JSON.parse(e.data.parameters),
               queryName: e.data.queryName,
             };
             onEvent('onTrigger', [], options);


### PR DESCRIPTION
Closes: [#2983](https://github.com/ToolJet/tj-ee/issues/2983)