### PR TITLE
fix: update query-pane in dark mode border top to 3px to match light mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -3478,7 +3478,7 @@ input:focus-visible {
   }
 
   .query-pane {
-    border-top: 1px solid var(--slate5) !important;
+    border-top: 3px solid var(--slate5) !important;
   }
 
   .input-icon .input-icon-addon img {


### PR DESCRIPTION
issue: dark mode alignment is incorrect (In dark mode the border is 1px compared to 3px in light mode)

screenshots:

![light-mode-query-pane-before](https://github.com/user-attachments/assets/97d1a9af-2682-4067-a869-300a409025f3)


![dark-mode-query-pane-before](https://github.com/user-attachments/assets/2e68d7fb-67c4-47a9-bf88-fd03995fb465)

solution:

update `query-pane` style to `border-top: 3px solid var(--slate5) !important;` in `theme.dark`

screenshots:

![dark-mode-query-pane-after](https://github.com/user-attachments/assets/9d8da105-62c7-429c-b763-2611af526514)

tooljet version: 3.7.0-ce

fixes #11432


