### PR TITLE
Docs: Adding PostgREST as a mandatory installation

### DIFF
--- a/docs/docs/contributing-guide/setup/architecture.md
+++ b/docs/docs/contributing-guide/setup/architecture.md
@@ -13,7 +13,7 @@ ToolJet server is a Node.js API application. Server is responsible for authentic
 **Dependencies:**
 - **PostgreSQL** - ToolJet server persists data to a postgres database. 
 - **Email service** (SMTP/Sendgrid/Mailgun/etc) - Required to send user invitations and password reset emails.   
-- **PostgREST (Optional)** - Standalone web server that converts PostgreSQL database into queryable RESTful APIs for ToolJet Database.
+- **PostgREST** - Standalone web server that converts PostgreSQL database into queryable RESTful APIs for ToolJet Database.
     
 ### 2. ToolJet Client  
 

--- a/docs/docs/contributing-guide/setup/macos.md
+++ b/docs/docs/contributing-guide/setup/macos.md
@@ -36,11 +36,11 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     brew install postgresql@13
     ```
     
-    1.4 Install PostgREST(optional)
+    1.4 Install PostgREST
 
-    :::info 
-    Required only if ToolJet Database is being used. 
-    :::       
+    :::info
+    Please use PostgREST version 12.2.0
+    :::
 
     ```bash
     brew install postgrest
@@ -85,6 +85,10 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     PG_USER=postgres
     PG_PASS=postgres
     PG_DB=tooljet_development
+    TOOLJET_DB=tooljet_db
+    TOOLJET_DB_USER=postgres
+    TOOLJET_DB_HOST=localhost
+    TOOLJET_DB_PASS=postgres
     ORM_LOGGING=all
    ```
 

--- a/docs/docs/contributing-guide/setup/ubuntu.md
+++ b/docs/docs/contributing-guide/setup/ubuntu.md
@@ -39,12 +39,10 @@ Follow these steps to setup and run ToolJet on Ubuntu. Open terminal and run the
     sudo apt-get install libpq-dev
     ```
     
-    1.3 Install PostgREST (optional)
+    1.3 Install PostgREST
 
