### PR TITLE
refactor: migrate save indicator tooltips from react-tooltip to a custom ToolTip component

### DIFF
--- a/frontend/src/AppBuilder/Header/EditorHeader.jsx
+++ b/frontend/src/AppBuilder/Header/EditorHeader.jsx
@@ -14,7 +14,6 @@ import './styles/style.scss';
 
 import Steps from './Steps';
 import SaveIndicator from './SaveIndicator';
-import { Tooltip } from 'react-tooltip';
 
 export const EditorHeader = ({ darkMode, isUserInZeroToOneFlow }) => {
   const { moduleId, isModuleEditor } = useModuleContext();
@@ -114,14 +113,6 @@ export const EditorHeader = ({ darkMode, isUserInZeroToOneFlow }) => {
           </div>
         </div>
       </header>
-      <Tooltip
-        id="editor-header-tooltip"
-        className="tw-text-text-default tw-bg-background-inverse tw-p-3 tw-rounded-md tw-text-xs tw-font-medium"
-        style={{ zIndex: 9999 }}
-        place="bottom"
-        delayShow={300}
-        delayHide={100}
-      />
     </div>
   );
 };

--- a/frontend/src/AppBuilder/Header/SaveIndicator.jsx
+++ b/frontend/src/AppBuilder/Header/SaveIndicator.jsx
@@ -1,45 +1,37 @@
 import React from 'react';
 import { CloudCheck, CloudAlert } from 'lucide-react';
 import Loader from '@/ToolJetUI/Loader/Loader';
+import { ToolTip } from '@/_components';
 
 const SaveIndicator = ({ isSaving, saveError }) => {
   if (isSaving) {
     return (
-      <div
-        className="d-flex align-items-center"
-        style={{ gap: '4px' }}
-        data-tooltip-id="editor-header-tooltip"
-        data-tooltip-content="Saving in progress! Don't close the app yet."
-      >
-        <div className="d-flex align-items-center" style={{ width: '16px', height: '16px' }}>
-          <Loader width={16} height={16} reverse={true} />
+      <ToolTip message="Saving in progress! Don't close the app yet." placement="bottom">
+        <div className="d-flex align-items-center" style={{ gap: '4px' }}>
+          <div className="d-flex align-items-center" style={{ width: '16px', height: '16px' }}>
+            <Loader width={16} height={16} reverse={true} />
+          </div>
+          <p className="mb-0 mx-1 text-center tw-text-text-default">Saving...</p>
         </div>
-        <p className="mb-0 mx-1 text-center tw-text-text-default">Saving...</p>
-      </div>
+      </ToolTip>
     );
   }
   if (saveError) {
     return (
-      <div
-        className="d-flex align-items-center"
-        style={{ gap: '4px' }}
-        data-tooltip-id="editor-header-tooltip"
-        data-tooltip-content="Could not save changes"
-      >
-        <CloudAlert width={16} height={16} color="var(--icon-danger)" />
-        <p className="mb-0 text-center tw-text-text-danger">Could not save changes</p>
-      </div>
+      <ToolTip message="Could not save changes" placement="bottom">
+        <div className="d-flex align-items-center" style={{ gap: '4px' }}>
+          <CloudAlert width={16} height={16} color="var(--icon-danger)" />
+          <p className="mb-0 text-center tw-text-text-danger">Could not save changes</p>
+        </div>
+      </ToolTip>
     );
   }
   return (
-    <div
-      className="d-flex align-items-center"
-      style={{ gap: '4px' }}
-      data-tooltip-id="editor-header-tooltip"
-      data-tooltip-content="Changes saved!"
-    >
-      <CloudCheck width={16} height={16} color="var(--icon-success)" />
-    </div>
+    <ToolTip message="Changes saved!" placement="bottom">
+      <div className="d-flex align-items-center" style={{ gap: '4px' }}>
+        <CloudCheck width={16} height={16} color="var(--icon-success)" />
+      </div>
+    </ToolTip>
   );
 };
 


### PR DESCRIPTION
This pull request refactors how tooltips are implemented in the editor header area. Instead of using the external `react-tooltip` library, the code now uses a custom `ToolTip` component for displaying tooltips in the `SaveIndicator`. This change simplifies the tooltip implementation and removes unnecessary dependencies from the header.