### PR TITLE
fix(group-permissions): correct userId/groupId mapping in createGroup…

### DIFF
--- a/server/src/modules/group-permissions/repository.ts
+++ b/server/src/modules/group-permissions/repository.ts
@@ -181,7 +181,7 @@ export class GroupPermissionsRepository extends Repository<GroupPermissions> {
   createGroupUser(userId: string, groupId: string, manager?: EntityManager): Promise<GroupUsers> {
     return dbTransactionWrap((manager: EntityManager) => {
       return catchDbException(() => {
-        return manager.save(manager.create(GroupUsers, { groupId: userId }));
+        return manager.save(manager.create(GroupUsers, { userId: groupId }));
       }, [DATA_BASE_CONSTRAINTS.GROUP_USER_UNIQUE]);
     }, manager);
   }


### PR DESCRIPTION
### Summary
Fixes an incorrect mapping in `GroupPermissionsRepository.createGroupUser`, where the method mistakenly created:

```ts
manager.create(GroupUsers, { groupId: userId });
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request fixes a bug in the GroupPermissionsRepository by correcting the mapping of userId and groupId in the createGroupUser method, which previously used groupId as userId, potentially leading to incorrect data being saved.</li>

<li>The fix ensures that the correct identifiers are used, improving the integrity of group user creation.</li>

<li>Overall, this update addresses a critical bug in the GroupPermissionsRepository related to user and group identifier mapping.</li>

</ul>

</div>