### PR TITLE
fix `TreeSelect` colors in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -6617,7 +6617,6 @@ input.hide-input-arrows {
 
 .custom-checkbox-tree {
   overflow-y: scroll;
-  color: #3e525b;
 
   .react-checkbox-tree label:hover {
     background: none !important;
@@ -6628,13 +6627,14 @@ input.hide-input-arrows {
     .rct-icon-expand-open,
     .rct-icon-expand-close {
       &::before {
-        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1024 1024' focusable='false' data-icon='caret-down' width='12px' height='12px' fill='currentColor' aria-hidden='true'%3E%3Cpath d='M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z'%3E%3C/path%3E%3C/svg%3E") !important;
+        content: "\2BC8";
+        font-size: 16px;
       }
     }
 
-    .rct-icon-expand-close {
-      transform: rotate(-90deg);
-      -webkit-transform: rotate(-90deg);
+    .rct-icon-expand-open {
+      transform: rotate(90deg);
+      -webkit-transform: rotate(90deg);
     }
   }
 }


### PR DESCRIPTION
Changes:
- remove hard-coded `color: #3e525b;`. The `textColor` is already set in `TreeSelect.jsx` according to current theme.
- replace  hard-coded url svg `content` with html unicode character (Black Medium Right-Pointing Triangle Centred) https://www.compart.com/en/unicode/U+2BC8
- update rotate in expanded state according to the new unicode character

Screenshots:

![Dark](https://github.com/user-attachments/assets/4af5eb48-10c8-43f4-a667-fed4791e3e44)

![Light](https://github.com/user-attachments/assets/ac8bd0e9-4e87-44d0-888f-74f15ddbd23e)
