### PR TITLE
fix: Limit concurrent toast notifications to 2 to prevent UI flooding

### DIFF
--- a/frontend/src/_ui/Toast/index.js
+++ b/frontend/src/_ui/Toast/index.js
@@ -3,7 +3,7 @@ import { toast, Toaster, ToastBar } from 'react-hot-toast';
 
 const Toast = ({ toastOptions }) => {
   return (
-    <Toaster toastOptions={toastOptions}>
+    <Toaster toastOptions={toastOptions} limit={2}>
       {(t) => (
         <ToastBar toast={t}>
           {({ icon, message }) => (


### PR DESCRIPTION
**issue**: https://github.com/ToolJet/ToolJet/issues/13731

**Problem**:
lot of errors produce many toast notifications which are unnecessary

**Fix**: 
Added limit={2} to the shared Toaster so only two toasts render, excess toasts are queued by react-hot-toast

**Scope**:
Single centralized change in frontend/src/_ui/Toast/index.js; no modifications to call sites

_better fix would be to add a toaster manager which deduplicates repeated errors_

Closes #13731 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the user interface by limiting concurrent toast notifications to two, preventing UI flooding during error handling. The modification in the Toast component ensures only the most relevant notifications are displayed, addressing user overwhelm from excessive alerts.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>