### PR TITLE
feat: Enhance custom component to handle query execution and response

### DIFF
--- a/frontend/src/AppBuilder/Widgets/CustomComponent/iframe.html
+++ b/frontend/src/AppBuilder/Widgets/CustomComponent/iframe.html
@@ -16,14 +16,32 @@
                     fn(props);
                     callbackFn = fn;
                 },
+                // Returns a Promise that resolves with the query result, matching the behaviour of queries.queryName.run()
+                // Success: { status: 'ok', data: { ... } }
+                // Failure: { status: 'failed', message: '...', description: '...', data: { ... }, metadata: { ... } }
                 runQuery: (name, params) => {
-                    window.parent.postMessage({
-                    from: 'customComponent',
-                    message: "RUN_QUERY",
-                    queryName: name,
-                    parameters: JSON.stringify(params || {}),
-                    componentId: window.Tooljet.componentId
-                }, "*")},
+                    return new Promise((resolve) => {
+                        // Unique ID to correlate this request with its response when multiple queries run concurrently
+                        const requestId = 'rq_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+                        const handler = (e) => {
+                            if (e.data.message === 'RUN_QUERY_RESPONSE' &&
+                                e.data.componentId === window.Tooljet.componentId &&
+                                e.data.requestId === requestId) {
+                                window.removeEventListener('message', handler);
+                                resolve(e.data.queryResult);
+                            }
+                        };
+                        window.addEventListener('message', handler);
+                        window.parent.postMessage({
+                            from: 'customComponent',
+                            message: "RUN_QUERY",
+                            queryName: name,
+                            parameters: JSON.stringify(params || {}),
+                            componentId: window.Tooljet.componentId,
+                            requestId: requestId,
+                        }, "*");
+                    });
+                },
                 updateProps: obj => window.parent.postMessage({
                     from: 'customComponent',
                     message: "UPDATE_DATA",

--- a/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
@@ -296,7 +296,8 @@ export const createEventsSlice = (set, get) => ({
         const { queryName, parameters } = options;
         const queryId = queries.filter((query) => query.name === queryName && isQueryRunnable(query))?.[0]?.id;
         if (!queryId) return;
-        runQuery(queryId, queryName, true, mode, parameters, undefined, undefined, false, false, moduleId);
+        // Return the query result promise so it can be passed back to the custom component iframe
+        return runQuery(queryId, queryName, true, mode, parameters, undefined, undefined, false, false, moduleId);
       }
       if (eventName === 'onTableActionButtonClicked') {
         const { action, tableActionEvents } = options;


### PR DESCRIPTION
Fixes https://github.com/ToolJet/tj-ee/issues/4734

This pull request enhances the way custom components in the app builder communicate with their parent frame to run queries and receive results asynchronously. The main improvement is the implementation of a request/response mechanism that allows multiple queries to be executed concurrently from within custom component iframes, with robust error handling and result correlation.

**Improvements to custom component query execution:**

* Added a request/response pattern using a unique `requestId` to correlate each `runQuery` call from the iframe with its respective response, enabling concurrent query execution and proper result delivery. [[1]](diffhunk://#diff-0a1a68d5172e7d613d66fad9074c158489ad0477d141d6367c56e29e516018f0R19-R44) [[2]](diffhunk://#diff-413dc0fcb9abaa0dab4a03b5f4fec1ac38343d3f5144a09920ce6f45721ee1d1L49-R83)
* Updated the `onEvent('onTrigger', ...)` handler in `CustomComponent.jsx` to return a promise and post the query result or error back to the iframe, ensuring that the iframe always receives a response even in case of JS exceptions. [[1]](diffhunk://#diff-413dc0fcb9abaa0dab4a03b5f4fec1ac38343d3f5144a09920ce6f45721ee1d1L49-R83) [[2]](diffhunk://#diff-75ba7c5024e43fd2acc5575d4d13c000b9c684a808de316fc69524b419720074L299-R300)
* Modified the events slice to return the query result promise from `runQuery`, so the parent can await the result and forward it to the iframe.

**Enhancements to the iframe API:**

* Improved the `runQuery` method in `iframe.html` to return a promise that resolves with the query result, matching the structure and behavior of the main app’s query execution, and added documentation on expected result shapes for success and failure.