### PR TITLE
[fix]: Crash on form component while creating the custom radio button 

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Form/utils/fieldOperations.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Form/utils/fieldOperations.js
@@ -25,6 +25,8 @@ export const createNewComponentFromMeta = (column, parentId, nextTop) => {
   const componentData = deepClone(componentMeta);
   const componentName = useStore.getState().generateUniqueComponentNameFromBaseName(column.name);
 
+  const addOptions = COMPONENT_WITH_OPTIONS.includes(componentType);
+
   const formField = {
     id: fieldId,
     name: componentName,
@@ -38,6 +40,7 @@ export const createNewComponentFromMeta = (column, parentId, nextTop) => {
           label: {
             value: column.label,
           },
+          ...(addOptions && { options: componentData.definition.properties.options }),
         },
         styles: {
           alignment: { value: 'top' },
@@ -218,7 +221,11 @@ const setValuesBasedOnType = (column, componentType, formField, isTypeChange = f
       componentType === 'RadioButtonV2'
     ) {
       if (!isTypeChange) {
-        set(formField.component.definition.properties, 'options.value', buildOptions(column.value));
+        const generatedOptions = buildOptions(column.value);
+        const val = Array.isArray(generatedOptions)
+          ? generatedOptions
+          : formField.component.definition.properties?.options.value;
+        set(formField.component.definition.properties, 'options.value', val);
       } else if (Array.isArray(formField.component.definition.properties?.options)) {
         set(
           formField.component.definition.properties,

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Form/utils/fieldOperations.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Form/utils/fieldOperations.js
@@ -174,7 +174,6 @@ const handleComponentTypeChange = (componentToUpdate, updatedField) => {
           label: {
             value: updatedField.label || componentToUpdate.component.definition.properties.label?.value,
           },
-          ...(addOptions && { options: componentToUpdate.component.definition.properties.options }),
         },
         styles: {
           alignment: { value: 'top' },
@@ -193,6 +192,14 @@ const handleComponentTypeChange = (componentToUpdate, updatedField) => {
       [nonActiveLayout]: existingLayouts[nonActiveLayout] || { top: 0, left: 3, width: 37, height: 30 },
     },
   };
+
+  if (addOptions) {
+    set(
+      newComponent.component.definition.properties,
+      'options',
+      componentToUpdate.component.definition.properties.options
+    );
+  }
 
   setValuesBasedOnType(updatedField, updatedField.componentType, newComponent, true);
 

--- a/frontend/src/AppBuilder/Widgets/Form/Form.jsx
+++ b/frontend/src/AppBuilder/Widgets/Form/Form.jsx
@@ -106,6 +106,7 @@ const FormComponent = (props) => {
     paddingBottom: showFooter ? '3px' : '7px',
     paddingLeft: `${CONTAINER_FORM_CANVAS_PADDING}px`,
     paddingRight: `${CONTAINER_FORM_CANVAS_PADDING}px`,
+    borderRadius: 'inherit',
   };
 
   const headerMaxHeight = parseInt(height, 10) - parseInt(footerHeight, 10) - 100 - 10;
@@ -118,6 +119,8 @@ const FormComponent = (props) => {
     paddingLeft: `${CONTAINER_FORM_CANVAS_PADDING}px`,
     paddingRight: `${CONTAINER_FORM_CANVAS_PADDING}px`,
     maxHeight: `${footerMaxHeight}px`,
+    borderBottomLeftRadius: `${borderRadius}px`,
+    borderBottomRightRadius: `${borderRadius}px`,
     backgroundColor:
       ['#fff', '#ffffffff'].includes(footerBackgroundColor) && darkMode ? '#1F2837' : footerBackgroundColor,
   };
@@ -128,6 +131,8 @@ const FormComponent = (props) => {
     paddingLeft: `${CONTAINER_FORM_CANVAS_PADDING}px`,
     paddingRight: `${CONTAINER_FORM_CANVAS_PADDING}px`,
     maxHeight: `${headerMaxHeight}px`,
+    borderTopLeftRadius: `${borderRadius}px`,
+    borderTopRightRadius: `${borderRadius}px`,
     backgroundColor:
       ['#fff', '#ffffffff'].includes(headerBackgroundColor) && darkMode ? '#1F2837' : headerBackgroundColor,
   };


### PR DESCRIPTION
This pull request introduces enhancements to the form component rendering and the handling of form field options in the app builder. Key changes include adding support for component-specific options, improving option value handling, and refining the visual styling of form components.

### Enhancements to form field options:
* [`frontend/src/AppBuilder/RightSideBar/Inspector/Components/Form/utils/fieldOperations.js`](diffhunk://#diff-5c82981bc7830a6b4af62bdd4322e4f524adbcea43a2e6768890b394b2070bf2R28-R29): Added logic to include `options` for components that require it (`COMPONENT_WITH_OPTIONS`) and dynamically set `options.value` based on the column value or existing properties. [[1]](diffhunk://#diff-5c82981bc7830a6b4af62bdd4322e4f524adbcea43a2e6768890b394b2070bf2R28-R29) [[2]](diffhunk://#diff-5c82981bc7830a6b4af62bdd4322e4f524adbcea43a2e6768890b394b2070bf2R43) [[3]](diffhunk://#diff-5c82981bc7830a6b4af62bdd4322e4f524adbcea43a2e6768890b394b2070bf2L221-R228)

### Visual styling improvements:
* [`frontend/src/AppBuilder/Widgets/Form/Form.jsx`](diffhunk://#diff-1efde8bb413dd289253627c3c4aa60fe2b3a4ac979737d11920813cc03754e07R109): Enhanced the form component's styling by adding support for `borderRadius` to inherit or apply specific values to all corners (top-left, top-right, bottom-left, bottom-right). [[1]](diffhunk://#diff-1efde8bb413dd289253627c3c4aa60fe2b3a4ac979737d11920813cc03754e07R109) [[2]](diffhunk://#diff-1efde8bb413dd289253627c3c4aa60fe2b3a4ac979737d11920813cc03754e07R122-R123) [[3]](diffhunk://#diff-1efde8bb413dd289253627c3c4aa60fe2b3a4ac979737d11920813cc03754e07R134-R135)