### PR TITLE
fix: prevent password reset with only whitespace characters (#14718)

### DIFF
--- a/frontend/src/_components/ResetPasswordModal.jsx
+++ b/frontend/src/_components/ResetPasswordModal.jsx
@@ -25,7 +25,7 @@ export function ResetPasswordModal({ darkMode = false, closeModal, show, user })
   }, [show]);
 
   const isDisabled = useMemo(() => {
-    return isLoading || (passwordOption === 'manual' && password.length < 5);
+    return isLoading || (passwordOption === 'manual' && (password.length < 5 || password.trim().length === 0));
   }, [isLoading, passwordOption, password]);
 
   const togglePasswordVisibility = () => {


### PR DESCRIPTION
### Description
This PR fixes an issue where the "Reset Password" button was enabled even if the user entered only blank spaces (e.g., 5 spaces). The button will now remain disabled unless there is at least one non-whitespace character.

### Testing
1. Log in as an Admin and open the "All Users" page.
2. Click "Reset Password" for any user.
3. Type 5 blank spaces into the password field.
   - **Expected:** The "Reset" button remains **disabled**.