### PR TITLE
fix: Added key prop to iframe for improved rendering stability

### DIFF
--- a/frontend/src/AppBuilder/Widgets/IFrame.jsx
+++ b/frontend/src/AppBuilder/Widgets/IFrame.jsx
@@ -108,6 +108,7 @@ export const IFrame = function IFrame({
         </div>
       ) : (
         <iframe
+          key={exposedVariablesTemporaryState.url}
           width={width - 4}
           height={height}
           src={exposedVariablesTemporaryState.url}


### PR DESCRIPTION
This pull request makes a small update to the `IFrame` widget component. The change ensures that the `iframe` element is re-mounted whenever the URL changes by setting its `key` prop to the current URL. This helps ensure the iframe reloads properly when the source URL is updated.