### PR TITLE
[#14778] Fix: ListView nested Container context propagation (listItem undefined)

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/RenderWidget.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/RenderWidget.jsx
@@ -224,6 +224,7 @@ const RenderWidget = ({
             adjustComponentPositions={adjustComponentPositions}
             componentCount={componentCount}
             dataCy={`draggable-widget-${componentName}`}
+            subContainerIndex={subContainerIndex}
           />
         </div>
       </OverlayTrigger>

--- a/frontend/src/AppBuilder/Widgets/Container/Container.jsx
+++ b/frontend/src/AppBuilder/Widgets/Container/Container.jsx
@@ -25,6 +25,7 @@ export const Container = ({
   adjustComponentPositions,
   currentLayout,
   componentCount = 0,
+  subContainerIndex,
 }) => {
   const { isDisabled, isVisible, isLoading } = useExposeState(
     properties.loadingState,
@@ -149,6 +150,7 @@ export const Container = ({
               canvasWidth={width}
               darkMode={darkMode}
               componentType="Container"
+              index={subContainerIndex}
             />
           </div>
         </>


### PR DESCRIPTION
## Description
Fixes a bug where widgets placed inside a Container, which itself is nested within a ListView, could not access the `{{ listItem }}` context variable.

The issue was that the `subContainerIndex` (representing the current row in the ListView) was dropped when rendering the Container widget, breaking the context chain for any children nested deeper.

## Changes
- **frontend/src/AppBuilder/AppCanvas/RenderWidget.jsx**: Updated to pass `subContainerIndex` to the component being rendered.
- **frontend/src/AppBuilder/Widgets/Container/Container.jsx**: Updated the Container widget to accept `subContainerIndex` and forward it as the `index` prop to its internal `ContainerComponent`.

## How to Test
1. Drag a **ListView** widget onto the canvas.
2. Place a **Container** widget inside the ListView.
3. Place a **Text** widget inside that Container.
4. Set the Text widget's data to `{{ listItem.first_name }}` (or any field from your list data).
5. **Verify:** The text widget now correctly displays data for each row instead of showing undefined/empty. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request addresses a bug related to context propagation in nested Container widgets within a ListView.</li>

<li>The changes ensure that the subContainerIndex is correctly passed down to child components, allowing them to access the listItem context variable.</li>

<li>This fix enhances the functionality of the ListView and Container widgets, ensuring that data is displayed correctly for each row.</li>

<li>Overall, this pull request addresses a bug in the ListView and Container widgets, improving context propagation.</li>

</ul>

</div>