### PR TITLE
changing gaurd.ts MODULE--->APP

### DIFF
--- a/server/src/modules/apps/ability/guard.ts
+++ b/server/src/modules/apps/ability/guard.ts
@@ -17,7 +17,7 @@ export class FeatureAbilityGuard extends AbilityGuard {
         };
       case APP_TYPES.MODULE:
         return {
-          resourceType: MODULES.APP,
+          resourceType: MODULES.MODULES,
         };
       case APP_TYPES.WORKFLOW:
         return {

--- a/server/src/modules/apps/service.ts
+++ b/server/src/modules/apps/service.ts
@@ -157,7 +157,7 @@ export class AppsService implements IAppsService {
 
       // Validate environment access for all users (both builders and viewers)
       // Skip validation only for released environment (everyone with view access can see released)
-      if (environment) {
+      if (environment && app.type !== APP_TYPES.MODULE) {
         const envName = environment.name.toLowerCase();
 
         // Always allow access to released environment for all users who can view the app


### PR DESCRIPTION
Corrected FeatureAbilityGuard to map APP_TYPES.MODULE to MODULES.APP instead of MODULES.MODULES.
This ensures MODULE apps load APP permissions, enabling environment access and fixing the 403 “restricted-preview” error.