### PR TITLE
Fix: Dropdown and Multiselect related integration bugs for sprint 11

### DIFF
--- a/frontend/src/Editor/Components/DropdownV2/DropdownV2.jsx
+++ b/frontend/src/Editor/Components/DropdownV2/DropdownV2.jsx
@@ -269,6 +269,11 @@ export const DropdownV2 = ({
 
   useEffect(() => {
     if (isInitialRender.current) return;
+    setExposedVariable('value', currentValue);
+  }, [currentValue]);
+
+  useEffect(() => {
+    if (isInitialRender.current) return;
     const validationStatus = validate(currentValue);
     setValidationStatus(validationStatus);
     setExposedVariable('isValid', validationStatus?.isValid);

--- a/frontend/src/Editor/Components/DropdownV2/utils.js
+++ b/frontend/src/Editor/Components/DropdownV2/utils.js
@@ -52,7 +52,14 @@ export const getInputBackgroundColor = ({ fieldBackgroundColor, darkMode, isLoad
 };
 
 export const highlightText = (text = '', highlight) => {
-  const parts = text?.split(new RegExp(`(${highlight})`, 'gi'));
+  // Escape special regex characters in the highlight string
+  const escapeRegExp = (string) => {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  };
+
+  const safeHighlight = highlight ? escapeRegExp(highlight) : '';
+  const parts = text?.split(new RegExp(`(${safeHighlight})`, 'gi'));
+
   return (
     <span>
       {parts.map((part, index) =>

--- a/frontend/src/Editor/Components/MultiselectV2/CustomValueContainer.jsx
+++ b/frontend/src/Editor/Components/MultiselectV2/CustomValueContainer.jsx
@@ -6,7 +6,11 @@ import './multiselectV2.scss';
 
 const CustomValueContainer = ({ children, ...props }) => {
   const selectProps = props.selectProps;
-  const values = Array.isArray(selectProps?.value) && selectProps?.value?.map((option) => option.label);
+  const values =
+    Array.isArray(selectProps?.value) &&
+    selectProps?.value
+      ?.filter((option) => option.value !== 'multiselect-custom-menulist-select-all') //Remove the Select all option if selected
+      ?.map((option) => option.label);
   const isAllOptionsSelected = selectProps?.value.length === selectProps.options.length;
   const valueContainerWidth = selectProps?.containerRef?.current?.offsetWidth;
   // eslint-disable-next-line import/namespace

--- a/frontend/src/Editor/Components/MultiselectV2/MultiselectV2.jsx
+++ b/frontend/src/Editor/Components/MultiselectV2/MultiselectV2.jsx
@@ -146,7 +146,7 @@ export const MultiselectV2 = ({
     if (action.option?.value === SELECT_ALL) {
       // Case 1 - If select all is selected
       if (action.action === 'select-option') {
-        setInputValue(modifiedSelectOptions);
+        setInputValue(selectOptions);
       } else {
         setInputValue([]);
       }
@@ -155,7 +155,7 @@ export const MultiselectV2 = ({
       setInputValue(items.filter((item) => item.value !== SELECT_ALL));
     } else if (selectOptions?.length === items?.length) {
       // Case 3 - If all options are selected except select all
-      setInputValue(modifiedSelectOptions);
+      setInputValue(selectOptions);
     } else {
       // Case 4 - Normal selection
       setInputValue(items);
@@ -503,7 +503,7 @@ export const MultiselectV2 = ({
             ref={selectRef}
             menuId={id}
             isDisabled={isMultiSelectDisabled}
-            value={selected}
+            value={selectOptions?.length === selected?.length ? modifiedSelectOptions : selected}
             onChange={onChangeHandler}
             options={modifiedSelectOptions}
             styles={customStyles}


### PR DESCRIPTION
Closes -
1. When Enable select all option is enabled & show all items are selected is disabled, select all should not be displayed with the options
2. Dropdown & Multiselect crash when special characters are searched
3. Issue for Dropdown default value where current exposed value is one, but selected on UI is two