### PR TITLE
Fix: Image components bugs and its migration logic

### DIFF
--- a/frontend/src/AppBuilder/WidgetManager/widgets/image.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/image.js
@@ -135,7 +135,9 @@ export const imageConfig = {
       displayName: 'Shape',
       options: [
         { name: 'None', value: 'none' },
+        { name: 'Rounded', value: 'rounded' },
         { name: 'Circle', value: 'circle' },
+        { name: 'Thumbnail', value: 'thumbnail' },
       ],
       validation: {
         schema: { type: 'string' },
@@ -258,7 +260,7 @@ export const imageConfig = {
     styles: {
       imageFit: { value: 'contain' },
       imageShape: { value: 'none' },
-      backgroundColor: { value: 'var(--cc-surface1-surface)' },
+      backgroundColor: { value: '' },
       borderColor: { value: '' },
       borderRadius: { value: '{{6}}' },
       boxShadow: { value: '0px 0px 0px 0px #00000090' },

--- a/frontend/src/AppBuilder/WidgetManager/widgets/image.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/image.js
@@ -175,6 +175,10 @@ export const imageConfig = {
     borderRadius: {
       type: 'numberInput',
       displayName: 'Border radius',
+      conditionallyRender: {
+        key: 'imageShape',
+        value: 'none',
+      },
       validation: { schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] }, defaultValue: 6 },
       accordian: 'Container',
     },

--- a/frontend/src/Editor/Components/Image/Image.jsx
+++ b/frontend/src/Editor/Components/Image/Image.jsx
@@ -166,7 +166,7 @@ export const Image = function Image({
       src={sourceURL}
       className={`zoom-image-wrap`}
       style={{
-        backgroundColor,
+        backgroundColor: backgroundColor || (imageShape === 'thumbnail' ? '#f4f6fa' : ''),
         padding: padding === 'default' ? '0px' : Number.parseInt(customPadding),
         objectFit: imageFit ? imageFit : 'contain',
         cursor: hasOnClickEvent ? 'pointer' : 'inherit',
@@ -175,8 +175,13 @@ export const Image = function Image({
         height,
         transform: `rotate(${rotation}deg)`,
         border: '1px solid',
-        borderRadius: imageShape === 'circle' ? '50%' : `${borderRadius}px`,
-        borderColor: borderColor ? borderColor : 'transparent',
+        borderRadius:
+          imageShape === 'circle'
+            ? '50%'
+            : imageShape === 'rounded' || imageShape === 'thumbnail'
+            ? '4px'
+            : `${borderRadius}px`,
+        borderColor: borderColor || (imageShape === 'thumbnail' ? '#e7eaef' : 'transparent'),
         objectPosition: alignment,
       }}
       height={height}

--- a/frontend/src/Editor/Components/Image/Image.jsx
+++ b/frontend/src/Editor/Components/Image/Image.jsx
@@ -205,10 +205,10 @@ export const Image = function Image({
             <Loader width="16" absolute={false} />
           </center>
         )}
-        {!isLoading && alternativeText && (
+        {!isLoading && (
           <>
             <BrokenImage />
-            <p>{alternativeText}</p>
+            {alternativeText && <p>{alternativeText}</p>}
           </>
         )}
       </div>

--- a/frontend/src/Editor/WidgetManager/configs/image.js
+++ b/frontend/src/Editor/WidgetManager/configs/image.js
@@ -175,6 +175,10 @@ export const imageConfig = {
     borderRadius: {
       type: 'numberInput',
       displayName: 'Border radius',
+      conditionallyRender: {
+        key: 'imageShape',
+        value: 'none',
+      },
       validation: { schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] }, defaultValue: 6 },
       accordian: 'Container',
     },

--- a/frontend/src/Editor/WidgetManager/configs/image.js
+++ b/frontend/src/Editor/WidgetManager/configs/image.js
@@ -135,7 +135,9 @@ export const imageConfig = {
       displayName: 'Shape',
       options: [
         { name: 'None', value: 'none' },
+        { name: 'Rounded', value: 'rounded' },
         { name: 'Circle', value: 'circle' },
+        { name: 'Thumbnail', value: 'thumbnail' },
       ],
       validation: {
         schema: { type: 'string' },
@@ -258,7 +260,7 @@ export const imageConfig = {
     styles: {
       imageFit: { value: 'contain' },
       imageShape: { value: 'none' },
-      backgroundColor: { value: '#FFFFFF' },
+      backgroundColor: { value: '' },
       borderColor: { value: '' },
       borderRadius: { value: '{{6}}' },
       boxShadow: { value: '0px 0px 0px 0px #00000090' },

--- a/server/data-migrations/1737041314335-UpdateVisibilityDisabledTooltipPaddingShapeForImageComponent.ts
+++ b/server/data-migrations/1737041314335-UpdateVisibilityDisabledTooltipPaddingShapeForImageComponent.ts
@@ -53,24 +53,23 @@ export class UpdateVisibilityDisabledTooltipPaddingShapeForImageComponent1737041
         styles.padding = { value: 'custom' };
       }
 
+      if (styles.borderType?.value === 'none') {
+        styles.imageShape = { value: 'none' };
+        delete styles.borderType;
+      }
+
       if (styles.borderType?.value === 'rounded-circle') {
         styles.imageShape = { value: 'circle' };
         delete styles.borderType;
       }
 
       if (styles.borderType?.value === 'rounded') {
-        styles.borderRadius = { value: '4' };
+        styles.imageShape = { value: 'rounded' };
         delete styles.borderType;
       }
 
       if (styles.borderType?.value === 'img-thumbnail') {
-        if (!styles.backgroundColor) {
-          styles.backgroundColor = { value: '#f4f6fa' };
-        }
-        styles.borderColor = { value: '#e7eaef' };
-        styles.borderRadius = { value: '4' };
-        styles.padding = { value: 'custom' };
-        styles.customPadding = { value: '4' };
+        styles.imageShape = { value: 'thumbnail' };
         delete styles.borderType;
       }
 

--- a/server/src/modules/apps/services/app-import-export.service.ts
+++ b/server/src/modules/apps/services/app-import-export.service.ts
@@ -77,7 +77,7 @@ type NewRevampedComponent =
   | 'Container'
   | 'Tabs'
   | 'Form'
-
+  | 'Image';
 
 const DefaultDataSourceNames: DefaultDataSourceName[] = [
   'restapidefault',
@@ -101,8 +101,8 @@ const NewRevampedComponents: NewRevampedComponent[] = [
   'TextArea',
   'Container',
   'Tabs',
-  'Form'
-
+  'Form',
+  'Image',
 ];
 
 @Injectable()
@@ -2390,6 +2390,33 @@ function migrateProperties(
     if (componentType === 'Form') {
       properties.showHeader = properties?.showHeader || false;
       properties.showFooter = properties?.showFooter || false;
+    }
+
+    if (componentType === 'Image') {
+      if (styles.padding) {
+        styles.customPadding = styles.padding;
+        styles.padding = { value: 'custom' };
+      }
+
+      if (styles.borderType?.value === 'rounded-circle') {
+        styles.imageShape = { value: 'circle' };
+        delete styles.borderType;
+      }
+
+      if (styles.borderType?.value === 'rounded') {
+        styles.imageShape = { value: 'rounded' };
+        delete styles.borderType;
+      }
+
+      if (styles.borderType?.value === 'img-thumbnail') {
+        styles.imageShape = { value: 'thumbnail' };
+        delete styles.borderType;
+      }
+
+      if (styles.borderType?.value === 'none') {
+        styles.imageShape = { value: 'none' };
+        delete styles.borderType;
+      }
     }
   }
   return { properties, styles, general, generalStyles, validation };

--- a/server/src/modules/apps/services/widget-config/image.js
+++ b/server/src/modules/apps/services/widget-config/image.js
@@ -135,7 +135,9 @@ export const imageConfig = {
       displayName: 'Shape',
       options: [
         { name: 'None', value: 'none' },
+        { name: 'Rounded', value: 'rounded' },
         { name: 'Circle', value: 'circle' },
+        { name: 'Thumbnail', value: 'thumbnail' },
       ],
       validation: {
         schema: { type: 'string' },
@@ -258,7 +260,7 @@ export const imageConfig = {
     styles: {
       imageFit: { value: 'contain' },
       imageShape: { value: 'none' },
-      backgroundColor: { value: 'var(--cc-surface1-surface)' },
+      backgroundColor: { value: '' },
       borderColor: { value: '' },
       borderRadius: { value: '{{6}}' },
       boxShadow: { value: '0px 0px 0px 0px #00000090' },

--- a/server/src/modules/apps/services/widget-config/image.js
+++ b/server/src/modules/apps/services/widget-config/image.js
@@ -175,6 +175,10 @@ export const imageConfig = {
     borderRadius: {
       type: 'numberInput',
       displayName: 'Border radius',
+      conditionallyRender: {
+        key: 'imageShape',
+        value: 'none',
+      },
       validation: { schema: { type: 'union', schemas: [{ type: 'string' }, { type: 'number' }] }, defaultValue: 6 },
       accordian: 'Container',
     },


### PR DESCRIPTION
Closes -
- Added round and thumbnail back to image shape options
- Changed migration logic accordingly
- Implemented import-export logic for Image component keeping in mind backward compatibility
- Broken image will be shown even if there is not alternate text
- Border radius style field will be only shown if the image shape is selected as 'None'