### PR TITLE
POC For Gyrpe Integration

### DIFF
--- a/.github/workflows/gyrpe-scan.yml
+++ b/.github/workflows/gyrpe-scan.yml
@@ -2,6 +2,9 @@ name: Grype POC - Docker Image Scan
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - trivy-integration-poc
 
 jobs:
   grype-poc-scan:


### PR DESCRIPTION
**What this POC does:**

> Trigger — Manual only (workflow_dispatch). Nothing runs automatically, you kick it off from the Actions tab.
> Step 1: Pull image — Downloads tooljet/tooljet:ee-lts-latest from DockerHub onto the GitHub runner.
> Step 2: Table scan — Grype scans the full image and prints a human-readable table directly in the Actions log. You can see every CVE, package name, installed version, fixed version, and severity right there.
> Step 3: JSON scan — Same scan again but outputs a structured JSON file for parsing and download.
> Step 4: Parse — Counts Critical and High CVEs from the JSON using jq.
> Step 5: Upload artifact — Saves grype-poc-results.json for 14 days so your manager can download and inspect every CVE in detail.
> Step 6: Create PR — Auto-creates a PR on lts-3.16 with the scan results table in the PR body, explains why Grype over Trivy, shows what layers are scanned vs current npm audit, and links to the full downloadable report.

Key differences from the Trivy POC:

- anchore/scan-action@v7 instead of aquasecurity/trivy-action@master
- JSON structure uses .matches[].vulnerability.severity instead of .Results[].Vulnerabilities[].Severity
- only-fixed: true instead of ignore-unfixed: true — same behavior, different parameter name
- No @master pinning — using proper @v7 tag which is safer