### PR TITLE
fix: add height utility class to HTML and Markdown cell to enable the editing on add new rows

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/HTML.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/HTML.jsx
@@ -112,7 +112,7 @@ export const HTMLColumn = ({
         {isEditing ? (
           cellValue
         ) : (
-          <span className="html-cell" dangerouslySetInnerHTML={{ __html: getCellValue(cellValue) }} />
+          <span className="html-cell h-100" dangerouslySetInnerHTML={{ __html: getCellValue(cellValue) }} />
         )}
       </div>
     );

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/Markdown.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/Markdown.jsx
@@ -110,7 +110,7 @@ export const MarkdownColumn = ({
           e.stopPropagation();
         }}
       >
-        <div>{isEditing ? cellValue : <ReactMarkdown>{getCellValue(cellValue)}</ReactMarkdown>}</div>
+        <div className="h-100">{isEditing ? cellValue : <ReactMarkdown>{getCellValue(cellValue)}</ReactMarkdown>}</div>
       </div>
     );
   };


### PR DESCRIPTION
This pull request includes minor updates to the styling of table cells in the `HTMLColumn` and `MarkdownColumn` components to ensure consistent height.

Styling updates:

* [`frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/HTML.jsx`](diffhunk://#diff-66cacd7289462482685a913d4cc0dae0f84986d7e544abc127402a6b096d94d5L115-R115): Added the `h-100` class to the `span` element in the `HTMLColumn` component to ensure it takes up the full height of its container.
* [`frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/Markdown.jsx`](diffhunk://#diff-cfaa0aa933aff4679fcfc8359ff5ea8ace8b6006d8b38123421344a0ab44d802L113-R113): Added the `h-100` class to the `div` element in the `MarkdownColumn` component for consistent height behavior.