### PR TITLE
Perf: lazy load components not required on viewer page and widgets with bigger external dependencies

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback, Suspense, lazy } from 'react';
 import { Container } from './Container';
-import Grid from './Grid';
-import { EditorSelecto } from './Selecto';
 import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
 import { HotkeyProvider } from './HotkeyProvider';
 import './appCanvas.scss';
@@ -28,7 +26,8 @@ import { debounce } from 'lodash';
 
 // Lazy load editor-only component to reduce viewer bundle size
 const AppCanvasBanner = lazy(() => import('@/AppBuilder/Header/AppCanvasBanner'));
-
+const EditorSelecto = React.lazy(() => import('./Selecto'));
+const Grid = React.lazy(() => import('./Grid'));
 
 export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
   const { moduleId, isModuleMode, appType } = useModuleContext();
@@ -127,8 +126,8 @@ export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
       currentMode === 'view'
         ? computeViewerBackgroundColor(isAppDarkMode, canvasBgColor)
         : !isAppDarkMode
-          ? '#EBEBEF'
-          : '#2F3C4C';
+        ? '#EBEBEF'
+        : '#2F3C4C';
 
     if (isModuleMode) {
       return {
@@ -310,13 +309,19 @@ export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
               )}
 
               {currentMode === 'view' || (currentLayout === 'mobile' && isAutoMobileLayout) ? null : (
-                <Grid currentLayout={currentLayout} gridWidth={gridWidth} />
+                <Suspense fallback="Loading...">
+                  <Grid currentLayout={currentLayout} gridWidth={gridWidth} />
+                </Suspense>
               )}
             </HotkeyProvider>
           </div>
         </div>
       </div>
-      {currentMode === 'edit' && <EditorSelecto />}
+      {currentMode === 'edit' && (
+        <Suspense fallback="Loading...">
+          <EditorSelecto />
+        </Suspense>
+      )}
     </div>
   );
 };

