### PR TITLE
fix(code-hinter): replace class with className (#6655)

### DIFF
--- a/frontend/src/Editor/CodeEditor/CodeHinter.jsx
+++ b/frontend/src/Editor/CodeEditor/CodeHinter.jsx
@@ -125,7 +125,7 @@ const DepericatedAlertForWorkspaceVariable = ({ text }) => {
       imgWidth={18}
     >
       <div className="d-flex align-items-center">
-        <div class="">{text}</div>
+        <div className="">{text}</div>
       </div>
     </Alert>
   );


### PR DESCRIPTION
This pull request updates the CodeHinter component to use `className` instead of `class` for JSX compatibility in React. Previously, using `class="..."` caused warnings and style inconsistencies when rendering the component. This change replaces all instances of `class` with `className` in `frontend/src/Editor/CodeEditor/CodeHinter.jsx`, ensuring correct rendering and avoiding React’s “unknown DOM property” warnings.

Closes #6655
