### PR TITLE
Fix: added forgot password base component, fixed contact super admin banner

### DIFF
--- a/frontend/src/modules/auth/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/frontend/src/modules/auth/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -1,44 +1,9 @@
-import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { toast } from 'react-hot-toast';
-import { authenticationService } from '@/_services';
-import OnboardingBackgroundWrapper from '@/modules/onboarding/components/OnboardingBackgroundWrapper';
-import { GeneralFeatureImage } from '@/modules/common/components';
-import { ForgotPasswordForm, ForgotPasswordInfoScreen } from './components';
+import { withEditionSpecificComponent } from '@/modules/common/helpers';
+import BasePasswordForgotPage from './components/BaseForgotPasswordPage/BaseForgotPasswordPage';
 
 const ForgotPasswordPage = () => {
-  const { t } = useTranslation();
-  const [showInfoScreen, setShowInfoScreen] = useState(false);
-  const [email, setEmail] = useState('');
-
-  const handleForgotPassword = async (email) => {
-    try {
-      await authenticationService.forgotPassword(email);
-      toast.success(
-        t('forgotPasswordPage.checkEmailForResetLink', 'Please check your email for the password reset link'),
-        {
-          id: 'toast-forgot-password-confirmation-code',
-        }
-      );
-      setEmail(email);
-      setShowInfoScreen(true);
-    } catch (error) {
-      toast.error(error.error || t('forgotPasswordPage.somethingWentWrong', 'Something went wrong, please try again'), {
-        id: 'toast-forgot-password-email-error',
-      });
-    }
-  };
-
-  if (showInfoScreen) {
-    return <OnboardingBackgroundWrapper MiddleComponent={() => <ForgotPasswordInfoScreen email={email} />} />;
-  }
-
-  return (
-    <OnboardingBackgroundWrapper
-      LeftSideComponent={() => <ForgotPasswordForm onSubmit={handleForgotPassword} />}
-      RightSideComponent={GeneralFeatureImage}
-    />
-  );
+  const contactAdmin = false;
+  return BasePasswordForgotPage({ contactAdmin });
 };
 
-export default ForgotPasswordPage;
+export default withEditionSpecificComponent(ForgotPasswordPage, 'auth');

--- a/frontend/src/modules/auth/pages/ForgotPasswordPage/components/BaseForgotPasswordPage/BaseForgotPasswordPage.jsx
+++ b/frontend/src/modules/auth/pages/ForgotPasswordPage/components/BaseForgotPasswordPage/BaseForgotPasswordPage.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-hot-toast';
+import { authenticationService } from '@/_services';
+import OnboardingBackgroundWrapper from '@/modules/onboarding/components/OnboardingBackgroundWrapper';
+import { GeneralFeatureImage } from '@/modules/common/components';
+import ForgotPasswordForm from '../ForgotPasswordForm';
+import ForgotPasswordInfoScreen from '../ForgotPasswordInfoScreen';
+
+const BaseForgotPasswordPage = ({ contactAdmin = false }) => {
+  const { t } = useTranslation();
+  const [showInfoScreen, setShowInfoScreen] = useState(false);
+  const [email, setEmail] = useState('');
+  const handleForgotPassword = async (email) => {
+    try {
+      await authenticationService.forgotPassword(email);
+      toast.success(
+        t('forgotPasswordPage.checkEmailForResetLink', 'Please check your email for the password reset link'),
+        {
+          id: 'toast-forgot-password-confirmation-code',
+        }
+      );
+      setEmail(email);
+      setShowInfoScreen(true);
+    } catch (error) {
+      toast.error(error.error || t('forgotPasswordPage.somethingWentWrong', 'Something went wrong, please try again'), {
+        id: 'toast-forgot-password-email-error',
+      });
+    }
+  };
+
+  if (showInfoScreen) {
+    return <OnboardingBackgroundWrapper MiddleComponent={() => <ForgotPasswordInfoScreen email={email} />} />;
+  }
+
+  return (
+    <OnboardingBackgroundWrapper
+      LeftSideComponent={() => <ForgotPasswordForm onSubmit={handleForgotPassword} contactAdmin={contactAdmin} />}
+      RightSideComponent={GeneralFeatureImage}
+    />
+  );
+};
+
+export default BaseForgotPasswordPage;

--- a/frontend/src/modules/auth/pages/ForgotPasswordPage/components/BaseForgotPasswordPage/index.js
+++ b/frontend/src/modules/auth/pages/ForgotPasswordPage/components/BaseForgotPasswordPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './BaseForgotPasswordPage';

--- a/frontend/src/modules/auth/pages/ForgotPasswordPage/components/ForgotPasswordForm/ForgotPasswordForm.jsx
+++ b/frontend/src/modules/auth/pages/ForgotPasswordPage/components/ForgotPasswordForm/ForgotPasswordForm.jsx
@@ -8,7 +8,7 @@ import { retrieveWhiteLabelText } from '@white-label/whiteLabelling';
 import './resources/styles/forgot-password-form.styles.scss';
 import { Alert } from '@/_ui/Alert';
 import SepratorComponent from '@/modules/common/components/SepratorComponent';
-const ForgotPasswordForm = ({ onSubmit }) => {
+const ForgotPasswordForm = ({ onSubmit, contactAdmin }) => {
   const { t } = useTranslation();
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState('');
@@ -72,18 +72,24 @@ const ForgotPasswordForm = ({ onSubmit }) => {
               isLoading={isLoading}
             />
           </form>
-          <SepratorComponent />
-          <Alert
-            svg="tj-info"
-            cls="reset-password-info-banner justify-content-center"
-            useDarkMode={false}
-            imgHeight={'25px'}
-            imgWidth={'25px'}
-          >
-            <div className="reset-password-info-text" data-cy="reset-password-info-banner">
-              {t('forgotPasswordPage.contactSuperAdmin', 'Contact super admin to reset your password')}
-            </div>
-          </Alert>
+          {contactAdmin ? (
+            <>
+              <SepratorComponent />
+              <Alert
+                svg="tj-info"
+                cls="reset-password-info-banner justify-content-center"
+                useDarkMode={false}
+                imgHeight={'25px'}
+                imgWidth={'25px'}
+              >
+                <div className="reset-password-info-text" data-cy="reset-password-info-banner">
+                  {t('forgotPasswordPage.contactSuperAdmin', 'Contact super admin to reset your password')}
+                </div>
+              </Alert>
+            </>
+          ) : (
+            <></>
+          )}
         </div>
       </OnboardingFormInsideWrapper>
     </OnboardingUIWrapper>


### PR DESCRIPTION
Fix for: [Issue](https://docs.google.com/spreadsheets/d/17vZggZMwrJwt4yH5ISMNMHxVCSKMj4m0WmiQ63MA5xo/edit?gid=93158703#gid=93158703&range=3:3)

Changes:
- Added Forgot `BaseForgotPasswordPage` component and EE `ForgotPasswordPage`
- Fixed Contact super admin banner to only show for EE