### PR TITLE
[chore]: Add GitHub Copilot review instructions for App Builder team

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,24 +1,4 @@
-# ToolJet App Builder — Code Review Instructions
-
-> Scoped to the **App Builder team**. Covers `frontend/src/AppBuilder/`, `frontend/src/_ui/`, `frontend/src/_stores/`, `server/src/modules/apps/`, `server/migrations/`, and `server/data-migrations/`.
-
----
-
-## Backward Compatibility (CRITICAL)
-
-### Widget Config Sync
-
-When any file inside `frontend/src/AppBuilder/WidgetManager/widgets/` is touched, the corresponding config in `server/src/modules/apps/services/widget-config/` MUST also be updated to stay in sync. Flag PRs that modify one without the other.
-
-### Widget Config Key Changes Require Migrations
-
-If a widget config change moves, renames, or removes a key (e.g., moving `loadingState` from `styles` to `properties`), this WILL break existing apps. A migration MUST be written in `server/migrations/` to transform saved app definitions. Flag any key restructuring that lacks an accompanying migration.
-
-### General Rule
-
-No change should break existing saved applications. When reviewing, always ask: "Would an app saved before this PR still load and behave correctly after it?"
-
----
+# ToolJet — Shared Copilot Instructions
 
 ## Styling
 
@@ -43,58 +23,17 @@ No change should break existing saved applications. When reviewing, always ask: 
 ## State Management
 
 - Zustand with Immer middleware only. No Redux/MobX/Recoil.
-- Global stores (`_stores/appDataStore`, `currentStateStore`, `dataQueriesStore`, `resolverStore`) should NOT be used in AppBuilder code unless absolutely critical. Prefer the AppBuilder store. Flag any new usage of global stores.
-- AppBuilder store: `AppBuilder/_stores/store.js` (30+ slices). All slices are namespaced by `moduleId` (default: `'canvas'`).
 - Use `shallow` comparison in `useStore` when selecting objects/arrays. Flag missing `shallow`.
-
-## Resolution System (`{{}}`)
-
-- Flow: unresolved value → `extractAndReplaceReferencesFromString` → `resolveDynamicValues` → `resolveCode` (via `new Function()`) → resolved value stored in `resolvedSlice`.
-- `{{...}}` references MUST be registered in the dependency graph via `addReferencesForDependencyGraph`. Missing this causes stale renders.
-- After `setExposedValue`, `updateDependencyValues` MUST be called to propagate changes.
-- Inside ListView/Kanban, `customResolvables` provide row-scoped context (`listItem` / `cardData`).
-
-## Rendering Pipeline
-
-`AppCanvas → Container → WidgetWrapper → RenderWidget → Widget`
-
-- Widgets receive resolved props from `RenderWidget`. They must NOT directly access store state.
-- `setExposedVariable` and `fireEvent` are passed as callbacks — widgets use these to communicate outward.
-
-## Subcontainer Architecture
-
-- `SubcontainerContext` carries `contextPath` array: `[{ containerId, index }, ...]`.
-- Row-scoped resolution uses prototype overlay (`prepareRowScope`/`updateRowScope`).
-- Child-to-parent: `setExposedValuesPerRow` → `_deriveListviewChain` (no callback chains).
-- ListView nesting limited to **2 levels**. Only row 0 is editable; others are read-only mirrors.
-- `findNearestSubcontainerAncestor` is critical for dependency resolution — verify it's used when walking the component tree.
-- Keywords: `listItem` (ListView), `cardData` (Kanban). Don't mix them up.
-
-## Widget Definitions
-
-Configs: `AppBuilder/WidgetManager/widgets/*.js` → registered in `componentTypes.js`.
-
-- New widgets MUST be lazy-loaded.
-- Use `useBatchedUpdateEffectArray` for batched state updates.
-- Default `definition` values should use design tokens, not hardcoded hex.
-- Remember: changes to config keys require server-side sync + potential migration (see Backward Compatibility above).
-
-## Event & Query Systems
-
-- Events: `fireEvent → handleEvent → executeActionsForEventId → executeAction`. Events support `runOnlyIf` and `debounce`.
-- Queries: `runQuery → resolve options → API call → update exposedValues.queries[name] → trigger dependency updates`.
-- Event definitions live in `eventsSlice`, not in component definitions.
-
-## Bundle & Performance
-
-- Viewer (`/applications/*`) and editor are separate lazy bundles via `RootRouter.jsx`. Do not import editor-only code into viewer paths.
-- Avoid `JSON.parse(JSON.stringify(...))` or `_.cloneDeep` in render/hot paths. Use Immer.
-- Flag O(N) loops inside already-O(N) resolution paths (eager resolution for ListView children).
 
 ## Icons & Assets
 
 - Use Tabler Icons (`@tabler/icons-react`) or Lucide React (`lucide-react`). Do NOT add new icon packages.
 - Static assets: `frontend/assets/images/`.
