### PR TITLE
Fix SVG icon cropping in datasource list

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -15734,8 +15734,9 @@ textarea.tj-text-input-widget {
   }
 }
 
-div.ds-svg-container img {
+.ds-svg-container svg {
   padding: 2px;
+  object-fit: contain;
 }
 
 .custom-textarea-height {


### PR DESCRIPTION
Adjust the styling of SVG icons in the datasource list to prevent cropping.
Closes #13243 

### Updated Icon Display
<img width="271" height="154" alt="image" src="https://github.com/user-attachments/assets/344229e2-4e18-404a-aef4-90cd634813cc" />