### PR TITLE
Fix: edit button visibility on app card in dark mode

### DIFF
--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -200,10 +200,10 @@ export default function AppCard({
                   <button
                     type="button"
                     className="tj-primary-btn tj-text-xsm edit-button"
-                    style={{ color: darkMode ? '#11181C' : '#FDFDFE' }}
+                    style={{ color: darkMode ? '#FFFFFF' : '#FDFDFE' }}
                     data-cy="edit-button"
                   >
-                    <SolidIcon name="editrectangle" width="14" fill={darkMode ? '#11181C' : '#FDFDFE'} />
+                    <SolidIcon name="editrectangle" width="14" fill={darkMode ? '#FFFFFF' : '#FDFDFE'} />
                     &nbsp;{t('globals.edit', 'Edit')}
                   </button>
                 </Link>


### PR DESCRIPTION
Fix Screenshot:
Changed Font Color, Icon to white on Dark mode
Closes #11263

![image](https://github.com/user-attachments/assets/920d5757-1b2d-45ca-9c98-64668f478e4a)
