### PR TITLE
fix: unify snackbar messages for visibility toggle

### DIFF
--- a/frontend/src/AppBuilder/Header/RightTopHeaderButtons/ManageAppUsers copy.jsx
+++ b/frontend/src/AppBuilder/Header/RightTopHeaderButtons/ManageAppUsers copy.jsx
@@ -102,9 +102,9 @@ class ManageAppUsersComponent extends React.Component {
         });
 
         if (newState) {
-          toast('Application is now public.');
+          toast('Application is now public');
         } else {
-          toast('Application visibility set to private');
+          toast('App is now private');
         }
       })
       .catch((error) => {

--- a/frontend/src/AppBuilder/Header/RightTopHeaderButtons/ManageAppUsers.jsx
+++ b/frontend/src/AppBuilder/Header/RightTopHeaderButtons/ManageAppUsers.jsx
@@ -103,9 +103,9 @@ class ManageAppUsersComponent extends React.Component {
         });
 
         if (newState) {
-          toast('Application is now public.');
+          toast('Application is now public');
         } else {
-          toast('Application visibility set to private');
+          toast('App is now private');
         }
       })
       .catch((error) => {

--- a/frontend/src/Editor/Header/RightTopHeaderButtons/ManageAppUsers.jsx
+++ b/frontend/src/Editor/Header/RightTopHeaderButtons/ManageAppUsers.jsx
@@ -102,9 +102,9 @@ class ManageAppUsersComponent extends React.Component {
         });
 
         if (newState) {
-          toast('Application is now public.');
+          toast('Application is now public');
         } else {
-          toast('Application visibility set to private');
+          toast('App is now private');
         }
       })
       .catch((error) => {


### PR DESCRIPTION
Updated snackbar messages when toggling app visibility:
- Public: 'App is now public'
- Private: 'App is now private'

Aligned punctuation and tone for consistency.