### PR TITLE
fix: support user search with full name

### DIFF
--- a/server/src/modules/users/repositories/repository.ts
+++ b/server/src/modules/users/repositories/repository.ts
@@ -46,7 +46,7 @@ export class UserRepository extends Repository<User> {
     let whereOptions: FindOptionsWhere<User> | FindOptionsWhere<User>[] = findOptions;
 
     if (options?.searchText) {
-      const searchLower = options.searchText.toLowerCase();
+      const searchLower = options.searchText.trim().toLowerCase();
 
       // Create an array of OR conditions
       whereOptions = [
@@ -54,8 +54,21 @@ export class UserRepository extends Repository<User> {
         { ...findOptions, firstName: ILike(`%${searchLower}%`) },
         { ...findOptions, lastName: ILike(`%${searchLower}%`) },
       ];
-    }
 
+      const parts = searchLower.split(/\s+/);
+
+      if (parts.length > 1) {
+        const firstWord = parts[0];
+        const lastWord = parts.slice(1).join(' ');
+
+        whereOptions.push({
+          ...findOptions,
+          firstName: ILike(`%${firstWord}%`),
+          lastName: ILike(`%${lastWord}%`),
+        });
+      }
+    }
+    
     const [items, total] = await this.manager.findAndCount(User, {
       select: {
         id: true,


### PR DESCRIPTION
### Description 
This PR fixes an issue where searching for users by their full name would return 0 results. Previously, the search logic treated the input as a single string literal, trying to find the entire phrase inside just the firstName OR just the lastName column, which caused matches to fail.

### Fixed at:
* workspace-settings/users
* settings/all-users

### Changes:
Implemented a split-match logic: if the search text contains multiple words(FirstName + Lastname), the query now checks if the First Name matches the first word AND the Last Name matches the second word.
