### PR TITLE
Preserve user input by gating setVersionName with useRef

### DIFF
--- a/frontend/src/AppBuilder/Header/CreateDraftVersionModal.jsx
+++ b/frontend/src/AppBuilder/Header/CreateDraftVersionModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState ,useRef} from 'react';
 import AlertDialog from '@/_ui/AlertDialog';
 import { Alert } from '@/_ui/Alert';
 import { toast } from 'react-hot-toast';
@@ -92,9 +92,16 @@ const CreateDraftVersionModal = ({
   }, [savedVersions, selectedVersion, selectedVersionForCreation]);
 
   // Update version name when selectedVersionForCreation changes or when modal opens
+  const hasInitializedVersionName = useRef(false);
+
   useEffect(() => {
-    if (showCreateAppVersion && selectedVersionForCreation?.name) {
+    if (!showCreateAppVersion) {
+      hasInitializedVersionName.current = false;
+      return;
+    }
+    if (!hasInitializedVersionName.current && selectedVersionForCreation?.name) {
       setVersionName(selectedVersionForCreation.name);
+      hasInitializedVersionName.current = true;
     }
   }, [selectedVersionForCreation, showCreateAppVersion]);
 


### PR DESCRIPTION
Bug: useEffect with selectedVersionForCreation in its dependency array was calling setVersionName on every dropdown change, not just on modal open — overwriting user input.

Fix: Introduced a useRef flag to gate the setVersionName call, ensuring it only executes once per modal lifecycle (on first available value after open).