### PR TITLE
Added GCP and EC2_AMI

### DIFF
--- a/docs/versioned_docs/version-3.16.0-LTS/setup/ami.md
+++ b/docs/versioned_docs/version-3.16.0-LTS/setup/ami.md
@@ -15,13 +15,19 @@ To use ToolJet AI features in your deployment, make sure to whitelist `https://a
 You should setup a PostgreSQL database manually to be used by ToolJet. We recommend using an **RDS PostgreSQL database**. You can find the system requirements [here](/docs/setup/system-requirements).
 :::
 
-## Deployment
+## Deploy using CloudFormation
 
 To deploy all the services at once, simply employ the following template:
 
 ```
 curl -LO https://tooljet-deployments.s3.us-west-1.amazonaws.com/cloudformation/EC2-cloudfomration.yml
 ```
+
+## Deploy using Terraform
+
+Use this terraform script to quickly spin up a vm.
+
+- Deploy on [AWS EC2 Using AMI](https://github.com/ToolJet/ToolJet/tree/develop/terraform/AMI_EC2)
 
 Follow the steps below to deploy ToolJet on AWS AMI instances.
 

--- a/docs/versioned_docs/version-3.16.0-LTS/setup/docker.md
+++ b/docs/versioned_docs/version-3.16.0-LTS/setup/docker.md
@@ -21,11 +21,12 @@ To enable ToolJet AI features in your ToolJet deployment, whitelist https://api-
 
 ### Provisioning VMs with Terraform (Optional)
 
-If you don’t already have a server, you can use Terraform scripts to quickly spin up a VM on AWS or Azure VM and then deploy ToolJet with Docker.
+If you don’t already have a server, you can use Terraform scripts to quickly spin up a VM on AWS, Azure or GCP and then deploy ToolJet with Docker.
 
-⚙️ Deploy on [AWS EC2](https://github.com/ToolJet/ToolJet/tree/develop/terraform/EC2)
-
-⚙️ Deploy on [Azure VM](https://github.com/ToolJet/ToolJet/tree/develop/terraform/Azure_VM)
+- Deploy on [AWS EC2](https://github.com/ToolJet/ToolJet/tree/develop/terraform/EC2)
+- Deploy on [AWS EC2 Using AMI](https://github.com/ToolJet/ToolJet/tree/develop/terraform/AMI_EC2)
+- Deploy on [Azure VM](https://github.com/ToolJet/ToolJet/tree/develop/terraform/Azure_VM)
+- Deploy on [Azure VM](https://github.com/ToolJet/ToolJet/tree/develop/terraform/GCP)
 
 ### Installing Docker and Docker Compose
 

--- a/docs/versioned_docs/version-3.16.0-LTS/setup/docker.md
+++ b/docs/versioned_docs/version-3.16.0-LTS/setup/docker.md
@@ -26,7 +26,7 @@ If you don’t already have a server, you can use Terraform scripts to quickly s
 - Deploy on [AWS EC2](https://github.com/ToolJet/ToolJet/tree/develop/terraform/EC2)
 - Deploy on [AWS EC2 Using AMI](https://github.com/ToolJet/ToolJet/tree/develop/terraform/AMI_EC2)
 - Deploy on [Azure VM](https://github.com/ToolJet/ToolJet/tree/develop/terraform/Azure_VM)
-- Deploy on [Azure VM](https://github.com/ToolJet/ToolJet/tree/develop/terraform/GCP)
+- Deploy on [GCP VM](https://github.com/ToolJet/ToolJet/tree/develop/terraform/GCP)
 
 ### Installing Docker and Docker Compose
 

--- a/terraform/AMI_EC2/ec2.tf
+++ b/terraform/AMI_EC2/ec2.tf
@@ -8,6 +8,7 @@ resource "tls_private_key" "tooljet_key" {
   algorithm = "RSA"
   rsa_bits  = 2048
 }
+
 # Define the key pair for EC2 access
 resource "aws_key_pair" "tooljet_key" {
   key_name   = "tooljet-key"
@@ -38,6 +39,7 @@ resource "aws_internet_gateway" "tooljet_igw" {
 resource "aws_subnet" "tooljet_public_subnet" {
   vpc_id                  = aws_vpc.tooljet_vpc.id
   cidr_block              = "10.0.1.0/24"
+  availability_zone       = var.availability_zone
   map_public_ip_on_launch = true
 
   tags = {
@@ -65,26 +67,26 @@ resource "aws_route_table_association" "tooljet_public_subnet_assoc" {
   route_table_id = aws_route_table.tooljet_public_route_table.id
 }
 
-# Define the EC2 instance
+# Define the EC2 instance using ToolJet AMI
 resource "aws_instance" "tooljet_instance" {
-  ami           = var.ami_id != "" ? var.ami_id : data.aws_ami.latest_custom_ami.id
-  instance_type = var.instance_type
-  key_name      = aws_key_pair.tooljet_key.key_name
-  #security_groups = [aws_security_group.tooljet_sg.name]
-  availability_zone = var.aws_instance_tooljet_instance_AZ
-  # Associate instance with the subnet and security group
-  subnet_id                   = aws_subnet.tooljet_public_subnet.id
-  vpc_security_group_ids      = [aws_security_group.tooljet_sg.id]
+  ami                         = var.tooljet_ami_id
+  instance_type              = var.instance_type
+  key_name                   = aws_key_pair.tooljet_key.key_name
+  subnet_id                  = aws_subnet.tooljet_public_subnet.id
+  vpc_security_group_ids     = [aws_security_group.tooljet_sg.id]
   associate_public_ip_address = true
-  depends_on                  = [aws_security_group.tooljet_sg]
+  availability_zone          = var.availability_zone
+
   # Root EBS volume configuration
   root_block_device {
-    volume_size = 20
+    volume_size = 20  
     volume_type = "gp3"
   }
-  # Load the shell script using file() function
-  user_data = file("${path.module}/install_tooljet.sh")
+
   tags = {
     Name = "TooljetAppServer"
   }
+
+  depends_on = [aws_security_group.tooljet_sg]
 }
+

--- a/terraform/AMI_EC2/output.tf
+++ b/terraform/AMI_EC2/output.tf
@@ -1,0 +1,21 @@
+# Outputs
+output "tooljet_private_key" {
+  value     = tls_private_key.tooljet_key.private_key_pem
+  sensitive = true
+}
+
+output "instance_ip" {
+  value = aws_instance.tooljet_instance.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.tooljet_instance.id
+}
+
+output "ami_id" {
+  value = var.tooljet_ami_id
+}
+
+output "ami_description" {
+  value = "Using ToolJet AMI ID: ${var.tooljet_ami_id}"
+}

--- a/terraform/AMI_EC2/sg.tf
+++ b/terraform/AMI_EC2/sg.tf
@@ -1,0 +1,27 @@
+# Define the security group
+resource "aws_security_group" "tooljet_sg" {
+  vpc_id      = aws_vpc.tooljet_vpc.id
+  name        = "tooljet-sg"
+  description = "Allow SSH, HTTP, HTTPS and ToolJet ports"
+
+  dynamic "ingress" {
+    for_each = var.ingress_ports
+    content {
+      from_port   = ingress.value
+      to_port     = ingress.value
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "TooljetSecurityGroup"
+  }
+}

--- a/terraform/AMI_EC2/terraform.tfvars
+++ b/terraform/AMI_EC2/terraform.tfvars
@@ -1,0 +1,8 @@
+region = ""
+availability_zone = ""
+instance_type = ""
+tooljet_ami_id = ""
+ingress_ports = [22, 80, 443, 3000]
+
+# terraform output -raw tooljet_private_key_pem > tooljet-key.pem
+# chmod 600 tooljet-key.pem

--- a/terraform/AMI_EC2/variables.tf
+++ b/terraform/AMI_EC2/variables.tf
@@ -1,0 +1,29 @@
+
+# Variables
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "availability_zone" {
+  description = "Availability zone for the subnet and instance"
+  type        = string
+  default     = "us-west-2a"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.medium"  # Recommended for ToolJet
+}
+
+variable "tooljet_ami_id" {
+  description = "ToolJet AMI ID - contact ToolJet team for the specific AMI ID in your region"
+  type        = string
+  
+}
+
+variable "ingress_ports" {
+  default = [22, 80, 443, 3000]
+}

--- a/terraform/GCP/install_tooljet.sh
+++ b/terraform/GCP/install_tooljet.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+sudo apt upgrade -y
+sudo apt update -y
+sudo apt install -y apt-transport-https ca-certificates curl software-properties-common
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt update -y
+
+sudo apt install -y docker-ce
+sudo systemctl start docker
+sudo systemctl enable docker

--- a/terraform/GCP/instance.tf
+++ b/terraform/GCP/instance.tf
@@ -1,0 +1,85 @@
+# Define provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+# Generate a TLS private key for SSH access
+resource "tls_private_key" "tooljet_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+# Create VPC network
+resource "google_compute_network" "tooljet_vpc" {
+  name                    = "tooljet-vpc"
+  auto_create_subnetworks = false
+  description             = "VPC network for Tooljet application"
+}
+
+# Create subnet
+resource "google_compute_subnetwork" "tooljet_subnet" {
+  name          = "tooljet-subnet"
+  ip_cidr_range = "10.0.1.0/24"
+  region        = var.region
+  network       = google_compute_network.tooljet_vpc.id
+}
+
+# Create firewall rules
+resource "google_compute_firewall" "tooljet_firewall" {
+  name    = "tooljet-firewall"
+  network = google_compute_network.tooljet_vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = var.firewall_ports
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["tooljet-server"]
+}
+
+# Get the latest Ubuntu image
+data "google_compute_image" "ubuntu" {
+  family  = "ubuntu-2404-lts-amd64"
+  project = "ubuntu-os-cloud"
+}
+
+# Create the compute instance
+resource "google_compute_instance" "tooljet_instance" {
+  name         = "tooljet-instance"
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  tags = ["tooljet-server"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.ubuntu.self_link
+      size  = 20
+      type  = "pd-standard"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.tooljet_vpc.id
+    subnetwork = google_compute_subnetwork.tooljet_subnet.id
+    
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  metadata = {
+    ssh-keys = "${var.ssh_username}:${tls_private_key.tooljet_key.public_key_openssh}"
+  }
+
+  metadata_startup_script = file("${path.module}/install_tooljet.sh")
+
+  service_account {
+    scopes = ["cloud-platform"]
+  }
+
+  depends_on = [google_compute_firewall.tooljet_firewall]
+}

--- a/terraform/GCP/outputs.tf
+++ b/terraform/GCP/outputs.tf
@@ -1,0 +1,25 @@
+output "tooljet_private_key" {
+  description = "The private SSH key for accessing the instance"
+  value       = tls_private_key.tooljet_key.private_key_pem
+  sensitive   = true
+}
+
+output "instance_ip" {
+  description = "The external IP address of the instance"
+  value       = google_compute_instance.tooljet_instance.network_interface[0].access_config[0].nat_ip
+}
+
+output "instance_id" {
+  description = "The ID of the compute instance"
+  value       = google_compute_instance.tooljet_instance.id
+}
+
+output "instance_name" {
+  description = "The name of the compute instance"
+  value       = google_compute_instance.tooljet_instance.name
+}
+
+output "ssh_command" {
+  description = "SSH command to connect to the instance"
+  value       = "ssh -i private_key.pem ${var.ssh_username}@${google_compute_instance.tooljet_instance.network_interface[0].access_config[0].nat_ip}"
+}

--- a/terraform/GCP/terraform.tfvars
+++ b/terraform/GCP/terraform.tfvars
@@ -1,0 +1,5 @@
+project_id    = "<your-project-id>"
+region        = "us-central1"
+zone          = "us-central1-a"
+machine_type  = "e2-medium"
+ssh_username  = "ubuntu"

--- a/terraform/GCP/variables.tf
+++ b/terraform/GCP/variables.tf
@@ -1,0 +1,34 @@
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "The GCP zone"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "machine_type" {
+  description = "The machine type for the compute instance"
+  type        = string
+  default     = "e2-medium"
+}
+
+variable "firewall_ports" {
+  description = "List of ports for firewall ingress"
+  type        = list(string)
+  default     = ["22", "80", "443", "3000"]
+}
+
+variable "ssh_username" {
+  description = "Username for SSH access"
+  type        = string
+  default     = "ubuntu"
+}


### PR DESCRIPTION
Added Terraform scripts for GCP and EC2_AMI also updated one file in EC2. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces new Terraform scripts for deploying resources on AWS EC2 and GCP, enhancing infrastructure setup for ToolJet applications with improved resource management and security. It includes configurations for networking, security groups, and updates to existing EC2 instance settings.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are well-structured and clear, making the review process straightforward.
-->
</div>