### PR TITLE
Fix: Key value pair dissapears inside Accordion when dynamic height is turned on and Accordion is expanded/collapsed in viewer

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/WidgetWrapper.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/WidgetWrapper.jsx
@@ -7,7 +7,7 @@ import RenderWidget from './RenderWidget';
 import { NO_OF_GRIDS } from './appCanvasConstants';
 import { isTruthyOrZero } from '@/_helpers/appUtils';
 
-const DYNAMIC_HEIGHT_AUTO_LIST = ['CodeEditor', 'Listview', 'TextArea', 'TagsInput'];
+const DYNAMIC_HEIGHT_AUTO_LIST = ['CodeEditor', 'Listview', 'TextArea', 'TagsInput', 'KeyValuePair'];
 
 const WidgetWrapper = memo(
   ({


### PR DESCRIPTION
This pull request makes a small update to the list of widgets that support dynamic height in the app builder. The change adds the `KeyValuePair` widget to the `DYNAMIC_HEIGHT_AUTO_LIST` array, allowing it to automatically adjust its height as needed.