-    :::info 
-    Required only if ToolJet Database is being used. 
-
-    Please use PostgREST version 10.1.1.x
+    :::info
+    Please use PostgREST version 12.2.0
     :::
 
     Please follow the installation [PostgREST](https://postgrest.org/en/stable/install.html) guide
@@ -83,6 +81,17 @@ Follow these steps to setup and run ToolJet on Ubuntu. Open terminal and run the
    TOOLJET_HOST=http://localhost:8082
    LOCKBOX_MASTER_KEY=1d291a926ddfd221205a23adb4cc1db66cb9fcaf28d97c8c1950e3538e3b9281
    SECRET_KEY_BASE=4229d5774cfe7f60e75d6b3bf3a1dbb054a696b6d21b6d5de7b73291899797a222265e12c0a8e8d844f83ebacdf9a67ec42584edf1c2b23e1e7813f8a3339041
+   NODE_ENV=development
+   # DATABASE CONFIG
+   PG_HOST=localhost
+   PG_PORT=5432
+   PG_USER=postgres
+   PG_PASS=postgres
+   PG_DB=tooljet_development
+   TOOLJET_DB=tooljet_db
+   TOOLJET_DB_USER=postgres
+   TOOLJET_DB_HOST=localhost
+   TOOLJET_DB_PASS=postgres
    ```
 
 5. Install and build dependencies

--- a/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/setup/architecture.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/setup/architecture.md
@@ -13,7 +13,7 @@ ToolJet server is a Node.js API application. Server is responsible for authentic
 **Dependencies:**
 - **PostgreSQL** - ToolJet server persists data to a postgres database. 
 - **Email service** (SMTP/Sendgrid/Mailgun/etc) - Required to send user invitations and password reset emails.   
-- **PostgREST (Optional)** - Standalone web server that converts PostgreSQL database into queryable RESTful APIs for ToolJet Database.
+- **PostgREST** - Standalone web server that converts PostgreSQL database into queryable RESTful APIs for ToolJet Database.
     
 ### 2. ToolJet Client  
 

--- a/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/setup/macos.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/setup/macos.md
@@ -36,33 +36,14 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     brew install postgresql@13
     ```
     
-    1.4 Install PostgREST(optional)
+    1.4 Install PostgREST
 
-    :::info 
-    Required only if ToolJet Database is being used. 
+    :::info
+    Please use PostgREST version 12.2.0
     :::
 
-    To install a specific version of PostgRest using Homebrew:
-
     ```bash
-    brew install postgrest@<version>
-    ```
-    To find out which versions are available, you can search with:
-
-    ```bash
-    brew search postgrest
-    ```
-
-    Once PostgREST is installed, you can start the PostgREST service using Homebrew services:
-
-    ```
-    brew services start postgrest
-    ```
-
-    Run the following command to check the status of the PostgREST service and other Homebrew-managed services:
-
-    ```
-    brew services list
+    brew install postgrest
     ```
 
     1.5 Fork the repository:
@@ -77,14 +58,14 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     git clone https://github.com/<your-username>/ToolJet.git
     ```
 
-3. Set up environment variables
+2. Set up environment variables
 
     Create a `.env` file by copying `.env.example`. More information on the variables that can be set is given in the [environment variables reference](/docs/setup/env-vars)
     ```bash
     cp .env.example .env
     ```
 
-4. Populate the keys in the env file
+3. Populate the keys in the env file
    :::info
    `SECRET_KEY_BASE` requires a 64 byte key. (If you have `openssl` installed, run `openssl rand -hex 64` to create a 64 byte secure   random key)
 
@@ -104,10 +85,14 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     PG_USER=postgres
     PG_PASS=postgres
     PG_DB=tooljet_development
+    TOOLJET_DB=tooljet_db
+    TOOLJET_DB_USER=postgres
+    TOOLJET_DB_HOST=localhost
+    TOOLJET_DB_PASS=postgres
     ORM_LOGGING=all
    ```
 
-5. Install and build dependencies
+4. Install and build dependencies
     ```bash
     npm install
     npm install --prefix server
@@ -115,7 +100,7 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     npm run build:plugins
     ```
 
-6. Set up database
+5. Set up database
     ```bash
     npm run --prefix server db:create
     npm run --prefix server db:reset
@@ -124,24 +109,24 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     If at any point you need to reset the database, use this command `npm run --prefix server db:reset`
     :::
 
-7. Run plugins compilation in watch mode
+6. Run plugins compilation in watch mode
     ```bash
     cd ./plugins && npm start
     ```
 
-8. Run the server
+7. Run the server
     ```bash
     cd ./server && npm run start:dev
     ```
 
-9. Run the client
+8. Run the client
     ```bash
     cd ./frontend && npm start
     ```
 
     The client will start on the port 8082, you can access the client by visiting:  [http://localhost:8082](http://localhost:8082)
 
-10. Create login credentials
+9. Create login credentials
 
     Visiting [http://localhost:8082](http://localhost:8082) should redirect you to the login page, click on the signup link and enter your email. The emails sent by the server in development environment are captured and are opened in your default browser. Click the invitation link in the email preview to setup the account.
 

--- a/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/setup/ubuntu.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/setup/ubuntu.md
@@ -39,12 +39,10 @@ Follow these steps to setup and run ToolJet on Ubuntu. Open terminal and run the
     sudo apt-get install libpq-dev
     ```
     
-    1.3 Install PostgREST (optional)
+    1.3 Install PostgREST
 
-    :::info 
-    Required only if ToolJet Database is being used. 
-
-    Please use PostgREST version 10.1.1.x
+    :::info
+    Please use PostgREST version 12.2.0
     :::
 
     Please follow the installation [PostgREST](https://postgrest.org/en/stable/install.html) guide
@@ -83,6 +81,17 @@ Follow these steps to setup and run ToolJet on Ubuntu. Open terminal and run the
    TOOLJET_HOST=http://localhost:8082
    LOCKBOX_MASTER_KEY=1d291a926ddfd221205a23adb4cc1db66cb9fcaf28d97c8c1950e3538e3b9281
    SECRET_KEY_BASE=4229d5774cfe7f60e75d6b3bf3a1dbb054a696b6d21b6d5de7b73291899797a222265e12c0a8e8d844f83ebacdf9a67ec42584edf1c2b23e1e7813f8a3339041
+   NODE_ENV=development
+   # DATABASE CONFIG
+   PG_HOST=localhost
+   PG_PORT=5432
+   PG_USER=postgres
+   PG_PASS=postgres
+   PG_DB=tooljet_development
+   TOOLJET_DB=tooljet_db
+   TOOLJET_DB_USER=postgres
+   TOOLJET_DB_HOST=localhost
+   TOOLJET_DB_PASS=postgres
    ```
 
 5. Install and build dependencies
@@ -92,11 +101,11 @@ Follow these steps to setup and run ToolJet on Ubuntu. Open terminal and run the
     npm install --prefix frontend
     npm run build:plugins
     ```
-
    > **_NOTE:_**
    > If the `npm run build:plugins` command fails due to some packages are missing, try running the following command to install the necessary packages:
    `sudo apt install build-essential`
    > then proceed to `npm run build:plugins` step again
+    
 
 6. Set up database
     ```bash

--- a/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/setup/architecture.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/setup/architecture.md
@@ -12,8 +12,8 @@ ToolJet server is a Node.js API application. Server is responsible for authentic
 
 **Dependencies:**
 - **PostgreSQL** - ToolJet server persists data to a postgres database. 
-- **Email service** (SMTP/Sendgrid/Mailgun/etc) - Required to send user invitations and password reset emails.   
-- **PostgREST (Optional)** - Standalone web server that converts PostgreSQL database into queryable RESTful APIs for ToolJet Database.
+- **Email service** (SMTP/Sendgrid/Mailgun/etc) - Required to send user invitations and password reset emails.
+- **PostgREST** - Standalone web server that converts PostgreSQL database into queryable RESTful APIs for ToolJet Database.
     
 ### 2. ToolJet Client  
 

--- a/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/setup/macos.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/setup/macos.md
@@ -36,11 +36,11 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     brew install postgresql@13
     ```
     
-    1.4 Install PostgREST(optional)
+    1.4 Install PostgREST
 
-    :::info 
-    Required only if ToolJet Database is being used. 
-    :::       
+    :::info
+    Please use PostgREST version 12.2.0
+    :::
 
     ```bash
     brew install postgrest
@@ -85,6 +85,10 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
     PG_USER=postgres
     PG_PASS=postgres
     PG_DB=tooljet_development
+    TOOLJET_DB=tooljet_db
+    TOOLJET_DB_USER=postgres
+    TOOLJET_DB_HOST=localhost
+    TOOLJET_DB_PASS=postgres
     ORM_LOGGING=all
    ```
 

--- a/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/setup/ubuntu.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/setup/ubuntu.md
@@ -39,12 +39,10 @@ Follow these steps to setup and run ToolJet on Ubuntu. Open terminal and run the
     sudo apt-get install libpq-dev
     ```
     
-    1.3 Install PostgREST (optional)
+    1.3 Install PostgREST
 
-    :::info 
-    Required only if ToolJet Database is being used. 
-
-    Please use PostgREST version 10.1.1.x
+    :::info
+    Please use PostgREST version 12.2.0
     :::
 
     Please follow the installation [PostgREST](https://postgrest.org/en/stable/install.html) guide
@@ -83,6 +81,17 @@ Follow these steps to setup and run ToolJet on Ubuntu. Open terminal and run the
    TOOLJET_HOST=http://localhost:8082
    LOCKBOX_MASTER_KEY=1d291a926ddfd221205a23adb4cc1db66cb9fcaf28d97c8c1950e3538e3b9281
    SECRET_KEY_BASE=4229d5774cfe7f60e75d6b3bf3a1dbb054a696b6d21b6d5de7b73291899797a222265e12c0a8e8d844f83ebacdf9a67ec42584edf1c2b23e1e7813f8a3339041
+   NODE_ENV=development
+   # DATABASE CONFIG
+   PG_HOST=localhost
+   PG_PORT=5432
+   PG_USER=postgres
+   PG_PASS=postgres
+   PG_DB=tooljet_development
+   TOOLJET_DB=tooljet_db
+   TOOLJET_DB_USER=postgres
+   TOOLJET_DB_HOST=localhost
+   TOOLJET_DB_PASS=postgres
    ```
 
 5. Install and build dependencies


### PR DESCRIPTION
- PostgREST needs to be mandatory installation since it is required for ToolJetDB