### PR TITLE
Change RAM requirement for VM deployments

### DIFF
--- a/docs/versioned_docs/version-3.16.0-LTS/setup/system-requirements.md
+++ b/docs/versioned_docs/version-3.16.0-LTS/setup/system-requirements.md
@@ -23,7 +23,7 @@ ToolJet is developed for Linux-based operating systems. Please consider using a 
 
 - **Operating System:** Ubuntu 22.04 or later
 - **Processor Architecture:** x86 (arm64 is not supported)
-- **RAM:** 2GB
+- **RAM:** 4GB
 - **CPU:** 1 vCPU
 - **Storage:** At least 8GiB, but can increase according to your requirements.
 


### PR DESCRIPTION
Updated RAM requirement from 2GB to 4GB for VM deployments.