### PR TITLE
Enhancement: Scroll to selected item in Dropdown (single + multi-select)  lts-3.16

### DIFF
--- a/frontend/src/AppBuilder/Widgets/DropdownV2/CustomMenuList.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/CustomMenuList.jsx
@@ -15,6 +15,7 @@ const CustomMenuList = ({ selectProps, ...props }) => {
     selectProps;
 
   const parentRef = useRef(null);
+  const hasScrolledOnOpenRef = useRef(null);
   const virtualizer = useVirtualizer({
     count: props?.children?.length || 0,
     getScrollElement: () => parentRef.current,
@@ -28,6 +29,21 @@ const CustomMenuList = ({ selectProps, ...props }) => {
       searchInput.focus();
     }
   }, []);
+
+  const firstSelectedIndex = props?.options?.findIndex(opt => opt.value === (Array.isArray(selectProps?.value) ? selectProps.value[0]?.value : selectProps.value?.value));
+
+  useEffect(() => {
+    if (!selectProps?.menuIsOpen) {
+      hasScrolledOnOpenRef.current = false;
+      return;
+    }
+    if (hasScrolledOnOpenRef.current) return;
+
+    if (firstSelectedIndex >= 0) {
+      virtualizer.scrollToIndex(firstSelectedIndex, { align: 'center' });
+      hasScrolledOnOpenRef.current = true;
+    }
+  }, [selectProps?.menuIsOpen, firstSelectedIndex]);
 
   return (
     <div

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/CustomSelect.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/CustomSelect.jsx
@@ -31,6 +31,28 @@ const COLORS = [
 
 const CustomMenuList = ({ optionsLoadingState, children, selectProps, inputRef, ...props }) => {
   const { onInputChange, inputValue, onMenuInputFocus } = selectProps;
+  const hasScrolledOnOpenRef = useRef(false);
+  const menuListRef = useRef(null);
+
+  const firstSelectedIndex = props?.options?.findIndex(opt => opt.value === (Array.isArray(selectProps?.value) ? selectProps.value[0]?.value : selectProps.value?.value));
+
+  useEffect(() => {
+    if (!selectProps?.menuIsOpen) {
+      hasScrolledOnOpenRef.current = false;
+      return;
+    }
+
+    if (hasScrolledOnOpenRef.current) return;
+    if (firstSelectedIndex < 0) return;
+
+    const menuEl = menuListRef.current;
+    const optionEl = menuEl?.children?.[firstSelectedIndex];
+
+    if (menuEl && optionEl) {
+      optionEl.scrollIntoView({ block: 'center' });
+      hasScrolledOnOpenRef.current = true;
+    }
+  }, [selectProps?.menuIsOpen, firstSelectedIndex]);
 
   return (
     <div
@@ -69,7 +91,7 @@ const CustomMenuList = ({ optionsLoadingState, children, selectProps, inputRef, 
         />
       </div>
       <div style={{ borderTop: '1px solid var(--cc-default-border)' }}>
-        <MenuList {...props} selectProps={selectProps} style={{ backgroundColor: 'var(--cc-surface1-surface)' }}>
+        <MenuList {...props} innerRef={menuListRef} selectProps={selectProps} style={{ backgroundColor: 'var(--cc-surface1-surface)' }}>
           {optionsLoadingState ? (
             <div className="text-center py-4">
               <div className="spinner-border text-primary" role="status">


### PR DESCRIPTION
### Enhancement: Scroll to selected item in Dropdown and Multi-select 

### Current Behavior
- Dropdowns always open from the top.
- Selected items may be out of view in large lists.

### New Behavior

- Single-select dropdown scrolls to the selected option when opened.
- Multi-select dropdown scrolls to the first selected option when opened.
- Applied behavior to both dropdown and multi-select columns in table components.

### Implementation

- Used virtualizer.scrollToIndex(firstSelectedIndex, { align: 'center' }) to scroll to the selected option.
- Scroll is triggered only when the menu opens to avoid unexpected jumps during selection changes.
- Logic safely handles both single-select and multi-select cases.

### Testing

- Tested with small and large option lists.
- Verified behavior for Single-select dropdown, Multi-select dropdown, Table column dropdowns and multi-selects

### Notes
This PR is created from the lts-3.16 branch as requested.

### Issue Reference
Fixes #14770