### PR TITLE
fix: Update accessor key for cell value retrieval in generateColumnData function

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.js
@@ -121,7 +121,9 @@ export default function generateColumnsData({
             ? getAddNewRowDetailFromIndex(id, row.index)
             : getEditedRowFromIndex(id, row.index);
 
-          let cellValue = changeSet ? changeSet[cell.column.columnDef?.meta?.name] ?? cell.getValue() : cell.getValue();
+          let cellValue = changeSet
+            ? changeSet[cell.column.columnDef?.accessorKey] ?? cell.getValue()
+            : cell.getValue();
           cellValue = cellValue === undefined || cellValue === null ? '' : cellValue;
           const rowData = tableData?.[row.index];
 


### PR DESCRIPTION
This pull request updates the logic for determining cell values in the `generateColumnsData` utility function to improve compatibility with column definitions. When the column name is different from the key and has underscore in it, the column editing is not working properly

### Key Change:

* **Improved column accessor compatibility:**
  - Updated the `cellValue` assignment to use `cell.column.columnDef?.accessorKey` instead of `cell.column.columnDef?.meta?.name` for accessing the change set. This ensures compatibility with the accessor key defined in column definitions. (`[frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.jsL124-R126](diffhunk://#diff-3c60cb2973988b9360070a7121dc508e171d53c6543c02ed7df3be9d9211d68fL124-R126)`)