### PR TITLE
fix: Add missing guards to ToolJet DB endpoints

### DIFF
--- a/server/src/modules/tooljet-db/controller.ts
+++ b/server/src/modules/tooljet-db/controller.ts
@@ -165,7 +165,7 @@ export class TooljetDbController {
   @InitFeature(FEATURE_KEY.JOIN_TABLES)
   @Post('/organizations/:organizationId/join')
   @UseFilters(new TooljetDbJoinExceptionFilter())
-  @UseGuards(JwtAuthGuard, OrganizationAuthGuard, FeatureAbilityGuard)
+  @UseGuards(OrganizationAuthGuard, FeatureAbilityGuard)
   async joinTables(@Req() req, @Body() tooljetDbJoinDto: TooljetDbJoinDto, @Param('organizationId') organizationId) {
     const params = {
       joinQueryJson: { ...tooljetDbJoinDto },


### PR DESCRIPTION
### Changes:
Added authentication guards to :
1. POST /organizations/:organizationId/table/:tableName/bulk-upload
2. POST /organizations/:organizationId/join