### PR TITLE
[docs]: Fix Broken Anchor Tag

### DIFF
--- a/docs/docs/app-builder/share.md
+++ b/docs/docs/app-builder/share.md
@@ -46,7 +46,7 @@ For embedding private ToolJet apps, you'll need to set an environment variable i
 |:-------------- |:------------------------------------ |
 | ENABLE_PRIVATE_APP_EMBED | `true` or `false` |
 
-You can learn more [here](/docs/setup/env-vars#enabling-embedding-of-private-apps).
+You can learn more [here](/docs/setup/env-vars#embedding-private-apps).
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/docs/data-sources/google.sheets.md
+++ b/docs/docs/data-sources/google.sheets.md
@@ -11,7 +11,7 @@ ToolJet has the capability to establish a connection with Google Sheet for both 
 
 If you decide to self-host ToolJet, there are a few additional steps you need to take:
 
-1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth--optional-) to configure the necessary settings.
+1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth) to configure the necessary settings.
 2. Assign the corresponding values obtained from the previous step to the following environment variables:
    - **GOOGLE_CLIENT_ID**
    - **GOOGLE_CLIENT_SECRET**

--- a/docs/docs/marketplace/marketplace_overview.md
+++ b/docs/docs/marketplace/marketplace_overview.md
@@ -13,24 +13,6 @@ ToolJet Marketplace allows users to enhance their workspaces by adding custom pl
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-## Enabling Marketplace 
-
-To **Enable** the marketplace feature, users need to add the following environment variable to their **[`.env`](/docs/setup/env-vars#marketplace)** file:
-
-```bash
-ENABLE_MARKETPLACE_FEATURE=true
-```
-
-When running ToolJet locally, ensure that all the plugins are available by building marketplace before starting the server.
-
-:::info Note
-The logged-in user should be an **Administrator** to access the marketplace page.
-:::
-
-</div>
-
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
-
 ## Installing a Plugin
 
 To navigate to the Marketplace page, click on the settings icon on the bottom left of the dashboard, and click on **Marketplace** from the selection menu.

--- a/docs/docs/setup/ecs.md
+++ b/docs/docs/setup/ecs.md
@@ -125,8 +125,8 @@ The setup above is just a template. Feel free to update the task definition and 
 To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. You can learn more about this feature [here](/docs/tooljet-db/tooljet-database).
 
 Deploying ToolJet Database is mandatory from ToolJet 3.0 or else the migration might break, checkout the following docs to know more about new major version, including breaking changes that require you to adjust your applications accordingly:
+
 - [ToolJet 3.0 Migration Guide for Self-Hosted Versions](./upgrade-to-v3.md)
-](./upgrade-to-v3.md)
 - [Cloud](./cloud-v3-migration.md)
 
 Follow the steps below to deploy PostgREST on a ECS cluster. 
@@ -147,7 +147,7 @@ Follow the steps below to deploy PostgREST on a ECS cluster.
 
   </div>
   
