### PR TITLE
Fix: Response, Request and Metadata coming out to be undefined on query failure and success inside Inspector

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -420,7 +420,7 @@ export const createQueryPanelSlice = (set, get) => ({
 
       // Handler for transformation and completion of query results
       const processQueryResults = async (data, rawData = null) => {
-        let finalData = data;
+        let finalData = data?.data;
         rawData = rawData || data;
 
         if (dataQuery.options.enableTransformation) {
@@ -514,9 +514,9 @@ export const createQueryPanelSlice = (set, get) => ({
             } : query.kind === 'restapi'
               ? {
                   metadata: errorData?.metadata,
-                  request: errorData?.requestObject,
-                  response: errorData?.responseObject,
-                  responseHeaders: errorData?.responseHeaders,
+                  request: errorData?.data?.requestObject,
+                  response: errorData?.data?.responseObject,
+                  responseHeaders: errorData?.data?.responseHeaders,
                 }
               : {}),
           },
@@ -672,7 +672,7 @@ export const createQueryPanelSlice = (set, get) => ({
               return;
             } else {
               const rawData = data.data;
-              const result = await processQueryResults(data.data, rawData);
+              const result = await processQueryResults(data, rawData);
               resolve(result);
             }
           })


### PR DESCRIPTION
This PR fixes an issue where the Inspector panel was showing undefined for Response, Request, and Metadata fields after query execution (both on success and failure). The root cause was incorrect data extraction from the query result and error objects.

Changes:
- Corrected the assignment of finalData in processQueryResults to use the proper data structure.
- Updated error handling for REST API queries to extract requestObject, responseObject, and responseHeaders from the correct nested location (errorData.data).
- Ensured consistent data flow to the Inspector for both successful and failed queries.