### PR TITLE
insert many bug fix

### DIFF
--- a/plugins/packages/mongodb/lib/index.ts
+++ b/plugins/packages/mongodb/lib/index.ts
@@ -32,7 +32,7 @@ export default class MongodbService implements QueryService {
         case 'insert_many':
           result = await db
             .collection(queryOptions.collection)
-            .insertMany(this.parseEJSON(queryOptions.document), this.parseEJSON(queryOptions.options));
+            .insertMany(this.parseEJSON(queryOptions.documents), this.parseEJSON(queryOptions.options));
           break;
         case 'find_one':
           result = await db

--- a/plugins/packages/mongodb/lib/operations.json
+++ b/plugins/packages/mongodb/lib/operations.json
@@ -134,7 +134,7 @@
         "className": "codehinter-plugins",
         "placeholder": "Enter collection"
       },
-      "document": {
+      "documents": {
         "label": "Documents",
         "key": "documents",
         "type": "codehinter",


### PR DESCRIPTION
document will be used for insertOne

documents will be used for insertMany

Earlier, for insertMany, the UI was sending the payload under the key document, while the MongoDB plugin explicitly expects documents (array).
This caused ambiguity and mismatches between the UI payload and the plugin contract.

To avoid confusion and ensure consistency:

Singular document → single record (insertOne)

Plural documents → multiple records (insertMany)

This aligns with MongoDB’s API semantics and removes any ambiguity in request handling.