### PR TITLE
Fix: OAuth plugin fails due to undefined environmentId

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "frontend/ee"]
 	path = frontend/ee
 	url = https://github.com/ToolJet/ee-frontend.git
-    branch = main
+    branch = lts-3.16
 [submodule "server/ee"]
 	path = server/ee
 	url = https://github.com/ToolJet/ee-server.git
-    branch = main
+    branch = lts-3.16

--- a/frontend/src/_services/ai.service.js
+++ b/frontend/src/_services/ai.service.js
@@ -271,8 +271,8 @@ async function getCopilotSuggestion(body) {
 async function getCreditBalance() {
   const requestOptions = { method: 'GET', headers: authHeader(), credentials: 'include' };
 
-  return fetch(`${config.apiUrl}/ai/get-credits-balance`, requestOptions).then(
-    handleResponse({ avoidUpgradeModal: true })
+  return fetch(`${config.apiUrl}/ai/get-credits-balance`, requestOptions).then((response) =>
+    handleResponse(response, undefined, undefined, true)
   );
 }
 


### PR DESCRIPTION
Closes: [#13975](https://github.com/ToolJet/ToolJet/issues/13975)