### PR TITLE
[Doc] Azure container apps V3.16 LTS

### DIFF
--- a/docs/versioned_docs/version-3.16.0-LTS/setup/azure-container.md
+++ b/docs/versioned_docs/version-3.16.0-LTS/setup/azure-container.md
@@ -29,7 +29,7 @@ ToolJet comes with a **built-in Redis setup**, which is used for multiplayer edi
    :::
    <img className="screenshot-full img-full" src="/img/setup/azure-container/step3-2.png" alt="Deploying ToolJet on Azure container apps" />
 5. Click on the **Create** button at the bottom of the page.
-6. Then you will be redirected to the Create Container App tab, uncheck the **Use quickstart image** option to select the image source manually. Make sure to provide the image tag, and then enter `server/entrypoint.sh, npm, run, start:prod` in the "Arguments override" field.
+6. Then you will be redirected to the Create Container App tab, uncheck the **Use quickstart image** option to select the image source manually. Make sure to provide the image tag, and then enter `server/ee-entrypoint.sh, npm, run, start:prod` in the "Arguments override" field.
    <img className="screenshot-full img-m" src="/img/setup/azure-container/step3-v2.png" alt="Deploying ToolJet on Azure container apps" />
 7. Under "Environmental variables", please add the below ToolJet application variables:
 


### PR DESCRIPTION

ERROR

```
2025-10-29T12:49:41.5530822Z stderr F npm notice New major version of npm available! 10.9.2 -> 11.6.2
2025-10-29T12:49:41.5531004Z stderr F npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.6.2
2025-10-29T12:49:41.5531040Z stderr F npm notice To update run: npm install -g npm@11.6.2
2025-10-29T12:49:41.5531062Z stderr F npm notice
2025-10-29T12:49:41.5579860Z stderr F ./server/ee-entrypoint.sh: line 75: /app/server/entrypoint.sh: No such file or directory
```
Updated `server/entrypoint.sh, npm, run, start:prod ` to  `server/ee-entrypoint.sh, npm, run, start:prod`
In V3.16 docs.