### PR TITLE
fix: constants form cancel button text getting selected on input pass…

### DIFF
--- a/frontend/src/_ui/AppButton/AppButton.scss
+++ b/frontend/src/_ui/AppButton/AppButton.scss
@@ -14,6 +14,7 @@
     cursor: pointer;
     line-height: 20px;
     text-decoration: none !important;
+    user-select: none;
 
     .tj-btn-left-icon,
     .tj-btn-right-icon {


### PR DESCRIPTION
fix: constants form cancel button text getting selected on input password hide show click

issue: when clicking on hide/show click of Value field in constants-form, the cancel button gets selected

solution:
- the actual button is not getting selected. It's rather the text of the button that's getting selected when we click fast (acting as double click) selecting the nearby text
- adding `user:select : none` on the button component style should avoid selecting text on the button

screenshots:
![before](https://github.com/user-attachments/assets/7f09e152-7bc8-4674-8618-2e9058a3b89a)
![after](https://github.com/user-attachments/assets/83ac4078-76a1-45a9-ba92-1fce99607e0b)

tooljet version: 3.7.0-ce



fixes: #11414 