### PR TITLE
Fix: Import issue for Workflow context inside code-editors for CE

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
@@ -25,7 +25,7 @@ import { handleSearchPanel } from './SearchBox';
 import { useQueryPanelKeyHooks } from './useQueryPanelKeyHooks';
 import { isInsideParent } from './utils';
 import { CodeHinterBtns } from './CodehinterOverlayTriggers';
-import WorkflowEditorContext from '../../../ee/modules/Workflows/pages/WorkflowEditorPage/context';
+import WorkflowEditorContext from '@/modules/workflows/pages/WorkflowEditorPage/context';
 
 const langSupport = Object.freeze({
   javascript: javascript(),

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -34,7 +34,7 @@ import { CodeHinterContext } from '../CodeBuilder/CodeHinterContext';
 import { createReferencesLookup } from '@/_stores/utils';
 import { useQueryPanelKeyHooks } from './useQueryPanelKeyHooks';
 import Icon from '@/_ui/Icon/solidIcons/index';
-import WorkflowEditorContext from '../../../ee/modules/Workflows/pages/WorkflowEditorPage/context';
+import WorkflowEditorContext from '@/modules/workflows/pages/WorkflowEditorPage/context';
 
 const SingleLineCodeEditor = ({ componentName, fieldMeta = {}, componentId, ...restProps }) => {
   const { moduleId } = useModuleContext();

--- a/frontend/src/modules/workflows/pages/WorkflowEditorPage/context.js
+++ b/frontend/src/modules/workflows/pages/WorkflowEditorPage/context.js
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+const WorkflowEditorContext = createContext({
+  editorSession: {},
+  editorSessionActions: {
+    copyNodeToClipboard: () => {},
+    handleNodeDuplicate: () => {},
+  },
+});
+
+export default WorkflowEditorContext;


### PR DESCRIPTION
Code editors were failing to import `WorkflowEditorContext` when using the Community Edition (CE) instead of Enterprise Edition (EE), causing import errors.

Changes:

- Moved WorkflowEditorContext from EE-specific path to a shared location at `@/modules/workflows/pages/WorkflowEditorPage/context`
- Updated import statements in both `MultiLineCodeEditor.jsx` and `SingleLineCodeEditor.jsx`
- Created a new context file with basic workflow editor functionality

[ee-frontend](https://github.com/ToolJet/ee-frontend/pull/201)