### PR TITLE
Fix: Error message not getting displayed in app builder when query fails

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -34,6 +34,7 @@ const initialState = {
   showDeleteConfirmation: false,
   renamingQueryId: null,
   deletingQueryId: null,
+  asyncQueryRuns: [],
 };
 
 export const createQueryPanelSlice = (set, get) => ({


### PR DESCRIPTION
Closes: [Issue](https://github.com/orgs/ToolJet/projects/29/views/4?filterQuery=sprint%3A%22Sprint+12%22+is%3Adraft&groupedBy%5BcolumnId%5D=185194210&pane=issue&itemId=118722469)