### PR TITLE
Fix: REST API datasource ensures that array and object values are properly stringified before being added to the search parameters

### DIFF
--- a/plugins/packages/restapi/lib/index.ts
+++ b/plugins/packages/restapi/lib/index.ts
@@ -183,7 +183,14 @@ export default class RestapiQueryService implements QueryService {
     }
 
     // Sanitize and append search parameters
-    for (const [key, value] of sanitizeSearchParams(sourceOptions, queryOptions, hasDataSource)) {
+    // eslint-disable-next-line prefer-const
+    for (let [key, value] of sanitizeSearchParams(sourceOptions, queryOptions, hasDataSource)) {
+      if (Array.isArray(value) || Object.prototype.toString.call(value) === '[object Object]') {
+        // If the value is an array or object, stringify it
+        value = JSON.stringify(value);
+        searchParams.append(key, value);
+        continue;
+      }
       searchParams.append(key, String(value));
     }
 


### PR DESCRIPTION
closes #13752 