### PR TITLE
docs: Fix typo 'docusauras' to 'docusaurus' in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ This directory contains the following folders:
 │   └── tooljet-database.md
 ├── versions.json        # file to indicate what versions are available
 ├── versioned_docs
-│   ├── version-x.x.x    # Current/latest version (set it on docusauras.config.js)
+│   ├── version-x.x.x    # Current/latest version (set it on docusaurus.config.js)
 │   │   ├── Enterprise
 │   │   │   └── multi-environment.md   # https://docs.tooljet.ai/docs/Enterprise/multi-environment
 │   │   └── tooljet-database.md.       # https://docs.tooljet.ai/docs/tooljet-database


### PR DESCRIPTION
## Summary
This PR fixes a typo in the documentation README where 'docusauras.config.js' was incorrectly written instead of 'docusaurus.config.js'.

## Changes
- Fixed filename reference in `docs/README.md`
- Corrected 'docusauras.config.js' to 'docusaurus.config.js'

## Why this change is needed
The typo could confuse contributors who are setting up the local development environment, as the correct filename is 'docusaurus.config.js'.

## Additional Note
This is my first contribution to this project, but I wanted to make a small contribution by fixing this typo to help improve the documentation quality. 😊