### PR TITLE
Fix: hidden left sidebar and header in app builder

### DIFF
--- a/frontend/src/AppBuilder/Header/EditorHeader.jsx
+++ b/frontend/src/AppBuilder/Header/EditorHeader.jsx
@@ -12,6 +12,7 @@ import RightTopHeaderButtons from './RightTopHeaderButtons/RightTopHeaderButtons
 import BuildSuggestions from './BuildSuggestions';
 import GitSyncManager from './GitSyncManager';
 import UpdatePresenceMultiPlayer from './UpdatePresenceMultiPlayer';
+import '../../_styles/header.scss';
 
 export const EditorHeader = ({ darkMode }) => {
   const { isSaving, saveError, isVersionReleased } = useStore(

--- a/frontend/src/_styles/header.scss
+++ b/frontend/src/_styles/header.scss
@@ -1,0 +1,3 @@
+.navbar {
+  z-index: 1 !important;
+}

--- a/frontend/src/_styles/left-sidebar.scss
+++ b/frontend/src/_styles/left-sidebar.scss
@@ -4,7 +4,7 @@
   background: var(--page-default) !important;
   display: flex;
   gap: 16px;
-
+  z-index: 1 !important;
   .sidebar-svg-icon {
     height: 32px;
     width: 32px;


### PR DESCRIPTION
closes #12984
Fixes:
- left sidebar and header got hidden behind walkthrough overlay

<img width="1728" height="996" alt="Screenshot 2025-07-22 at 8 23 47 AM" src="https://github.com/user-attachments/assets/fb245cf4-811a-4ffb-9dc1-8608da9f48e7" />

<img width="1728" height="991" alt="Screenshot 2025-07-22 at 8 23 38 AM" src="https://github.com/user-attachments/assets/9cc50d5b-6a3c-497b-9e46-8c1c86f52ccf" />
