### PR TITLE
Fix: Validation added for data-types in ToolJet database.

### DIFF
--- a/frontend/src/HomePage/ExportAppModal.jsx
+++ b/frontend/src/HomePage/ExportAppModal.jsx
@@ -70,7 +70,7 @@ export default function ExportAppModal({ title, show, closeModal, customClassNam
             });
           }
 
-          if (item.kind === 'tooljetdb' && item.options.table_id) extractedIdData.push(item.options.table_id);
+          if (item.kind === 'tooljetdb' && item.options.tableId) extractedIdData.push(item.options.tableId);
         });
         const uniqueSet = new Set(extractedIdData);
         const selectedVersiontable = Array.from(uniqueSet).map((item) => ({ table_id: item }));

--- a/frontend/src/modules/dataSources/components/GlobalDataSources/index.jsx
+++ b/frontend/src/modules/dataSources/components/GlobalDataSources/index.jsx
@@ -474,7 +474,7 @@ export const GlobalDataSources = ({ darkMode = false, updateSelectedDatasource }
     <div className="row gx-0">
       <Sidebar renderSidebarList={renderSidebarList} updateSelectedDatasource={updateSelectedDatasource} />
       <div ref={containerRef} className={cx('col animation-fade datasource-modal-container', {})}>
-        {containerRef && containerRef?.current && (
+        {containerRef && containerRef?.current && selectedDataSource && (
           <DataSourceManager
             showBackButton={selectedDataSource ? false : true}
             showDataSourceManagerModal={showDataSourceManagerModal}

--- a/server/src/modules/tooljet-db/dto/index.ts
+++ b/server/src/modules/tooljet-db/dto/index.ts
@@ -20,6 +20,7 @@ import {
   IsIn,
 } from 'class-validator';
 import { sanitizeInput, formatTimestamp, validateDefaultValue, formatJSONB } from 'src/helpers/utils.helper';
+import { TooljetDatabaseDataTypes, TJDB } from '../types';
 
 export function Match(property: string, validationOptions?: ValidationOptions) {
   return (object: any, propertyName: string) => {
@@ -189,11 +190,11 @@ export class PostgrestTableColumnDto {
   @Validate(SQLInjectionValidator, { message: 'Column name does not support special characters' })
   column_name: string;
 
-  @IsString()
+  @IsIn(Object.values(TJDB), { message: 'Incorrect datatype.' })
   @IsNotEmpty()
   @Transform(({ value }) => sanitizeInput(value))
   @Validate(SQLInjectionValidator)
-  data_type: string;
+  data_type: TooljetDatabaseDataTypes;
 
   @IsOptional()
   @Transform(({ value, obj }) => {
@@ -290,11 +291,11 @@ export class EditColumnTableDto {
   @Validate(SQLInjectionValidator, { message: 'Column name does not support special characters' })
   column_name: string;
 
-  @IsString()
+  @IsIn(Object.values(TJDB), { message: 'Incorrect datatype.' })
   @IsNotEmpty()
   @Transform(({ value }) => sanitizeInput(value))
   @Validate(SQLInjectionValidator)
-  data_type: string;
+  data_type: TooljetDatabaseDataTypes;
 
   @IsOptional()
   @Transform(({ value, obj }) => {


### PR DESCRIPTION
**Fixes**
1. When an app is exported for a selected version, the ToolJet database schema is not exported. (Modularisation issue)
2. Validating the datatype utilised in the ToolJet database.
3. While we are on the datasource page, the datasource configuration page also mounted.