### PR TITLE
Fix: Session validation for PAT apps

### DIFF
--- a/frontend/src/AppBuilder/EmbedApp.jsx
+++ b/frontend/src/AppBuilder/EmbedApp.jsx
@@ -12,6 +12,12 @@ export function setPatToken(patToken) {
 
 export function getPatToken() {
   if (inMemoryPatToken) return inMemoryPatToken;
+  // Fallback to window.name (persists across same-tab navigations)
+  if (window.name && window.name.length > 0) {
+    inMemoryPatToken = window.name;
+    return inMemoryPatToken;
+  }
+  return undefined;
 }
 
 export default function EmbedAppRedirect() {

--- a/frontend/src/_services/session.service.js
+++ b/frontend/src/_services/session.service.js
@@ -3,6 +3,7 @@ import config from 'config';
 import queryString from 'query-string';
 import { getWorkspaceId } from '@/_helpers/utils';
 import { getRedirectToWithParams } from '@/_helpers/routes';
+import { getPatToken } from '@/AppBuilder/EmbedApp';
 
 export const sessionService = {
   validateSession,
@@ -10,10 +11,15 @@ export const sessionService = {
 };
 
 function validateSession(appId, workspaceSlug) {
+  // Get PAT token if present (for embedded/PAT flows)
+  const patToken = getPatToken && getPatToken();
+  const headers = patToken ? { tj_auth_token: patToken } : undefined;
   const requestOptions = {
     method: 'GET',
     credentials: 'include',
+    ...(headers && { headers }),
   };
+
   const query = queryString.stringify({ appId, workspaceSlug });
   return fetch(`${config.apiUrl}/session${query ? `?${query}` : ''}`, requestOptions).then(
     handleResponseWithoutValidation


### PR DESCRIPTION
Closes: [#4592](https://github.com/ToolJet/tj-ee/issues/4592)

**Description**

- This PR fixes an issue where session validation failed for Personal Access Token (PAT)–based embedded app logins, resulting in an empty user state on the frontend.
- The frontend was not sending the `tj_auth_token` header with the signed PAT for session validation requests, causing the backend guard to reject the session.

**Changes**

- Updated the session validation API call to include the `tj_auth_token` header when a PAT is present.
- Ensured backward compatibility for non-PAT (normal) logins.

**Impact**

- PAT-based embedded app sessions now validate correctly and user state is hydrated as expected.
- No impact on standard login flows.