### PR TITLE
Fix: OAuth datasource page crash

### DIFF
--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -1539,11 +1539,15 @@ export const hasBuilderRole = (roleObj) => {
 };
 
 export function checkIfToolJetCloud(version) {
+  if (!version) return false;
+  
   const parsed = version.split('-');
   return parsed[1] === 'cloud';
 }
 
 export function checkIfToolJetEE(version) {
+  if (!version) return false;
+  
   const parsed = version.split('-');
   return parsed[1] === 'ee';
 }


### PR DESCRIPTION
Fixes datasource page crash caused due to `tooljetVersion` being `undefined`.
Closes #14226 