### PR TITLE
Fix: wrap MaintenanceMode component in a div to control its disabled state

### DIFF
--- a/frontend/src/AppBuilder/LeftSidebar/GlobalSettings/index.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/GlobalSettings/index.jsx
@@ -40,7 +40,9 @@ const GlobalSettings = ({ darkMode, onClose }) => {
         {/* Main Content Section */}
         <div className="global-settings-main-content">
           <SlugInput />
-          <MaintenanceMode darkMode={darkMode} />
+          <div className={cx({ disabled: shouldFreeze })}>
+            <MaintenanceMode darkMode={darkMode} />
+          </div>
           <AppExport darkMode={darkMode} />
         </div>
 


### PR DESCRIPTION
Resolves - Maintenance mode should not be accessible for saved version. It is accessible currently.