### PR TITLE
Fix: Retrieve Workflow App ID from New Store with Conditional Assignment

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/Workflows.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/Workflows.jsx
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import useStore from '@/AppBuilder/_stores/store';
 import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
 import usePopoverObserver from '@/AppBuilder/_hooks/usePopoverObserver';
+import useWorkflowStore from '@/_stores/workflowStore';
 
 export function Workflows({ options, optionsChanged, currentState }) {
   const { moduleId } = useModuleContext();
@@ -15,7 +16,9 @@ export function Workflows({ options, optionsChanged, currentState }) {
   const [_selectedWorkflowId, setSelectedWorkflowId] = useState(undefined);
   const [params, setParams] = useState([...(options.params ?? [{ key: '', value: '' }])]);
 
-  const appId = useStore((state) => state.appStore.modules[moduleId].app.appId);
+  const workflowIdFromStore = useWorkflowStore((state) => state.workflowId);
+  const appIdFromStore = useStore((state) => state.appStore.modules[moduleId].app.appId);
+  const appId = workflowIdFromStore || appIdFromStore;
 
   usePopoverObserver(
     document.getElementsByClassName('query-details')[0],

--- a/frontend/src/_stores/workflowStore.js
+++ b/frontend/src/_stores/workflowStore.js
@@ -1,0 +1,8 @@
+import create from 'zustand';
+
+const useWorkflowStore = create((set) => ({
+  workflowId: null,
+  setWorkflowId: (id) => set({ workflowId: id }),
+}));
+
+export default useWorkflowStore;


### PR DESCRIPTION
**Changes**

Since the workflow component retrieved the app ID from the store using the module ID, it was failing earlier. Now, we retrieve the workflow app ID from the new store and assign the app ID conditionally.