### PR TITLE
Fix dropdown and multiselect in table not closing when fx is used for is editable field

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Table/Components/TableRow.jsx
+++ b/frontend/src/AppBuilder/Widgets/Table/Components/TableRow.jsx
@@ -85,19 +85,14 @@ export const TableRow = React.memo(
             : ''
         }`}
         {...rowProps}
-        onClickCapture={() => {
-          // toggleRowSelected will triggered useRededcuer function in useTable and in result will get the selectedFlatRows consisting row which are selected
-          const selectedRow = row.original;
-          const selectedRowId = row.id;
-          setExposedVariables({ selectedRow, selectedRowId });
-          fireEvent('onRowClicked');
-        }}
         onClick={async () => {
           if (allowSelection) {
             await toggleRowSelected(row.id);
           }
           const selectedRow = row.original;
           const selectedRowId = row.id;
+          setExposedVariables({ selectedRow, selectedRowId });
+          fireEvent('onRowClicked');
           mergeToTableDetails({ selectedRow, selectedRowId });
         }}
         onMouseOver={() => {
@@ -211,6 +206,7 @@ export const TableRow = React.memo(
               {...cellProps}
               style={{ ...cellProps.style, backgroundColor: cellBackgroundColor ?? 'inherit' }}
               onClick={(e) => {
+                console.log('isEditable', isEditable);
                 if (
                   (isEditable || ['rightActions', 'leftActions'].includes(cell.column.id)) &&
                   allowSelection &&

--- a/frontend/src/AppBuilder/Widgets/Table/CustomSelect.jsx
+++ b/frontend/src/AppBuilder/Widgets/Table/CustomSelect.jsx
@@ -95,7 +95,7 @@ export const CustomSelect = ({
     }),
   };
   const customComponents = {
-    MenuList: (props) => <CustomMenuList {...props} optionsLoadingState={optionsLoadingState} inputRef={inputRef} />,
+    MenuList: CustomMenuList,
     Option: CustomMultiSelectOption,
     DropdownIndicator: isEditable ? DropdownIndicator : null,
     ...(isMulti && {
@@ -114,7 +114,6 @@ export const CustomSelect = ({
       return isMulti ? [] : {};
     }
   }, [isMulti, defaultOptionsList, options, useDynamicOptions]);
-
   const _value = useMemo(() => {
     // Return null to show default value
     if (!value) {
@@ -184,6 +183,8 @@ export const CustomSelect = ({
           hideSelectedOptions={false}
           isClearable={false}
           clearIndicator={false}
+          inputRef={inputRef}
+          optionsLoadingState={optionsLoadingState}
           darkMode={darkMode}
           {...{
             menuIsOpen: isFocused || undefined,
@@ -195,8 +196,8 @@ export const CustomSelect = ({
   );
 };
 
-export const CustomMenuList = ({ optionsLoadingState, children, selectProps, inputRef, ...props }) => {
-  const { onInputChange, inputValue, onMenuInputFocus } = selectProps;
+export const CustomMenuList = ({ children, selectProps, ...props }) => {
+  const { optionsLoadingState, inputRef, onInputChange, inputValue, onMenuInputFocus } = selectProps;
 
   return (
     <div className="table-select-custom-menu-list" onClick={(e) => e.stopPropagation()}>
@@ -212,11 +213,11 @@ export const CustomMenuList = ({ optionsLoadingState, children, selectProps, inp
           spellCheck="false"
           type="text"
           value={inputValue}
-          onChange={(e) =>
+          onChange={(e) => {
             onInputChange(e.currentTarget.value, {
               action: 'input-change',
-            })
-          }
+            });
+          }}
           onMouseDown={(e) => {
             e.stopPropagation();
             e.target.focus();

--- a/frontend/src/_ui/JSONTreeViewer/JSONNode.jsx
+++ b/frontend/src/_ui/JSONTreeViewer/JSONNode.jsx
@@ -276,6 +276,7 @@ export const JSONNode = ({ data, ...restProps }) => {
               }}
               style={{ height: '13px', width: '13px', marginBottom: '4px' }}
               className="mx-1 copy-to-clipboard"
+              onMouseDown={(e) => e.preventDefault()}
             >
               <DefaultCopyIcon />
             </span>
@@ -286,6 +287,7 @@ export const JSONNode = ({ data, ...restProps }) => {
             onClick={() => {
               moreActions['actions'][0].dispatchAction(data, currentNode);
             }}
+            onMouseDown={(e) => e.preventDefault()}
             data-cy={`copy-value-to-clicpboard`}
           >
             <SolidIcon width="12" height="12" name="copy" />


### PR DESCRIPTION
Fixes: 

1. Dropdown and Multiselect in table not closing when fx is used for is editable field
2. copying path values from the inspector ends up copying the previously copied value instead of the currently selected one.