### PR TITLE
fix for Incorrect URL for sign up while sharing app

### DIFF
--- a/frontend/src/_helpers/authorizeWorkspace.js
+++ b/frontend/src/_helpers/authorizeWorkspace.js
@@ -25,7 +25,6 @@ import { fetchWhiteLabelDetails } from '@/_helpers/white-label/whiteLabelling';
 export const authorizeWorkspace = () => {
   /* Default APIs */
   const workspaceIdOrSlug = getWorkspaceIdOrSlugFromURL();
-
   // fetchWhiteLabelDetails(workspaceIdOrSlug).finally(() => {
   if (!isThisExistedRoute()) {
     updateCurrentSession({


### PR DESCRIPTION
Issue:
This issue occurs when the user is already logged into a different workspace (ws-1) and then accesses a released app URL belonging to another workspace (ws-2).
In this scenario, since the user is not a member of ws-2, clicking Sign Up causes the context to switch back to the currently logged-in workspace (ws-1), which results in the observed error and incorrect workspace being shown.
I’m unable to reproduce this when the user is not logged into any workspace before accessing the released app URL.
Attachment: https://jam.dev/c/a9ee50bf-47ea-4521-b23e-0f003b3a3ea9