### PR TITLE
Update default AMI regions in variables.pkr.hcl

### DIFF
--- a/deploy/ec2/ee/variables.pkr.hcl
+++ b/deploy/ec2/ee/variables.pkr.hcl
@@ -19,7 +19,7 @@ variable "ami_groups" {
 
 variable "ami_regions" {
   type    = list(string)
-  default = ["us-west-1","us-east-1", "us-east-2", "eu-central-1"]
+  default = ["us-west-1","us-east-1", "us-east-2"]
 }
 
 variable "PACKER_BUILDER_TYPE" {


### PR DESCRIPTION
Removed 'eu-central-1' from the default AMI regions list.