### PR TITLE
Tabs Migration

### DIFF
--- a/server/data-migrations/1751315254641-BackfillDynamicOptionsPropertyForTabs.ts
+++ b/server/data-migrations/1751315254641-BackfillDynamicOptionsPropertyForTabs.ts
@@ -1,0 +1,44 @@
+import { Component } from 'src/entities/component.entity';
+import { processDataInBatches } from '@helpers/migration.helper';
+import { EntityManager, MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BackfillDynamicOptionsPropertyForTabs1751315254641 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const batchSize = 100;
+        const entityManager = queryRunner.manager;
+
+        await processDataInBatches(
+            entityManager,
+            async (entityManager: EntityManager) => {
+                return await entityManager.find(Component, {
+                    where: { type: 'Tabs' },
+                    order: { createdAt: 'ASC' },
+                });
+            },
+            async (entityManager: EntityManager, components: Component[]) => {
+                await this.processUpdates(entityManager, components);
+            },
+            batchSize
+        );
+    }
+
+    private async processUpdates(entityManager, components) {
+        for (const component of components) {
+            const properties = component.properties;
+
+            // Set useDynamicOptions to true if it doesn't exist
+            if (properties.useDynamicOptions === undefined) {
+                properties.useDynamicOptions =  { value: true };
+            }
+
+            await entityManager.update(Component, component.id, {
+                properties,
+            });
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}

--- a/server/src/modules/apps/services/app-import-export.service.ts
+++ b/server/src/modules/apps/services/app-import-export.service.ts
@@ -72,7 +72,8 @@ type NewRevampedComponent =
   | 'VerticalDivider'
   | 'Link'
   | 'DaterangePicker'
-  | 'TextArea';
+  | 'TextArea'
+  | 'Tabs';
 
 const DefaultDataSourceNames: DefaultDataSourceName[] = [
   'restapidefault',
@@ -94,6 +95,7 @@ const NewRevampedComponents: NewRevampedComponent[] = [
   'Link',
   'DaterangePicker',
   'TextArea',
+  'Tabs',
 ];
 
 @Injectable()
@@ -2156,6 +2158,15 @@ function migrateProperties(
         delete properties.maxValue;
       }
     }
+
+    if (componentType === 'Tabs') {
+      if (properties.useDynamicOptions === undefined) {
+        properties.useDynamicOptions = { value: true };
+      }
+    }
+
+    
+    
   }
   return { properties, styles, general, generalStyles, validation };
 }


### PR DESCRIPTION
On upgrading version or importing older tabs component the children were missing as the useDynamicOptions wasn't turned on by default.