### PR TITLE
fix(form): enable resizing of component inside scrollable form container (#13087)

### DIFF
--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -1141,12 +1141,46 @@ const ResizeGhostWidget = ({ resizingComponentId, widgets, currentLayout, canvas
     return '';
   }
 
+  // Helper to determine if the widget is at the bottom of a scrollable container
+  function needsPortal() {
+    const widget = widgets?.[resizingComponentId];
+    if (!widget) return false;
+    const layout = widget.layouts?.[currentLayout] || widget.layouts?.['desktop'];
+    if (!layout) return false;
+    // Try to find the DOM node for the widget
+    const el = document.getElementById(resizingComponentId);
+    if (!el) return false;
+    const parent = el.closest('.jet-form-body');
+    if (!parent) return false;
+    const parentRect = parent.getBoundingClientRect();
+    const widgetRect = el.getBoundingClientRect();
+    // If the widget's bottom is within 20px of the parent's bottom (visible area), use portal
+    return widgetRect.bottom > parentRect.bottom - 20;
+  }
+
+  let usePortal = false;
+  let absoluteLeft = 0;
+  let absoluteTop = 0;
+  if (typeof window !== 'undefined' && needsPortal()) {
+    // Calculate absolute position for the portal overlay
+    const el = document.getElementById(resizingComponentId);
+    if (el) {
+      const rect = el.getBoundingClientRect();
+      absoluteLeft = rect.left + window.scrollX;
+      absoluteTop = rect.bottom + window.scrollY - 8; // 8px offset for handle
+      usePortal = true;
+    }
+  }
+
   return (
     <GhostWidget
       layouts={widgets?.[resizingComponentId]?.layouts}
       currentLayout={currentLayout}
       canvasWidth={canvasWidth}
       gridWidth={gridWidth}
+      usePortal={usePortal}
+      absoluteLeft={absoluteLeft}
+      absoluteTop={absoluteTop}
     />
   );
 };

--- a/frontend/src/Editor/GhostWidget.jsx
+++ b/frontend/src/Editor/GhostWidget.jsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import { isEmpty } from 'lodash';
+import { ReactPortal } from '../_components/Portal/ReactPortal';
 
-export default function GhostWidget({ layouts, currentLayout, canvasWidth, gridWidth }) {
+export default function GhostWidget({
+  layouts,
+  currentLayout,
+  canvasWidth,
+  gridWidth,
+  usePortal = false,
+  absoluteLeft = 0,
+  absoluteTop = 0,
+}) {
   let layoutStyle = {};
   if (!isEmpty(layouts?.[currentLayout] || layouts?.['desktop'])) {
     const layoutData = layouts?.[currentLayout] || layouts?.['desktop'];
@@ -12,16 +21,31 @@ export default function GhostWidget({ layouts, currentLayout, canvasWidth, gridW
       transform: `translate(${layoutData.left * gridWidth}px, ${layoutData.top}px)`,
     };
   }
-  return (
-    <div
-      className="resize-ghost-widget"
-      style={{
+
+  // If usePortal, override transform and use absolute positioning
+  const portalStyle = usePortal
+    ? {
+        zIndex: 9999,
+        position: 'absolute',
+        left: absoluteLeft,
+        top: absoluteTop,
+        width: layoutStyle.width,
+        height: layoutStyle.height,
+        background: '#D9E2FC',
+        opacity: '0.7',
+      }
+    : {
         zIndex: 4,
         position: 'absolute',
         background: '#D9E2FC',
         opacity: '0.7',
         ...layoutStyle,
-      }}
-    ></div>
-  );
+      };
+
+  const ghost = <div className="resize-ghost-widget" style={portalStyle}></div>;
+
+  if (usePortal) {
+    return <ReactPortal>{ghost}</ReactPortal>;
+  }
+  return ghost;
 }

--- a/frontend/src/Editor/SubContainer.jsx
+++ b/frontend/src/Editor/SubContainer.jsx
@@ -696,12 +696,46 @@ const ResizeGhostWidget = ({ resizingComponentId, widgets, currentLayout, canvas
     return '';
   }
 
+  // Helper to determine if the widget is at the bottom of a scrollable container
+  function needsPortal() {
+    const widget = widgets?.[resizingComponentId];
+    if (!widget) return false;
+    const layout = widget.layouts?.[currentLayout] || widget.layouts?.['desktop'];
+    if (!layout) return false;
+    // Try to find the DOM node for the widget
+    const el = document.getElementById(resizingComponentId);
+    if (!el) return false;
+    const parent = el.closest('.jet-form-body');
+    if (!parent) return false;
+    const parentRect = parent.getBoundingClientRect();
+    const widgetRect = el.getBoundingClientRect();
+    // If the widget's bottom is within 20px of the parent's bottom (visible area), use portal
+    return widgetRect.bottom > parentRect.bottom - 20;
+  }
+
+  let usePortal = false;
+  let absoluteLeft = 0;
+  let absoluteTop = 0;
+  if (typeof window !== 'undefined' && needsPortal()) {
+    // Calculate absolute position for the portal overlay
+    const el = document.getElementById(resizingComponentId);
+    if (el) {
+      const rect = el.getBoundingClientRect();
+      absoluteLeft = rect.left + window.scrollX;
+      absoluteTop = rect.bottom + window.scrollY - 8; // 8px offset for handle
+      usePortal = true;
+    }
+  }
+
   return (
     <GhostWidget
       layouts={widgets?.[resizingComponentId]?.layouts}
       currentLayout={currentLayout}
       canvasWidth={canvasWidth}
       gridWidth={gridWidth}
+      usePortal={usePortal}
+      absoluteLeft={absoluteLeft}
+      absoluteTop={absoluteTop}
     />
   );
 };


### PR DESCRIPTION
## 🐛 Issue

**[Form]: Not able to resize the component**  
When a component is placed at the bottom of a `Form` and the `Form` is resized to introduce a scrollbar, the component becomes unresizable.  
- The resizer handle does **not appear on hover**
- Even after selecting the component, resizing is **not possible**

Tracked in: [#13087](https://github.com/ToolJet/ToolJet/issues/13087)

---

## ✅ What This PR Does

This pull request resolves the issue by ensuring the component remains resizable inside a scrollable `Form`. It fixes the UI visibility and layout constraints that prevented the resizer handle from appearing and functioning properly.

---

## 🔧 Files Changed

- `frontend/src/Editor/Container.jsx`  
  → Adjusted logic for container boundaries to handle scrollable areas.

- `frontend/src/Editor/GhostWidget.jsx`  
  → Ensured that the resize handle appears correctly on hover and is interactive.

- `frontend/src/Editor/SubContainer.jsx`  
  → Improved layout tracking for components near the bottom of scrollable containers.

---

## 🎯 Fixes

```md
Fixes #13087
