### PR TITLE
[hotfix]: set minimum width for CustomSelect component to table select and multiselect

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/CustomSelect.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/CustomSelect.jsx
@@ -39,6 +39,7 @@ const CustomMenuList = ({ optionsLoadingState, children, selectProps, inputRef, 
       style={{
         backgroundColor: 'var(--cc-surface1-surface)',
         border: '1px solid var(--cc-default-border)',
+        minWidth: '200px',
       }}
     >
       <div

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/_components/TableRow.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/_components/TableRow.jsx
@@ -108,8 +108,8 @@ export const TableRow = ({
                 fireEvent('onRowClicked');
                 return;
               }
-
-              if (isEditable && allowSelection && !selectRowOnCellEdit) {
+              // if the cell is editable and the row is selected, don't unselect the row
+              if (isEditable && allowSelection && (!selectRowOnCellEdit || row.getIsSelected())) {
                 e.stopPropagation();
                 fireEvent('onRowClicked');
               }


### PR DESCRIPTION
Fixes 

1.  set minimum width for CustomSelect component to table select and multiselect
2. Prevent deselection when editing selected field