### PR TITLE
fix: Disable pagination should render all the data in Table

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableContainer/TableContainer.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableContainer/TableContainer.jsx
@@ -27,6 +27,7 @@ export const TableContainer = ({
   // Table properties
   const showBulkSelector = useTableStore((state) => state.getTableProperties(id)?.showBulkSelector, shallow);
   const enableSorting = useTableStore((state) => state.getTableProperties(id)?.enabledSort, shallow);
+  const enablePagination = useTableStore((state) => state.getTableProperties(id)?.enablePagination, shallow);
   const columnSizes = useTableStore((state) => state.getTableProperties(id)?.columnSizes, shallow);
 
   // Server side properties
@@ -89,6 +90,7 @@ export const TableContainer = ({
       data,
       columns,
       enableSorting,
+      enablePagination,
       showBulkSelector,
       serverSidePagination,
       serverSideSort,

--- a/frontend/src/AppBuilder/Widgets/NewTable/_hooks/useTable.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_hooks/useTable.js
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import {
   getCoreRowModel,
   useReactTable,
@@ -12,6 +12,7 @@ export function useTable({
   data,
   columns,
   enableSorting,
+  enablePagination,
   showBulkSelector,
   serverSidePagination,
   serverSideSort,
@@ -23,12 +24,19 @@ export function useTable({
   // Pagination state
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: rowsPerPage,
+    pageSize: enablePagination ? rowsPerPage : data.length,
   });
 
   const [columnVisibility, setColumnVisibility] = useState({});
   const [columnFilters, setColumnFilters] = useState([]);
   const [columnOrder, setColumnOrder] = useState(columns.map((column) => column.id));
+
+  useEffect(() => {
+    setPagination({
+      pageIndex: 0,
+      pageSize: enablePagination ? rowsPerPage : data.length,
+    });
+  }, [enablePagination, rowsPerPage, data.length]);
 
   // When the columns change, the data is not getting re-rendered. So, we need to create a new data array
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This pull request introduces support for enabling or disabling pagination in the `NewTable` widget. The changes include updates to both the `TableContainer` component and the `useTable` hook to handle this new feature.

### Pagination Feature Enhancements:

* **`frontend/src/AppBuilder/Widgets/NewTable/_components/TableContainer/TableContainer.jsx`:** Added support for the `enablePagination` property in the table configuration and passed it to the table instance. (`[[1]](diffhunk://#diff-7b97ebd7a0e7e85584322076cb6a89085c7459d79c0db53f8ef56931f1dff8bcR30)`, `[[2]](diffhunk://#diff-7b97ebd7a0e7e85584322076cb6a89085c7459d79c0db53f8ef56931f1dff8bcR93)`)
* **`frontend/src/AppBuilder/Widgets/NewTable/_hooks/useTable.js`:** 
  - Introduced the `enablePagination` property in the `useTable` hook and updated the pagination logic to dynamically adjust the `pageSize` based on whether pagination is enabled. (`[[1]](diffhunk://#diff-41a881b6ee8271dca045ea668e4ce8b8db8d45d2c01867ef7eed8810ce0cb6c6R15)`, `[[2]](diffhunk://#diff-41a881b6ee8271dca045ea668e4ce8b8db8d45d2c01867ef7eed8810ce0cb6c6L26-R40)`)
  - Added a `useEffect` to reset the pagination state when `enablePagination`, `rowsPerPage`, or `data.length` changes. (`[frontend/src/AppBuilder/Widgets/NewTable/_hooks/useTable.jsL26-R40](diffhunk://#diff-41a881b6ee8271dca045ea668e4ce8b8db8d45d2c01867ef7eed8810ce0cb6c6L26-R40)`)