### PR TITLE
Fix: Remove extra HREF from Join Workspace URL

### DIFF
--- a/server/src/modules/email/mails/default_invite_user.hbs
+++ b/server/src/modules/email/mails/default_invite_user.hbs
@@ -34,7 +34,7 @@
         </tr>
         <tr>
           <td>
-            <a href={{inviteUrl}} target="_blank" class="padding-r-40" href="#">
+            <a href="{{inviteUrl}}" target="_blank" class="padding-r-40">
               <button class="primary-btn">
                 Join workspace
               </button>


### PR DESCRIPTION
The join workspace URL had two hrefs; the final one was shadowing the invite URL, which caused the link to be unclickable.