### PR TITLE
Fix wait only if host and port are specified

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -35,11 +35,12 @@ fi
 
 # Check Redis connection
 if [ -z "$REDIS_URL" ]; then
-  if [ -z "$REDIS_HOST" ] || [ -z "$REDIS_PORT" ]; then
+  if [ -n "$REDIS_HOST" ] && [ -n "$REDIS_PORT" ]; then
     echo "Waiting for Redis connection..."
+    ./server/scripts/wait-for-it.sh $REDIS_HOST:${REDIS_PORT:-6379} --strict --timeout=300 -- echo "Redis is up"
+  else
+    echo "Redis connection parameters not set, skipping Redis connection check"
   fi
-
-  ./server/scripts/wait-for-it.sh $REDIS_HOST:${REDIS_PORT:-6379} --strict --timeout=300 -- echo "Redis is up"
 else
   echo "REDIS_URL connection is set"
 fi


### PR DESCRIPTION
## Description
Fixed Redis connection check in entrypoint.sh to properly handle connection parameters. 

## Changes
- Only attempts Redis connection when both host and port are provided
  - If not set, error occurs :`Error: you need to provide a host and port to test.`

## Context
While setting up the development environment using Docker (following the [contributing guide](https://docs.tooljet.ai/docs/contributing-guide/setup/docker/)) that not set Redis up, 
I noticed that the Redis connection check was attempting to connect even when required parameters were missing. 
This could lead to unnecessary errors during the setup process.


## Related Documentation
- [ToolJet Docker Setup Guide](https://docs.tooljet.ai/docs/contributing-guide/setup/docker/)