--- a/frontend/src/AppBuilder/AppCanvas/RenderWidget.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/RenderWidget.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect, useMemo, useState, Suspense } from 'react';
+import React, { memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import useStore from '@/AppBuilder/_stores/store';
 import { shallow } from 'zustand/shallow';
 import { getComponentToRender } from '@/AppBuilder/_helpers/editorHelpers';
@@ -7,9 +7,6 @@ import { renderTooltip } from '@/_helpers/appUtils';
 import { useTranslation } from 'react-i18next';
 import ErrorBoundary from '@/_ui/ErrorBoundary';
 import { BOX_PADDING } from './appCanvasConstants';
-
-// Components that are lazy loaded and need Suspense wrapper
-const LAZY_LOADED_COMPONENTS = ['ModuleContainer', 'ModuleViewer'];
 
 const SHOULD_ADD_BOX_SHADOW_AND_VISIBILITY = [
   'Table',
@@ -234,31 +231,7 @@ const RenderWidget = ({
               : ''
           }`} //required for custom CSS
         >
-          {LAZY_LOADED_COMPONENTS.includes(componentType) ? (
-            <Suspense fallback={<div style={{ height: '100%', width: '100%' }} />}>
-              <ComponentToRender
-                id={id}
-                key={key}
-                {...obj}
-                setExposedVariable={setExposedVariable}
-                setExposedVariables={setExposedVariables}
-                height={widgetHeight - 4}
-                width={widgetWidth}
-                parentId={parentId}
-                fireEvent={fireEventWrapper}
-                validate={validate}
-                resetComponent={resetComponent}
-                onComponentClick={onComponentClick}
-                darkMode={darkMode}
-                componentName={componentName}
-                adjustComponentPositions={adjustComponentPositions}
-                componentCount={componentCount}
-                dataCy={`draggable-widget-${componentName}`}
-                currentMode={currentMode}
-                subContainerIndex={subContainerIndex}
-              />
-            </Suspense>
-          ) : (
+          <Suspense fallback="Loading...">
             <ComponentToRender
               id={id}
               key={key}
@@ -280,7 +253,7 @@ const RenderWidget = ({
               currentMode={currentMode}
               subContainerIndex={subContainerIndex}
             />
-          )}
+          </Suspense>
         </div>
       </OverlayTrigger>
     </ErrorBoundary>

--- a/frontend/src/AppBuilder/AppCanvas/Selecto.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/Selecto.jsx
@@ -7,7 +7,7 @@ import { shallow } from 'zustand/shallow';
 import { findHighestLevelofSelection } from './Grid/gridUtils';
 import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
 
-export const EditorSelecto = () => {
+const EditorSelecto = () => {
   const { moduleId } = useModuleContext();
   const setActiveRightSideBarTab = useStore((state) => state.setActiveRightSideBarTab);
   const setRightSidebarOpen = useStore((state) => state.setRightSidebarOpen);
@@ -142,3 +142,5 @@ export const EditorSelecto = () => {
     </>
   );
 };
+
+export default EditorSelecto;

--- a/frontend/src/AppBuilder/Widgets/Calendar/Calendar.jsx
+++ b/frontend/src/AppBuilder/Widgets/Calendar/Calendar.jsx
@@ -27,7 +27,7 @@ const parseDate = (date, dateFormat) => {
 
 const allowedCalendarViews = ['month', 'week', 'day'];
 
-export const Calendar = function ({
+export default function Calendar({
   id,
   component,
   height,
@@ -65,7 +65,7 @@ export const Calendar = function ({
         : {};
     const color = event.textColor ?? 'white';
     const style = { backgroundColor, ...textStyle, padding: 3, paddingLeft: 5, paddingRight: 5, color };
-    
+
     return { style };
   };
 
@@ -200,4 +200,4 @@ export const Calendar = function ({
       />
     </div>
   );
-};
+}

--- a/frontend/src/AppBuilder/Widgets/Chart.jsx
+++ b/frontend/src/AppBuilder/Widgets/Chart.jsx
@@ -12,7 +12,7 @@ import { getCssVarValue, getModifiedColor } from './utils';
 
 var tinycolor = require('tinycolor2');
 
-export const Chart = function Chart({
+export default function Chart({
   width,
   height,
   darkMode,
@@ -26,7 +26,6 @@ export const Chart = function Chart({
   const isInitialRender = useRef(true);
   const [loadingState, setLoadingState] = useState(false);
   const themeChanged = useStore((state) => state.themeChanged);
-
 
   const getColor = (color) => {
     if (tinycolor(color).getBrightness() > 128) return '#000';
@@ -290,7 +289,7 @@ export const Chart = function Chart({
       )}
     </div>
   );
-};
+}
 
 // onClick event was not working when the component is re-rendered for every click. Hance, memoization is used
 const PlotComponent = memo(

--- a/frontend/src/AppBuilder/Widgets/Chat/index.js
+++ b/frontend/src/AppBuilder/Widgets/Chat/index.js
@@ -12,7 +12,7 @@ import { validateMessageHistory, validateSingleMessageObject } from './utils/hel
 import toast from 'react-hot-toast';
 import { getModifiedColor } from '@/AppBuilder/Widgets/utils';
 
-export const Chat = ({ id, component, properties, styles, setExposedVariables, fireEvent }) => {
+const Chat = ({ id, component, properties, styles, setExposedVariables, fireEvent }) => {
     const darkTheme = localStorage.getItem('darkMode') === 'true';
     const chatMessagesRef = useRef(null);
 
@@ -383,3 +383,5 @@ export const Chat = ({ id, component, properties, styles, setExposedVariables, f
         </div>
     );
 };
+
+export default Chat;

--- a/frontend/src/AppBuilder/Widgets/FilePicker.jsx
+++ b/frontend/src/AppBuilder/Widgets/FilePicker.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import FilePickerComponent from '@/AppBuilder/Widgets/FilePicker/FilePicker';
 
 // This component now acts as a wrapper, passing props to the new implementation
-export const FilePicker = (props) => {
+const FilePicker = (props) => {
   return <FilePickerComponent {...props} />;
 };
 
@@ -31,3 +31,5 @@ FilePicker.propTypes = {
   All the original logic (hooks, state, helper functions, effects, rendering)
   has been moved to frontend/src/AppBuilder/Widgets/FilePicker/FilePicker.jsx
 */
+
+export default FilePicker;

--- a/frontend/src/AppBuilder/Widgets/Form/RenderSchema.jsx
+++ b/frontend/src/AppBuilder/Widgets/Form/RenderSchema.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, Suspense } from 'react';
 import { getComponentToRender } from '@/AppBuilder/_helpers/editorHelpers';
 import useStore from '@/AppBuilder/_stores/store';
 import { shallow } from 'zustand/shallow';
@@ -38,21 +38,23 @@ const RenderSchema = ({ component, parent, id, onOptionChange, onOptionsChange, 
 
   const formId = `${parent}-${id}`;
   return (
-    <ComponentToRender
-      properties={component?.definition?.properties}
-      styles={component?.definition?.styles}
-      generalProperties={component?.definition?.general}
-      generalStyles={component?.definition?.generalStyles}
-      width={component?.defaultSize?.width}
-      height={component?.defaultSize?.height}
-      setExposedVariable={setExposedVariable}
-      setExposedVariables={setExposedVariables}
-      validate={validate}
-      darkMode={darkMode}
-      fireEvent={fireEvent}
-      formId={formId}
-      id={id}
-    />
+    <Suspense fallback="Loading...">
+      <ComponentToRender
+        properties={component?.definition?.properties}
+        styles={component?.definition?.styles}
+        generalProperties={component?.definition?.general}
+        generalStyles={component?.definition?.generalStyles}
+        width={component?.defaultSize?.width}
+        height={component?.defaultSize?.height}
+        setExposedVariable={setExposedVariable}
+        setExposedVariables={setExposedVariables}
+        validate={validate}
+        darkMode={darkMode}
+        fireEvent={fireEvent}
+        formId={formId}
+        id={id}
+      />
+    </Suspense>
   );
 };
 

--- a/frontend/src/AppBuilder/Widgets/Image/Image.jsx
+++ b/frontend/src/AppBuilder/Widgets/Image/Image.jsx
@@ -9,7 +9,7 @@ import ZoomOutImage from '@/AppBuilder/Widgets/Image/icons/zoomout-image.svg';
 import RotateImage from '@/AppBuilder/Widgets/Image/icons/rotate-image.svg';
 import './image.scss';
 
-export const Image = function Image({
+export default function Image({
   setExposedVariable,
   setExposedVariables,
   componentName,
@@ -342,4 +342,4 @@ export const Image = function Image({
       )}
     </div>
   );
-};
+}

--- a/frontend/src/AppBuilder/Widgets/Map/Map.jsx
+++ b/frontend/src/AppBuilder/Widgets/Map/Map.jsx
@@ -6,7 +6,7 @@ import { darkModeStyles } from './styles';
 import { useTranslation } from 'react-i18next';
 import './styles.scss';
 
-export const Map = function Map({
+export default function Map({
   id,
   width,
   height,
@@ -228,4 +228,4 @@ export const Map = function Map({
       </LoadScript>
     </div>
   );
-};
+}

--- a/frontend/src/AppBuilder/Widgets/PDF.jsx
+++ b/frontend/src/AppBuilder/Widgets/PDF.jsx
@@ -12,7 +12,7 @@ const PasswordResponses = {
 // Using new URL keeps this portable across bundlers (Webpack 5, Vite, etc.)
 pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
 
-export const PDF = React.memo(({ styles, properties, width, height, componentName, dataCy }) => {
+const PDF = React.memo(({ styles, properties, width, height, componentName, dataCy }) => {
   const { visibility, boxShadow } = styles;
   const { url, scale, pageControls, showDownloadOption } = properties;
   const [numPages, setNumPages] = useState(null);
@@ -250,3 +250,5 @@ export const PDF = React.memo(({ styles, properties, width, height, componentNam
     </div>
   );
 });
+
+export default PDF;

--- a/frontend/src/AppBuilder/Widgets/QrScanner/QrScanner.jsx
+++ b/frontend/src/AppBuilder/Widgets/QrScanner/QrScanner.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import QrReader from 'react-qr-reader';
 import ErrorModal from './ErrorModal';
 
-export const QrScanner = function QrScanner({ styles, fireEvent, setExposedVariable, dataCy }) {
+export default function QrScanner({ styles, fireEvent, setExposedVariable, dataCy }) {
   const handleError = async (errorMessage) => {
     console.log(errorMessage);
     await setErrorOccured(true);
@@ -24,4 +24,4 @@ export const QrScanner = function QrScanner({ styles, fireEvent, setExposedVaria
       {errorOccured ? <ErrorModal /> : <QrReader onError={handleError} onScan={handleScan} />}
     </div>
   );
-};
+}

--- a/frontend/src/AppBuilder/Widgets/RichTextEditor.jsx
+++ b/frontend/src/AppBuilder/Widgets/RichTextEditor.jsx
@@ -4,7 +4,7 @@ import 'draft-js/dist/Draft.css';
 import { DraftEditor } from './DraftEditor';
 import { useDynamicHeight } from '@/_hooks/useDynamicHeight';
 
-export const RichTextEditor = function RichTextEditor({
+export default function RichTextEditor({
   id,
   width,
   height,
@@ -103,4 +103,4 @@ export const RichTextEditor = function RichTextEditor({
       ></DraftEditor>
     </div>
   );
-};
+}

--- a/frontend/src/AppBuilder/Widgets/TreeSelect.jsx
+++ b/frontend/src/AppBuilder/Widgets/TreeSelect.jsx
@@ -5,7 +5,7 @@ import CheckboxTree from 'react-checkbox-tree';
 import 'react-checkbox-tree/lib/react-checkbox-tree.css';
 import { isExpectedDataType } from '@/_helpers/utils.js';
 
-export const TreeSelect = ({
+const TreeSelect = ({
   height,
   properties,
   styles,
@@ -136,3 +136,5 @@ export const TreeSelect = ({
     </div>
   );
 };
+
+export default TreeSelect;

--- a/frontend/src/AppBuilder/_helpers/editorHelpers.js
+++ b/frontend/src/AppBuilder/_helpers/editorHelpers.js
@@ -1,12 +1,11 @@
+import { lazy } from 'react';
 import { Button } from '@/AppBuilder/Widgets/Button';
-import { Image } from '@/AppBuilder/Widgets/Image/Image';
 import { Text } from '@/AppBuilder/Widgets/Text';
 import { Table } from '@/AppBuilder/Widgets/NewTable/Table';
 
 import { TextInput } from '@/AppBuilder/Widgets/TextInput';
 import { TextArea } from '@/AppBuilder/Widgets/TextArea';
 import { NumberInput } from '@/AppBuilder/Widgets/NumberInput';
-import { RichTextEditor } from '@/AppBuilder/Widgets/RichTextEditor';
 import { DropDown } from '@/AppBuilder/Widgets/DropDown';
 import { DropdownV2 } from '@/AppBuilder/Widgets/DropdownV2/DropdownV2';
 import { Checkbox } from '@/AppBuilder/Widgets/Checkbox';
@@ -18,16 +17,12 @@ import { TimePicker } from '@/AppBuilder/Widgets/Date/TimePicker';
 import { DaterangePicker } from '@/AppBuilder/Widgets/Date/DaterangePicker';
 import { Multiselect } from '@/AppBuilder/Widgets/Multiselect';
 import { MultiselectV2 } from '@/AppBuilder/Widgets/MultiselectV2/MultiselectV2';
-import { Chart } from '@/AppBuilder/Widgets/Chart';
-import { Map as MapComponent } from '@/AppBuilder/Widgets/Map/Map';
-import { QrScanner } from '@/AppBuilder/Widgets/QrScanner/QrScanner';
 import { ToggleSwitch } from '@/AppBuilder/Widgets/Toggle';
 import { ToggleSwitchV2 } from '@/AppBuilder/Widgets/ToggleV2';
 import { RadioButton } from '@/AppBuilder/Widgets/RadioButton';
 import { RadioButtonV2 } from '@/AppBuilder/Widgets/RadioButtonV2/RadioButtonV2';
 import { Rating as StarRating } from '@/AppBuilder/Widgets/Rating/Rating';
 import { Divider } from '@/AppBuilder/Widgets/Divider';
-import { FilePicker } from '@/AppBuilder/Widgets/FilePicker';
 import { PasswordInput } from '@/AppBuilder/Widgets/PasswordInput';
 import { EmailInput } from '@/AppBuilder/Widgets/EmailInput';
 import { PhoneInput } from '@/AppBuilder/Widgets/PhoneCurrency/PhoneInput';
@@ -51,14 +46,12 @@ import { VerticalDivider } from '@/AppBuilder/Widgets/VerticalDivider';
 import { ColorPicker } from '@/AppBuilder/Widgets/ColorPicker';
 import { KanbanBoard } from '@/AppBuilder/Widgets/KanbanBoard/KanbanBoard';
 import { Steps } from '@/AppBuilder/Widgets/Steps';
-import { TreeSelect } from '@/AppBuilder/Widgets/TreeSelect';
 import { Icon } from '@/AppBuilder/Widgets/Icon';
 import { Link } from '@/AppBuilder/Widgets/Link/Link';
 import { BoundedBox } from '@/AppBuilder/Widgets/BoundedBox/BoundedBox';
 import { isPDFSupported } from '@/_helpers/appUtils';
 
 import { Form } from '@/AppBuilder/Widgets/Form/Form';
-import { Calendar } from '@/AppBuilder/Widgets/Calendar/Calendar';
 import { Container } from '@/AppBuilder/Widgets/Container/Container';
 import { Listview } from '@/AppBuilder/Widgets/Listview/Listview';
 import { Tabs } from '@/AppBuilder/Widgets/Tabs';
@@ -66,20 +59,26 @@ import { Kanban } from '@/AppBuilder/Widgets/Kanban/Kanban';
 import { Modal } from '@/AppBuilder/Widgets/Modal';
 import { ModalV2 } from '@/AppBuilder/Widgets/ModalV2/ModalV2';
 
-import { Chat } from '@/AppBuilder/Widgets/Chat';
-import { lazy } from 'react';
-
 // Lazy load module components to reduce viewer bundle size
 const ModuleContainer = lazy(() =>
   import('@/modules/Modules/components').then((m) => ({ default: m.ModuleContainer }))
 );
-const ModuleViewer = lazy(() =>
-  import('@/modules/Modules/components').then((m) => ({ default: m.ModuleViewer }))
-);
+const ModuleViewer = lazy(() => import('@/modules/Modules/components').then((m) => ({ default: m.ModuleViewer })));
 
 import { APP_HEADER_HEIGHT, QUERY_PANE_HEIGHT } from '../AppCanvas/appCanvasConstants';
 
 // import './requestIdleCallbackPolyfill';
+
+const Calendar = lazy(() => import('@/AppBuilder/Widgets/Calendar/Calendar'));
+const Chart = lazy(() => import('@/AppBuilder/Widgets/Chart'));
+const Chat = lazy(() => import('@/AppBuilder/Widgets/Chat'));
+const FilePicker = lazy(() => import('@/AppBuilder/Widgets/FilePicker'));
+const Image = lazy(() => import('@/AppBuilder/Widgets/Image/Image'));
+const MapComponent = lazy(() => import('@/AppBuilder/Widgets/Map/Map'));
+const PDF = lazy(() => import('@/AppBuilder/Widgets/PDF'));
+const QrScanner = lazy(() => import('@/AppBuilder/Widgets/QrScanner/QrScanner'));
+const RichTextEditor = lazy(() => import('@/AppBuilder/Widgets/RichTextEditor'));
+const TreeSelect = lazy(() => import('@/AppBuilder/Widgets/TreeSelect'));
 
 export function memoizeFunction(func) {
   const cache = new Map();
@@ -167,7 +166,7 @@ export const AllComponents = {
   ModuleViewer,
 };
 if (isPDFSupported()) {
-  AllComponents.PDF = await import('@/AppBuilder/Widgets/PDF').then((module) => module.PDF);
+  AllComponents.PDF = PDF;
 }
 
 export const getComponentToRender = (componentName) => {
@@ -361,5 +360,5 @@ export function checkAndExtractEntityId(errorString) {
 
 export const computeCanvasContainerHeight = (queryPanelHeight, isDraggingQueryPane) => {
   return `calc(${100}% - ${isDraggingQueryPane ? 0 : Math.max(queryPanelHeight + APP_HEADER_HEIGHT, APP_HEADER_HEIGHT + QUERY_PANE_HEIGHT)
-    }px)`;
+  }px)`;
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -129,6 +129,7 @@ module.exports = {
       }),
     ],
     splitChunks: {
+      chunks: 'all',
       // chunks: 'all',
       // maxInitialRequests: 10, // Reduced from 25 - limits initial load chunks
       // maxAsyncRequests: 10,   // Limits async chunks (lazy loaded)
@@ -216,15 +217,18 @@ module.exports = {
         //   reuseExistingChunk: true,
         // },
 
-        // Everything else - catch-all for remaining node_modules
         defaultVendors: {
           test: /[\\/]node_modules[\\/]/,
           name: 'vendor',
-          chunks: 'all',
-          // name: 'vendor-misc',
-          // priority: 10,
-          // minChunks: 2, // Only split if used in 2+ places
-          // reuseExistingChunk: true,
+          priority: -10,
+          reuseExistingChunk: true,
+          chunks: 'initial',
+        },
+        lucideReact: {
+          test: /[\\/]node_modules[\\/]lucide-react/,
+          name: 'lucide-react',
+          priority: 20, // Higher priority than vendors
+          reuseExistingChunk: true,
         },
       },
     },
@@ -354,6 +358,7 @@ module.exports = {
   output: {
     publicPath: ASSET_PATH,
     path: path.resolve(__dirname, 'build'),
+    // chunkFilename: '[name].[contenthash].js',
   },
   externals: {
     // global app config object


### PR DESCRIPTION
Before:

<img width="1510" height="856" alt="image" src="https://github.com/user-attachments/assets/07057c5f-a66d-4690-8051-38437a05e695" />

After:

<img width="1512" height="858" alt="image" src="https://github.com/user-attachments/assets/2ef908be-749a-4ffc-b5b8-0c1711165f23" />

Lazy loading done for below components
- Widgets like Chart, FilePicker, PDF, Chat, RichTextEditor, QrScanner, Calendar, Map, Image & TreeSelect
- Grid & Selecto components and its dependencies which are not required on Viewer page

This helps us in decreasing the initial load time of an app by lazy loading things which are not always required, hence boosting up the page load speed.

Resolves: https://github.com/ToolJet/tj-ee/issues/4518