### PR TITLE
Fix: prevent cloning of app if app limit is reached

### DIFF
--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -389,9 +389,10 @@ class HomePageComponent extends React.Component {
     const { appsLimit } = this.state;
     const current = appsLimit?.current ?? 0;
     const total = appsLimit?.total ?? 0;
+    const canAddUnlimited = appsLimit?.canAddUnlimited ?? false;
 
     //  Check app limit before cloning
-    if (current >= total) {
+    if (!canAddUnlimited && current >= total) {
       toast.error("You have reached your maximum limit for apps. Upgrade your plan for more.");
       return;
     }


### PR DESCRIPTION
### Summary
- Added a check to prevent cloning an app when the app limit is reached.
- Shows a toast message: "You have reached your maximum limit for apps. Upgrade your plan for more."

-Reference - https://github.com/orgs/ToolJet/projects/28/views/14?sliceBy%5Bvalue%5D=_noValue&filterQuery=&pane=issue&itemId=135765173
