### PR TITLE
Fix empty state flash when searching users in groups

### DIFF
--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
@@ -147,6 +147,8 @@ class BaseManageGroupPermissionResources extends React.Component {
       selectedUsers: [],
       isLoadingUsers: false,
       isAddingUsers: false,
+      isLoadingSearch: false,
+      searchQuery: '',
     });
   };
 

--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
@@ -362,13 +362,13 @@ class BaseManageGroupPermissionResources extends React.Component {
   };
 
   toggleUserTabSearchBox = () => {
-    const { showUserSearchBox } = this.state;
+    const { showUserSearchBox, groupPermission } = this.state;
 
     if (showUserSearchBox) {
       this.setState({ isLoadingSearch: true, searchQuery: '' });
 
       groupPermissionV2Service
-        .getUsersInGroup(this.props.groupPermissionId, '')
+        .getUsersInGroup(groupPermission.id, '')
         .then((data) => {
           this.setState({
             usersInGroup: data,


### PR DESCRIPTION
The below demo is recorded with throttling to demonstrate the user experience when the internet is slow:

https://github.com/user-attachments/assets/30f4a580-0a53-4df0-ab66-e7357e31b84d


Introduced two new states for the fix:
- isLoadingSearch: for in table search loading, so search UI doesn't gets hidden on clear toggle of search box, which would have been the case if wenused isLoadingUsers only
- searchQuery:  to show “No results” when there really are none.

> Closes #11254 