### PR TITLE
feat: add env vars to disable check ca certificate tls in db connection

### DIFF
--- a/docs/docs/setup/env-vars.md
+++ b/docs/docs/setup/env-vars.md
@@ -27,6 +27,7 @@ ToolJet requires several environment variables to function properly. Below is a 
 - `PG_USER`: Username
 - `PG_PASS`: Password
 - `PG_PORT`: Port
+- `PG_DISABLE_SSL_VERIFY_CERT`: Disable TLS CA certificate check (self signed), default is false
   
 **Docker Compose Setup:** If you are using a Docker Compose setup with an in-built PostgreSQL instance, set `PG_HOST` to `postgres`. This ensures that Docker's internal DNS resolves the hostname correctly, allowing the ToolJet server to connect to the database seamlessly.
 
@@ -47,6 +48,7 @@ Replace `username`, `password`, `hostname`, `port`, and `database_name` with you
 - `TOOLJET_DB_USER`: Database username
 - `TOOLJET_DB_PASS`: Database password
 - `TOOLJET_DB_PORT`: Database port
+- `TOOLJET_DB_DISABLE_SSL_VERIFY_CERT`: Disable database TLS CA certificate check (self signed), default is false
 
 #### Why ToolJet Requires Two Databases
 

--- a/server/data-migration-config.ts
+++ b/server/data-migration-config.ts
@@ -7,13 +7,13 @@ function sslConfig(envVars) {
   if (envVars?.DATABASE_URL)
     config = {
       url: envVars.DATABASE_URL,
-      ssl: { rejectUnauthorized: false },
+      ssl: { rejectUnauthorized: envVars?.PG_DISABLE_SSL_VERIFY_CERT || false },
     };
 
   if (envVars?.CA_CERT)
     config = {
       ...config,
-      ...{ ssl: { rejectUnauthorized: false, ca: envVars.CA_CERT } },
+      ...{ ssl: { rejectUnauthorized: envVars?.PG_DISABLE_SSL_VERIFY_CERT || false, ca: envVars.CA_CERT } },
     };
 
   return config;

--- a/server/ormconfig.ts
+++ b/server/ormconfig.ts
@@ -7,13 +7,13 @@ function dbSslConfig(envVars) {
   if (envVars?.DATABASE_URL)
     config = {
       url: envVars.DATABASE_URL,
-      ssl: { rejectUnauthorized: false },
+      ssl: { rejectUnauthorized: envVars?.PG_DISABLE_SSL_VERIFY_CERT || false },
     };
 
   if (envVars?.CA_CERT)
     config = {
       ...config,
-      ...{ ssl: { rejectUnauthorized: false, ca: envVars.CA_CERT } },
+      ...{ ssl: { rejectUnauthorized: envVars?.PG_DISABLE_SSL_VERIFY_CERT || false, ca: envVars.CA_CERT } },
     };
 
   return config;
@@ -25,13 +25,13 @@ function tooljetDbSslConfig(envVars) {
   if (envVars?.TOOLJET_DB_URL)
     config = {
       url: envVars.TOOLJET_DB_URL,
-      ssl: { rejectUnauthorized: false },
+      ssl: { rejectUnauthorized: envVars?.TOOLJET_DB_DISABLE_SSL_VERIFY_CERT || false },
     };
 
   if (envVars?.CA_CERT)
     config = {
       ...config,
-      ...{ ssl: { rejectUnauthorized: false, ca: envVars.CA_CERT } },
+      ...{ ssl: { rejectUnauthorized: envVars?.TOOLJET_DB_DISABLE_SSL_VERIFY_CERT || false, ca: envVars.CA_CERT } },
     };
 
   return config;

--- a/server/scripts/populate-sample-db.ts
+++ b/server/scripts/populate-sample-db.ts
@@ -27,7 +27,7 @@ function createPGconnection(envVars): Client {
   if (envVars?.CA_CERT) {
     config = {
       ...config,
-      ssl: { rejectUnauthorized: false, ca: envVars.CA_CERT },
+      ssl: { rejectUnauthorized: envVars?.SAMPLE_PG_DB_DISABLE_SSL_VERIFY_CERT || false, ca: envVars.CA_CERT },
     };
   }
 


### PR DESCRIPTION
enables `rejectUnauthorized: true` in ORM config, default is still false 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces a risk by allowing the disabling of CA certificate verification through environment variables, which may weaken database connection security.</li>

<li>The changes affect multiple configuration files, ensuring that SSL settings can be dynamically adjusted based on the provided environment variables.</li>

<li>This feature aims to improve flexibility in database connections, particularly in development or testing environments.</li>

<li>Overall, the changes introduce risks related to database connection security by modifying SSL settings in multiple configuration files.</li>

</ul>

</div>