### PR TITLE
fix: Ensure onRowClicked event is fired even when row selection is disabled

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/TableData.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/TableData.jsx
@@ -79,9 +79,15 @@ export const TableData = ({
 
   // Handles row click for row selection
   const handleRowClick = (row) => {
-    if (!allowSelection) return;
     lastClickedRowRef.current = { row: row?.original, index: row.index };
-
+    if (!allowSelection) {
+      setExposedVariables({
+        selectedRow: row?.original ?? {},
+        selectedRowId: isNaN(row.index) ? String(row.index) : row.index,
+      });
+      fireEvent('onRowClicked');
+      return;
+    }
     // Update row selection
     row.toggleSelected();
   };

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -263,6 +263,8 @@ export const TableExposedVariables = ({
   ]);
 
   useEffect(() => {
+    // onRowClicked event will be fired when a row is clicked
+    // it should be triggered even when allowSelection is false which is handled in the handleRowClick()
     if (allowSelection && Object.keys(lastClickedRow).length > 0) {
       fireEvent('onRowClicked');
     }


### PR DESCRIPTION
This pull request modifies the behavior of row selection and event handling in the `NewTable` widget to ensure the `onRowClicked` event is consistently fired, even when row selection is disabled. The most important changes include updates to the `TableData` and `TableExposedVariables` components.

### Changes to row selection and event handling:

* [`frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/TableData.jsx`](diffhunk://#diff-6e3b61fc62809192fe1681f67ac877755886ce4cfda015acf0836ed9bcb32cdaL82-R90): Updated the `handleRowClick` function to fire the `onRowClicked` event and set exposed variables (`selectedRow` and `selectedRowId`) when `allowSelection` is false, ensuring consistent event handling.

* [`frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx`](diffhunk://#diff-cf00b0ecbaef4363eaddae1bf0b02c4cb759e663d5af9ef14ef51cc198614b38R266-R267): Added a comment explaining that the `onRowClicked` event is triggered even when `allowSelection` is false, clarifying the behavior introduced in the `handleRowClick` function.