### PR TITLE
fix: Folder name max length validation #10654.

### DIFF
--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -1207,7 +1207,7 @@ export const validateName = (
       };
     }
 
-    if (newName.length > 50) {
+    if (newName.length >= 50) {
       errorMsg = `Maximum length has been reached.`;
       showError &&
         toast.error(errorMsg, {


### PR DESCRIPTION
Hi,

References: https://github.com/ToolJet/ToolJet/issues/10654

As inspected by me the issue was the folder length was just greater than 50.  Hence the validation was not triggered.
Now added check for the same.
I am thankful for the opportunity to contribute.
Warm Regards,
Pranav Shastri