### PR TITLE
Fix forked branch handling by dynamically setting the repo URL. 🚀

### DIFF
--- a/.github/workflows/render-preview-deploy.yml
+++ b/.github/workflows/render-preview-deploy.yml
@@ -21,22 +21,33 @@ jobs:
       - name: Sync repo
         uses: actions/checkout@v3
 
-      - name: Check if PR is from the same repo
+      - name: Check if Forked Repository
         id: check_repo
-        run: echo "::set-output name=is_fork::$(if [[ '${{ github.event.pull_request.head.repo.full_name }}' != '${{ github.event.pull_request.base.repo.full_name }}' ]]; then echo true; else echo false; fi)"
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "is_fork=true" >> $GITHUB_ENV
+            echo "FORKED_OWNER=${{ github.event.pull_request.head.repo.owner.login }}" >> $GITHUB_ENV
+          else
+            echo "is_fork=false" >> $GITHUB_ENV
+          fi
 
-      - name: Fetch the remote branch if it's a forked PR
-        if: steps.check_repo.outputs.is_fork == 'true'
+      - name: Set Repository URL
+        run: |
+          if [[ "$is_fork" == "true" ]]; then
+            echo "REPO_URL=https://github.com/${FORKED_OWNER}/ToolJet" >> $GITHUB_ENV
+          else
+            echo "REPO_URL=https://github.com/ToolJet/ToolJet" >> $GITHUB_ENV
+          fi
+
+      - name: Fetch and Checkout Forked Branch
+        if: env.is_fork == 'true'
         run: |
           git fetch origin pull/${{ github.event.number }}/head:${{ env.BRANCH_NAME }}
           git checkout ${{ env.BRANCH_NAME }}
 
-      - name: Checkout
-        if: steps.check_repo.outputs.is_fork == 'false'
+      - name: Checkout Default Branch
+        if: env.is_fork == 'false'
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
 
       - name: Creating deployment for CE
         id: create-ce-deployment
@@ -53,7 +64,7 @@ jobs:
             "name": "ToolJet CE PR #${{ env.PR_NUMBER }}",
             "notifyOnFail": "default",
             "ownerId": "tea-caeo4bj19n072h3dddc0",
-            "repo": "https://github.com/ToolJet/ToolJet",
+            "repo": "'"$REPO_URL"'",
             "slug": "tooljet-ce-pr-${{ env.PR_NUMBER }}",
             "suspended": "not_suspended",
             "suspenders": [],


### PR DESCRIPTION
- Detect if the branch is from a fork

- Dynamically set the repo URL to use the fork's owner

- Ensure correct repository reference during workflow execution