### PR TITLE
fix: remove completion operation from OpenAI plugin (#12487)

### DIFF
--- a/marketplace/plugins/openai/lib/index.ts
+++ b/marketplace/plugins/openai/lib/index.ts
@@ -1,7 +1,7 @@
 import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-marketplace/common';
 import { SourceOptions, QueryOptions, Operation } from './types';
 import OpenAI from 'openai'; // Correct import for SDK 4.56.0
-import { getCompletion, getChatCompletion, generateImage, generateEmbedding } from './query_operations';
+import { getChatCompletion, generateImage, generateEmbedding } from './query_operations';
 
 export default class Openai implements QueryService {
   async run(sourceOptions: SourceOptions, queryOptions: QueryOptions, dataSourceId: string): Promise<QueryResult> {
@@ -11,10 +11,6 @@ export default class Openai implements QueryService {
 
     try {
       switch (operation) {
-        case Operation.Completion:
-          result = await getCompletion(openai, queryOptions);
-          break;
-
         case Operation.Chat:
           result = await getChatCompletion(openai, queryOptions);
           break;

--- a/marketplace/plugins/openai/lib/operations.json
+++ b/marketplace/plugins/openai/lib/operations.json
@@ -16,7 +16,6 @@
 			"description": "Single select dropdown for operation",
 			"list": [
 				{ "value": "chat", "name": "Chat" },
-				{ "value": "completion", "name": "Completion" },
 				{ "value": "image_generation", "name": "Generate AI Image(s)" },
 				{ "value": "generate_embedding", "name": "Generate embedding" }
 			]
@@ -202,58 +201,6 @@
 					"height": "36px"
 				}
 			}
-		},
-		"completion": {
-			"model": {
-				"label": "Model",
-				"key": "model",
-				"type": "dropdown-component-flip",
-				"description": "Select OpenAI Model",
-				"list": [
-					{ "value": "gpt-3.5-turbo-instruct", "name": "GPT 3.5 Turbo" }
-				]
-			},
-              "gpt-3.5-turbo-instruct": {
-                "prompt": {
-                  "label": "Prompt",
-                  "key": "prompt",
-                  "type": "codehinter",
-                  "description": "Enter prompt",
-                  "height": "150px"
-                },
-                "max_tokens": {
-                  "label": "Max Tokens",
-                  "key": "max_tokens",
-                  "type": "codehinter",
-                  "description": "Enter from 1 to 2048",
-                  "width": "320px",
-                  "height": "36px"
-                },
-                "temperature": {
-                  "label": "Temperature",
-                  "key": "temperature",
-                  "type": "codehinter",
-                  "description": "Enter from 0 to 1",
-                  "width": "320px",
-                  "height": "36px"
-                },
-                "stop_sequence": {
-                  "label": "Stop Sequence",
-                  "key": "stop_sequence",
-                  "type": "codehinter",
-                  "description": "Enter stop sequence",
-                  "width": "320px",
-                  "height": "36px"
-                },
-                "suffix": {
-                  "label": "Suffix",
-                  "key": "suffix",
-                  "type": "codehinter",
-                  "description": "Enter suffix",
-                  "width": "320px",
-                  "height": "36px"
-                }
-              }
 		},
 		"image_generation": {
   			"model": {

--- a/marketplace/plugins/openai/lib/query_operations.ts
+++ b/marketplace/plugins/openai/lib/query_operations.ts
@@ -44,24 +44,6 @@ const getSizeEnum = (
   return isNaN(num) ? 1 : Math.max(1, Math.min(10, num)); // Ensure it's between 1 and 10
 };*/
 
-export async function getCompletion(
-  openai: OpenAI,
-  options: QueryOptions
-): Promise<string | { error: string; statusCode: number }> {
-  const { model, prompt, max_tokens, temperature, stop_sequence, suffix } = options;
-
-  const response = await openai.completions.create({
-    model: model || 'gpt-3.5-turbo-instruct',
-    prompt: prompt,
-    temperature: typeof temperature === 'string' ? parseFloat(temperature) : temperature || 0,
-    max_tokens: typeof max_tokens === 'string' ? parseInt(max_tokens) : max_tokens || 67,
-    stop: stop_sequence || null,
-    suffix: suffix || null,
-  });
-
-  return response.choices[0].text; // Access the response correctly
-}
-
 export async function getChatCompletion(
   openai: OpenAI,
   options: QueryOptions

--- a/marketplace/plugins/openai/lib/types.ts
+++ b/marketplace/plugins/openai/lib/types.ts
@@ -25,7 +25,6 @@ export type QueryOptions = {
 };
 
 export enum Operation {
-  Completion = 'completion',
   Chat = 'chat',
   ImageGeneration = 'image_generation',
   GenerateEmbedding = 'generate_embedding',


### PR DESCRIPTION
### Description
Removes the "Completion" operation from the OpenAI plugin. This operation is deprecated.

### Changes Made
- Removed "Completion" option from `operations.json`.
- Removed completion logic from `query_operations.ts`.
- Cleaned up `index.ts` to remove the switch case for completion.

### Related Issue
Fixes #12487
