### PR TITLE
fix: dark mode UI inconsistency in local data source pop up fixes #6909

### DIFF
--- a/frontend/src/_styles/left-sidebar.scss
+++ b/frontend/src/_styles/left-sidebar.scss
@@ -456,6 +456,14 @@
     }
   }
 }
+
+.theme-dark {
+  .card.active {
+    background: var(--slate12) !important;
+    color: var(--text-default) !important;
+  }
+}
+
 .viewer-page-handler.dark {
   .card.active {
     background: #2c405c;


### PR DESCRIPTION
## Description
Fixes issue #6909 - Dark mode UI inconsistency in local data source pop up.

### Problem
The local data source pop up has white background in dark mode, which is inconsistent with other pop ups in the application.

### Solution
Added proper dark theme styling for card items in the left sidebar datasource section. When in dark mode (theme-dark), card items now use the proper slate12 background color instead of white.

### Changes
- Added .theme-dark .card.active style in left-sidebar.scss to properly style active cards in dark mode

## Testing
- Verified that the fix applies proper background color in dark mode
- No breaking changes to light mode functionality

### Related Issue
#6909