### PR TITLE
Fix: Added PostgREST and Redis versions

### DIFF
--- a/docs/versioned_docs/version-3.0.0-LTS/setup/env-vars.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/env-vars.md
@@ -51,7 +51,7 @@ Replace `username`, `password`, `hostname`, `port`, and `database_name` with you
 **Automatic Database Creation:** The database name specified in `TOOLJET_DB` will be automatically created during the server boot process in all production deployment setups.
 
 #### PostgREST
-ToolJet uses PostgREST for API access. 
+ToolJet uses **PostgREST (v12.2.0)** for API access. The following environment variables are required for PostgREST:
 
 - `PGRST_JWT_SECRET`: JWT secret (Generate using `openssl rand -hex 32`). If this parameter is not specified, PostgREST will refuse authentication requests.
 - `PGRST_DB_URI`: Database connection string
@@ -78,7 +78,7 @@ Ensure that:
 
 #### Redis Configuration
 
-Include the following Redis environment variables within the ToolJet deployment **only if you are connecting to an external Redis instance for a multi-service or multi-pod setup** and have followed the necessary steps to create Redis.
+Include the following Redis environment variables within the ToolJet deployment only if you are connecting to an external **Redis instance (v6.2)** for a multi-service or multi-pod setup and have followed the necessary steps to create Redis.
 
 ```
 REDIS_HOST=

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/google-cloud-run.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/google-cloud-run.md
@@ -125,9 +125,6 @@ PGRST_DB_URI=postgres://TOOLJET_DB_USER:TOOLJET_DB_PASS@TOOLJET_DB_HOST:5432/TOO
 **Note:** These environment variables are in general and might change in the future. You can also refer env variable [**here**](/docs/setup/env-vars). 
 
 
-  Update `TOOLJET_HOST` environment variable if you want to use the default url assigned with Cloud run after the initial deploy.
-
-
 
 :::tip
 If you are using [Public IP](https://cloud.google.com/sql/docs/postgres/connect-run) for Cloud SQL, then database host connection (value for `PG_HOST`) needs to be set using unix socket format, `/cloudsql/<CLOUD_SQL_CONNECTION_NAME>`.  


### PR DESCRIPTION
- Specified the version for Redis and PostgREST in the env variable page.
- Corrections in Cloud Run deployment document for duplicate TOOLJET_HOST variable