### PR TITLE
Add partition key placeholder in CosmosDB operations

### DIFF
--- a/plugins/packages/cosmosdb/lib/operations.json
+++ b/plugins/packages/cosmosdb/lib/operations.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/operations.schema.json",
   "title": "CosmosDB datasource",
@@ -159,6 +158,7 @@
         "type": "codehinter",
         "lineNumbers": false,
         "description": "Enter partition key",
+        "placeholder": "Enter partition key",
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins"


### PR DESCRIPTION
Add a placeholder for the partition key input in the CosmosDB operations