### PR TITLE
fix: prevent duplicate API calls on TJDB

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -32,6 +32,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
   const paramListContainerRef = useRef(null);
   const selectedQuery = useStore((state) => state.queryPanel.selectedQuery);
   const selectedDataSource = useStore((state) => state.queryPanel.selectedDataSource);
+  const creatingQueryInProcessId = useStore((state) => state.dataQuery.creatingQueryInProcessId);
   const changeDataQuery = useStore((state) => state.dataQuery.changeDataQuery);
   const updateDataQuery = useStore((state) => state.dataQuery.updateDataQuery);
   const [showLocalDataSourceDeprecationBanner, setshowLocalDataSourceDeprecationBanner] = useState(false);
@@ -223,7 +224,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
         </div>
         <ElementToRender
           renderCopilot={(props) => renderCopilot({ ...props, selectedDataSource })}
-          key={selectedQuery?.id}
+          key={creatingQueryInProcessId || selectedQuery?.id}
           pluginSchema={selectedDataSource?.plugin?.operations_file?.data}
           selectedDataSource={selectedDataSource}
           options={selectedQuery?.options}

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/Workflows.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/Workflows.jsx
@@ -11,11 +11,6 @@ import useWorkflowStore from '@/_stores/workflowStore';
 import { useTranslation } from 'react-i18next';
 import { CustomToggleSwitch } from '../Components/CustomToggleSwitch';
 
-// cache to prevent duplicate API calls during query creation
-let fetchWorkflowsPromiseCache = null;
-let fetchWorkflowsCacheTimestamp = null;
-const CACHE_DURATION_MS = 2000;
-
 export function Workflows({ options, optionsChanged, currentState }) {
   const { moduleId } = useModuleContext();
   const { t } = useTranslation();
@@ -39,27 +34,14 @@ export function Workflows({ options, optionsChanged, currentState }) {
   );
 
   useEffect(() => {
-    const now = Date.now();    
-    // cached promise
-    if (fetchWorkflowsPromiseCache && fetchWorkflowsCacheTimestamp && (now - fetchWorkflowsCacheTimestamp) < CACHE_DURATION_MS) {
-      fetchWorkflowsPromiseCache.then((workflows) => {
-        if (workflows) {
-          setWorkflowOptions(workflows);
-        }
-      });
-      return;
-    }
-    // Create a new promise and cache it with timestamp
-    fetchWorkflowsCacheTimestamp = now;
-    const fetchPromise = appsService.getWorkflows(appId).then(({ workflows }) => {
-      const workflowList = workflows.map((workflow) => ({
-        value: workflow.id,
-        name: workflow.name,
-      }));
-      setWorkflowOptions(workflowList);
-      return workflowList;
-    });    
-    fetchWorkflowsPromiseCache = fetchPromise;
+    appsService.getWorkflows(appId).then(({ workflows }) => {
+      setWorkflowOptions(
+        workflows.map((workflow) => ({
+          value: workflow.id,
+          name: workflow.name,
+        }))
+      );
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
### Description
- Added  skipJoinTableUpdateRef to prevent secondary update loop..
- Merged table_id and join_table updates into a single call within handleTableNameSelect to prevent multiple parent re-renders.
- Added a  useEffect to sync tableInfo with the columns state, ensuring filter dropdowns populate correctly after metadata retrieval(removed fetchTableInformation logic and useEffect).

Review Changes:
- Used creatingQueryInProcessId as stable key to prevent component remount during tempId to realId transition.
- Removed unused functions.
