### PR TITLE
[fix]: optimize value updates in exposedValues to skip unchanged entries

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/WidgetBox/WidgetBox.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/WidgetBox/WidgetBox.jsx
@@ -13,7 +13,6 @@ const NEW_WIDGETS = [
   'DatePickerV2',
   'TimePicker',
   'ModalV2',
-  'TextArea',
   'EmailInput',
   'PhoneInput',
   'CurrencyInput',

--- a/frontend/src/AppBuilder/Widgets/NewTable/Table.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/Table.jsx
@@ -78,6 +78,15 @@ export const Table = memo(
     const allAppEvents = useEvents();
 
     const shouldAutogenerateColumns = useRef(false);
+    const hasDataChanged = useRef(false);
+
+    useEffect(() => {
+      hasDataChanged.current = false;
+    }, [shouldRender]);
+
+    useEffect(() => {
+      hasDataChanged.current = true;
+    }, [restOfProperties.data]);
 
     // Initialize component on the table store
     useEffect(() => {
@@ -182,6 +191,7 @@ export const Table = memo(
           componentName={componentName}
           setExposedVariables={setExposedVariables}
           fireEvent={fireEvent}
+          hasDataChanged={hasDataChanged.current}
         />
       </div>
     );

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableContainer/TableContainer.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableContainer/TableContainer.jsx
@@ -18,6 +18,7 @@ export const TableContainer = ({
   componentName,
   fireEvent,
   setExposedVariables,
+  hasDataChanged,
 }) => {
   const { getColumnProperties, getEditedRowFromIndex, getEditedFieldsOnIndex, updateEditedRowsAndFields } =
     useTableStore();
@@ -149,6 +150,7 @@ export const TableContainer = ({
         componentName={componentName}
         pageIndex={pagination.pageIndex + 1}
         lastClickedRow={lastClickedRowRef.current}
+        hasDataChanged={hasDataChanged}
       />
       <Header
         id={id}

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -34,7 +34,6 @@ export const TableExposedVariables = ({
   const setComponentProperty = useStore((state) => state.setComponentProperty, shallow);
 
   const mounted = useMounted();
-  const previousLastClickedRow = usePrevious(lastClickedRow?.row);
 
   const {
     selectedRows,
@@ -132,14 +131,6 @@ export const TableExposedVariables = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedRows, allowSelection, setExposedVariables, fireEvent, lastClickedRow, showBulkSelector]); // Didn't add mounted as it's not a dependency
-
-  useEffect(() => {
-    if (allowSelection) {
-      if (previousLastClickedRow?.id !== lastClickedRow?.row?.id) {
-        fireEvent('onRowClicked');
-      }
-    }
-  }, [previousLastClickedRow, lastClickedRow, fireEvent, allowSelection]);
 
   // Expose page index
   useEffect(() => {
@@ -249,6 +240,12 @@ export const TableExposedVariables = ({
       });
     }
   }, [lastClickedRow, setExposedVariables]);
+
+  useEffect(() => {
+    if (allowSelection) {
+      fireEvent('onRowClicked');
+    }
+  }, [lastClickedRow, fireEvent, allowSelection]);
 
   useEffect(() => {
     function selectRow(key, value) {

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -19,6 +19,7 @@ export const TableExposedVariables = ({
   componentName,
   pageIndex = 1,
   lastClickedRow,
+  hasDataChanged,
 }) => {
   const { moduleId } = useModuleContext();
   const editedRows = useTableStore((state) => state.getAllEditedRows(id), shallow);
@@ -213,6 +214,7 @@ export const TableExposedVariables = ({
   }, [setPageIndex, setExposedVariables, clientSidePagination]);
 
   useEffect(() => {
+    if (!hasDataChanged) return;
     resetRowSelection();
     function selectRow(key, value) {
       const index = data.findIndex((item) => item[key] == value);
@@ -237,7 +239,7 @@ export const TableExposedVariables = ({
         selectedRowId: null,
       });
     }
-  }, [data, defaultSelectedRow, setExposedVariables, setRowSelection, resetRowSelection]);
+  }, [data, defaultSelectedRow, setExposedVariables, setRowSelection, resetRowSelection, hasDataChanged]);
 
   useEffect(() => {
     if (lastClickedRow) {

--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -1462,7 +1462,7 @@ export const createQueryPanelSlice = (set, get) => ({
     runQueryOnShortcut: () => {
       const { queryPanel } = get();
       const { runQuery, selectedQuery } = queryPanel;
-      runQuery(selectedQuery?.id, selectedQuery?.name, undefined, 'edit', {}, true);
+      runQuery(selectedQuery?.id, selectedQuery?.name, undefined, 'edit', {}, true, undefined, true);
     },
     previewQueryOnShortcut: (moduleId = 'canvas') => {
       const { queryPanel } = get();

--- a/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
@@ -345,6 +345,7 @@ export const createResolvedSlice = (set, get) => ({
   },
 
   setExposedValues: (id, type, values, moduleId = 'canvas') => {
+    const skipKeys = new Set();
     set(
       (state) => {
         Object.entries(values).forEach(([key, value]) => {
@@ -352,7 +353,13 @@ export const createResolvedSlice = (set, get) => ({
             state.resolvedStore.modules[moduleId].exposedValues[type][id] = {
               [key]: value,
             };
-          else state.resolvedStore.modules[moduleId].exposedValues[type][id][key] = value;
+          else {
+            // If the value is equal to the existing value, add the key to the skipKeys set and do not update it
+            // using lodash's isEqual as the state is immer proxy and cannot be compared directly
+            if (_.isEqual(value, state.resolvedStore.modules[moduleId].exposedValues[type][id][key])) {
+              skipKeys.add(key);
+            } else state.resolvedStore.modules[moduleId].exposedValues[type][id][key] = value;
+          }
         });
       },
       false,
@@ -362,7 +369,8 @@ export const createResolvedSlice = (set, get) => ({
       }
     );
     Object.entries(values).forEach(([key, value]) => {
-      if (typeof value !== 'function') get().updateDependencyValues(`components.${id}.${key}`, moduleId);
+      if (typeof value !== 'function' && !skipKeys.has(key))
+        get().updateDependencyValues(`components.${id}.${key}`, moduleId);
     });
   },
 


### PR DESCRIPTION
This pull request introduces enhancements to the `setExposedValues` method in the `resolvedSlice.js` file to optimize state updates and dependency management. The changes ensure that unnecessary updates are avoided by introducing a mechanism to skip redundant key updates.

This change was added to stop the circular dependency on the `Table` component. `shouldRender` key was maintained to trigger a re-render for table. If the same Table is linked to the column properties, this was causing an infinite loop by exposing the new values and once the value is exposed, the table got re-rendered. If the table is re-rendered then it exposes the values

### Optimizations in state updates:

* [`frontend/src/AppBuilder/_stores/slices/resolvedSlice.js`](diffhunk://#diff-3109ee24f941f7389f37853c07c454d59dbd47a795e1ac222f909231684c4b0cR348-R362): Added a `skipKeys` set to track keys whose values are unchanged, using lodash's `isEqual` for comparison. This prevents redundant updates to the `resolvedStore.modules[moduleId].exposedValues`.

### Improvements in dependency management:

* [`frontend/src/AppBuilder/_stores/slices/resolvedSlice.js`](diffhunk://#diff-3109ee24f941f7389f37853c07c454d59dbd47a795e1ac222f909231684c4b0cL365-R373): Modified the logic to skip dependency updates for keys present in the `skipKeys` set, ensuring only necessary updates are performed.