+
+## Security
+
+- No API keys/secrets in client-side code.
+- Backend: parameterized queries only, never concatenate user input into SQL.
 
 ## Common Review Flags
 
@@ -107,35 +46,3 @@ Configs: `AppBuilder/WidgetManager/widgets/*.js` → registered in `componentTyp
 - Missing `key` props in `.map()`
 - Missing `shallow` in `useStore` selectors
 - Direct DOM manipulation (except canvas drop calculations)
-- Widget config changes without server-side sync or migration
-- New usage of global stores (`appDataStore`, `currentStateStore`, `dataQueriesStore`, `resolverStore`) in AppBuilder code — prefer the AppBuilder store
-
-## Security
-
-- No API keys/secrets in client-side code.
-- `resolveCode` uses `new Function()` — be cautious about evaluated expressions.
-- Backend: parameterized queries only, never concatenate user input into SQL.
-
----
-
-## Data Migration Logging Guidelines
-
-**Applies to:** `server/data-migrations/**/*`
-
-New migrations must include progress logging:
-
-1. **Baseline** — Before processing, query and log total records:
-   `[START] {Action} | Total: {Total}`
-
-2. **Progress** — During execution, log using current/total format:
-   `[PROGRESS] {Current}/{Total} ({Percentage}%)`
-
-3. **Confirmation** — Log final success:
-   `[SUCCESS] {Action} finished.`
-
-### Reviewer Checklist for `server/data-migrations/`
-
-- [ ] Count query establishes a **total** before processing
-- [ ] Log statements use the **`x/total`** ratio pattern
-- [ ] Clear **success** log at the end
-- [ ] No silent bulk updates without console feedback

--- a/.github/instructions/appbuilder-review.instructions.md
+++ b/.github/instructions/appbuilder-review.instructions.md
@@ -1,0 +1,54 @@
+---
+applyTo: "frontend/src/AppBuilder/**/*"
+excludeAgent: "coding-agent"
+---
+
+# App Builder — Code Review Rules
+
+## Backward Compatibility (CRITICAL)
+
+No change should break existing saved applications. When reviewing, always ask: "Would an app saved before this PR still load and behave correctly after it?"
+
+## Resolution System (`{{}}`)
+
+- Flow: unresolved value → `extractAndReplaceReferencesFromString` → `resolveDynamicValues` → `resolveCode` (via `new Function()`) → resolved value stored in `resolvedSlice`.
+- `{{...}}` references MUST be registered in the dependency graph via `addReferencesForDependencyGraph`. Missing this causes stale renders.
+- After `setExposedValue`, `updateDependencyValues` MUST be called to propagate changes.
+- Inside ListView/Kanban, `customResolvables` provide row-scoped context (`listItem` / `cardData`).
+
+## Rendering Pipeline
+
+`AppCanvas → Container → WidgetWrapper → RenderWidget → Widget`
+
+- Widgets receive resolved props from `RenderWidget`. They must NOT directly access store state.
+- `setExposedVariable` and `fireEvent` are passed as callbacks — widgets use these to communicate outward.
+
+## Subcontainer Architecture
+
+- `SubcontainerContext` carries `contextPath` array: `[{ containerId, index }, ...]`.
+- Row-scoped resolution uses prototype overlay (`prepareRowScope`/`updateRowScope`).
+- Child-to-parent: `setExposedValuesPerRow` → `_deriveListviewChain` (no callback chains).
+- ListView nesting limited to **2 levels**. Only row 0 is editable; others are read-only mirrors.
+- `findNearestSubcontainerAncestor` is critical for dependency resolution — verify it's used when walking the component tree.
+- Keywords: `listItem` (ListView), `cardData` (Kanban). Don't mix them up.
+
+## Event & Query Systems
+
+- Events: `fireEvent → handleEvent → executeActionsForEventId → executeAction`. Events support `runOnlyIf` and `debounce`.
+- Queries: `runQuery → resolve options → API call → update exposedValues.queries[name] → trigger dependency updates`.
+- Event definitions live in `eventsSlice`, not in component definitions.
+
+## Bundle & Performance
+
+- Viewer (`/applications/*`) and editor are separate lazy bundles via `RootRouter.jsx`. Do not import editor-only code into viewer paths.
+- Avoid `JSON.parse(JSON.stringify(...))` or `_.cloneDeep` in render/hot paths. Use Immer.
+- Flag O(N) loops inside already-O(N) resolution paths (eager resolution for ListView children).
+
+## State Management
+
+- Global stores (`appDataStore`, `currentStateStore`, `dataQueriesStore`, `resolverStore`) should NOT be used in AppBuilder code unless absolutely critical. Prefer the AppBuilder store. Flag any new usage.
+- AppBuilder store: `AppBuilder/_stores/store.js` (30+ slices). All slices are namespaced by `moduleId` (default: `'canvas'`).
+
+## Security
+
+- `resolveCode` uses `new Function()` — be cautious about evaluated expressions.

--- a/.github/instructions/data-migrations.instructions.md
+++ b/.github/instructions/data-migrations.instructions.md
@@ -1,0 +1,31 @@
+---
+applyTo: "server/data-migrations/**/*"
+---
+
+# Data Migration — Logging Guidelines
+
+New migrations MUST include progress logging to help monitor deployments.
+
+## Required Logging Pattern
+
+1. **Baseline** — Before processing, query and log total records:
+   `[START] {Action} | Total: {Total}`
+
+2. **Progress** — During execution, log using current/total format:
+   `[PROGRESS] {Current}/{Total} ({Percentage}%)`
+
+3. **Confirmation** — Log final success:
+   `[SUCCESS] {Action} finished.`
+
+## Reviewer Checklist
+
+- [ ] Count query establishes a **total** before processing
+- [ ] Log statements use the **`x/total`** ratio pattern
+- [ ] Clear **success** log at the end
+- [ ] No silent bulk updates without console feedback
+
+## When Generating Migration Code
+
+- Include a count query for the denominator before processing.
+- Wrap iterative logic in a batch/loop that logs `current/total` progress.
+- Avoid silent bulk updates that provide no console feedback.

