### PR TITLE
fix: enable click-outside to close nested color picker

### DIFF
--- a/frontend/src/AppBuilder/CodeBuilder/Elements/Color.jsx
+++ b/frontend/src/AppBuilder/CodeBuilder/Elements/Color.jsx
@@ -70,26 +70,27 @@ export const Color = ({
   };
 
   const ColorPicker = () => {
-    return (
-      <>
-        {SwatchesToggle()}
-        {showPicker && componentType === 'swatches' && CustomOptionList()}
-        {showPicker && componentType === 'color' && (
-          <div>
-            {/* <div style={coverStyles} onClick={() => setShowPicker(false)} /> */}
-            <div style={pickerStyle}>
-              <SketchPicker
-                onFocus={() => setShowPicker(true)}
-                color={value}
-                onChangeComplete={handleColorChange}
-                style={{ bottom: 0 }}
-              />
-            </div>
+  return (
+    <>
+      {SwatchesToggle()}
+      {showPicker && componentType === 'swatches' && CustomOptionList()}
+      {showPicker && componentType === 'color' && (
+        <div>
+          {/* Overlay to handle clicks outside the color picker */}
+          <div style={coverStyles} onClick={() => setShowPicker(false)} />
+          <div style={pickerStyle}>
+            <SketchPicker
+              onFocus={() => setShowPicker(true)}
+              color={value}
+              onChangeComplete={handleColorChange}
+              style={{ bottom: 0 }}
+            />
           </div>
-        )}
-      </>
-    );
-  };
+        </div>
+      )}
+    </>
+  );
+};
   const ColorPickerInputBox = () => {
     return (
       <div


### PR DESCRIPTION
Fixes #13918

This PR fixes the issue where nested color pickers (e.g., inside box shadow selectors) cannot be closed by clicking outside of them within the parent popup.

Root Cause
The overlay div that handles clicks outside the color picker was commented out in the code, preventing the picker from closing when clicking outside.

Changes Made
- Uncommented the overlay div (`coverStyles`) in the `ColorPicker` component
- Added comment explaining the fix for future reference
- This overlay creates a full-screen transparent layer that detects clicks outside the picker

File Changed
- `frontend/src/AppBuilder/CodeBuilder/Elements/Color.jsx` (Line 78)


 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes the nested color picker issue by enabling it to close when clicking outside of it, achieved by uncommenting an overlay div. A comment was also added for clarity regarding the overlay's purpose.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>