### PR TITLE
Fix: Avoid setting Content-Type header for requests without body and configure different host for all environments in OpenAPI [PRE-RELEASE]

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/Openapi.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/Openapi.jsx
@@ -32,6 +32,7 @@ class OpenapiComponent extends React.Component {
       },
       spec: selectedDataSource.options?.spec?.value,
       selectedOperation: selectedDataSource.options?.spec?.value?.paths[options?.path]?.[options?.operation] || null,
+      operationParams: {},
     };
   }
 
@@ -46,9 +47,31 @@ class OpenapiComponent extends React.Component {
     }
   }
 
+  getOperationKey = (operation, path) => {
+    return `${operation}_${path}`;
+  };
+
   changeOperation = (value) => {
     const operation = value.split(',')[0];
     const path = value.split(',')[1];
+
+    if (this.state.options.operation && this.state.options.path) {
+      const currentOperationKey = this.getOperationKey(this.state.options.operation, this.state.options.path);
+      this.setState((prevState) => ({
+        operationParams: {
+          ...prevState.operationParams,
+          [currentOperationKey]: prevState.options.params,
+        },
+      }));
+    }
+
+    const newOperationKey = this.getOperationKey(operation, path);
+    const savedParams = this.state.operationParams[newOperationKey] || {
+      path: {},
+      query: {},
+      request: {},
+      header: {},
+    };
 
     this.setState(
       {
@@ -57,6 +80,7 @@ class OpenapiComponent extends React.Component {
           ...this.state.options,
           path,
           operation,
+          params: savedParams,
         },
       },
       () => {
@@ -197,8 +221,14 @@ class OpenapiComponent extends React.Component {
   }
 
   removeParam = (paramType, paramName) => {
-    const newOptions = JSON.parse(JSON.stringify(this.state.options));
-    newOptions['params'][paramType][paramName] = undefined;
+    const newOptions = { ...this.state.options };
+    const newParams = { ...newOptions.params };
+    const newParamType = { ...newParams[paramType] };
+
+    delete newParamType[paramName];
+
+    newParams[paramType] = newParamType;
+    newOptions.params = newParams;
 
     this.setState(
       {
@@ -223,9 +253,9 @@ class OpenapiComponent extends React.Component {
       queryParams = this.resolveParameters('query');
       headerParams = this.resolveParameters('header');
 
-      if (selectedOperation.requestBody) {
-        const requestType = Object.keys(selectedOperation.requestBody.content)[0];
-        requestBody = selectedOperation.requestBody.content[requestType];
+      if (selectedOperation.request_body) {
+        const requestType = Object.keys(selectedOperation.request_body.content)[0];
+        requestBody = selectedOperation.request_body.content[requestType];
       }
     }
 

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/Openapi.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/Openapi.jsx
@@ -177,6 +177,10 @@ class OpenapiComponent extends React.Component {
   };
 
   resolveHosts() {
+    const { selectedDataSource } = this.props;
+    if (selectedDataSource.options?.host?.value) {
+      return [selectedDataSource.options.host.value];
+    }
     const path = this.state.options.path;
     const operation = this.state.selectedOperation;
     if (operation?.servers && operation?.servers.length > 0) {
@@ -275,13 +279,14 @@ class OpenapiComponent extends React.Component {
                 <div className="col openapi-operation-options">
                   <Select
                     options={this.computeHostOptions(baseUrls)}
-                    value={this.state.options.host}
+                    value={this.props.selectedDataSource.options?.host?.value || this.state.options.host}
                     onChange={this.changeHost}
                     width="100%"
                     customOption={this.renderHostOptions}
                     placeholder={this.props.t('openApi.selectHost', 'Select a host')}
                     styles={queryManagerSelectComponentStyle(this.props.darkMode, '100%')}
                     useCustomStyles={true}
+                    isDisabled={!!this.props.selectedDataSource.options?.host?.value}
                   />
                 </div>
               </div>

--- a/frontend/src/_ui/Select/styles.js
+++ b/frontend/src/_ui/Select/styles.js
@@ -88,23 +88,25 @@ export function queryManagerSelectComponentStyle(darkMode, width = 224, height =
         backgroundColor: darkMode ? '#323C4B' : '#F8FAFF',
       },
     }),
-    control: (provided) => ({
+    control: (provided, state) => ({
       ...provided,
       boxShadow: 'none',
-      backgroundColor: darkMode ? '#2b3547' : '#ffffff',
+      backgroundColor: state.isDisabled ? (darkMode ? '#1f2936' : '#f4f6fa') : darkMode ? '#2b3547' : '#ffffff',
       borderRadius: '6px',
       height: 32,
       minHeight: 32,
-      borderColor: darkMode ? 'inherit' : ' #D7DBDF',
+      borderColor: state.isDisabled && darkMode ? 'none' : darkMode ? 'inherit' : '#D7DBDF',
       '&:hover': {
-        backgroundColor: darkMode ? '' : '#F8F9FA',
+        backgroundColor: state.isDisabled ? (darkMode ? '#1f2936' : '#f4f6fa') : darkMode ? '' : '#F8F9FA',
+        cursor: state.isDisabled ? 'not-allowed !important' : 'pointer',
       },
       '&:active': {
-        backgroundColor: darkMode ? '' : '#F8FAFF',
-        borderColor: '#3E63DD',
-        boxShadow: '0px 0px 0px 2px #C6D4F9 ',
+        backgroundColor: state.isDisabled ? (darkMode ? '#1f2936' : '#f4f6fa') : darkMode ? '' : '#F8FAFF',
+        borderColor: state.isDisabled ? (darkMode ? 'none' : '#D7DBDF') : '#3E63DD',
+        boxShadow: state.isDisabled ? 'none' : '0px 0px 0px 2px #C6D4F9',
       },
-      cursor: 'pointer',
+      cursor: state.isDisabled ? 'not-allowed !important' : 'pointer',
+      pointerEvents: state.isDisabled ? 'none' : 'auto',
     }),
     container: (provided) => ({
       ...provided,
@@ -116,9 +118,9 @@ export function queryManagerSelectComponentStyle(darkMode, width = 224, height =
       ...provided,
       marginBottom: '0',
     }),
-    singleValue: (provided) => ({
+    singleValue: (provided, state) => ({
       ...provided,
-      color: darkMode ? '#fff' : '#11181C',
+      color: state.isDisabled ? (darkMode ? '#6b7280' : '#9ca3af') : darkMode ? '#fff' : '#11181C',
     }),
     indicatorsContainer: (provided, _state) => ({
       ...provided,
@@ -127,17 +129,17 @@ export function queryManagerSelectComponentStyle(darkMode, width = 224, height =
     indicatorSeparator: (_state) => ({
       display: 'none',
     }),
-    input: (provided) => ({
+    input: (provided, state) => ({
       ...provided,
-      color: darkMode ? '#fff' : '#232e3c',
+      color: state.isDisabled ? (darkMode ? '#6b7280' : '#9ca3af') : darkMode ? '#fff' : '#232e3c',
     }),
     menu: (provided) => ({
       ...provided,
       backgroundColor: darkMode ? 'rgb(31,40,55)' : 'white',
     }),
-    placeholder: (provided) => ({
+    placeholder: (provided, state) => ({
       ...provided,
-      color: darkMode ? '#fff' : '#11181C',
+      color: state.isDisabled ? (darkMode ? '#6b7280' : '#9ca3af') : darkMode ? '#fff' : '#11181C',
     }),
   };
 }

--- a/plugins/packages/openapi/lib/index.ts
+++ b/plugins/packages/openapi/lib/index.ts
@@ -53,7 +53,8 @@ export default class Openapi implements QueryService {
   ): Promise<RestAPIResult> {
     const { host, path, operation, params } = queryOptions;
     const { request, query, header, path: pathParams } = params;
-    const url = new URL(host + this.resolvePathParams(pathParams, path));
+    const resolvedHost = sourceOptions.host || host;
+    const url = new URL(resolvedHost + this.resolvePathParams(pathParams, path));
     const parsedRequest = request ? this.parseRequest(request) : undefined;
     const json =
       operation !== 'get' && parsedRequest && Object.keys(parsedRequest).length > 0

--- a/plugins/packages/openapi/lib/index.ts
+++ b/plugins/packages/openapi/lib/index.ts
@@ -55,7 +55,10 @@ export default class Openapi implements QueryService {
     const { request, query, header, path: pathParams } = params;
     const url = new URL(host + this.resolvePathParams(pathParams, path));
     const parsedRequest = request ? this.parseRequest(request) : undefined;
-    const json = operation !== 'get' ? this.sanitizeObject(parsedRequest) : undefined;
+    const json =
+      operation !== 'get' && parsedRequest && Object.keys(parsedRequest).length > 0
+        ? this.sanitizeObject(parsedRequest)
+        : undefined;
 
     const _requestOptions: OptionsOfTextResponseBody = {
       method: operation,
@@ -63,8 +66,11 @@ export default class Openapi implements QueryService {
       searchParams: {
         ...query,
       },
-      json,
     };
+
+    if (json && Object.keys(json).length > 0) {
+      _requestOptions.json = json;
+    }
 
     const authValidatedRequestOptions: QueryResult = await validateAndSetRequestOptionsBasedOnAuthType(
       sourceOptions,

--- a/plugins/packages/openapi/lib/manifest.json
+++ b/plugins/packages/openapi/lib/manifest.json
@@ -20,6 +20,9 @@
       },
       "client_secret": {
         "encrypted": true
+      },
+      "host": {
+        "type": "string"
       }
     },
     "customTesting": true
@@ -62,22 +65,49 @@
       "value": ""
     },
     "headers": {
-      "value": [["", ""]]
+      "value": [
+        [
+          "",
+          ""
+        ]
+      ]
     },
     "custom_query_params": {
-      "value": [["", ""]]
+      "value": [
+        [
+          "",
+          ""
+        ]
+      ]
     },
     "custom_auth_params": {
-      "value": [["", ""]]
+      "value": [
+        [
+          "",
+          ""
+        ]
+      ]
     },
     "client_auth": {
       "value": "header"
     },
     "access_token_custom_headers": {
-      "value": [["", ""]]
+      "value": [
+        [
+          "",
+          ""
+        ]
+      ]
     }
   },
   "properties": {
+    "host": {
+      "label": "Host",
+      "key": "host",
+      "type": "text",
+      "description": "Enter host",
+      "helpText": "Overrides the host defined in the OpenAPI spec"
+    },
     "format": {
       "label": "Format",
       "key": "format",
@@ -85,5 +115,7 @@
       "description": "Format of definition"
     }
   },
-  "required": ["definition"]
+  "required": [
+    "definition"
+  ]
 }

--- a/plugins/packages/openapi/lib/types.ts
+++ b/plugins/packages/openapi/lib/types.ts
@@ -8,6 +8,7 @@ export type SourceOptions = {
   api_keys: any;
   auth_key: string;
   spec: any;
+  host?: string;
 };
 export type QueryOptions = {
   host: string;


### PR DESCRIPTION
Fixes done:

1. Won't be sending content-type header without body
2. Ability to configure host using separate input for different environments