### PR TITLE
fix: update banner visibility logic and adjust left sidebar styles

### DIFF
--- a/frontend/src/App/App.jsx
+++ b/frontend/src/App/App.jsx
@@ -229,7 +229,7 @@ class AppComponent extends React.Component {
     return (
       <>
         <div className={!isApplicationsPath && (isAdmin || isBuilder) ? 'banner-layout-wrapper' : ''}>
-          {!isApplicationsPath && (isAdmin || isBuilder) && showBanner && (
+          {!isApplicationsPath && !this.isEditorOrViewerFromPath() && (isAdmin || isBuilder) && showBanner && (
             <BasicPlanMigrationBanner darkMode={darkMode} closeBanner={this.closeBasicPlanMigrationBanner} />
           )}
           <div

--- a/frontend/src/AppBuilder/LeftSidebar/LeftSidebar.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/LeftSidebar.jsx
@@ -259,7 +259,7 @@ export const BaseLeftSidebar = ({
 
   return (
     <div
-      className={cx('left-sidebar !tw-z-10', { 'dark-theme theme-dark': darkMode })}
+      className={cx('left-sidebar !tw-z-10 tw-gap-1.5', { 'dark-theme theme-dark': darkMode })}
       data-cy="left-sidebar-inspector"
       style={{ zIndex: 9999 }}
     >

--- a/frontend/src/_styles/left-sidebar.scss
+++ b/frontend/src/_styles/left-sidebar.scss
@@ -16,7 +16,6 @@
   padding-top: 8px;
   background: var(--page-weak) !important;
   display: flex;
-  gap: 2px;
   flex-direction: column;
   align-items: center;
   border-right: 1px solid var(--border-weak);


### PR DESCRIPTION
- Updated the condition for displaying the Basic Plan Migration Banner to exclude editor or viewer paths.
- Added a gap to the left sidebar layout for improved spacing.
- Removed unnecessary gap from the left sidebar SCSS styles.