### PR TITLE
Fix: Query content getting duplicated to other queries on switching

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -32,7 +32,6 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
   const paramListContainerRef = useRef(null);
   const selectedQuery = useStore((state) => state.queryPanel.selectedQuery);
   const selectedDataSource = useStore((state) => state.queryPanel.selectedDataSource);
-  const creatingQueryInProcessId = useStore((state) => state.dataQuery.creatingQueryInProcessId);
   const changeDataQuery = useStore((state) => state.dataQuery.changeDataQuery);
   const updateDataQuery = useStore((state) => state.dataQuery.updateDataQuery);
   const [showLocalDataSourceDeprecationBanner, setshowLocalDataSourceDeprecationBanner] = useState(false);
@@ -224,7 +223,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
         </div>
         <ElementToRender
           renderCopilot={(props) => renderCopilot({ ...props, selectedDataSource })}
-          key={creatingQueryInProcessId || selectedQuery?.id}
+          key={selectedQuery?.id}
           pluginSchema={selectedDataSource?.plugin?.operations_file?.data}
           selectedDataSource={selectedDataSource}
           options={selectedQuery?.options}

--- a/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
@@ -117,7 +117,7 @@ export const createDataQuerySlice = (set, get) => ({
         .create(appId, appVersionId, name, kind, options, dataSourceId, pluginId)
         .then((data) => {
           set((state) => {
-            state.creatingQueryInProcessId = null;
+            state.dataQuery.creatingQueryInProcessId = null;
             state.dataQuery.queries.modules[moduleId] = state.dataQuery.queries.modules[moduleId].map((query) => {
               if (query.id === tempId) {
                 return {
@@ -169,7 +169,7 @@ export const createDataQuerySlice = (set, get) => ({
         })
         .catch((error) => {
           set((state) => {
-            state.creatingQueryInProcessId = null;
+            state.dataQuery.creatingQueryInProcessId = null;
             state.dataQuery.queries.modules[moduleId] = state.dataQuery.queries.modules[moduleId].filter(
               (query) => query.id !== tempId
             );


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/4770

This pull request refactors how the `creatingQueryInProcessId` state is managed in the query management system. The main improvement is to ensure that `creatingQueryInProcessId` is consistently accessed and updated under the `dataQuery` slice, which helps prevent state management bugs and improves code clarity.

**State management consistency:**

* Updated the `createDataQuerySlice` reducer to set and clear `creatingQueryInProcessId` under `state.dataQuery` instead of directly on the root state, ensuring consistent state structure. [[1]](diffhunk://#diff-c79c676e11302e4be285bb5e02eb6088676e79376fd4f20e0c265ae75fd72259L120-R120) [[2]](diffhunk://#diff-c79c676e11302e4be285bb5e02eb6088676e79376fd4f20e0c265ae75fd72259L172-R172)

**Component usage updates:**

* Removed the direct usage of `creatingQueryInProcessId` from the `BaseQueryManagerBody` component, and updated the `key` prop for the rendered element to rely only on `selectedQuery?.id`, simplifying component re-render logic. [[1]](diffhunk://#diff-0255f10990a502f4bccec18c3b8212b4d4b7562dbfa0e4485042d5d0e05562a9L35) [[2]](diffhunk://#diff-0255f10990a502f4bccec18c3b8212b4d4b7562dbfa0e4485042d5d0e05562a9L227-R226)