### PR TITLE
fix: Replace Icons with TablerIcon component 

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageMenu/MobileNavigationMenu.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageMenu/MobileNavigationMenu.jsx
@@ -95,7 +95,7 @@ const MobileNavigationMenu = ({ currentPageId, darkMode, switchDarkMode, bgStyle
       <Header className={'mobile-header'}>
         <div onClick={toggleSidebar} className="cursor-pointer">
           <div className="icon-btn">
-            <TablerIcon name="IconX" size={16} color="var(--icon-strong)" />
+            <TablerIcon iconName="IconX" size={16} color="var(--icon-strong)" />
           </div>
         </div>
         <div className="w-100 tw-min-w-0 tw-shrink tw-px-[7px]">
@@ -163,10 +163,10 @@ const MobileNavigationMenu = ({ currentPageId, darkMode, switchDarkMode, bgStyle
         container: document.getElementsByClassName('canvas-wrapper')[0],
         overlayClassName: 'tw-absolute tw-h-dvh',
         className: `tw-absolute tw-p-0 mobile-page-menu-popup ${isMobilePreviewMode && !isPreviewInEditor
-            ? 'tw-h-[calc(100%_-_44px)]' // To account for the preview settings header height
-            : currentMode === 'view' && !isMobilePreviewMode
-              ? 'tw-h-dvh' // In released app, the height should equal to mobile browsers viewport height
-              : 'tw-h-full'
+          ? 'tw-h-[calc(100%_-_44px)]' // To account for the preview settings header height
+          : currentMode === 'view' && !isMobilePreviewMode
+            ? 'tw-h-dvh' // In released app, the height should equal to mobile browsers viewport height
+            : 'tw-h-full'
           }`,
         style: bgStyles,
       }}

--- a/frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageMenu/PageGroup.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageMenu/PageGroup.jsx
@@ -2,6 +2,7 @@
 import React, { useRef, useState } from 'react';
 import _ from 'lodash';
 import TablerIcon from '@/_ui/Icon/TablerIcon';
+import { IconDotsVertical } from '@tabler/icons-react';
 // eslint-disable-next-line import/no-unresolved
 import useStore from '@/AppBuilder/_stores/store';
 import OverflowTooltip from '@/_components/OverflowTooltip';
@@ -228,7 +229,7 @@ const RenderPageGroup = ({
         aria-expanded={isExpanded}
       >
         <TriggerBody />
-        <TablerIcon name='IconChevronUp'
+        <TablerIcon iconName='IconChevronUp'
           size={16}
           color="var(--nav-item-icon-color)"
           className={`cursor-pointer tw-flex-shrink-0 tw-transition tw-duration-200 group-data-[state=closed]:tw-rotate-180`}
@@ -340,7 +341,7 @@ export const RenderPageAndPageGroup = ({
         {overflowLinks.length > 0 && position === 'top' && (
           <NavigationMenuItem>
             <NavigationMenuTrigger indicator={false} className={`more-pages-btn`}>
-              <TablerIcon name="IconDotsVertical" size={16} color="var(--nav-item-icon-color)" />
+              <TablerIcon iconName="IconDotsVertical" size={16} color="var(--nav-item-icon-color)" />
               More
             </NavigationMenuTrigger>
             <NavigationMenuContent className={`!tw-min-w-full page-menu-popup ${darkMode && 'dark-theme'}`}>


### PR DESCRIPTION
This pull request refactors how Tabler icons are used in the mobile navigation menu and page group components. The main change is replacing direct imports of all Tabler icons with a custom `TablerIcon` component, which standardizes icon usage and likely improves maintainability and performance. There are also minor code style and formatting adjustments.

**Icon usage refactor:**

* Replaced direct imports of all Tabler icons (`import * as Icons from '@tabler/icons-react'`) with a single custom `TablerIcon` component (`import TablerIcon from '@/_ui/Icon/TablerIcon'`) in `MobileNavigationMenu.jsx`.
* Updated all usages of Tabler icons in `MobileNavigationMenu.jsx` and `PageGroup.jsx` to use the `TablerIcon` component with the appropriate icon name prop instead of the previous `Icons.IconX`, `Icons.IconChevronUp`, and `Icons.IconDotsVertical` references. [[1]](diffhunk://#diff-90efbcec3e84c9485d6e9128d68ba735130aeb21412feee1f5ba439660f3601fL98-R98) [[2]](diffhunk://#diff-29946147d487c1e645722f26834fb3c75033b19c71dd9f7ae3f7ed11866be5e4L189-R189) [[3]](diffhunk://#diff-29946147d487c1e645722f26834fb3c75033b19c71dd9f7ae3f7ed11866be5e4L231-R231) [[4]](diffhunk://#diff-29946147d487c1e645722f26834fb3c75033b19c71dd9f7ae3f7ed11866be5e4L343-R343)

**Minor code style improvements:**

* Cleaned up string interpolation and formatting in class names for conditional styling in both `MobileNavigationMenu.jsx` and `PageGroup.jsx`. [[1]](diffhunk://#diff-90efbcec3e84c9485d6e9128d68ba735130aeb21412feee1f5ba439660f3601fL165-R165) [[2]](diffhunk://#diff-29946147d487c1e645722f26834fb3c75033b19c71dd9f7ae3f7ed11866be5e4L156-R156)