### PR TITLE
Updates the step counter to account for a removed step in the app builder's guided walkthrough

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/RightSidebarToggle.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/RightSidebarToggle.jsx
@@ -39,7 +39,7 @@ const RightSidebarToggle = ({ darkMode = false }) => {
         }}
         darkMode={darkMode}
         icon="plus"
-        className={`left-sidebar-item left-sidebar-layout left-sidebar-inspector`}
+        className={`left-sidebar-item left-sidebar-layout left-sidebar-inspector component-image-holder`}
         tip="Components"
       />
       <SidebarItem

--- a/frontend/src/AppBuilder/_helpers/createWalkThrough.js
+++ b/frontend/src/AppBuilder/_helpers/createWalkThrough.js
@@ -29,7 +29,7 @@ export const initEditorWalkThrough = () => {
           title: 'Drag and drop components',
           description: 'From the component sidebar, drag and drop components to the canvas.',
           position: 'left',
-          closeBtnText: 'Skip (1/6)',
+          closeBtnText: 'Skip (1/5)',
         },
       },
       {
@@ -38,7 +38,7 @@ export const initEditorWalkThrough = () => {
           title: 'Inspector',
           description: 'Inspector lets you check the properties of components, results of queries etc.',
           position: 'right',
-          closeBtnText: 'Skip (2/6)',
+          closeBtnText: 'Skip (2/5)',
         },
       },
       {
@@ -48,7 +48,7 @@ export const initEditorWalkThrough = () => {
           description:
             'Create queries to interact with your data sources, run JavaScript snippets and to make API requests.',
           position: 'top',
-          closeBtnText: 'Skip (3/6)',
+          closeBtnText: 'Skip (3/5)',
         },
       },
       {
@@ -58,7 +58,7 @@ export const initEditorWalkThrough = () => {
           description:
             'Click on preview to view the current changes on app viewer. Click on share button to view the sharing options.',
           position: 'left',
-          closeBtnText: 'Skip (4/6)',
+          closeBtnText: 'Skip (4/5)',
         },
       },
       {
@@ -68,9 +68,10 @@ export const initEditorWalkThrough = () => {
           description:
             ' Release the editing version to make the changes live. Released versions cannot be modified, you will have to create another version to make more changes.',
           position: 'left',
-          closeBtnText: 'Skip (5/6)',
+          closeBtnText: 'Skip (5/5)',
         },
       },
+      // comments/collaborate is disabled for now. Need to add this back and update the steps counter to 6 from 5
       {
         element: '.sidebar-comments',
         popover: {


### PR DESCRIPTION
This pull request includes updates to the `RightSidebarToggle` component and adjustments to the editor walkthrough steps in the app builder. The most notable changes involve adding a new CSS class to the sidebar toggle and modifying the walkthrough step counter to reflect the removal of a step.

### Component Updates:
* [`frontend/src/AppBuilder/RightSideBar/RightSidebarToggle.jsx`](diffhunk://#diff-5ab8aa1162b90d5e985156990c6f0d367e313d6469e22e262a040f5435b8b28eL42-R42): Added the `component-image-holder` CSS class to the `className` property of the `RightSidebarToggle` component to improve styling for components.

### Editor Walkthrough Adjustments:
* [`frontend/src/AppBuilder/_helpers/createWalkThrough.js`](diffhunk://#diff-452f96ec48ad61c2818a39add40e6dea3543b3dfc84601370dd1389720500fc0L32-R32): Updated the `closeBtnText` for all walkthrough steps to reflect the reduction in total steps from 6 to 5 due to the temporary removal of the comments/collaborate step. A comment was added to indicate that this step may be reintroduced in the future. [[1]](diffhunk://#diff-452f96ec48ad61c2818a39add40e6dea3543b3dfc84601370dd1389720500fc0L32-R32) [[2]](diffhunk://#diff-452f96ec48ad61c2818a39add40e6dea3543b3dfc84601370dd1389720500fc0L41-R41) [[3]](diffhunk://#diff-452f96ec48ad61c2818a39add40e6dea3543b3dfc84601370dd1389720500fc0L51-R51) [[4]](diffhunk://#diff-452f96ec48ad61c2818a39add40e6dea3543b3dfc84601370dd1389720500fc0L61-R61) [[5]](diffhunk://#diff-452f96ec48ad61c2818a39add40e6dea3543b3dfc84601370dd1389720500fc0L71-R74)