### PR TITLE
fix: correct path to regenerate_lts_table.sh in workflow

### DIFF
--- a/.github/workflows/updating-dockertag.yml
+++ b/.github/workflows/updating-dockertag.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install -y jq curl
 
       - name: 🧠 Run regenerate_lts_table.sh
-        run: bash ./regenerate_lts_table.sh
+        run: bash ./docs/regenerate_lts_table.sh
 
       - name: 📦 Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/docs/regenerate_lts_table.sh
+++ b/docs/regenerate_lts_table.sh
@@ -81,7 +81,7 @@ get_lts_tags() {
         fi
         
         local page_tags
-        page_tags=$(echo "$resp" | jq -r '.results[]? | select(.name | test("ee-lts$")) | .name' 2>/dev/null)
+        page_tags=$(echo "$resp" | jq -r '.results[]? | select(.name | test("^v.*ee-lts$")) | .name' 2>/dev/null)
         
         if [[ -n "$page_tags" ]]; then
             while IFS= read -r tag; do


### PR DESCRIPTION
feat: add regenerate_lts_table.sh script for LTS version table updates