### PR TITLE
fix(mongodb): handle URL-encoded credentials in connection strings

### DIFF
--- a/plugins/packages/mongodb/lib/index.ts
+++ b/plugins/packages/mongodb/lib/index.ts
@@ -316,9 +316,19 @@ async getConnection(sourceOptions: SourceOptions): Promise<any> {
 
   const finalHosts = hostsList.join(",");
   const finalDb = explicitDb || dbNameFromConn || "";
-  const authSection = needsAuth
-    ? `${encodeURIComponent(finalUser)}:${encodeURIComponent(finalPass)}@`
-    : "";
+  const safeEncode = (value: string) => {
+  try {
+    const decoded = decodeURIComponent(value);
+    if (decoded !== value) {
+      return value;
+    }
+  } catch (e) {}
+  return encodeURIComponent(value);
+};
+
+const authSection = needsAuth
+  ? `${safeEncode(finalUser)}:${safeEncode(finalPass)}@`
+  : "";
 
   let finalUri = `${protocol}://${authSection}${finalHosts}`;
 


### PR DESCRIPTION
## Summary

Fixes incorrect handling of URL-encoded credentials in MongoDB connection strings.

When users provide credentials containing special characters (e.g. `@`), they often pre-encode them in the connection string as `%40`. The previous implementation applied `encodeURIComponent` again, resulting in **double encoding** and causing authentication failures.

---

## Problem

If a user passes a password like `Test%40123`, it should be decoded as `Test@123` — but instead the old code was producing `Test%2540123`.

| | Value |
|---|---|
| Input password | `Test%40123` |
| Expected | `Test@123` ✅ |
| Actual (before fix) | `Test%2540123` ❌ |

This happened because `encodeURIComponent` was being called on a value that was **already encoded**.

---

## Solution

Introduced a helper function `safeEncode` that:

- Detects if a value is already URL-encoded
- Skips re-encoding if so, preventing double encoding
- Maintains backward compatibility for raw (un-encoded) credentials

---

## Code Change

MongoDB username and password are now passed through `safeEncode` before constructing the connection URI.
```diff
- encodeURIComponent(finalUser)
- encodeURIComponent(finalPass)
+ safeEncode(finalUser)
+ safeEncode(finalPass)
```

---

## Impact

- Fixes authentication failures when using URL-encoded credentials
- No breaking changes
- Backward compatible with existing connection strings

---

## Related Issue

Fixes #15397