### PR TITLE
Docs: Minor changes in deployment docs

### DIFF
--- a/docs/versioned_docs/version-3.0.0-LTS/setup/azure-container.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/azure-container.md
@@ -10,9 +10,9 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist https://api-
 :::
 
 :::info
-Please note that you need to set up a PostgreSQL database manually to be used by ToolJet. 
+Please note that you need to set up a **PostgreSQL database** manually to be used by ToolJet. 
 
-ToolJet comes with a built-in Redis setup, which is used for multiplayer editing and background jobs. However, for multi-service setup, it's recommended to use an external Redis instance.
+ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::
 
 ## Deploying ToolJet application

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/docker.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/docker.md
@@ -10,13 +10,14 @@ import TabItem from '@theme/TabItem';
 
 Follow the steps below to deploy ToolJet on a server using Docker Compose. ToolJet requires a PostgreSQL database to store applications definitions, (encrypted) credentials for datasources and user authentication data.
 
+::::info
+If you rather want to try out ToolJet on your local machine with Docker, you can follow the steps [here](/docs/setup/try-tooljet/).
+
 :::warning
 To enable ToolJet AI features in your ToolJet deployment, whitelist https://api-gateway.tooljet.ai.
 :::
 
-:::info
-If you rather want to try out ToolJet on your local machine with Docker, you can follow the steps [here](/docs/setup/try-tooljet/).
-:::
+::::
 
 ### Installing Docker and Docker Compose
 Install docker and docker-compose on the server.

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/ec2.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/ec2.md
@@ -10,7 +10,7 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist https://api-
 :::
 
 :::info
-You should setup a PostgreSQL database manually to be used by the ToolJet server.
+You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
 :::
 
 

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/ecs.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/ecs.md
@@ -10,9 +10,9 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist https://api-
 :::
 
 :::info
-You should setup a PostgreSQL database manually to be used by ToolJet. 
+You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
 
