### PR TITLE
feat: added opeartion to create objectId

### DIFF
--- a/plugins/packages/mongodb/lib/index.ts
+++ b/plugins/packages/mongodb/lib/index.ts
@@ -1,5 +1,5 @@
 import { QueryResult, QueryService, QueryError, ConnectionTestResult } from '@tooljet-plugins/common';
-const { MongoClient } = require('mongodb');
+const { MongoClient, ObjectId } = require('mongodb');
 const JSON5 = require('json5');
 import { EJSON } from 'bson';
 import { SourceOptions, QueryOptions } from './types';
@@ -16,7 +16,7 @@ export default class MongodbService implements QueryService {
         case 'list_collections':
           result = await db.listCollections().toArray();
           break;
-         case 'create_collection':
+        case 'create_collection':
           const collection = await db.createCollection(queryOptions.collection, this.parseEJSON(queryOptions.options));
           result = {
             collectionName: collection.collectionName,
@@ -132,6 +132,9 @@ export default class MongodbService implements QueryService {
             .collection(queryOptions.collection)
             .aggregate(this.parseEJSON(queryOptions.pipeline), this.parseEJSON(queryOptions.options))
             .toArray();
+          break;
+        case 'create_objectid':
+          result = { objectId: new ObjectId().toHexString() };
           break;
       }
     } catch (error) {

--- a/plugins/packages/mongodb/lib/operations.json
+++ b/plugins/packages/mongodb/lib/operations.json
@@ -88,8 +88,24 @@
         {
           "name": "Bulk Operations",
           "value": "bulk_write"
+        },
+        {
+          "name": "Create ObjectId",
+          "value": "create_objectid"
         }
       ]
+    },
+    "create_objectid": {
+      "id": {
+        "label": "Hex String (optional)",
+        "key": "id",
+        "type": "codehinter",
+        "mode": "javascript",
+        "placeholder": "\"507f1f77bcf86cd799439011\"",
+        "description": "Enter a 24-character hex string to create ObjectId. Leave empty to auto-generate.",
+        "height": "36px",
+        "editorType": "extendedSingleLine"
+      }
     },
     "insert_one": {
       "collection": {


### PR DESCRIPTION
Added operation to generate ObjectID in mongoDB

SS:
<img width="889" height="582" alt="{F964B348-6F95-4D77-BEB5-CA08D6414A2C}" src="https://github.com/user-attachments/assets/2c5accb1-ff06-4d8d-b055-54a370512994" />
