### PR TITLE
Fix: edit button visibility on app card in dark mode

### DIFF
--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -200,10 +200,10 @@ export default function AppCard({
                   <button
                     type="button"
                     className="tj-primary-btn tj-text-xsm edit-button"
-                    style={{ color: darkMode ? '#11181C' : '#FDFDFE' }}
+                    style={{ color: darkMode ? '#FFFFFF' : '#FDFDFE' }}
                     data-cy="edit-button"
                   >
-                    <SolidIcon name="editrectangle" width="14" fill={darkMode ? '#11181C' : '#FDFDFE'} />
+                    <SolidIcon name="editrectangle" width="14" fill={darkMode ? '#FFFFFF' : '#FDFDFE'} />
                     &nbsp;{t('globals.edit', 'Edit')}
                   </button>
                 </Link>


### PR DESCRIPTION
Changed Font Color, Icon to white on Dark mode
Closes: #11263 

Fix Screenshot:
![{58D971F7-B78B-4A24-B9D5-A11FD84831B9}](https://github.com/user-attachments/assets/b31396b0-ded4-44eb-937b-e7b22e5a6c56)
