### PR TITLE
Fix: Page groups not collapsing in Viewer mode

### DIFF
--- a/frontend/src/_styles/pages-sidebar.scss
+++ b/frontend/src/_styles/pages-sidebar.scss
@@ -225,6 +225,7 @@
         display: flex;
         flex-direction: column;
         box-sizing: content-box;
+        
         &.no-preview-settings {
             height: 100% !important;
         }
@@ -319,6 +320,10 @@
 
                 .tj-list-item {
                     margin-top: 6px !important;
+                }
+
+                &.collapsed {
+                    display: none;
                 }
             }
         }
@@ -724,6 +729,10 @@
     
                 .tj-list-item {
                   margin-top: 6px !important;
+                }
+
+                &.collapsed {
+                    display: none;
                 }
               }
             }


### PR DESCRIPTION
Closes: https://github.com/ToolJet/tj-ee/issues/4708

This pull request introduces minor updates to the sidebar styles, mainly adding a new `.collapsed` class to hide certain elements and making a small formatting adjustment.

Sidebar styling improvements:

* Added a `.collapsed` class to `.tj-list-item-container` elements to allow them to be hidden via `display: none;` in two places within `pages-sidebar.scss`. [[1]](diffhunk://#diff-547acba86899a1758e905e7b758c27fbed15d7e8cfee89ac4c325060e2936e1fR324-R327) [[2]](diffhunk://#diff-547acba86899a1758e905e7b758c27fbed15d7e8cfee89ac4c325060e2936e1fR733-R736)

Formatting:

* Added a blank line for improved readability in the flex container section.