### PR TITLE
fix: add effect to clear edited rows and update exposed variables on data change

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -244,6 +244,8 @@ export const TableExposedVariables = ({
     }
   }, [allowSelection, lastClickedRow, selectedRows, setExposedVariables, showBulkSelector]);
 
+
+  // Clear dataUpdates & changeSet when data is changed
   useEffect(() => {
     if (!hasDataChanged) return;
     clearEditedRows(id);


### PR DESCRIPTION
Resolves [When a table cell value is updated, the row beneath it gets modified as well.](https://github.com/orgs/ToolJet/projects/26/views/4?filterQuery=sprint%3A%40current+++assignee%3Amanishkushare&pane=issue&itemId=125866382&issue=ToolJet%7Ctj-ee%7C4105)