### PR TITLE
Feature: Automation for auto-merge submodule PRs after base PR merges to main

### DIFF
--- a/.github/workflows/merging-pr.yml
+++ b/.github/workflows/merging-pr.yml
@@ -1,0 +1,75 @@
+name: Merge Submodule PRs
+
+on:
+  pull_request:
+    types: [closed, labeled]
+
+jobs:
+  merge-submodules:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract Branch Name
+        run: echo "BRANCH_NAME=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+
+      - name: Merge PR in ee-server (if exists)
+        run: |
+          PR=$(gh pr list -R ToolJet/ee-server --head "$BRANCH_NAME" --state open --json number -q '.[0].number')
+          if [ -n "$PR" ]; then
+            echo "Found ee-server PR: #$PR"
+            gh pr merge -R ToolJet/ee-server "$PR" --merge --admin
+          else
+            echo "No open ee-server PR for branch $BRANCH_NAME"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_PR }}
+
+      - name: Merge PR in ee-frontend (if exists)
+        run: |
+          PR=$(gh pr list -R ToolJet/ee-frontend --head "$BRANCH_NAME" --state open --json number -q '.[0].number')
+          if [ -n "$PR" ]; then
+            echo "Found ee-frontend PR: #$PR"
+            gh pr merge -R ToolJet/ee-frontend "$PR" --merge --admin
+          else
+            echo "No open ee-frontend PR for branch $BRANCH_NAME"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_PR }}
+
+  check-submodule-prs:
+    if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-merge'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract Branch Name
+        run: echo "BRANCH_NAME=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+
+      - name: Check and Comment Linked Submodule PRs
+        run: |
+          echo "🔍 Checking linked submodule PRs for \`$BRANCH_NAME\`:" > comment.md
+          echo "" >> comment.md
+
+          SERVER_URL=$(gh pr list -R ToolJet/ee-server --head "$BRANCH_NAME" --state open --json url -q '.[0].url')
+          FRONTEND_URL=$(gh pr list -R ToolJet/ee-frontend --head "$BRANCH_NAME" --state open --json url -q '.[0].url')
+
+          if [ -n "$SERVER_URL" ]; then
+            echo "✅ ee-server PR - $SERVER_URL" >> comment.md
+          else
+            echo "❌ No open PR in ee-server" >> comment.md
+          fi
+
+          if [ -n "$FRONTEND_URL" ]; then
+            echo "✅ ee-frontend PR - $FRONTEND_URL" >> comment.md
+          else
+            echo "❌ No open PR in ee-frontend" >> comment.md
+          fi
+
+          echo "" >> comment.md
+          echo "📝 **Note**: The submodule PRs will be auto-merged once you merge this base PR-$PR_NUMBER into \`main\`." >> comment.md
+
+          gh pr comment "$PR_NUMBER" --repo ToolJet/ToolJet --body-file comment.md
+
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_PR }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Automate Submodule PR Merging

This PR adds a GitHub Action that:

Automatically merges related PRs in ee-server and ee-frontend when a base PR is merged into main.

Adds a comment showing the status of submodule PRs when the `ready-to-merge` label is applied.

Example Comment Output: 
```
🔍 Checking linked submodule PRs for `feature/x`:

✅ ee-server PR - https://github.com/ToolJet/ee-server/pull/123
✅ ee-frontend PR - https://github.com/ToolJet/ee-frontend/pull/456

📝 Note: The submodule PRs will be auto-merged once you merge this base PR-789 into `main`.

```