### PR TITLE
fix: improve dark mode visibility for TreeSelect widget fixes #11798

### DIFF
--- a/frontend/src/_styles/left-sidebar.scss
+++ b/frontend/src/_styles/left-sidebar.scss
@@ -456,6 +456,14 @@
     }
   }
 }
+
+.theme-dark {
+  .card.active {
+    background: var(--slate12) !important;
+    color: var(--text-default) !important;
+  }
+}
+
 .viewer-page-handler.dark {
   .card.active {
     background: #2c405c;

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -6337,6 +6337,23 @@ input.hide-input-arrows {
   }
 }
 
+.theme-dark .custom-checkbox-tree {
+  color: #e0e0e0;
+
+  .rct-title {
+    color: #e0e0e0 !important;
+  }
+
+  .rct-icon-expand-open::before,
+  .rct-icon-expand-close::before {
+    filter: invert(1);
+  }
+
+  .rct-checkbox input:checked + .rct-checkbox-icon {
+    filter: invert(0.6) sepia(1) saturate(5) hue-rotate(180deg);
+  }
+}
+
 // sso enable/disable box
 .tick-cross-info {
   .main-box {


### PR DESCRIPTION
## Description

Fixes the dark mode visibility issue for the TreeSelect widget where tree items were barely visible in dark mode.

### Changes

- Added  styles in 
- Light text color (#e0e0e0) for tree items in dark mode
- Inverted icons for better visibility
- Fixed checkbox icons in dark mode

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test

1. In ToolJet, switch to dark mode
2. Drag out a TreeSelect widget
3. Verify tree items are now readable

## Related issue

Fixes #11798