### PR TITLE
Fix: Prevent Editing of Codehinter Inputs in Inspector and Page Styles When Editor Is Frozen

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageSettings.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageSettings.jsx
@@ -205,7 +205,7 @@ export const PageSettings = () => {
               </div>
             </Tab>
             <Tab eventKey="styles" title="Styles">
-              <div className={cx({ disabled: isVersionReleased })}>
+              <div className={cx({ disabled: isVersionReleased || shouldFreeze })}>
                 <div className="tj-text-xsm color-slate12 settings-tab ">
                   <RenderStyles pagesMeta={pagesMeta} renderCustomStyles={renderCustomStyles} />
                 </div>

--- a/frontend/src/AppBuilder/RightSideBar/RightSideBar.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/RightSideBar.jsx
@@ -10,6 +10,7 @@ export const RightSideBar = ({ darkMode }) => {
   const { isModuleEditor } = useModuleContext();
   const queryPanelHeight = useStore((state) => state.queryPanel.queryPanelHeight);
   const isDraggingQueryPane = useStore((state) => state.queryPanel.isDraggingQueryPane);
+  const shouldFreeze = useStore((state) => state.getShouldFreeze());
 
   const activeTab = useStore((state) => state.activeRightSideBarTab);
   const isRightSidebarOpen = useStore((state) => state.isRightSidebarOpen);
@@ -32,7 +33,11 @@ export const RightSideBar = ({ darkMode }) => {
     <div className="sub-section">
       <div
         style={{ height: `${popoverContentHeight}vh`, overflow: 'auto' }}
-        className={cx('editor-sidebar', { 'dark-theme theme-dark': darkMode })}
+        className={cx(
+          'editor-sidebar',
+          { 'dark-theme theme-dark': darkMode },
+          { 'tw-pointer-events-none': shouldFreeze }
+        )}
       >
         <div className={cx({ 'dark-theme theme-dark': darkMode })} style={{ position: 'relative', height: '100%' }}>
           {activeTab === 'pages' && <PageSettings />}


### PR DESCRIPTION
This PR ensures that codehinter inputs in the component inspector and page styles tab are no longer editable when the editor is frozen (e.g., during version release or other freeze conditions).