### PR TITLE
fix: display correct property name in code-hinter popup header

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx
@@ -19,6 +19,7 @@ export default function SuccessNotificationInputs({ currentState, options, darkM
             initialValue={options.successMessage}
             onChange={(value) => optionchanged('successMessage', value)}
             placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}
+            componentName="Success Message"
             cyLabel={'success-message'}
           />
         </div>

--- a/frontend/src/Editor/QueryManager/Components/SuccessNotificationInputs.jsx
+++ b/frontend/src/Editor/QueryManager/Components/SuccessNotificationInputs.jsx
@@ -19,6 +19,7 @@ export default function SuccessNotificationInputs({ currentState, options, darkM
             initialValue={options.successMessage}
             onChange={(value) => optionchanged('successMessage', value)}
             placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}
+            componentName="Success Message"
             cyLabel={'success-message'}
           />
         </div>


### PR DESCRIPTION
## Problem
When expanding the code hinter from the **Success Message** input in the query editor, the popup header incorrectly displayed `Editor` instead of the property name.

## Fix
Added the `componentName` prop to the `CodeHinter` component in `SuccessNotificationInputs.jsx` (both AppBuilder and Editor versions) so the popup header correctly displays **Success Message**.

Fixes #6655