### PR TITLE
fix: improve tree select widget visibility in dark mode

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -6337,6 +6337,14 @@ input.hide-input-arrows {
   }
 }
 
+.theme-dark .custom-checkbox-tree {
+  color: #d1d5db;
+
+  .react-checkbox-tree label {
+    color: #d1d5db;
+  }
+}
+
 // sso enable/disable box
 .tick-cross-info {
   .main-box {


### PR DESCRIPTION
## Summary
Fix poor visibility of tree select widget text in dark mode.

## Problem
The `.custom-checkbox-tree` class uses a hardcoded dark color (`#3e525b`) without a dark mode override, making the tree items barely readable against the dark background.

## Fix
Added `.theme-dark .custom-checkbox-tree` style override to set text and label color to `#d1d5db` (light gray) for proper contrast in dark mode.

## Changes
- `frontend/src/_styles/theme.scss`: Added dark mode styles for `.custom-checkbox-tree`

Fixes #11798