### PR TITLE
Fix upgrade button text visibility on hover in dark mode

### DIFF
--- a/frontend/src/_styles/license.scss
+++ b/frontend/src/_styles/license.scss
@@ -831,6 +831,16 @@
         background: linear-gradient(96.1deg, #ff5f6d -15.44%, #ffc371 99.37%);
         color: var(--slate12);
         border: none;
+        // .theme-dark &,
+        // .dark-theme & {
+        //     color: #ffffff;
+
+        //     &:hover,
+        //     &:focus,
+        //     &:active {
+        //         color: #ffffff;
+        //     }
+        // }
         .theme-dark &,
         .dark-theme & {
             color: #ffffff;
@@ -841,6 +851,7 @@
                 color: #ffffff;
             }
         }
+
     }
 }
 


### PR DESCRIPTION
### What is the issue?
In dark mode, the Upgrade button text becomes unreadable on hover due to hover styles overriding text color.

### What is the fix?
Added a dark-mode–specific override to preserve text color on hover, focus, and active states.

### How was this tested?
- Reproduced issue in dark mode on https://app.tooljet.com
- Verified fix using Chrome DevTools by forcing `:hover` state

### Screenshots
Before: ❌ Text not visible  
After: ✅ Text visible

### Checklist
- [x] UI-only change
- [x] No breaking changes
- [x] Tested in dark mode