### PR TITLE
Fix: When the table is placed inside a form, user is unable to select a row by directly clicking inside the checkbox

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Form/Form.jsx
+++ b/frontend/src/AppBuilder/Widgets/Form/Form.jsx
@@ -267,7 +267,7 @@ const FormComponent = (props) => {
     const formattedChildDataClone = deepClone(formattedChildData);
     const exposedVariables = {
       ...(!advanced && { children: formattedChildDataClone }),
-      data: removeFunctionObjects(formattedChildData),
+      data: removeFunctionObjects(formattedChildDataClone),
       isValid: childValidation,
       formData, // Expose formData
     };


### PR DESCRIPTION
Closes: https://github.com/ToolJet/ToolJet/issues/11537