### PR TITLE
[Elasticsearch]  add option to catch error while trying to run Test Connection

### DIFF
--- a/plugins/packages/elasticsearch/lib/index.ts
+++ b/plugins/packages/elasticsearch/lib/index.ts
@@ -79,12 +79,18 @@ export default class ElasticsearchService implements QueryService {
   }
 
   async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
-    const client = await this.getConnection(sourceOptions);
-    await client.info();
+    try{
+      const client = await this.getConnection(sourceOptions);
+      await client.info();
 
-    return {
-      status: 'ok',
-    };
+      return {
+        status: 'ok',
+        message: 'Connection successful',
+      };
+    }catch(err : any){
+      const errorMessage = err || 'Unknown error';
+      throw new QueryError(errorMessage, err,{});
+    }
   }
 
   determineProtocol(sourceOptions: SourceOptions) {


### PR DESCRIPTION
[Elasticsearch]  add option to catch error while trying to run "Test connection"