-ToolJet comes with a built-in Redis setup, which is used for multiplayer editing and background jobs. However, for multi-service setups, it's recommended to use an external Redis instance.
+ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-service setup**, it's recommended to use an **external Redis instance**.
 :::
 
 You can effortlessly deploy Amazon Elastic Container Service (ECS) by utilizing a [CloudFormation template](https://aws.amazon.com/cloudformation/):
@@ -105,10 +105,10 @@ Deploying ToolJet Database is mandatory from ToolJet 3.0 or else the migration m
 To set up ToolJet Database, the following **environment variables are mandatory** and must be configured:
 
 ```env
-TOOLJET_DB=
-TOOLJET_DB_HOST=
-TOOLJET_DB_USER=
-TOOLJET_DB_PASS=
+TOOLJET_DB=tooljet_db # Default database name
+TOOLJET_DB_HOST=<postgresql-database-host>
+TOOLJET_DB_USER=<username>
+TOOLJET_DB_PASS=<password>
 ```
 
 Additionally, for **PostgREST**, the following **mandatory** environment variables must be set:

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/env-vars.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/env-vars.md
@@ -111,9 +111,6 @@ By default, an account is locked after 5 failed login attempts. You can control 
 #### Restrict Signups  
 Set `DISABLE_SIGNUPS=true` to allow only invited users to sign up. The signup page will still be visible but unusable.
 
-#### Serving the Client  
-- `SERVE_CLIENT=false`: Stops the backend from serving the frontend.
-
 #### SMTP Configuration
 ToolJet sends emails via SMTP. 
 

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/google-cloud-run.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/google-cloud-run.md
@@ -10,9 +10,9 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist https://api-
 :::
 
 :::info
-You should manually set up a PostgreSQL database to be used by ToolJet. We recommend using **Cloud SQL** for this purpose. 
+You should manually set up a **PostgreSQL database** to be used by ToolJet. We recommend using **Cloud SQL** for this purpose. 
 
-ToolJet comes with a built-in Redis setup, which is used for multiplayer editing and background jobs. However, for multi-service setups, it's recommended to use an external Redis instance.
+ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-service setup**, it's recommended to use an **external Redis instance**.
 :::
 
 <!-- Follow the steps below to deploy ToolJet on Cloud run with `gcloud` CLI. -->
@@ -87,10 +87,10 @@ Deploying ToolJet Database is mandatory from ToolJet 3.0 or else the migration m
 To set up ToolJet Database, the following **environment variables are mandatory** and must be configured:
 
 ```env
-TOOLJET_DB=
-TOOLJET_DB_HOST=
-TOOLJET_DB_USER=
-TOOLJET_DB_PASS=
+TOOLJET_DB=tooljet_db # Default database name
+TOOLJET_DB_HOST=<postgresql-database-host>
+TOOLJET_DB_USER=<username>
+TOOLJET_DB_PASS=<password>
 ```
 
 Additionally, for **PostgREST**, the following **mandatory** environment variables must be set:

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes-aks.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes-aks.md
@@ -5,10 +5,15 @@ title: Kubernetes (AKS)
 
 # Deploying ToolJet on Kubernetes (AKS)
 
-:::info
-You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using Azure Database for PostgreSQL since this guide is for deploying using AKS.
+:::warning
+To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
+:::
 
-ToolJet comes with a built-in Redis setup, which is used for multiplayer editing and background jobs. However, for multi-pod setup, it's recommended to use an external Redis instance.
+
+:::info
+You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using **Azure Database for PostgreSQL** since this guide is for deploying using AKS. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+
+ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::
 
 Follow the steps below to deploy ToolJet on a AKS Kubernetes cluster.
@@ -29,7 +34,7 @@ LOCKBOX_MASTER_KEY=<generate using openssl rand -hex 32>
 SECRET_KEY_BASE=<generate using openssl rand -hex 64>
 
 PG_USER=<username>
-PG_HOST=<postgresql-instance-ip>
+PG_HOST=<postgresql-database-host>
 PG_PASS=<password>
 PG_DB=tooljet_production
 ```
@@ -37,10 +42,6 @@ Make sure to edit the environment variables in the `deployment.yaml`. You can ch
 
 :::info
 If there are self signed HTTPS endpoints that Tooljet needs to connect to, please make sure that `NODE_EXTRA_CA_CERTS` environment variable is set to the absolute path containing the certificates. You can make use of kubernetes secrets to mount the certificate file onto the containers.
-:::
-
-:::warning
-To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
 :::
 
 3. Create k8s service and reserve a static IP and expose it via a service load balancer as mentioned in the [doc](https://docs.microsoft.com/en-us/azure/aks/static-ip). You can refer `service.yaml`.
@@ -69,10 +70,10 @@ Deploying ToolJet Database is mandatory from ToolJet 3.0 or else the migration m
 To set up ToolJet Database, the following **environment variables are mandatory** and must be configured:
 
 ```env
-TOOLJET_DB=
-TOOLJET_DB_HOST=
-TOOLJET_DB_USER=
-TOOLJET_DB_PASS=
+TOOLJET_DB=tooljet_db # Default database name
+TOOLJET_DB_HOST=<postgresql-database-host>
+TOOLJET_DB_USER=<username>
+TOOLJET_DB_PASS=<password>
 ```
 
 Additionally, for **PostgREST**, the following **mandatory** environment variables must be set:

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes-eks.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes-eks.md
@@ -10,9 +10,9 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api
 :::
 
 :::info
-You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an RDS PostgreSQL database. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
 
-ToolJet comes with a built-in Redis setup, which is used for multiplayer editing and background jobs. However, for multi-pod setup, it's recommended to use an external Redis instance.
+ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::
 
 1. Create an EKS cluster and connect to it to start with the deployment. You can follow the steps as mentioned in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html).
@@ -35,7 +35,7 @@ LOCKBOX_MASTER_KEY=<generate using openssl rand -hex 32>
 SECRET_KEY_BASE=<generate using openssl rand -hex 64>
 
 PG_USER=<username>
-PG_HOST=<postgresql-instance-ip>
+PG_HOST=<postgresql-database-host>
 PG_PASS=<password>
 PG_DB=tooljet_production
 ```
@@ -59,10 +59,10 @@ Deploying ToolJet Database is mandatory from ToolJet 3.0 or else the migration m
 To set up ToolJet Database, the following **environment variables are mandatory** and must be configured:
 
 ```env
-TOOLJET_DB=
-TOOLJET_DB_HOST=
-TOOLJET_DB_USER=
-TOOLJET_DB_PASS=
+TOOLJET_DB=tooljet_db # Default database name
+TOOLJET_DB_HOST=<postgresql-database-host>
+TOOLJET_DB_USER=<username>
+TOOLJET_DB_PASS=<password>
 ```
 
 Additionally, for **PostgREST**, the following **mandatory** environment variables must be set:

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes-gke.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes-gke.md
@@ -5,10 +5,14 @@ title: Kubernetes (GKE)
 
 # Deploying ToolJet on Kubernetes (GKE)
 
-:::info
-You should setup a PostgreSQL database manually to be used by ToolJet. 
+:::warning
+To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
+:::
 
-ToolJet comes with a built-in Redis setup, which is used for multiplayer editing and background jobs. However, for multi-pod setup, it's recommended to use an external Redis instance.
+:::info
+You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+
+ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::
 
 Follow the steps below to deploy ToolJet on a GKE Kubernetes cluster.
@@ -41,7 +45,7 @@ LOCKBOX_MASTER_KEY=<generate using openssl rand -hex 32>
 SECRET_KEY_BASE=<generate using openssl rand -hex 64>
 
 PG_USER=<username>
-PG_HOST=<postgresql-instance-ip>
+PG_HOST=<postgresql-database-host>
 PG_PASS=<password>
 PG_DB=tooljet_production
 ```
@@ -49,10 +53,6 @@ Make sure to edit the environment variables in the `deployment.yaml`. You can ch
 
 :::info
 If there are self signed HTTPS endpoints that Tooljet needs to connect to, please make sure that `NODE_EXTRA_CA_CERTS` environment variable is set to the absolute path containing the certificates. You can make use of kubernetes secrets to mount the certificate file onto the containers.
-:::
-
-:::warning
-To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
 :::
 
 4. Create k8s service
@@ -94,10 +94,10 @@ Deploying ToolJet Database is mandatory from ToolJet 3.0 or else the migration m
 To set up ToolJet Database, the following **environment variables are mandatory** and must be configured:
 
 ```env
-TOOLJET_DB=
-TOOLJET_DB_HOST=
-TOOLJET_DB_USER=
-TOOLJET_DB_PASS=
+TOOLJET_DB=tooljet_db # Default database name
+TOOLJET_DB_HOST=<postgresql-database-host>
+TOOLJET_DB_USER=<username>
+TOOLJET_DB_PASS=<password>
 ```
 
 Additionally, for **PostgREST**, the following **mandatory** environment variables must be set:

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes.md
@@ -5,10 +5,14 @@ title: Kubernetes
 
 # Deploying ToolJet on Kubernetes
 
-:::info
-You should setup a PostgreSQL database manually to be used by ToolJet. 
+:::warning
+To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
+:::
 
-ToolJet comes with a built-in Redis setup, which is used for multiplayer editing and background jobs. However, for multi-pod setup, it's recommended to use an external Redis instance.
+:::info
+You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+
+ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::
 
 Follow the steps below to deploy ToolJet on a Kubernetes cluster.
@@ -25,21 +29,17 @@ LOCKBOX_MASTER_KEY=<generate using openssl rand -hex 32>
 SECRET_KEY_BASE=<generate using openssl rand -hex 64>
 
 PG_USER=<username>
-PG_HOST=<postgresql-instance-ip>
+PG_HOST=<postgresql-database-host>
 PG_PASS=<password>
 PG_DB=tooljet_production
 ```
 Also, for setting up additional environment variables in the .env file, please check our documentation on environment variables [here](/docs/setup/env-vars).
 
-:::warning
-To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
-:::
-
 3. Create a Kubernetes deployment
 
-   ```bash
-   kubectl apply -f https://tooljet-deployments.s3.us-west-1.amazonaws.com/kubernetes/deployment.yaml
-   ```
+```bash
+kubectl apply -f https://tooljet-deployments.s3.us-west-1.amazonaws.com/kubernetes/deployment.yaml
+```
 
 :::info
 The file given above is just a template and might not suit production environments. You should download the file and configure parameters such as the replica count and environment variables according to your needs.
@@ -51,9 +51,9 @@ If there are self signed HTTPS endpoints that ToolJet needs to connect to, pleas
 
 4. Verify if ToolJet is running
 
-   ```bash
-    kubectl get pods
-   ```
+```bash
+kubectl get pods
+```
 
 5. Create a Kubernetes services to publish the Kubernetes deployment that you've created. This step varies with cloud providers. We have a [template](https://tooljet-deployments.s3.us-west-1.amazonaws.com/kubernetes/service.yaml) for exposing the ToolJet server as a service using an AWS loadbalancer.
 
@@ -79,10 +79,10 @@ Deploying ToolJet Database is mandatory from ToolJet 3.0 or else the migration m
 To set up ToolJet Database, the following **environment variables are mandatory** and must be configured:
 
 ```env
-TOOLJET_DB=
-TOOLJET_DB_HOST=
-TOOLJET_DB_USER=
-TOOLJET_DB_PASS=
+TOOLJET_DB=tooljet_db # Default database name
+TOOLJET_DB_HOST=<postgresql-database-host>
+TOOLJET_DB_USER=<username>
+TOOLJET_DB_PASS=<password>
 ```
 
 Additionally, for **PostgREST**, the following **mandatory** environment variables must be set:

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/openshift.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/openshift.md
@@ -5,10 +5,14 @@ title: Openshift
 
 # Deploying ToolJet on Openshift
 
-:::info
-You should setup a PostgreSQL database manually to be used by ToolJet. 
+:::warning
+To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
+:::
 
-ToolJet comes with a built-in Redis setup, which is used for multiplayer editing and background jobs. However, for multi-pod setups, it's recommended to use an external Redis instance.
+:::info
+You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+
+ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::
 
 Follow the steps below to deploy ToolJet on Openshift.
@@ -21,15 +25,11 @@ LOCKBOX_MASTER_KEY=<generate using openssl rand -hex 32>
 SECRET_KEY_BASE=<generate using openssl rand -hex 64>
 
 PG_USER=<username>
-PG_HOST=<postgresql-instance-ip>
+PG_HOST=<postgresql-database-host>
 PG_PASS=<password>
 PG_DB=tooljet_production
 ```
 Also, for setting up additional environment variables in the .env file, please check our documentation on environment variables [here](/docs/setup/env-vars).
-
-:::warning
-To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
-:::
 
 3. Once you have logged into the Openshift developer dashboard click on `+Add` tab. Select import YAML from the local machine.
 
@@ -83,10 +83,10 @@ Deploying ToolJet Database is mandatory from ToolJet 3.0 or else the migration m
 To set up ToolJet Database, the following **environment variables are mandatory** and must be configured:
 
 ```env
-TOOLJET_DB=
-TOOLJET_DB_HOST=
-TOOLJET_DB_USER=
-TOOLJET_DB_PASS=
+TOOLJET_DB=tooljet_db # Default database name
+TOOLJET_DB_HOST=<postgresql-database-host>
+TOOLJET_DB_USER=<username>
+TOOLJET_DB_PASS=<password>
 ```
 
 Additionally, for **PostgREST**, the following **mandatory** environment variables must be set:

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/system-requirements.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/system-requirements.md
@@ -13,11 +13,11 @@ The official Docker tag for the Enterprise Edition is tooljet/tooljet:ee-lts-lat
 
 ### Supported Linux distribution
 
-[ToolJet images](https://hub.docker.com/r/tooljet/tooljet/tags) can run on any Linux machine with x86 architecture (64-bit). Ensure that your system meets the minimum requirements specified below before installing ToolJet.
+[ToolJet images](https://hub.docker.com/r/tooljet/tooljet/tags) can run on any Linux machine with **x86 architecture (64-bit)**. Ensure that your system meets the minimum requirements specified below before installing ToolJet.
 
 ### Microsoft Windows
 
-ToolJet is developed for Linux-based operating systems. Please consider using a virtual machine or Windows Subsystem for Linux 2 (WSL2) to run ToolJet on Windows.
+ToolJet is developed for Linux-based operating systems. Please consider using a virtual machine or **Windows Subsystem for Linux 2 (WSL2)** to run ToolJet on Windows.
 
 ## VM deployments:
 
@@ -25,7 +25,7 @@ ToolJet is developed for Linux-based operating systems. Please consider using a 
 - **Processor Architecture:** x86 (arm64 is not supported)
 - **RAM:** 2GB
 - **CPU:** 1 vCPU
-- **Storage:** At least 8GiB, but can increase according to your requirements.
+- **Storage:** At least 10GiB, but can increase according to your requirements.
 
 ## Orchestrated Deployments:
 
@@ -33,10 +33,10 @@ ToolJet is developed for Linux-based operating systems. Please consider using a 
 
 Note: Adjustments can be made based on specific needs and the expected load on the server.
 
-:::info
-To enable multiplayer editing and background jobs in ToolJet, you need to configure Redis. It is recommended to use Redis version 6.x.
-:::
+## Redis
 
-## Database software:
+Redis required for **multiplayer editing and background jobs**. ToolJet includes a **built-in Redis setup**, but for **multi pod/services** deployment, an **external Redis instance** is recommended. Use **Redis version 6.x** for optimal performance.
 
-- It is recommended that your PostgreSQL database is of version 13.x.
+## PostgreSQL 
+
+ToolJet requires PostgreSQL for data storage. It is recommended to use **PostgreSQL version 13.x** for optimal compatibility and performance.

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/try-tooljet.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/try-tooljet.md
@@ -7,10 +7,15 @@ title: Try ToolJet
 
 ## On local with Docker
 
+::::info
+
+This deployment is **not suitable for production**. It is a lightweight setup designed for quickly exploring ToolJet and trying out its features.
+
 :::warning
 To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api-gateway.tooljet.ai`.
 :::
 
+::::
 
 You can run the command below to have ToolJet up and running right away.
 


### PR DESCRIPTION
- Add a note in try-tooljet mentioning that it is not to be used for production
- Minor corrections in kubernetes deployment docs
- Minor changes in system requirement docs highlighting PostgreSQL and Redis
- Removed the serve_client variable from Environment variable page