### PR TITLE
Added fix for contributors

### DIFF
--- a/.github/workflows/render-preview-deploy-v2.yml
+++ b/.github/workflows/render-preview-deploy-v2.yml
@@ -2,7 +2,7 @@ name: Render Preview Deploy (DockerHub-based)
 
 on:
   pull_request:
-    types: [labeled, unlabeled, closed, synchronize]
+    types: [closed, synchronize]
   pull_request_target:
     types: [labeled, unlabeled]
 
@@ -23,9 +23,9 @@ jobs:
 
   build-and-deploy-ce:
     if: |
-      github.event.pull_request.head.repo.fork == false &&
       github.event.action == 'labeled' &&
-      github.event.label.name == 'create-ce-review-app'
+      github.event.label.name == 'create-ce-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -343,7 +343,8 @@ jobs:
   suspend-ce:
     if: |
       github.event.action == 'labeled' &&
-      github.event.label.name == 'suspend-ce-review-app'
+      github.event.label.name == 'suspend-ce-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -387,7 +388,8 @@ jobs:
   resume-ce:
     if: |
       github.event.action == 'unlabeled' &&
-      github.event.label.name == 'suspend-ce-review-app'
+      github.event.label.name == 'suspend-ce-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -428,7 +430,8 @@ jobs:
 
   destroy-ce:
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'destroy-ce-review-app') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'destroy-ce-review-app' &&
+       contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)) ||
       github.event.action == 'closed'
     runs-on: ubuntu-latest
 
@@ -488,9 +491,9 @@ jobs:
 
   build-and-deploy-ee-lts:
     if: |
-      github.event.pull_request.head.repo.fork == false &&
       github.event.action == 'labeled' &&
-      github.event.label.name == 'create-ee-lts-review-app'
+      github.event.label.name == 'create-ee-lts-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -822,7 +825,8 @@ jobs:
   suspend-ee-lts:
     if: |
       github.event.action == 'labeled' &&
-      github.event.label.name == 'suspend-ee-lts-review-app'
+      github.event.label.name == 'suspend-ee-lts-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -866,7 +870,8 @@ jobs:
   resume-ee-lts:
     if: |
       github.event.action == 'unlabeled' &&
-      github.event.label.name == 'suspend-ee-lts-review-app'
+      github.event.label.name == 'suspend-ee-lts-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -907,7 +912,8 @@ jobs:
 
   destroy-ee-lts:
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'destroy-ee-lts-review-app') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'destroy-ee-lts-review-app' &&
+       contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)) ||
       github.event.action == 'closed'
     runs-on: ubuntu-latest
 
@@ -967,9 +973,9 @@ jobs:
 
   build-and-deploy-ee-pre-release:
     if: |
-      github.event.pull_request.head.repo.fork == false &&
       github.event.action == 'labeled' &&
-      github.event.label.name == 'create-ee-pre-release-review-app'
+      github.event.label.name == 'create-ee-pre-release-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -1301,7 +1307,8 @@ jobs:
   suspend-ee-pre-release:
     if: |
       github.event.action == 'labeled' &&
-      github.event.label.name == 'suspend-ee-pre-release-review-app'
+      github.event.label.name == 'suspend-ee-pre-release-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -1345,7 +1352,8 @@ jobs:
   resume-ee-pre-release:
     if: |
       github.event.action == 'unlabeled' &&
-      github.event.label.name == 'suspend-ee-pre-release-review-app'
+      github.event.label.name == 'suspend-ee-pre-release-review-app' &&
+      contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)
     runs-on: ubuntu-latest
 
     steps:
@@ -1386,7 +1394,8 @@ jobs:
 
   destroy-ee-pre-release:
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'destroy-ee-pre-release-review-app') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'destroy-ee-pre-release-review-app' &&
+       contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'), github.event.sender.author_association)) ||
       github.event.action == 'closed'
     runs-on: ubuntu-latest
 


### PR DESCRIPTION

**FIX: secure review app label triggers for fork PRs**

_Problem:_
When a contributor opened a PR from a fork, adding a label like create-ee-lts-review-app to trigger a review app deployment required manual workflow approval. Even after approving, the jobs would silently skip because of the head.repo.fork == false condition on the job-level if:. This made it impossible to test fork PRs via review apps.
Additionally, there was no restriction on who could trigger label-based jobs — any contributor with label permissions could potentially trigger deployments.

_Changes:_

on: trigger — moved labeled and unlabeled event types from pull_request to pull_request_target. The closed and synchronize events remain on pull_request as before.
author_association check — added to the if: condition of all label-triggered jobs (build-and-deploy-*, suspend-*, resume-*, destroy-*). Only users with MEMBER, OWNER, or COLLABORATOR association can trigger these jobs. The destroy-* jobs retain the existing closed event branch without this check so PRs still auto-cleanup on close.

_What this solves:_

Team members can now add labels to fork contributor PRs and the jobs will run immediately without any approval gate
Contributors cannot trigger deployments by adding labels themselves — only repo members/owners/collaborators can
All rebuild-* jobs and every other part of the workflow is completely unchanged