### PR TITLE
fix: Ensure query is executed in modules upon query success

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -476,7 +476,7 @@ export const createQueryPanelSlice = (set, get) => ({
           moduleId
         );
 
-        onEvent('onDataQuerySuccess', queryEvents, mode);
+        onEvent('onDataQuerySuccess', queryEvents, {}, mode, moduleId);
         return { status: 'ok', data: finalData };
       };
 


### PR DESCRIPTION
This pull request makes a small change to the `createQueryPanelSlice` function to improve the event handling for data query success events. The change ensures that the `onEvent` function now receives the correct parameters, including an empty options object and the `moduleId`, which may be needed for more precise event handling.

* Updated the call to `onEvent` in `queryPanelSlice.js` to include an empty options object and pass `moduleId` for improved event context.