### PR TITLE
Fix: Page menu settings are changed to default values when a module is dropped inside Editor

### DIFF
--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -300,9 +300,9 @@ const useAppData = (
             constantsResp =
               isPublicAccess && appData.is_public
                 ? await orgEnvironmentConstantService.getConstantsFromPublicApp(
-                  slug,
-                  viewerEnvironment?.environment?.id
-                )
+                    slug,
+                    viewerEnvironment?.environment?.id
+                  )
                 : await orgEnvironmentConstantService.getConstantsFromEnvironment(viewerEnvironment?.environment?.id);
           } catch (error) {
             console.error('Error fetching viewer environment:', error);
@@ -354,8 +354,8 @@ const useAppData = (
               'is_maintenance_on' in result
                 ? result.is_maintenance_on
                 : 'isMaintenanceOn' in result
-                  ? result.isMaintenanceOn
-                  : false,
+                ? result.isMaintenanceOn
+                : false,
             organizationId: appData.organizationId || appData.organization_id,
             homePageId: homePageId,
             isPublic: appData.is_public,
@@ -636,8 +636,8 @@ const useAppData = (
             'is_maintenance_on' in appData
               ? appData.is_maintenance_on
               : 'isMaintenanceOn' in appData
-                ? appData.isMaintenanceOn
-                : false,
+              ? appData.isMaintenanceOn
+              : false,
           organizationId: appData.organizationId || appData.organization_id,
           homePageId: appData.editing_version.homePageId,
           isPublic: appData.isPublic,


### PR DESCRIPTION
Closes: https://github.com/ToolJet/tj-ee/issues/4683

This pull request makes a small adjustment to the `useAppData` hook to ensure that page settings are only set when not in `moduleMode`. This helps prevent unnecessary or incorrect updates to page settings when the application is in module mode.