### PR TITLE
Revert back browser tab titles

### DIFF
--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -129,6 +129,13 @@ const useAppData = (appId, moduleId, darkMode, mode = 'edit', { environmentId, v
 
   const initialLoadRef = useRef(true);
 
+  const { isReleasedVersionId } = useStore(
+    (state) => ({
+      isReleasedVersionId: state?.releasedVersionId == state.currentVersionId || state.isVersionReleased,
+    }),
+    shallow
+  );
+
   const fetchAndInjectCustomStyles = async (isPublicAccess = false) => {
     try {
       const head = document.head || document.getElementsByTagName('head')[0];
@@ -462,8 +469,13 @@ const useAppData = (appId, moduleId, darkMode, mode = 'edit', { environmentId, v
   }, [isComponentLayoutReady]);
 
   useEffect(() => {
-    fetchAndSetWindowTitle({ page: pageTitles.EDITOR, appName: app.appName });
-  }, [app.appName]);
+    fetchAndSetWindowTitle({
+      page: pageTitles.EDITOR,
+      appName: app.appName,
+      mode: mode,
+      isReleased: isReleasedVersionId,
+    });
+  }, [app.appName, isReleasedVersionId]);
 
   useEffect(() => {
     if (!themeAccess) return;

--- a/frontend/src/_helpers/white-label/whiteLabelling.js
+++ b/frontend/src/_helpers/white-label/whiteLabelling.js
@@ -65,6 +65,7 @@ export async function setFaviconAndTitle(location) {
     'reset-password': '',
     'workspace-constants': 'Workspace constants',
     setup: '',
+    '/': 'Dashboard',
   };
 
   const pageTitleKey = Object.keys(pageTitles).find((path) => location?.pathname.includes(path));
@@ -77,6 +78,8 @@ export async function fetchAndSetWindowTitle(pageDetails) {
   const whiteLabelText = retrieveWhiteLabelText();
   let pageTitleKey = pageDetails?.page || '';
   let pageTitle = '';
+  let mode = pageDetails?.mode || '';
+  let isPreview = !pageDetails?.isReleased || false;
   switch (pageTitleKey) {
     case pageTitles.VIEWER: {
       const titlePrefix = pageDetails?.preview ? 'Preview - ' : '';
@@ -85,13 +88,21 @@ export async function fetchAndSetWindowTitle(pageDetails) {
     }
     case pageTitles.EDITOR:
     case pageTitles.WORKFLOW_EDITOR: {
-      pageTitle = pageDetails?.appName || 'My App';
+      if (mode == 'edit') {
+        pageTitle = `${pageDetails?.appName}`;
+      } else {
+        pageTitle = `Preview - ${pageDetails?.appName}` || 'My App';
+      }
       break;
     }
     default: {
       pageTitle = pageTitleKey;
       break;
     }
+  }
+  if (!isPreview && mode === 'view') {
+    document.title = `${pageDetails?.appName}`;
+    return;
   }
   document.title = !(pageDetails?.preview === false) ? `${pageTitle} | ${whiteLabelText}` : `${pageTitle}`;
 }


### PR DESCRIPTION
Fixes : https://github.com/ToolJet/tj-ee/issues/3440


**Test Cases :** 

1. Dashboard Title:

Current: "ToolJet"
Expected: "Dashboard | ToolJet"
2. Preview Title:

Current: "${appName} | ToolJet"
Expected: "Preview - ${appName} | ToolJet"
3. Launched App Title:

Current: "${appName} | ToolJet"
Expected: "${data.appName}"


**Note: Verify the white labelling tab names exhaustively.**

