### PR TITLE
fix: add optional chaining to prevent console error when clicking header

### DIFF
--- a/frontend/src/Editor/Container.jsx
+++ b/frontend/src/Editor/Container.jsx
@@ -373,7 +373,7 @@ export const Container = ({
         }
 
         if (item.name === 'comment') {
-          const canvasBoundingRect = document.getElementsByClassName('real-canvas')[0].getBoundingClientRect();
+          const canvasBoundingRect = document.getElementsByClassName('real-canvas')[0]?.getBoundingClientRect();
           const offsetFromTopOfWindow = canvasBoundingRect.top;
           const offsetFromLeftOfWindow = canvasBoundingRect.left;
           const currentOffset = monitor.getSourceClientOffset();
@@ -389,7 +389,7 @@ export const Container = ({
           return undefined;
         }
 
-        const canvasBoundingRect = document.getElementsByClassName('real-canvas')[0].getBoundingClientRect();
+        const canvasBoundingRect = document.getElementsByClassName('real-canvas')[0]?.getBoundingClientRect();
         const componentMeta = deepClone(
           componentTypes.find((component) => component.component === item.component.component)
         );
@@ -745,7 +745,7 @@ export const Container = ({
   const handleAddThreadOnComponent = async (_, __, e) => {
     e.stopPropogation && e.stopPropogation();
 
-    const canvasBoundingRect = document.getElementsByClassName('real-canvas')[0].getBoundingClientRect();
+    const canvasBoundingRect = document.getElementsByClassName('real-canvas')[0]?.getBoundingClientRect();
     const offsetFromTopOfWindow = canvasBoundingRect.top;
     const offsetFromLeftOfWindow = canvasBoundingRect.left;
 


### PR DESCRIPTION
## Description

Fixes #4019: Clicking on the header was printing error in console.

## Changes

- Added optional chaining (?.) to getBoundingClientRect() calls at lines 376, 392, and 748 in Container.jsx
- This prevents errors when the real-canvas element is not present

## Testing

- Open the editor
- Click on the header
- No console error should appear