### PR TITLE
Fix: Placeholder and description text changes in Postgresql, Mssql and Notion datasource

### DIFF
--- a/plugins/packages/mssql/lib/operations.json
+++ b/plugins/packages/mssql/lib/operations.json
@@ -75,7 +75,7 @@
           "width": "320px",
           "height": "36px",
           "className": "codehinter-plugins",
-          "placeholder": "Enter Enter primary key column"
+          "placeholder": "Enter primary key column"
         },
         "records": {
           "label": "Records to update",

--- a/plugins/packages/notion/lib/operations.json
+++ b/plugins/packages/notion/lib/operations.json
@@ -174,7 +174,7 @@
           "key": "icon_value",
           "type": "codehinter",
           "placeholder": "Enter icon external url / emoji here",
-          "description": "Enter Enter value here",
+          "description": "Enter value here",
           "lineNumbers": false,
           "height": "36px",
           "className": "codehinter-plugins"

--- a/plugins/packages/postgresql/lib/operations.json
+++ b/plugins/packages/postgresql/lib/operations.json
@@ -95,7 +95,7 @@
           "width": "320px",
           "height": "36px",
           "className": "codehinter-plugins",
-          "placeholder": "Enter Enter primary key column"
+          "placeholder": "Enter primary key column"
         },
         "records": {
           "label": "Records to update",


### PR DESCRIPTION
Correct placeholder and description text in PostgreSQL, Notion, and MSSQL plugin operation schemas.
Closes #13031 

### Updated Placeholder
<img width="1533" height="328" alt="image" src="https://github.com/user-attachments/assets/25b87e21-eb76-44bc-8bf2-1fb9f426d908" />
