### PR TITLE
Removes extra api calls on workspace creation

### DIFF
--- a/frontend/src/modules/common/components/OrganizationManager/CreateOrganization.jsx
+++ b/frontend/src/modules/common/components/OrganizationManager/CreateOrganization.jsx
@@ -180,7 +180,7 @@ export const CreateOrganization = ({ showCreateOrg, setShowCreateOrg }) => {
       // this is to denote that the user has tried editing the slug -- so now slug and name are independent of each other
       isSlugSet.current = true;
     }
-  }, [name.value, slug.value, slugProgress, workspaceNameProgress, isSlugSet]);
+  }, [name.value, slugProgress, workspaceNameProgress, isSlugSet]);
 
   const isDisabled =
     isCreating ||


### PR DESCRIPTION
Issue : While workspace creation workspace and slug unique check api's were called multiple times due to a bug in the useEffect.


Fix : Removed re-rendering and ensured that we are making single api calls for workspace and slug unique checks.
