### PR TITLE
[fix]: Dropdown zIndex issue on firefox

### DIFF
--- a/frontend/src/_styles/dropdown-custom.scss
+++ b/frontend/src/_styles/dropdown-custom.scss
@@ -19,7 +19,7 @@
 }
 
 .react-select__single-value {
-    color: var(--slate12) ;
+    color: var(--slate12);
 }
 
 .react-select__menu {
@@ -106,8 +106,8 @@
 }
 
 // following is the styles for table select column type menu list and options styles. If its same for all the select elements in the editor, then we can make it common and not specific for table select
-.table-select-custom-menu-list{
-    .react-select__menu-list{
+.table-select-custom-menu-list {
+    .react-select__menu-list {
         padding: 2px;
         // this is needed otherwise :active state doesn't look nice, gap is required
         display: flex;
@@ -116,7 +116,8 @@
         background-color: var(--base) !important;
         overflow-y: auto;
     }
-    .react-select__option{
+
+    .react-select__option {
         display: flex;
         justify-content: space-between;
         padding: 8px 12px;
@@ -129,15 +130,66 @@
         font-size: 12px;
         font-style: normal;
         font-weight: 400;
-        line-height: 20px; /* 166.667% */
-        &.react-select__option--is-selected{
+        line-height: 20px;
+
+        /* 166.667% */
+        &.react-select__option--is-selected {
             color: var(--indigo9) !important;
         }
-        &:active{
+
+        &:active {
             background: var(--base) !important;
             box-shadow: 0px 0px 0px 4px var(--slate6);
-            color : var(--slate12) !important;
+            color: var(--slate12) !important;
         }
     }
 }
 
+// Firefox-specific fixes for Radix UI Select in modals and popovers
+@-moz-document url-prefix() {
+
+    // Fix for dropdowns in modals
+    .modal-dialog [data-radix-select-content] {
+        position: fixed !important;
+        z-index: 99999 !important;
+        max-height: 200px !important;
+        overflow-y: auto !important;
+    }
+
+    // Fix for dropdowns in popovers  
+    .popover [data-radix-select-content] {
+        position: fixed !important;
+        z-index: 99999 !important;
+        max-height: 200px !important;
+        overflow-y: auto !important;
+    }
+
+    // Ensure proper positioning for column mapping modal specifically
+    .column-mapping-modal-body [data-radix-select-content] {
+        max-height: 150px !important;
+        min-width: 140px !important;
+    }
+
+    // Ensure proper viewport constraint for form field popovers
+    .form-field-popover-body [data-radix-select-content] {
+        max-height: 200px !important;
+        min-width: 200px !important;
+    }
+}
+
+// General improvements for all browsers to ensure proper dropdown behavior
+[data-radix-select-content] {
+    // Ensure the dropdown content is always properly positioned
+    transform-origin: var(--radix-select-content-transform-origin);
+    animation: none !important; // Disable animations that might cause positioning issues
+
+    // For modals, ensure the dropdown doesn't exceed modal bounds
+    .modal-dialog & {
+        max-height: 250px;
+    }
+
+    // For popovers, ensure the dropdown doesn't exceed popover bounds  
+    .popover & {
+        max-height: 250px;
+    }
+}

--- a/frontend/src/_styles/popover.scss
+++ b/frontend/src/_styles/popover.scss
@@ -61,3 +61,33 @@ div[data-radix-popper-content-wrapper]:has(.PopoverContent.drawer-height) {
     left: 1px !important;
   }
 }
+
+// Ensure form field popovers have proper overflow handling for dropdowns
+.form-field-popover-body {
+  overflow: visible !important; // Allow dropdowns to extend beyond popover bounds
+
+  // Ensure proper stacking context for radix select
+  [data-radix-select-trigger] {
+    position: relative;
+    z-index: 1;
+  }
+}
+
+// Fix for bootstrap popovers containing radix select
+.popover {
+  overflow: visible !important;
+
+  .popover-body {
+    overflow: visible !important;
+  }
+
+  // Ensure proper z-index layering
+  z-index: 1050;
+
+  // Firefox specific fixes
+  @-moz-document url-prefix() {
+    [data-radix-select-content] {
+      position: fixed !important;
+    }
+  }
+}

--- a/frontend/src/components/ui/Dropdown/Index.jsx
+++ b/frontend/src/components/ui/Dropdown/Index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from './Select';
 import { DropdownLabel, HelperMessage, ValidationMessage } from './DropdownUtils/DropdownUtils';
@@ -15,6 +15,26 @@ const DropdownComponent = ({ options = {}, ...props }) => {
       setTriggerWidth(triggerRef.current.offsetWidth);
     }
   }, []);
+
+  // Enhanced container resolution for better Firefox support
+  const getContainer = useCallback(() => {
+    if (props.container) {
+      return typeof props.container === 'function' ? props.container() : props.container;
+    }
+
+    // Auto-detect container based on context
+    if (triggerRef.current) {
+      // Check if inside a modal
+      const modal = triggerRef.current.closest('.modal-dialog');
+      if (modal) return modal;
+
+      // Check if inside a popover
+      const popover = triggerRef.current.closest('.popover');
+      if (popover) return popover;
+    }
+
+    return document.body;
+  }, [props.container]);
 
   const dropdownStyle = `${
     isValid === true ? '!tw-border-border-success-strong' : isValid === false ? '!tw-border-border-danger-strong' : ''
@@ -43,7 +63,10 @@ const DropdownComponent = ({ options = {}, ...props }) => {
         <SelectTrigger ref={triggerRef} open={open} className={dropdownStyle} {...props}>
           <SelectValue placeholder={props.placeholder} />
         </SelectTrigger>
-        <SelectContent style={{ width: triggerWidth > 0 ? `${triggerWidth}px` : props.width }}>
+        <SelectContent
+          style={{ width: triggerWidth > 0 ? `${triggerWidth}px` : props.width }}
+          container={getContainer()}
+        >
           <SelectGroup>
             {Object.keys(options).map((key) => (
               <SelectItem
@@ -93,6 +116,7 @@ DropdownComponent.propTypes = {
   leadingIcon: PropTypes.bool,
   trailingAction: PropTypes.oneOf(['icon', 'counter']),
   helperText: PropTypes.string,
+  container: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 };
 
 DropdownComponent.defaultProps = {

--- a/frontend/src/components/ui/Dropdown/Select.jsx
+++ b/frontend/src/components/ui/Dropdown/Select.jsx
@@ -86,8 +86,8 @@ const SelectScrollDownButton = React.forwardRef(({ className, ...props }, ref) =
 ));
 SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
 
-const SelectContent = React.forwardRef(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
+const SelectContent = React.forwardRef(({ className, children, position = 'popper', container, ...props }, ref) => (
+  <SelectPrimitive.Portal container={container}>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
@@ -97,6 +97,10 @@ const SelectContent = React.forwardRef(({ className, children, position = 'poppe
         className
       )}
       position={position}
+      sideOffset={4}
+      collisionPadding={8}
+      avoidCollisions={true}
+      sticky="always"
       {...props}
     >
       <SelectScrollUpButton />


### PR DESCRIPTION
Fixed the zIndex dropdown issue on firefox. Screenshot of an issue

<img width="301" alt="image" src="https://github.com/user-attachments/assets/92342f4b-96df-4303-b0a5-51103217cf4f" />

<img width="765" alt="image" src="https://github.com/user-attachments/assets/4ecb7545-c30e-4636-b1ed-d2152c04e562" />
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR resolves Firefox dropdown zIndex issues through coordinated CSS styling updates and component logic enhancements. The changes include Firefox-specific positioning rules, improved container resolution, and enhanced prop forwarding to ensure consistent dropdown behavior across browsers.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>