### PR TITLE
Feat: Added flag to disable 'zoom on drag' behaviour in Chart component for mobile view

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Chart.jsx
+++ b/frontend/src/AppBuilder/Widgets/Chart.jsx
@@ -192,7 +192,7 @@ export default function Chart({
     ...(chartLayout.annotations && { annotations: chartLayout.annotations }),
     barmode: barmode,
     hoverlabel: { namelength: -1 },
-    ...(Object.keys(chartLayout).includes('dragmode') && { dragmode: chartLayout.dragmode }),
+    ...('dragmode' in chartLayout && { dragmode: chartLayout.dragmode }),
   };
 
   const computeChartData = (data, dataString) => {


### PR DESCRIPTION
Fixes: https://github.com/ToolJet/tj-ee/issues/4753

This pull request introduces a minor enhancement to the `Chart` widget. The main change is that the chart's layout will now include the `dragmode` property if it is present in the `chartLayout` object, allowing for more flexible chart interactions.

* Chart layout now conditionally includes the `dragmode` property if specified in `chartLayout`, improving support for interactive chart features. (`frontend/src/AppBuilder/Widgets/Chart.jsx`)