-  Under environmental variable please add corresponding PostgREST env variables. You can also refer [env variable](/docs/setup/env-vars/#postgrest-server-required).
+  Under environmental variable please add corresponding PostgREST env variables. You can also refer [env variable](/docs/setup/env-vars#postgrest).
 
   <div style={{textAlign: 'center'}}>
 
@@ -181,7 +181,7 @@ Follow the steps below to deploy PostgREST on a ECS cluster.
 
   </div>
 
-Update ToolJet deployment with the appropriate env variables [here](/docs/setup/env-vars/#enable-tooljet-database-required) and apply the changes.
+Update ToolJet deployment with the appropriate env variables [here](/docs/setup/env-vars#tooljet-database) and apply the changes.
 
 </div>
 

--- a/docs/docs/setup/google-cloud-run.md
+++ b/docs/docs/setup/google-cloud-run.md
@@ -66,7 +66,7 @@ If you are using [Public IP](https://cloud.google.com/sql/docs/postgres/connect-
 Click on deploy once the above parameters are set. 
 
 :::info
-Once the Service is created and live, to make the  Cloud Service URL public. Please follow the steps [**here**](https://cloud.google.com/run/docs/securing/managing-access) to make the service public.
+Once the Service is created and live, to make the Cloud Service URL public. Please follow the steps [**here**](https://cloud.google.com/run/docs/securing/managing-access) to make the service public.
 :::
 
 ## Deploying ToolJet Database 
@@ -89,8 +89,7 @@ To use ToolJet Database, you'd have to set up and deploy PostgREST server which 
 3. Under containers tab, please make sure the port is set 3000 and CPU capacity is set to 1GiB.
 
     <img className="screenshot-full" src="/img/cloud-run/port-and-capacity-postgrest.png" alt="port-and-capacity-postgrest" />
-  
-4. Under environmental variable please add corresponding ToolJet database env variables. You can also refer [env variable](/docs/setup/env-vars/#enable-tooljet-database-required).
+4. Under environmental variable please add corresponding ToolJet database env variables. You can also refer [env variable](/docs/setup/env-vars#tooljet-database).
 
 5. Please go to connection tab. Under Cloud SQL instance please select the PostgreSQL database which you have set-up for ToolJet application or the separate PostgreSQL database created respective to ToolJet Database from the drop-down option.
 
@@ -99,10 +98,10 @@ To use ToolJet Database, you'd have to set up and deploy PostgREST server which 
     Click on deploy once the above parameters are set. 
 
     :::info
-    Once the Service is created and live, to make the  Cloud Service URL public. Please follow the steps [**here**](https://cloud.google.com/run/docs/securing/managing-access) to make the service public.
+    Once the Service is created and live, to make the Cloud Service URL public. Please follow the steps [**here**](https://cloud.google.com/run/docs/securing/managing-access) to make the service public.
     :::
 
-6. Additional Environmental variable to be added to ToolJet application or ToolJet Server connect to PostgREST server. You can also refer env variable [**here**](./env-vars/#enable-tooljet-database-required)
+6. Additional Environmental variable to be added to ToolJet application or ToolJet Server connect to PostgREST server. You can also refer env variable [**here**](/docs/setup/env-vars#tooljet-database)
 
     <img className="screenshot-full" src="/img/cloud-run/env-for-tooljet.png" alt="env-for-tooljet" />
 

--- a/docs/docs/setup/kubernetes-aks.md
+++ b/docs/docs/setup/kubernetes-aks.md
@@ -58,7 +58,7 @@ You will be able to access your ToolJet installation once the pods and services 
 
 ## ToolJet Database
 
-To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars/#enable-tooljet-database-required).
+To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars#tooljet-database).
 
 1. Setup PostgREST server
 

--- a/docs/docs/setup/kubernetes-eks.md
+++ b/docs/docs/setup/kubernetes-eks.md
@@ -6,7 +6,7 @@ title: Kubernetes (EKS)
 Follow the steps below to deploy ToolJet on an EKS Kubernetes cluster.
 
 :::info
-You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an RDS PostgreSQL database. You can find the system requirements [here](/docs/setup/system-requirements#database-software)
+You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an RDS PostgreSQL database. You can find the system requirements [here](/docs/setup/system-requirements#postgresql)
 :::
 
 1. Create an EKS cluster and connect to it to start with the deployment. You can follow the steps as mentioned in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html).
@@ -46,7 +46,7 @@ Make sure to edit the environment variables in the `deployment.yaml`. We advise 
 
 ## ToolJet Database
 
-To use ToolJet Database, you'd have to set up and deploy a PostgREST server, which helps in querying the ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars/#enable-tooljet-database-required).
+To use ToolJet Database, you'd have to set up and deploy a PostgREST server, which helps in querying the ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars#tooljet-database).
 
 1. Set up PostgREST server
 

--- a/docs/docs/setup/kubernetes-gke.md
+++ b/docs/docs/setup/kubernetes-gke.md
@@ -82,7 +82,7 @@ You will be able to access your ToolJet installation once the pods, service and 
 
 ## ToolJet Database
 
-To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars/#enable-tooljet-database-required).
+To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars#tooljet-database).
 
 1. Setup PostgREST server
 

--- a/docs/docs/setup/upgrade-to-v3.md
+++ b/docs/docs/setup/upgrade-to-v3.md
@@ -222,8 +222,8 @@ The `metadata` object will contain detailed information about the request and re
 ToolJet Database is now a core requirement for the ToolJet 3.0. 
 To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. <br/>
 Please check the environment variables that you need to configure to set up:
-- [PostgREST](/docs/setup/env-vars#postgrest-server-required)
-- [ToolJet Database](/docs/setup/env-vars#enable-tooljet-database-required)
+- [PostgREST](/docs/setup/env-vars#postgrest)
+- [ToolJet Database](/docs/setup/env-vars#tooljet-database)
 
 ## Help and Support
 

--- a/docs/docs/tooljet-db/tooljet-database.md
+++ b/docs/docs/tooljet-db/tooljet-database.md
@@ -17,7 +17,7 @@ Requires:
 - PostgREST server
 - Additional configuration for ToolJet server
 
-This feature is only enabled if [`ENABLE_TOOLJET_DB`](/docs/setup/env-vars#enable-tooljet-database-required) is set to `true`.
+This feature is only enabled if [`ENABLE_TOOLJET_DB`](/docs/setup/env-vars#tooljet-database) is set to `true`.
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 

--- a/docs/docs/widgets/map.md
+++ b/docs/docs/widgets/map.md
@@ -6,7 +6,7 @@ title: Map
 The **Map** component enables users to display a map on the app. It can be used to display or choose a single location or multiple locations on the map. The Map component can be used to display the location of a business, a store, or a restaurant. It can also be used to display the location of a user on the map. It allows users to interact with the map interface and pick specific points of interest.
 
 :::tip Using Self-hosted 
-If you are utilizing the self-hosted version of ToolJet, it is necessary to configure the Google Maps API key as an environment variable. Please refer to the [environment variable setup documentation](/docs/setup/env-vars/#google-maps-configuration--optional-).
+If you are utilizing the self-hosted version of ToolJet, it is necessary to configure the Google Maps API key as an environment variable. Please refer to the [environment variable setup documentation](/docs/setup/env-vars#google-maps-api).
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/versioned_docs/version-2.50.0-LTS/Enterprise/superadmin.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/Enterprise/superadmin.md
@@ -28,7 +28,7 @@ The user details entered while setting up ToolJet will have Super Admin privileg
 | Manage SSO in their workspace | ✅ | ✅ |
 | Manage Workspace Variables in their workspace | ✅ | ✅ |
 | Manage Workspace Constants in their workspace | ✅ | ✅ |
-| [Manage data sources for the user group in their workspace](/docs/data-sources/overview#user-permissions) | ✅ | ✅ |
+| [Manage data sources for the user group in their workspace](/docs/2.50.0-LTS/data-sources/overview#user-permissions) | ✅ | ✅ |
 | [Access any user's personal workspace (create, edit or delete apps)](#access-any-workspace) | ❌ | ✅ |
 | [Archive Admin or any user of any workspace](#archiveunarchive-users) | ❌ | ✅ |
 | [Access any user's ToolJet database (create, edit or delete database)](#access-tooljet-db-in-any-workspace) | ❌ | ✅ |

--- a/docs/versioned_docs/version-2.50.0-LTS/app-builder/share.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/app-builder/share.md
@@ -46,7 +46,7 @@ For embedding private ToolJet apps, you'll need to set an environment variable i
 |:-------------- |:------------------------------------ |
 | ENABLE_PRIVATE_APP_EMBED | `true` or `false` |
 
-You can learn more [here](/docs/setup/env-vars#enabling-embedding-of-private-apps).
+You can learn more [here](/docs/setup/env-vars#embedding-private-apps).
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/versioned_docs/version-2.50.0-LTS/data-sources/google.sheets.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/data-sources/google.sheets.md
@@ -11,7 +11,7 @@ ToolJet has the capability to establish a connection with Google Sheet for both 
 
 If you decide to self-host ToolJet, there are a few additional steps you need to take:
 
-1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth--optional-) to configure the necessary settings.
+1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth) to configure the necessary settings.
 2. Assign the corresponding values obtained from the previous step to the following environment variables:
    - **GOOGLE_CLIENT_ID**
    - **GOOGLE_CLIENT_SECRET**

--- a/docs/versioned_docs/version-2.50.0-LTS/marketplace/marketplace_overview.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/marketplace/marketplace_overview.md
@@ -13,24 +13,6 @@ ToolJet Marketplace allows users to enhance their workspaces by adding custom pl
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-## Enabling Marketplace 
-
-To **Enable** the marketplace feature, users need to add the following environment variable to their **[`.env`](/docs/setup/env-vars#marketplace)** file:
-
-```bash
-ENABLE_MARKETPLACE_FEATURE=true
-```
-
-When running ToolJet locally, ensure that all the plugins are available by building marketplace before starting the server.
-
-:::info Note
-The logged-in user should be an **Administrator** to access the marketplace page.
-:::
-
-</div>
-
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
-
 ## Installing a Plugin
 
 To navigate to the Marketplace page, click on the settings icon on the bottom left of the dashboard, and click on **Marketplace** from the selection menu.

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/ecs.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/ecs.md
@@ -167,7 +167,7 @@ Follow the steps below to deploy PostgREST on a ECS cluster.
 
   </div>
 
-Update ToolJet deployment with the appropriate env variables [here](/docs/setup/env-vars/#enable-tooljet-database-required) and apply the changes.
+Update ToolJet deployment with the appropriate env variables [here](/docs/setup/env-vars#tooljet-database) and apply the changes.
 
 ## Upgrading to the Latest LTS Version
 

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/kubernetes-aks.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/kubernetes-aks.md
@@ -58,7 +58,7 @@ You will be able to access your ToolJet installation once the pods and services 
 
 ## ToolJet Database
 
-To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars/#enable-tooljet-database-required).
+To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars#tooljet-database).
 
 1. Setup PostgREST server
 

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/kubernetes-eks.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/kubernetes-eks.md
@@ -6,7 +6,7 @@ title: Kubernetes (EKS)
 Follow the steps below to deploy ToolJet on an EKS Kubernetes cluster.
 
 :::info
-You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an RDS PostgreSQL database. You can find the system requirements [here](/docs/setup/system-requirements#database-software)
+You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an RDS PostgreSQL database. You can find the system requirements [here](/docs/2.50.0-LTS/setup/system-requirements#database-software)
 :::
 
 1. Create an EKS cluster and connect to it to start with the deployment. You can follow the steps as mentioned in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html).
@@ -42,11 +42,12 @@ Make sure to edit the environment variables in the `deployment.yaml`. We advise 
 3. Create a Kubernetes service to publish the Kubernetes deployment that you have created. We have a [template](https://tooljet-deployments.s3.us-west-1.amazonaws.com/kubernetes/service.yaml) for exposing the ToolJet server as a service using an AWS Load Balancer.
 
 **Example:**
+
 - [Application load balancing on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html)
 
 ## ToolJet Database
 
-To use ToolJet Database, you'd have to set up and deploy a PostgREST server, which helps in querying the ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars/#enable-tooljet-database-required).
+To use ToolJet Database, you'd have to set up and deploy a PostgREST server, which helps in querying the ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars#tooljet-database).
 
 1. Set up PostgREST server
 

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/kubernetes-gke.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/kubernetes-gke.md
@@ -82,7 +82,7 @@ You will be able to access your ToolJet installation once the pods, service and 
 
 ## ToolJet Database
 
-To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars/#enable-tooljet-database-required).
+To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars#tooljet-database).
 
 1. Setup PostgREST server
 

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/kubernetes.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/kubernetes.md
@@ -61,7 +61,7 @@ If you want to serve ToolJet client from services such as Firebase or Netlify, p
 
 ## ToolJet Database
 
-If you intend to use this feature, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars/#enable-tooljet-database-required) for additional environment variables configuration to be done.
+If you intend to use this feature, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars#tooljet-database) for additional environment variables configuration to be done.
 
 1. Setup PostgREST server
 

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/openshift.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/openshift.md
@@ -70,7 +70,7 @@ If there are self signed HTTPS endpoints that ToolJet needs to connect to, pleas
 
 You can know more about tooljet database [here](/docs/tooljet-db/tooljet-database)
 
-To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars/#enable-tooljet-database-required).
+To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. Please [follow the instructions here](/docs/setup/env-vars#tooljet-database).
 
 ```
 https://tooljet-deployments.s3.us-west-1.amazonaws.com/openshift/postgrest.yaml

--- a/docs/versioned_docs/version-2.50.0-LTS/setup/upgrade-to-v3.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/setup/upgrade-to-v3.md
@@ -231,8 +231,8 @@ The `metadata` object will contain detailed information about the request and re
 ToolJet Database is now a core requirement for the ToolJet 3.0. 
 To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database. <br/>
 Please check the environment variables that you need to configure to set up:
-- [PostgREST](/docs/setup/env-vars#postgrest-server-required)
-- [ToolJet Database](/docs/setup/env-vars#enable-tooljet-database-required)
+- [PostgREST](/docs/setup/env-vars#postgrest)
+- [ToolJet Database](/docs/setup/env-vars#tooljet-database)
 
 <!-- Don't use relative path. Needs to redirect to current docs instead of versioned -->
 

--- a/docs/versioned_docs/version-2.50.0-LTS/user-authentication/sso/auto-sso-login.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/user-authentication/sso/auto-sso-login.md
@@ -23,7 +23,7 @@ To enable automatic SSO login, follow these steps:
 
 2. Disable password login for your workspace.
 
-3. Add the following variable to your [enviroment variables](/docs/setup/env-vars#sso-configurations-optional):
+3. Add the following variable to your [enviroment variables](/docs/setup/env-vars#single-sign-on-sso):
 
 ``` yaml
 SSO_SKIP_LOGIN_SCREEN = true

--- a/docs/versioned_docs/version-2.50.0-LTS/widgets/map.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/widgets/map.md
@@ -6,7 +6,7 @@ title: Map
 The **Map** component enables users to display a map on the app. It can be used to display or choose a single location or multiple locations on the map. The Map component can be used to display the location of a business, a store, or a restaurant. It can also be used to display the location of a user on the map. It allows users to interact with the map interface and pick specific points of interest.
 
 :::tip Using Self-hosted 
-If you are utilizing the self-hosted version of ToolJet, it is necessary to configure the Google Maps API key as an environment variable. Please refer to the [environment variable setup documentation](/docs/setup/env-vars/#google-maps-configuration--optional-).
+If you are utilizing the self-hosted version of ToolJet, it is necessary to configure the Google Maps API key as an environment variable. Please refer to the [environment variable setup documentation](/docs/setup/env-vars#google-maps-api).
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/versioned_docs/version-3.0.0-LTS/Enterprise/superadmin.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/Enterprise/superadmin.md
@@ -20,7 +20,7 @@ The user details entered while setting up ToolJet will have Super Admin privileg
 | Manage SSO in their workspace | ✅ | ✅ |
 | Manage Workspace Variables in their workspace | ✅ | ✅ |
 | Manage Workspace Constants in their workspace | ✅ | ✅ |
-| [Manage data sources for the user group in their workspace](/docs/data-sources/overview#user-permissions) | ✅ | ✅ |
+| [Manage data sources for the user group in their workspace](/docs/3.0.0-LTS/data-sources/overview#user-permissions) | ✅ | ✅ |
 | [Access any user's personal workspace (create, edit or delete apps)](#access-any-workspace) | ❌ | ✅ |
 | [Archive Admin or any user of any workspace](#archiveunarchive-users) | ❌ | ✅ |
 | [Access any user's ToolJet database (create, edit or delete database)](#access-tooljet-db-in-any-workspace) | ❌ | ✅ |

--- a/docs/versioned_docs/version-3.0.0-LTS/app-builder/share.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/app-builder/share.md
@@ -46,7 +46,7 @@ For embedding private ToolJet apps, you'll need to set an environment variable i
 |:-------------- |:------------------------------------ |
 | ENABLE_PRIVATE_APP_EMBED | `true` or `false` |
 
-You can learn more [here](/docs/setup/env-vars#enabling-embedding-of-private-apps).
+You can learn more [here](/docs/setup/env-vars#embedding-private-apps).
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/versioned_docs/version-3.0.0-LTS/data-sources/google.sheets.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/data-sources/google.sheets.md
@@ -11,7 +11,7 @@ ToolJet has the capability to establish a connection with Google Sheet for both 
 
 If you decide to self-host ToolJet, there are a few additional steps you need to take:
 
-1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth--optional-) to configure the necessary settings.
+1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth) to configure the necessary settings.
 2. Assign the corresponding values obtained from the previous step to the following environment variables:
    - **GOOGLE_CLIENT_ID**
    - **GOOGLE_CLIENT_SECRET**

--- a/docs/versioned_docs/version-3.0.0-LTS/marketplace/marketplace_overview.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/marketplace/marketplace_overview.md
@@ -13,24 +13,6 @@ ToolJet Marketplace allows users to enhance their workspaces by adding custom pl
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-## Enabling Marketplace 
-
-To **Enable** the marketplace feature, users need to add the following environment variable to their **[`.env`](/docs/setup/env-vars#marketplace)** file:
-
-```bash
-ENABLE_MARKETPLACE_FEATURE=true
-```
-
-When running ToolJet locally, ensure that all the plugins are available by building marketplace before starting the server.
-
-:::info Note
-The logged-in user should be an **Administrator** to access the marketplace page.
-:::
-
-</div>
-
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
-
 ## Installing a Plugin
 
 To navigate to the Marketplace page, click on the settings icon on the bottom left of the dashboard, and click on **Marketplace** from the selection menu.

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/ecs.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/ecs.md
@@ -148,7 +148,7 @@ Follow the steps below to deploy PostgREST on a ECS cluster.
 
   </div>
   
-  Under environmental variable please add corresponding PostgREST env variables. You can also refer [env variable](/docs/setup/env-vars/#postgrest-server-required).
+  Under environmental variable please add corresponding PostgREST env variables. You can also refer [env variable](/docs/setup/env-vars#postgrest).
 
   <div style={{textAlign: 'center'}}>
 
@@ -182,7 +182,7 @@ Follow the steps below to deploy PostgREST on a ECS cluster.
 
   </div>
 
-Update ToolJet deployment with the appropriate env variables [here](/docs/setup/env-vars/#enable-tooljet-database-required) and apply the changes.
+Update ToolJet deployment with the appropriate env variables [here](/docs/setup/env-vars#tooljet-database) and apply the changes.
 
 </div>
 

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes-eks.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/kubernetes-eks.md
@@ -6,7 +6,7 @@ title: Kubernetes (EKS)
 Follow the steps below to deploy ToolJet on an EKS Kubernetes cluster.
 
 :::info
-You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an RDS PostgreSQL database. You can find the system requirements [here](/docs/setup/system-requirements#database-software)
+You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an RDS PostgreSQL database. You can find the system requirements [here](/docs/3.0.0-LTS/setup/system-requirements#database-software)
 :::
 
 1. Create an EKS cluster and connect to it to start with the deployment. You can follow the steps as mentioned in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html).

--- a/docs/versioned_docs/version-3.0.0-LTS/setup/upgrade-to-v3.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/setup/upgrade-to-v3.md
@@ -229,8 +229,8 @@ The `metadata` object will contain detailed information about the request and re
 ToolJet Database is now a core requirement for the ToolJet 3.0. 
 To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database.  <br/>
 Please check the environment variables that you need to configure to set up:
-- [PostgREST](/docs/setup/env-vars#postgrest-server-required)
-- [ToolJet Database](/docs/setup/env-vars#enable-tooljet-database-required)
+- [PostgREST](/docs/setup/env-vars#postgrest)
+- [ToolJet Database](/docs/setup/env-vars#tooljet-database)
 
 ## Help and Support
 

--- a/docs/versioned_docs/version-3.0.0-LTS/widgets/map.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/widgets/map.md
@@ -6,7 +6,7 @@ title: Map
 The **Map** component enables users to display a map on the app. It can be used to display or choose a single location or multiple locations on the map. The Map component can be used to display the location of a business, a store, or a restaurant. It can also be used to display the location of a user on the map. It allows users to interact with the map interface and pick specific points of interest.
 
 :::tip Using Self-hosted 
-If you are utilizing the self-hosted version of ToolJet, it is necessary to configure the Google Maps API key as an environment variable. Please refer to the [environment variable setup documentation](/docs/setup/env-vars/#google-maps-configuration--optional-).
+If you are utilizing the self-hosted version of ToolJet, it is necessary to configure the Google Maps API key as an environment variable. Please refer to the [environment variable setup documentation](/docs/setup/env-vars#google-maps-api).
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/versioned_docs/version-3.5.0-LTS/app-builder/share.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/app-builder/share.md
@@ -46,7 +46,7 @@ For embedding private ToolJet apps, you'll need to set an environment variable i
 |:-------------- |:------------------------------------ |
 | ENABLE_PRIVATE_APP_EMBED | `true` or `false` |
 
-You can learn more [here](/docs/setup/env-vars#enabling-embedding-of-private-apps).
+You can learn more [here](/docs/setup/env-vars#embedding-private-apps).
 :::
 
 <div style={{textAlign: 'center'}}>

--- a/docs/versioned_docs/version-3.5.0-LTS/data-sources/google.sheets.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/data-sources/google.sheets.md
@@ -11,7 +11,7 @@ ToolJet has the capability to establish a connection with Google Sheet for both 
 
 If you decide to self-host ToolJet, there are a few additional steps you need to take:
 
-1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth--optional-) to configure the necessary settings.
+1. Proceed with the setup steps provided in the [Google OAuth 2.0 guide](/docs/setup/env-vars#google-oauth) to configure the necessary settings.
 2. Assign the corresponding values obtained from the previous step to the following environment variables:
    - **GOOGLE_CLIENT_ID**
    - **GOOGLE_CLIENT_SECRET**

--- a/docs/versioned_docs/version-3.5.0-LTS/marketplace/marketplace_overview.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/marketplace/marketplace_overview.md
@@ -13,24 +13,6 @@ ToolJet Marketplace allows users to enhance their workspaces by adding custom pl
 
 <div style={{paddingTop:'24px', paddingBottom:'24px'}}>
 
-## Enabling Marketplace 
-
-To **Enable** the marketplace feature, users need to add the following environment variable to their **[`.env`](/docs/setup/env-vars#marketplace)** file:
-
-```bash
-ENABLE_MARKETPLACE_FEATURE=true
-```
-
-When running ToolJet locally, ensure that all the plugins are available by building marketplace before starting the server.
-
-:::info Note
-The logged-in user should be an **Administrator** to access the marketplace page.
-:::
-
-</div>
-
-<div style={{paddingTop:'24px', paddingBottom:'24px'}}>
-
 ## Installing a Plugin
 
 To navigate to the Marketplace page, click on the settings icon on the bottom left of the dashboard, and click on **Marketplace** from the selection menu.

--- a/docs/versioned_docs/version-3.5.0-LTS/setup/ec2.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/setup/ec2.md
@@ -10,7 +10,7 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist https://api-
 :::
 
 :::info
-You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#postgresql).
 :::
 
 

--- a/docs/versioned_docs/version-3.5.0-LTS/setup/ecs.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/setup/ecs.md
@@ -10,7 +10,7 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist https://api-
 :::
 
 :::info
-You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#postgresql).
 
 ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-service setup**, it's recommended to use an **external Redis instance**.
 :::

--- a/docs/versioned_docs/version-3.5.0-LTS/setup/kubernetes-aks.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/setup/kubernetes-aks.md
@@ -11,7 +11,7 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api
 
 
 :::info
-You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using **Azure Database for PostgreSQL** since this guide is for deploying using AKS. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using **Azure Database for PostgreSQL** since this guide is for deploying using AKS. You can find the system requirements [here](/docs/setup/system-requirements#postgresql).
 
 ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::

--- a/docs/versioned_docs/version-3.5.0-LTS/setup/kubernetes-eks.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/setup/kubernetes-eks.md
@@ -10,7 +10,7 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api
 :::
 
 :::info
-You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+You should set up a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements#postgresql).
 
 ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::

--- a/docs/versioned_docs/version-3.5.0-LTS/setup/kubernetes-gke.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/setup/kubernetes-gke.md
@@ -10,7 +10,7 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api
 :::
 
 :::info
-You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#postgresql).
 
 ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::

--- a/docs/versioned_docs/version-3.5.0-LTS/setup/kubernetes.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/setup/kubernetes.md
@@ -10,7 +10,7 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api
 :::
 
 :::info
-You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#postgresql).
 
 ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::

--- a/docs/versioned_docs/version-3.5.0-LTS/setup/openshift.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/setup/openshift.md
@@ -10,7 +10,7 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist `https://api
 :::
 
 :::info
-You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#database-software).
+You should setup a **PostgreSQL database** manually to be used by ToolJet. You can find the system requirements [here](/docs/setup/system-requirements#postgresql).
 
 ToolJet comes with a **built-in Redis setup**, which is used for multiplayer editing and background jobs. However, for **multi-pod setup**, it's recommended to use an **external Redis instance**.
 :::

--- a/docs/versioned_docs/version-3.5.0-LTS/setup/upgrade-to-v3.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/setup/upgrade-to-v3.md
@@ -222,8 +222,8 @@ The `metadata` object will contain detailed information about the request and re
 ToolJet Database is now a core requirement for the ToolJet 3.0. 
 To use ToolJet Database, you'd have to set up and deploy PostgREST server which helps querying ToolJet Database.  <br/>
 Please check the environment variables that you need to configure to set up:
-- [PostgREST](/docs/setup/env-vars#postgrest-server-required)
-- [ToolJet Database](/docs/setup/env-vars#enable-tooljet-database-required)
+- [PostgREST](/docs/setup/env-vars#postgrest)
+- [ToolJet Database](/docs/setup/env-vars#tooljet-database)
 
 ## Help and Support
 

--- a/docs/versioned_docs/version-3.5.0-LTS/widgets/map.md
+++ b/docs/versioned_docs/version-3.5.0-LTS/widgets/map.md
@@ -6,7 +6,7 @@ title: Map
 The **Map** component enables users to display a map on the app. It can be used to display or choose a single location or multiple locations on the map. The Map component can be used to display the location of a business, a store, or a restaurant. It can also be used to display the location of a user on the map. It allows users to interact with the map interface and pick specific points of interest.
 
 :::tip Using Self-hosted 
-If you are utilizing the self-hosted version of ToolJet, it is necessary to configure the Google Maps API key as an environment variable. Please refer to the [environment variable setup documentation](/docs/setup/env-vars/#google-maps-configuration--optional-).
+If you are utilizing the self-hosted version of ToolJet, it is necessary to configure the Google Maps API key as an environment variable. Please refer to the [environment variable setup documentation](/docs/setup/env-vars#google-maps-api).
 :::
 
 <div style={{textAlign: 'center'}}>


### PR DESCRIPTION
Changes were made in the env var file through #12176 

Which resulted in broken links for several other docs, which will be fixed through this PR.