### PR TITLE
Added logs fetching

### DIFF
--- a/.github/workflows/render-preview-deploy.yml
+++ b/.github/workflows/render-preview-deploy.yml
@@ -943,36 +943,39 @@ jobs:
               // If deployment failed, fetch and include error logs
               if (status === 'build_failed' || status === 'deploy_failed' || status === 'failed') {
                 try {
-                  // Fetch logs using Render API - direction=backward to get most recent logs first
-                  const logsUrl = `https://api.render.com/v1/logs?resourceIds=${ceServiceId}&direction=backward&limit=20`;
-                  console.log('Fetching CE logs from:', logsUrl);
-                  
-                  const logsRes = await fetch(logsUrl, {
+                  const logsRes = await fetch(`https://api.render.com/v1/logs?direction=backward&limit=200`, {
                     headers: {
                       'accept': 'application/json',
                       'authorization': `Bearer ${apiKey}`
                     }
                   });
                   
-                  console.log('CE Logs Response Status:', logsRes.status);
-                  const logsResponse = await logsRes.json();
-                  console.log('CE Logs Response:', JSON.stringify(logsResponse).substring(0, 500));
+                  if (!logsRes.ok) {
+                    throw new Error(`HTTP error! status: ${logsRes.status}`);
+                  }
                   
-                  // The API returns an array of log objects directly
-                  if (Array.isArray(logsResponse) && logsResponse.length > 0) {
-                    // Extract log messages (logs are already in backward direction, so reverse to show chronologically)
-                    const allLogs = logsResponse.map(log => log.message || log.text || '').filter(msg => msg.trim() !== '').reverse();
-                    const errorLogs = allLogs.join('\n');
-                    if (errorLogs) {
-                      ceInfo += `\n\n**Error Logs (last 20 lines):**\n\`\`\`\n${errorLogs}\n\`\`\``;
+                  const logsData = await logsRes.json();
+                  
+                  if (logsData && logsData.logs && Array.isArray(logsData.logs) && logsData.logs.length > 0) {
+                    // Filter logs for this specific service
+                    const serviceLogs = logsData.logs.filter(log => {
+                      const resourceLabel = log.labels?.find(l => l.name === 'resource');
+                      return resourceLabel && resourceLabel.value === ceServiceId;
+                    });
+                    
+                    if (serviceLogs.length > 0) {
+                      // Get last 20 log messages
+                      const errorLogs = serviceLogs.slice(-20).map(log => log.message || '').filter(msg => msg.trim() !== '').join('\n');
+                      if (errorLogs) {
+                        ceInfo += `\n\n**Error Logs (last 20 lines):**\n\`\`\`\n${errorLogs}\n\`\`\``;
+                      }
+                    } else {
+                      ceInfo += `\n\n**Error Logs:** No logs found for this service`;
                     }
-                  } else {
-                    console.log('No logs found in response');
-                    ceInfo += `\n\n**Error Logs:** No logs available for this deployment`;
                   }
                 } catch (error) {
                   console.log('Failed to fetch CE error logs:', error);
-                  ceInfo += `\n\n**Error Logs:** Failed to retrieve error logs - ${error.message}`;
+                  ceInfo += `\n\n**Error Logs:** Failed to retrieve error logs`;
                 }
               }
             }
@@ -1052,36 +1055,39 @@ jobs:
               // If deployment failed, fetch and include error logs
               if (status === 'build_failed' || status === 'deploy_failed' || status === 'failed') {
                 try {
-                  // Fetch logs using Render API - direction=backward to get most recent logs first
-                  const logsUrl = `https://api.render.com/v1/logs?resourceIds=${eeServiceId}&direction=backward&limit=20`;
-                  console.log('Fetching EE logs from:', logsUrl);
-                  
-                  const logsRes = await fetch(logsUrl, {
+                  const logsRes = await fetch(`https://api.render.com/v1/logs?direction=backward&limit=200`, {
                     headers: {
                       'accept': 'application/json',
                       'authorization': `Bearer ${apiKey}`
                     }
                   });
                   
-                  console.log('EE Logs Response Status:', logsRes.status);
-                  const logsResponse = await logsRes.json();
-                  console.log('EE Logs Response:', JSON.stringify(logsResponse).substring(0, 500));
+                  if (!logsRes.ok) {
+                    throw new Error(`HTTP error! status: ${logsRes.status}`);
+                  }
                   
-                  // The API returns an array of log objects directly
-                  if (Array.isArray(logsResponse) && logsResponse.length > 0) {
-                    // Extract log messages (logs are already in backward direction, so reverse to show chronologically)
-                    const allLogs = logsResponse.map(log => log.message || log.text || '').filter(msg => msg.trim() !== '').reverse();
-                    const errorLogs = allLogs.join('\n');
-                    if (errorLogs) {
-                      eeInfo += `\n\n**Error Logs (last 20 lines):**\n\`\`\`\n${errorLogs}\n\`\`\``;
+                  const logsData = await logsRes.json();
+                  
+                  if (logsData && logsData.logs && Array.isArray(logsData.logs) && logsData.logs.length > 0) {
+                    // Filter logs for this specific service
+                    const serviceLogs = logsData.logs.filter(log => {
+                      const resourceLabel = log.labels?.find(l => l.name === 'resource');
+                      return resourceLabel && resourceLabel.value === eeServiceId;
+                    });
+                    
+                    if (serviceLogs.length > 0) {
+                      // Get last 20 log messages
+                      const errorLogs = serviceLogs.slice(-20).map(log => log.message || '').filter(msg => msg.trim() !== '').join('\n');
+                      if (errorLogs) {
+                        eeInfo += `\n\n**Error Logs (last 20 lines):**\n\`\`\`\n${errorLogs}\n\`\`\``;
+                      }
+                    } else {
+                      eeInfo += `\n\n**Error Logs:** No logs found for this service`;
                     }
-                  } else {
-                    console.log('No logs found in response');
-                    eeInfo += `\n\n**Error Logs:** No logs available for this deployment`;
                   }
                 } catch (error) {
                   console.log('Failed to fetch EE error logs:', error);
-                  eeInfo += `\n\n**Error Logs:** Failed to retrieve error logs - ${error.message}`;
+                  eeInfo += `\n\n**Error Logs:** Failed to retrieve error logs`;
                 }
               }
             }


### PR DESCRIPTION
if (status === 'build_failed' || status === 'deploy_failed' || status === 'failed') {
  // Fetch error logs
  GET /v1/services/{serviceId}/deploys/{deployId}/logs
  
  // Extract last 20 log entries
  // Append to comment
}
```

**Step 1: Comment with Error Logs** (when failed)
```
### Community Edition
- App: https://tooljet-ce-pr-14504.onrender.com
- Dashboard: https://dashboard.render.com/web/srv-xyz123
- Commit: 05fff73
- Message: chore: Replace query panel icons with lucid icons
- Status: failed ❌

**Error Logs (last 20 lines):**
```
Error: Docker build failed at layer 15
npm ERR! code ELIFECYCLE
npm ERR! errno 1
... (up to 20 lines of actual errors)
```
```

**Step 2: Remove Label**
```
Automatically removes: render-check-deployment label


