### PR TITLE
fix: Added discard changes CSA on table

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -30,6 +30,7 @@ export const TableExposedVariables = ({
   const clientSidePagination = useTableStore((state) => state.getTableProperties(id)?.clientSidePagination, shallow);
   const defaultSelectedRow = useTableStore((state) => state.getTableProperties(id)?.defaultSelectedRow, shallow);
   const columnSizes = useTableStore((state) => state.getTableProperties(id)?.columnSizes, shallow);
+  const clearEditedRows = useTableStore((state) => state.clearEditedRows, shallow);
 
   const setComponentProperty = useStore((state) => state.setComponentProperty, shallow);
 
@@ -353,6 +354,14 @@ export const TableExposedVariables = ({
       debouncedSetProperty.cancel();
     };
   }, [columnSizing, columnSizes, debouncedSetProperty, id]);
+
+  useEffect(() => {
+    function discardChanges() {
+      setExposedVariables({ dataUpdates: [], changeSet: {} });
+      clearEditedRows(id);
+    }
+    setExposedVariables({ discardChanges });
+  }, [clearEditedRows, id, setExposedVariables]);
 
   return null;
 };


### PR DESCRIPTION
This pull request introduces a new mechanism for discarding changes in the `TableExposedVariables` component. The main improvement is the addition of a `discardChanges` function, which resets both local state and edited rows in the table store.

Enhancements to state management and exposed variables:

* Added a `clearEditedRows` selector from the table store to allow clearing edited rows for a specific table.
* Introduced a `discardChanges` function in a `useEffect` hook, which resets `dataUpdates` and `changeSet`, and calls `clearEditedRows` with the table's `id`. This function is now exposed via `setExposedVariables`.