### PR TITLE
SSL security fix for github Enterprise setup in Git-sync

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -93,6 +93,7 @@
         "ts-node": "^10.0.0",
         "tsconfig-paths": "^3.10.1",
         "typeorm": "^0.3.24",
+        "undici": "^7.11.0",
         "uuid": "^8.3.2",
         "winston": "^3.13.1",
         "winston-daily-rotate-file": "^4.7.1",
@@ -20023,6 +20024,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
+      "integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/server/package.json
+++ b/server/package.json
@@ -131,6 +131,7 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typeorm": "^0.3.24",
+    "undici": "^7.11.0",
     "uuid": "^8.3.2",
     "winston": "^3.13.1",
     "winston-daily-rotate-file": "^4.7.1",


### PR DESCRIPTION
This PR introduces the ability to optionally disable SSL certificate verification for GitHub Enterprise API requests made via the Octokit client.

Only if .env variable is configured that will use -----> GIT_SSL_VERIFY_DISABLED=true


To achieve this, we’ve implemented a scoped approach using the UndiciAgent to control SSL behavior only for the Octokit instance being created, without affecting the global Node.js environment or any other part of the application.