### PR TITLE
Fix: Canvas scroll stops working when Legacy Modal is closed using CSA or `Close modal` event

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Modal.jsx
+++ b/frontend/src/AppBuilder/Widgets/Modal.jsx
@@ -90,8 +90,7 @@ export const Modal = function Modal({
         setShowModal(true);
       },
       close: async function () {
-        setExposedVariable('show', false);
-        setShowModal(false);
+        onHideModal();
       },
     };
     setExposedVariables(exposedVariables);


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/4724

This pull request makes a small change to the `Legacy Modal` widget's close behavior. Instead of directly updating the modal's visibility state, the `close` method now calls the `onHideModal` function, which likely centralizes the logic for hiding the modal and updating related state. It calls the `onHideSideEffects` function which restores canvas scroll functionality once modal closes.