--- a/.github/instructions/server-widget-config-review.instructions.md
+++ b/.github/instructions/server-widget-config-review.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "server/src/modules/apps/services/widget-config/**/*"
+excludeAgent: "coding-agent"
+---
+
+# Server Widget Config — Code Review Rules
+
+## Frontend Sync (CRITICAL)
+
+When any file here is modified, the corresponding config in `frontend/src/AppBuilder/WidgetManager/widgets/` MUST also be updated. Flag PRs that modify one without the other.
+
+## Key Changes Require Migrations
+
+If a config change moves, renames, or removes a key, a migration MUST be written in `server/migrations/` to transform saved app definitions. Flag any key restructuring that lacks an accompanying migration.
+
+## Backward Compatibility
+
+No change should break existing saved applications. Always ask: "Would an app saved before this PR still load and behave correctly after it?"

--- a/.github/instructions/widget-components-review.instructions.md
+++ b/.github/instructions/widget-components-review.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "frontend/src/AppBuilder/Widgets/**/*"
+excludeAgent: "coding-agent"
+---
+
+# Widget Components — Code Review Rules
+
+## Component Rules
+
+- New widgets MUST be lazy-loaded.
+- Use `useBatchedUpdateEffectArray` for batched state updates.
+- Widgets receive resolved props from `RenderWidget`. They must NOT directly access store state.
+- `setExposedVariable` and `fireEvent` are passed as callbacks — widgets use these to communicate outward.
+- Default values should use design tokens, not hardcoded hex colors.

--- a/.github/instructions/widget-config-review.instructions.md
+++ b/.github/instructions/widget-config-review.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "frontend/src/AppBuilder/WidgetManager/widgets/**/*"
+excludeAgent: "coding-agent"
+---
+
+# Widget Config — Code Review Rules
+
+## Server-Side Sync (CRITICAL)
+
+When any file here is modified, the corresponding config in `server/src/modules/apps/services/widget-config/` MUST also be updated. Flag PRs that modify one without the other.
+
+## Key Changes Require Migrations
+
+If a config change moves, renames, or removes a key (e.g., moving `loadingState` from `styles` to `properties`), this WILL break existing apps. A migration MUST be written in `server/migrations/` to transform saved app definitions. Flag any key restructuring that lacks an accompanying migration.
+
+## Widget Definition Rules
+
+- New widgets MUST be lazy-loaded.
+- Use `useBatchedUpdateEffectArray` for batched state updates.
+- Widget components must be registered in `componentTypes.js`.
+
+## Backward Compatibility
+
+Always ask: "Would an app saved before this PR still load and behave correctly after it?"


### PR DESCRIPTION
## 📝 What this does
Adds a `.github/copilot-instructions.md` file with code review guidelines scoped to the App Builder team, covering backward compatibility, styling conventions, state management, resolution system, and common review flags.

## 🔀 Changes
- Added Copilot review instructions covering widget config sync, migration requirements, Tailwind/styling rules, Zustand patterns, resolution pipeline, and security guidelines
