### PR TITLE
Fix: Request and Response objects undefined in debugger for failed REST API queries

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -497,8 +497,8 @@ export const createQueryPanelSlice = (set, get) => ({
             query.kind === 'restapi' && errorData?.data?.type !== 'tj-401'
               ? {
                   substitutedVariables: options,
-                  request: errorData?.requestObject,
-                  response: errorData?.responseObject,
+                  request: errorData?.data?.requestObject,
+                  response: errorData?.data?.responseObject,
                 }
               : errorData,
           isQuerySuccessLog: false,


### PR DESCRIPTION
This PR fixes an issue where the Request and Response objects were shown as undefined in the debugger when a REST API query failed. The error objects are now correctly extracted from the nested errorData.data structure, ensuring accurate debugging information is displayed.