### PR TITLE
Release: Marketplace sprint 12 hotfix 

### DIFF
--- a/frontend/src/_components/Slack.jsx
+++ b/frontend/src/_components/Slack.jsx
@@ -16,7 +16,7 @@ const Slack = ({ optionchanged, createDataSource, options, isSaving, _selectedDa
 
     let scope =
       'users:read,channels:read,groups:read,im:read,mpim:read,channels:history,groups:history,im:history,mpim:history';
-    if (options.access_type === 'chat:write') {
+    if (options?.access_type?.value === 'chat:write') {
       scope = `${scope},chat:write`;
     }
 

--- a/plugins/packages/cosmosdb/lib/index.ts
+++ b/plugins/packages/cosmosdb/lib/index.ts
@@ -25,7 +25,13 @@ export default class Cosmosdb implements QueryService {
           result = await getItem(client, queryOptions.database, queryOptions.container, queryOptions.itemId);
           break;
         case 'delete_item':
-          result = await deleteItem(client, queryOptions.database, queryOptions.container, queryOptions.itemId);
+          result = await deleteItem(
+            client,
+            queryOptions.database,
+            queryOptions.container,
+            queryOptions.itemId,
+            queryOptions?.partitionKey
+          );
           break;
         case 'query_database':
           result = await queryDatabase(client, queryOptions.database, queryOptions.container, queryOptions.query);

--- a/plugins/packages/cosmosdb/lib/operations.json
+++ b/plugins/packages/cosmosdb/lib/operations.json
@@ -152,6 +152,16 @@
         "height": "36px",
         "className": "codehinter-plugins",
         "placeholder": "item_id"
+      },
+      "partitionKey": {
+        "label": "Partition key",
+        "key": "partitionKey",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "description": "Enter partition key",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins"
       }
     },
     "query_database": {

--- a/plugins/packages/cosmosdb/lib/operations.ts
+++ b/plugins/packages/cosmosdb/lib/operations.ts
@@ -56,19 +56,29 @@ export function insertItems(client: CosmosClient, database: string, containerId:
   });
 }
 
-export function deleteItem(client: CosmosClient, database: string, containerId: string, itemId) {
+export function deleteItem(client: CosmosClient, database: string, containerId: string, itemId, partitionKey?: string) {
   return new Promise((resolve, reject) => {
     lookUpContainer(client, database, containerId)
       .then((container: Container) => {
-        container
-          .item(itemId)
-          .delete()
-          .then(() => {
-            resolve({ message: 'Item deleted' });
-          })
-          .catch((err) => {
-            reject(err);
-          });
+        partitionKey
+          ? container
+              .item(itemId, partitionKey)
+              .delete()
+              .then(() => {
+                resolve({ message: 'Item deleted' });
+              })
+              .catch((err) => {
+                reject(err);
+              })
+          : container
+              .item(itemId)
+              .delete()
+              .then(() => {
+                resolve({ message: 'Item deleted' });
+              })
+              .catch((err) => {
+                reject(err);
+              });
       })
       .catch((err) => {
         reject(err);

--- a/plugins/packages/cosmosdb/lib/types.ts
+++ b/plugins/packages/cosmosdb/lib/types.ts
@@ -9,4 +9,5 @@ export type QueryOptions = {
   items?: [];
   itemId?: string;
   query?: string;
+  partitionKey?: string;
 };

--- a/plugins/packages/redis/lib/index.ts
+++ b/plugins/packages/redis/lib/index.ts
@@ -62,6 +62,7 @@ export default class RedisQueryService implements QueryService {
       username,
       password,
       tls: tls,
+      ...(sourceOptions?.database && { db: sourceOptions.database }),
     });
   }
 }

--- a/plugins/packages/redis/lib/manifest.json
+++ b/plugins/packages/redis/lib/manifest.json
@@ -25,6 +25,9 @@
         "type": "string",
         "encrypted": true
       },
+      "database": {
+        "type": "string"
+      },
       "ca_cert": {
         "encrypted": true
       },
@@ -88,6 +91,12 @@
           "key": "port",
           "type": "text",
           "description": "Enter port"
+        },
+        "database": {
+          "label": "Database",
+          "key": "database",
+          "type": "text",
+          "description": "Enter database name"
         },
         "username": {
           "label": "Username",

--- a/plugins/packages/redis/lib/types.ts
+++ b/plugins/packages/redis/lib/types.ts
@@ -8,6 +8,7 @@ export type SourceOptions = {
   ca_cert: string;
   client_cert: string;
   client_key: string;
+  database?: string;
 };
 export type QueryOptions = {
   operation: string;


### PR DESCRIPTION
## What's Changed
### 🌟 Enhancements
- Ability to configure the database name in Redis datasource in [#13028](https://github.com/ToolJet/ToolJet/pull/13028) by @ganesh8056 

### 🛠️ Fixes
- The ability to provide a partition key for deleting items in CosmosDB datasource has been enabled in [#13029](https://github.com/ToolJet/ToolJet/pull/13029) by @ganesh8056
- Hotfix: Slack Oauth2 chat:write scope has been missed during Oauth process in [#13027](https://github.com/ToolJet/ToolJet/pull/13027) by @ganesh8056 
- Hotfix: Release the connection when manually acquiring it in the PostgreSQL data source in [#12571 ](https://github.com/ToolJet/ToolJet/pull/12571) by @ganesh8056 