### PR TITLE
fix: Pagination state update in useTable hook for server-side handling

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_hooks/useTable.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_hooks/useTable.js
@@ -32,11 +32,11 @@ export function useTable({
   const [columnOrder, setColumnOrder] = useState(columns.map((column) => column.id));
 
   useEffect(() => {
-    setPagination({
-      pageIndex: 0,
+    setPagination((prev) => ({
+      pageIndex: serverSidePagination ? prev.pageIndex ?? 0 : 0,
       pageSize: enablePagination ? rowsPerPage : data.length,
-    });
-  }, [enablePagination, rowsPerPage, data.length]);
+    }));
+  }, [enablePagination, rowsPerPage, data.length, serverSidePagination]);
 
   // When the columns change, the data is not getting re-rendered. So, we need to create a new data array
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This pull request updates the pagination logic in the `useTable` hook to better support server-side pagination. The main change ensures that when server-side pagination is enabled, the current page index is preserved instead of resetting to zero, improving user experience and preventing unwanted page jumps.

Pagination logic improvements:

* Updated the `useEffect` in `useTable.js` to conditionally retain the current `pageIndex` when `serverSidePagination` is enabled, rather than always resetting to zero.
* Added `serverSidePagination` to the dependency array of the effect to ensure pagination state updates correctly when this prop changes.