### PR TITLE
Fix: disable query menu button for users without data source permission

### DIFF
--- a/frontend/src/AppBuilder/QueryPanel/QueryCard.jsx
+++ b/frontend/src/AppBuilder/QueryPanel/QueryCard.jsx
@@ -104,7 +104,7 @@ export const QueryCard = ({ dataQuery, darkMode = false, localDs }) => {
           if (isQuerySelected) return;
           if (!shouldFreeze) {
             const menuBtn = document.getElementById(`query-handler-menu-${dataQuery?.id}`);
-            if (menuBtn.contains(e.target)) {
+            if (menuBtn && menuBtn.contains(e.target)) {
               e.stopPropagation();
             } else {
               toggleQueryHandlerMenu(false);
@@ -159,7 +159,7 @@ export const QueryCard = ({ dataQuery, darkMode = false, localDs }) => {
             </div>
           )}
         </div>
-        {!shouldFreeze && (
+        {!shouldFreeze && hasPermissions && (
           <div className={`col-auto query-rename-delete-btn ${isQuerySelected ? 'd-flex' : 'd-none'}`}>
             <ButtonComponent
               iconOnly


### PR DESCRIPTION
Disables the query menu button for users lacking data source permissions to prevent unauthorized actions and null reference errors.

Context: This issue was reported internally in a private team Slack thread.