### PR TITLE
[bugfix]/delete-confirmation-message-popup

### DIFF
--- a/frontend/src/MarketplacePage/InstalledPlugins.jsx
+++ b/frontend/src/MarketplacePage/InstalledPlugins.jsx
@@ -142,9 +142,7 @@ const InstalledPluginCard = ({ plugin, marketplacePlugin, fetchPlugins, isDevMod
 
   const pluginDeleteMessage = (
     <>
-      Deleting <strong>{capitalizeFirstLetter(name)}</strong> plugin will result in the permanent removal of all
-      associated datasources and its dataqueries. This action cannot be undone. Are you sure you wish to proceed with
-      the deletion?
+      Do you want to uninstall <strong>{capitalizeFirstLetter(name)}</strong>?
     </>
   );
 

--- a/frontend/src/modules/dataSources/components/List/index.jsx
+++ b/frontend/src/modules/dataSources/components/List/index.jsx
@@ -173,7 +173,7 @@ export const List = ({ updateSelectedDatasource }) => {
       </div>
       <ConfirmDialog
         show={isDeleteModalVisible}
-        message={'You will lose all the queries created from this data source. Do you really want to delete?'}
+        message={'Do you want to delete?'}
         confirmButtonLoading={isDeletingDatasource}
         onConfirm={() => executeDataSourceDeletion()}
         onCancel={() => cancelDeleteDataSource()}


### PR DESCRIPTION
![Screenshot 2025-06-02 164117](https://github.com/user-attachments/assets/e7d8acad-5838-4dce-8269-be096c14166d)
This PR is regarding issue number #12956

The DS Delete popup is replaced with the message : "Do you want to delete?"
And the plugin delete popup message is replaced with : "Do you want to uninstall <plugin name>?"