### PR TITLE
Fix/doc link visible in dark and light mode

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -108,7 +108,7 @@
 }
 
 .pagination-nav__sublabel {
-  color: #6A727C;
+  color: var(--ifm-link-color);
 }
 
 .pagination-nav__label {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -65,8 +65,7 @@
 
 
 [data-theme='dark'] .theme-doc-markdown a:not(.home-page a) {
-  color: white;
-
+  color: var(--ifm-link-color);
 }
 
 
@@ -113,7 +112,7 @@
 }
 
 .pagination-nav__label {
-  color: #1B1F24;
+  color: var(--ifm-link-color);
 }
 
 .pagination-nav__link--prev .pagination-nav__sublabel::before {
@@ -499,11 +498,11 @@ img {
 
 .navbar-signin,
 .navbar-signin:hover {
-  padding: 6px 9px !important;  
+  padding: 6px 9px !important;
 }
 
 .navbar-signin:hover,
-.navbar-website:hover{
+.navbar-website:hover {
   background-color: #F0F1F2;
 }
 
@@ -909,7 +908,7 @@ button[title="Switch between dark and light mode (currently light mode)"] svg,
 .breadcrumbs__item .breadcrumbs__link {
   padding-right: 4px;
   padding-left: 4px;
-  color: #2D343B;
+  color: var(--ifm-link-color);
 }
 
 .breadcrumbs__item:first-child .breadcrumbs__link {
@@ -941,6 +940,6 @@ button[title="Switch between dark and light mode (currently light mode)"] svg,
   color: #4368E3;
 }
 
-.footer{
+.footer {
   padding: 0px 70px !important;
 }


### PR DESCRIPTION
This PR addresses issue #12706. It resolves the problem where certain links were not visible by making adjustments to the CSS file. Additionally, I noticed that two links at the bottom are also not visible, so I will be updating their styles as well to ensure full visibility in dark and light both mode.

![image](https://github.com/user-attachments/assets/031289b5-a158-4b8b-b230-6a8932766129)
![image](https://github.com/user-attachments/assets/55ed5f1f-6eda-41c9-820e-75f02896711d)
![image](https://github.com/user-attachments/assets/3f2b7a1e-cfb5-4cd7-b2d9-5ac179ad01a8)
![image](https://github.com/user-attachments/assets/06232770-1325-4275-91a5-8722626c2c06)
