### PR TITLE
feat(marketplace): add SeaTable connector plugin

### DIFF
--- a/marketplace/plugins/seatable/README.md
+++ b/marketplace/plugins/seatable/README.md
@@ -1,0 +1,73 @@
+# SeaTable Connector for ToolJet
+
+A ToolJet marketplace plugin that connects to any [SeaTable](https://seatable.com) server (cloud or self-hosted) and provides full CRUD operations.
+
+## Supported Operations
+
+| Operation | Description |
+|---|---|
+| **List Rows** | Paginated row listing from any table |
+| **Get Row** | Fetch a single row by its ID |
+| **Create Row** | Insert a new row with column → value pairs |
+| **Update Row** | Update an existing row by ID |
+| **Delete Row** | Delete a row by ID |
+| **Search Rows (SQL)** | Query rows using SeaTable's SQL interface |
+| **Get Metadata** | Retrieve all tables, columns, and views (schema discovery) |
+
+## Connection Setup
+
+1. **Server URL** – The URL of your SeaTable server. This can be the SaaS offering `https://cloud.seatable.io` or any self-hosted SeaTable instance.
+2. **API Token** – A base-scoped API token. Create one in SeaTable: Base → Advanced → API Token.
+
+The plugin works with any SeaTable server and exchanges the API token for a short-lived base token automatically.
+
+## Development
+
+```bash
+npm install
+npm run build     # Compile TypeScript → dist/ (via @vercel/ncc)
+npm run watch     # Watch mode for development
+```
+
+## Testing
+
+Integration tests run against a real SeaTable instance:
+
+```bash
+SEATABLE_TEST_SERVER_URL=https://your-seatable-server.com \
+SEATABLE_TEST_API_TOKEN=your_api_token_here \
+npm test
+```
+
+Without the environment variables, integration tests are skipped automatically.
+
+## File Structure
+
+```
+├── package.json            # @tooljet-marketplace/seatable
+├── tsconfig.json           # TypeScript config (ToolJet monorepo compatible)
+├── README.md
+├── __tests__/
+│   └── index.js            # Integration tests (Jest)
+└── lib/                    # Source files (ToolJet convention)
+    ├── icon.svg            # SeaTable logo
+    ├── manifest.json       # Connection form schema (Server URL + API Token)
+    ├── operations.json     # Available operations and their parameters
+    ├── index.ts            # QueryService implementation (run + testConnection)
+    ├── query_operations.ts # Operation dispatcher
+    ├── seatable_client.ts  # SeaTable API client (auth + CRUD)
+    └── types.ts            # TypeScript type definitions
+```
+
+## How It Works
+
+The plugin follows SeaTable's two-step authentication:
+
+1. **Token exchange** – `GET /api/v2.1/dtable/app-access-token/` with the API token returns a base token + base UUID
+2. **Data operations** – All CRUD calls go to `/api-gateway/api/v2/dtables/{base_uuid}/...` with the base token
+
+This matches the pattern used by the official [SeaTable MCP Server](https://github.com/seatable/seatable-mcp).
+
+## Publishing to ToolJet Marketplace
+
+Submit a pull request to the [ToolJet repository](https://github.com/ToolJet/ToolJet). The plugin files go into `marketplace/plugins/seatable/`. The ToolJet team reviews the PR, and if approved, the plugin ships with the next release.

--- a/marketplace/plugins/seatable/__tests__/index.js
+++ b/marketplace/plugins/seatable/__tests__/index.js
@@ -1,0 +1,211 @@
+'use strict';
+
+/**
+ * Tests for the SeaTable ToolJet marketplace plugin.
+ *
+ * Set environment variables SEATABLE_TEST_SERVER_URL and SEATABLE_TEST_API_TOKEN
+ * to run integration tests against a real SeaTable instance.
+ * Without these variables, integration tests are skipped.
+ */
+
+const SeaTableQueryService = require('../dist/index').default || require('../dist/index');
+
+const SERVER_URL = process.env.SEATABLE_TEST_SERVER_URL;
+const API_TOKEN = process.env.SEATABLE_TEST_API_TOKEN;
+const HAS_CREDENTIALS = !!(SERVER_URL && API_TOKEN);
+
+const sourceOptions = {
+  server_url: SERVER_URL || 'https://cloud.seatable.io',
+  api_token: API_TOKEN || 'missing',
+};
+
+describe('seatable', () => {
+  let service;
+
+  beforeAll(() => {
+    service = new SeaTableQueryService();
+  });
+
+  // --- Minimum required stub (matches ToolJet convention) ---
+  it.todo('needs more tests');
+
+  // --- Integration tests (run only with credentials) ---
+
+  const describeIntegration = HAS_CREDENTIALS ? describe : describe.skip;
+
+  describeIntegration('integration: testConnection', () => {
+    it('should connect successfully with valid credentials', async () => {
+      const result = await service.testConnection(sourceOptions);
+      expect(result.status).toBe('ok');
+    });
+
+    it('should fail with invalid API token', async () => {
+      const result = await service.testConnection({
+        server_url: sourceOptions.server_url,
+        api_token: 'invalid_token_000000000000000000000000',
+      });
+      expect(result.status).toBe('failed');
+      expect(result.message).toBeDefined();
+    });
+
+    it('should fail with invalid server URL', async () => {
+      const result = await service.testConnection({
+        server_url: 'https://nonexistent.invalid',
+        api_token: sourceOptions.api_token,
+      });
+      expect(result.status).toBe('failed');
+    });
+  });
+
+  describeIntegration('integration: get_metadata', () => {
+    it('should return tables with columns', async () => {
+      const result = await service.run(sourceOptions, { operation: 'get_metadata' });
+      expect(result.status).toBe('ok');
+      expect(result.data).toBeDefined();
+      expect(result.data.tables).toBeInstanceOf(Array);
+      expect(result.data.tables.length).toBeGreaterThan(0);
+
+      const table = result.data.tables[0];
+      expect(table.name).toBeDefined();
+      expect(table._id).toBeDefined();
+      expect(table.columns).toBeInstanceOf(Array);
+    });
+  });
+
+  describeIntegration('integration: list_rows', () => {
+    it('should return rows from a table', async () => {
+      // First get table name from metadata
+      const meta = await service.run(sourceOptions, { operation: 'get_metadata' });
+      const tableName = meta.data.tables[0].name;
+
+      const result = await service.run(sourceOptions, {
+        operation: 'list_rows',
+        table_name: tableName,
+        page: '1',
+        page_size: '10',
+      });
+      expect(result.status).toBe('ok');
+      expect(result.data.rows).toBeInstanceOf(Array);
+      expect(result.data).toHaveProperty('has_more');
+    });
+
+    it('should throw when table_name is missing', async () => {
+      await expect(
+        service.run(sourceOptions, { operation: 'list_rows' })
+      ).rejects.toThrow();
+    });
+  });
+
+  describeIntegration('integration: CRUD lifecycle', () => {
+    let createdRowId;
+    let tableName;
+
+    beforeAll(async () => {
+      const meta = await service.run(sourceOptions, { operation: 'get_metadata' });
+      tableName = meta.data.tables[0].name;
+    });
+
+    it('should create a row', async () => {
+      const result = await service.run(sourceOptions, {
+        operation: 'create_row',
+        table_name: tableName,
+        row_data: JSON.stringify({ Name: 'ToolJet Test Row' }),
+      });
+      expect(result.status).toBe('ok');
+      expect(result.data._id).toBeDefined();
+      createdRowId = result.data._id;
+    });
+
+    it('should get the created row', async () => {
+      expect(createdRowId).toBeDefined();
+      const result = await service.run(sourceOptions, {
+        operation: 'get_row',
+        table_name: tableName,
+        row_id: createdRowId,
+      });
+      expect(result.status).toBe('ok');
+      expect(result.data._id).toBe(createdRowId);
+      expect(result.data.Name).toBe('ToolJet Test Row');
+    });
+
+    it('should update the row', async () => {
+      expect(createdRowId).toBeDefined();
+      const result = await service.run(sourceOptions, {
+        operation: 'update_row',
+        table_name: tableName,
+        row_id: createdRowId,
+        row_data: JSON.stringify({ Name: 'ToolJet Updated Row' }),
+      });
+      expect(result.status).toBe('ok');
+      expect(result.data.success).toBe(true);
+    });
+
+    it('should find the row via SQL', async () => {
+      expect(createdRowId).toBeDefined();
+      const result = await service.run(sourceOptions, {
+        operation: 'search_rows',
+        sql_query: `SELECT * FROM \`${tableName}\` WHERE Name = 'ToolJet Updated Row' LIMIT 5`,
+      });
+      expect(result.status).toBe('ok');
+      expect(result.data.results).toBeInstanceOf(Array);
+      expect(result.data.results.length).toBeGreaterThan(0);
+    });
+
+    it('should delete the row', async () => {
+      expect(createdRowId).toBeDefined();
+      const result = await service.run(sourceOptions, {
+        operation: 'delete_row',
+        table_name: tableName,
+        row_id: createdRowId,
+      });
+      expect(result.status).toBe('ok');
+      expect(result.data.deleted_rows).toBe(1);
+      createdRowId = null;
+    });
+
+    afterAll(async () => {
+      // Cleanup: if test failed before delete, try to clean up
+      if (createdRowId) {
+        try {
+          await service.run(sourceOptions, {
+            operation: 'delete_row',
+            table_name: tableName,
+            row_id: createdRowId,
+          });
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    });
+  });
+
+  describeIntegration('integration: error handling', () => {
+    it('should throw on unknown operation', async () => {
+      await expect(
+        service.run(sourceOptions, { operation: 'nonexistent' })
+      ).rejects.toThrow();
+    });
+
+    it('should throw when row_id is missing for get_row', async () => {
+      await expect(
+        service.run(sourceOptions, { operation: 'get_row', table_name: 'Table2' })
+      ).rejects.toThrow();
+    });
+
+    it('should throw when sql_query is missing for search_rows', async () => {
+      await expect(
+        service.run(sourceOptions, { operation: 'search_rows' })
+      ).rejects.toThrow();
+    });
+
+    it('should throw on invalid row_data JSON', async () => {
+      await expect(
+        service.run(sourceOptions, {
+          operation: 'create_row',
+          table_name: 'Table2',
+          row_data: 'not valid json{{{',
+        })
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/marketplace/plugins/seatable/lib/icon.svg
+++ b/marketplace/plugins/seatable/lib/icon.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="145"
+   height="145"
+   viewBox="0 0 145 145"
+   version="1.1"
+   xml:space="preserve"
+   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+   id="svg15"
+   sodipodi:docname="logo_seatable_vector_vector-quadratisch.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+   id="namedview17"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   width="144px"
+   fit-margin-top="0"
+   fit-margin-left="0"
+   fit-margin-right="0"
+   fit-margin-bottom="0"
+   inkscape:zoom="6.0625"
+   inkscape:cx="51.546392"
+   inkscape:cy="77.938144"
+   inkscape:window-width="2506"
+   inkscape:window-height="1376"
+   inkscape:window-x="54"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg15" />
+    <g
+   id="g6"
+   transform="translate(22)">
+        <path
+   d="M 13.26,109.938 47.172,143.85 95.915,95.108 c 8.844,-8.845 8.844,-23.185 0,-32.028 L 78.019,45.182 77.7,44.863 24.155,98.292 24.53,98.667 Z"
+   style="fill:url(#_Linear1)"
+   id="path2" />
+        <path
+   d="M 24.53,98.667 89.289,33.913 55.377,0 6.633,48.743 c -8.844,8.844 -8.844,23.184 0,32.028 z"
+   style="fill:#ff8000"
+   id="path4" />
+    </g>
+    <defs
+   id="defs13">
+        <linearGradient
+   id="_Linear1"
+   x1="0"
+   y1="0"
+   x2="1"
+   y2="0"
+   gradientUnits="userSpaceOnUse"
+   gradientTransform="matrix(-9.4681,-27.4234,27.4234,-9.4681,57.904,91.0448)"><stop
+     offset="0"
+     style="stop-color:rgb(255,128,0);stop-opacity:1"
+     id="stop8" /><stop
+     offset="1"
+     style="stop-color:rgb(236,40,55);stop-opacity:1"
+     id="stop10" /></linearGradient>
+    </defs>
+</svg>

--- a/marketplace/plugins/seatable/lib/index.ts
+++ b/marketplace/plugins/seatable/lib/index.ts
@@ -1,0 +1,61 @@
+import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-marketplace/common';
+import { queryOperations } from './query_operations';
+import { SourceOptions, QueryOptions } from './types';
+
+export default class SeaTableQueryService implements QueryService {
+  async run(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions,
+    _dataSourceId?: string,
+    _dataSourceUpdatedAt?: string,
+    _context?: Record<string, unknown>
+  ): Promise<QueryResult> {
+    const operation = queryOptions.operation;
+
+    try {
+      let result: object;
+
+      switch (operation) {
+        case 'list_rows':
+          result = await queryOperations.listRows(sourceOptions, queryOptions);
+          break;
+        case 'get_row':
+          result = await queryOperations.getRow(sourceOptions, queryOptions);
+          break;
+        case 'create_row':
+          result = await queryOperations.createRow(sourceOptions, queryOptions);
+          break;
+        case 'update_row':
+          result = await queryOperations.updateRow(sourceOptions, queryOptions);
+          break;
+        case 'delete_row':
+          result = await queryOperations.deleteRow(sourceOptions, queryOptions);
+          break;
+        case 'search_rows':
+          result = await queryOperations.searchRows(sourceOptions, queryOptions);
+          break;
+        case 'get_metadata':
+          result = await queryOperations.getMetadata(sourceOptions);
+          break;
+        default:
+          throw new QueryError(`Unknown operation: ${operation}`, '', {});
+      }
+
+      return { status: 'ok', data: result };
+    } catch (error: unknown) {
+      if (error instanceof QueryError) throw error;
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new QueryError(message, '', {});
+    }
+  }
+
+  async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
+    try {
+      await queryOperations.getMetadata(sourceOptions);
+      return { status: 'ok' };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Connection failed';
+      return { status: 'failed', message };
+    }
+  }
+}

--- a/marketplace/plugins/seatable/lib/manifest.json
+++ b/marketplace/plugins/seatable/lib/manifest.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/manifest.schema.json",
+  "title": "SeaTable datasource",
+  "description": "A schema defining SeaTable datasource",
+  "type": "api",
+  "source": {
+    "name": "SeaTable",
+    "kind": "seatable",
+    "exposedVariables": {
+      "isLoading": false,
+      "data": {},
+      "rawData": {}
+    },
+    "options": {
+      "server_url": {
+        "type": "string"
+      },
+      "api_token": {
+        "type": "string",
+        "encrypted": true
+      }
+    }
+  },
+  "defaults": {},
+  "properties": {
+    "server_url": {
+      "label": "Server URL",
+      "key": "server_url",
+      "type": "text",
+      "description": "URL of your SeaTable server (e.g. https://cloud.seatable.io or your self-hosted instance)"
+    },
+    "api_token": {
+      "label": "API Token",
+      "key": "api_token",
+      "type": "textarea",
+      "encrypted": true,
+      "description": "Base-scoped API token. Create in SeaTable: Base > Advanced > API Token."
+    }
+  },
+  "required": [
+    "server_url",
+    "api_token"
+  ]
+}

--- a/marketplace/plugins/seatable/lib/operations.json
+++ b/marketplace/plugins/seatable/lib/operations.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/operations.schema.json",
+  "title": "SeaTable datasource operations",
+  "description": "Operations supported by the SeaTable datasource",
+  "type": "api",
+  "defaults": {
+    "operation": "list_rows"
+  },
+  "properties": {
+    "operation": {
+      "label": "Operation",
+      "key": "operation",
+      "type": "dropdown-component-flip",
+      "description": "Select the operation to perform",
+      "list": [
+        { "value": "list_rows", "name": "List Rows" },
+        { "value": "get_row", "name": "Get Row" },
+        { "value": "create_row", "name": "Create Row" },
+        { "value": "update_row", "name": "Update Row" },
+        { "value": "delete_row", "name": "Delete Row" },
+        { "value": "search_rows", "name": "Search Rows (SQL)" },
+        { "value": "get_metadata", "name": "Get Metadata" }
+      ]
+    },
+    "table_name": {
+      "label": "Table Name",
+      "key": "table_name",
+      "type": "codehinter",
+      "description": "Name of the table (e.g. Contacts, Tasks)",
+      "show_if": {
+        "operation": "list_rows, get_row, create_row, update_row, delete_row"
+      }
+    },
+    "row_id": {
+      "label": "Row ID",
+      "key": "row_id",
+      "type": "codehinter",
+      "description": "The unique row identifier (_id field)",
+      "show_if": {
+        "operation": "get_row, update_row, delete_row"
+      }
+    },
+    "row_data": {
+      "label": "Row Data (JSON)",
+      "key": "row_data",
+      "type": "codehinter",
+      "description": "JSON object with column name → value pairs, e.g. {\"Name\": \"Alice\", \"Email\": \"alice@example.com\"}",
+      "show_if": {
+        "operation": "create_row, update_row"
+      }
+    },
+    "page": {
+      "label": "Page",
+      "key": "page",
+      "type": "codehinter",
+      "description": "Page number (1-based, default: 1)",
+      "show_if": {
+        "operation": "list_rows"
+      }
+    },
+    "page_size": {
+      "label": "Page Size",
+      "key": "page_size",
+      "type": "codehinter",
+      "description": "Number of rows per page (max 1000, default: 100)",
+      "show_if": {
+        "operation": "list_rows"
+      }
+    },
+    "sql_query": {
+      "label": "SQL Query",
+      "key": "sql_query",
+      "type": "codehinter",
+      "description": "SQL query, e.g. SELECT * FROM Contacts WHERE Name = 'Alice' LIMIT 10",
+      "show_if": {
+        "operation": "search_rows"
+      }
+    }
+  }
+}

--- a/marketplace/plugins/seatable/lib/query_operations.ts
+++ b/marketplace/plugins/seatable/lib/query_operations.ts
@@ -1,0 +1,105 @@
+import { SeaTableClient } from './seatable_client';
+import { SourceOptions, QueryOptions } from './types';
+
+function getClient(sourceOptions: SourceOptions): SeaTableClient {
+  const serverUrl = sourceOptions.server_url;
+  const apiToken = sourceOptions.api_token;
+  if (!serverUrl || !apiToken) {
+    throw new Error('Missing server_url or api_token in connection settings');
+  }
+  return new SeaTableClient(serverUrl, apiToken);
+}
+
+function parseJson(value: string | Record<string, unknown>): Record<string, unknown> {
+  if (typeof value === 'object' && value !== null) return value;
+  try {
+    return JSON.parse(value as string);
+  } catch {
+    throw new Error(`Invalid JSON: ${String(value)}`);
+  }
+}
+
+export const queryOperations = {
+  async listRows(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions
+  ): Promise<object> {
+    const client = getClient(sourceOptions);
+    const tableName = queryOptions.table_name;
+    const page = parseInt(String(queryOptions.page ?? '1'), 10) || 1;
+    const pageSize = parseInt(String(queryOptions.page_size ?? '100'), 10) || 100;
+
+    if (!tableName) throw new Error('table_name is required');
+    return client.listRows(tableName, page, pageSize);
+  },
+
+  async getRow(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions
+  ): Promise<object> {
+    const client = getClient(sourceOptions);
+    const tableName = queryOptions.table_name;
+    const rowId = queryOptions.row_id;
+
+    if (!tableName) throw new Error('table_name is required');
+    if (!rowId) throw new Error('row_id is required');
+    return client.getRow(tableName, rowId);
+  },
+
+  async createRow(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions
+  ): Promise<object> {
+    const client = getClient(sourceOptions);
+    const tableName = queryOptions.table_name;
+    if (!queryOptions.row_data) throw new Error('row_data is required');
+    const rowData = parseJson(queryOptions.row_data);
+
+    if (!tableName) throw new Error('table_name is required');
+    return client.createRow(tableName, rowData);
+  },
+
+  async updateRow(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions
+  ): Promise<object> {
+    const client = getClient(sourceOptions);
+    const tableName = queryOptions.table_name;
+    const rowId = queryOptions.row_id;
+    if (!queryOptions.row_data) throw new Error('row_data is required');
+    const rowData = parseJson(queryOptions.row_data);
+
+    if (!tableName) throw new Error('table_name is required');
+    if (!rowId) throw new Error('row_id is required');
+    return client.updateRow(tableName, rowId, rowData);
+  },
+
+  async deleteRow(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions
+  ): Promise<object> {
+    const client = getClient(sourceOptions);
+    const tableName = queryOptions.table_name;
+    const rowId = queryOptions.row_id;
+
+    if (!tableName) throw new Error('table_name is required');
+    if (!rowId) throw new Error('row_id is required');
+    return client.deleteRow(tableName, rowId);
+  },
+
+  async searchRows(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions
+  ): Promise<object> {
+    const client = getClient(sourceOptions);
+    const sql = queryOptions.sql_query;
+
+    if (!sql) throw new Error('sql_query is required');
+    return client.querySql(sql);
+  },
+
+  async getMetadata(sourceOptions: SourceOptions): Promise<object> {
+    const client = getClient(sourceOptions);
+    return client.getMetadata();
+  },
+};

--- a/marketplace/plugins/seatable/lib/seatable_client.ts
+++ b/marketplace/plugins/seatable/lib/seatable_client.ts
@@ -1,0 +1,140 @@
+import axios, { AxiosInstance } from 'axios';
+import {
+  SeaTableTokenResponse,
+  SeaTableRow,
+  SeaTableMetadata,
+  ListRowsResult,
+  SqlResult,
+} from './types';
+
+/**
+ * Lightweight SeaTable API client for ToolJet.
+ *
+ * Auth flow (matches the SeaTable MCP server pattern):
+ * 1. Exchange the long-lived API-Token for a short-lived Base-Token
+ *    via GET /api/v2.1/dtable/app-access-token/
+ * 2. Use the Base-Token for all subsequent data requests against
+ *    /api-gateway/api/v2/dtables/{base_uuid}/...
+ */
+export class SeaTableClient {
+  private readonly serverUrl: string;
+  private readonly apiToken: string;
+
+  private baseToken?: string;
+  private baseUuid?: string;
+  private http?: AxiosInstance;
+  private tokenExpiresAt = 0;
+
+  constructor(serverUrl: string, apiToken: string) {
+    this.serverUrl = serverUrl.replace(/\/$/, '');
+    this.apiToken = apiToken;
+  }
+
+  // --- Authentication -------------------------------------------------------
+
+  private async ensureAuthenticated(): Promise<void> {
+    if (this.http && Date.now() < this.tokenExpiresAt) return;
+
+    const url = `${this.serverUrl}/api/v2.1/dtable/app-access-token/`;
+    const res = await axios.get<SeaTableTokenResponse>(url, {
+      headers: { Authorization: `Bearer ${this.apiToken}` },
+      timeout: 15000,
+    });
+
+    this.baseToken = res.data.access_token;
+    this.baseUuid = res.data.dtable_uuid;
+
+    if (!this.baseToken || !this.baseUuid) {
+      throw new Error('SeaTable token exchange failed – missing access_token or dtable_uuid');
+    }
+
+    // Renew 1 minute before expiry (default token lifetime = 1h)
+    this.tokenExpiresAt = Date.now() + 59 * 60 * 1000;
+
+    this.http = axios.create({
+      baseURL: `${this.serverUrl}/api-gateway/api/v2/dtables/${this.baseUuid}`,
+      timeout: 30000,
+      headers: { Authorization: `Bearer ${this.baseToken}` },
+    });
+  }
+
+  private async request<T>(fn: (http: AxiosInstance) => Promise<T>): Promise<T> {
+    await this.ensureAuthenticated();
+    return fn(this.http!);
+  }
+
+  // --- Metadata -------------------------------------------------------------
+
+  async getMetadata(): Promise<SeaTableMetadata> {
+    return this.request(async (http) => {
+      const res = await http.get('/metadata/');
+      return res.data.metadata ?? res.data;
+    });
+  }
+
+  // --- Rows -----------------------------------------------------------------
+
+  async listRows(tableName: string, page = 1, pageSize = 100): Promise<ListRowsResult> {
+    return this.request(async (http) => {
+      const start = (page - 1) * pageSize;
+      const res = await http.get('/rows/', {
+        params: { table_name: tableName, start, limit: pageSize, convert_keys: true },
+      });
+      const rows: SeaTableRow[] = res.data.rows ?? [];
+      return { rows, has_more: rows.length === pageSize };
+    });
+  }
+
+  async getRow(tableName: string, rowId: string): Promise<SeaTableRow> {
+    return this.request(async (http) => {
+      const res = await http.get(`/rows/${rowId}/`, {
+        params: { table_name: tableName, convert_keys: true },
+      });
+      return res.data;
+    });
+  }
+
+  async createRow(tableName: string, row: Record<string, unknown>): Promise<SeaTableRow> {
+    return this.request(async (http) => {
+      const res = await http.post('/rows/', {
+        table_name: tableName,
+        rows: [row],
+        convert_keys: true,
+      });
+      return res.data.first_row ?? res.data;
+    });
+  }
+
+  async updateRow(
+    tableName: string,
+    rowId: string,
+    row: Record<string, unknown>
+  ): Promise<{ success: boolean }> {
+    return this.request(async (http) => {
+      const res = await http.put('/rows/', {
+        table_name: tableName,
+        updates: [{ row_id: rowId, row }],
+      });
+      return res.data;
+    });
+  }
+
+  async deleteRow(tableName: string, rowId: string): Promise<{ success: boolean }> {
+    return this.request(async (http) => {
+      const res = await http.delete('/rows/', {
+        data: { table_name: tableName, row_ids: [rowId] },
+      });
+      return res.data;
+    });
+  }
+
+  async querySql(sql: string): Promise<SqlResult> {
+    return this.request(async (http) => {
+      const res = await http.post('/sql/', { sql, convert_keys: true });
+      return {
+        metadata: res.data.metadata ?? {},
+        results: res.data.results ?? res.data.rows ?? [],
+      };
+    });
+  }
+}

--- a/marketplace/plugins/seatable/lib/types.ts
+++ b/marketplace/plugins/seatable/lib/types.ts
@@ -1,0 +1,78 @@
+export type SourceOptions = {
+  server_url: string;
+  api_token: string;
+};
+
+export type QueryOptions = {
+  operation:
+    | 'list_rows'
+    | 'get_row'
+    | 'create_row'
+    | 'update_row'
+    | 'delete_row'
+    | 'search_rows'
+    | 'get_metadata';
+  table_name?: string;
+  row_id?: string;
+  row_data?: string | Record<string, unknown>;
+  page?: string;
+  page_size?: string;
+  sql_query?: string;
+};
+
+export type SeaTableTokenResponse = {
+  access_token: string;
+  dtable_uuid: string;
+  dtable_server: string;
+  workspace_id: number;
+  dtable_name: string;
+  app_name: string;
+  use_api_gateway: boolean;
+};
+
+export type SeaTableRow = {
+  _id: string;
+  _mtime?: string;
+  _ctime?: string;
+  _creator?: string;
+  _last_modifier?: string;
+  [key: string]: unknown;
+};
+
+export type SeaTableTable = {
+  _id: string;
+  name: string;
+  columns: SeaTableColumn[];
+  views: SeaTableView[];
+};
+
+export type SeaTableColumn = {
+  key: string;
+  name: string;
+  type: string;
+  width?: number;
+  editable?: boolean;
+  data?: Record<string, unknown>;
+};
+
+export type SeaTableView = {
+  _id: string;
+  name: string;
+  type: string;
+};
+
+export type SeaTableMetadata = {
+  tables: SeaTableTable[];
+  version: number;
+  format_version: number;
+};
+
+export type ListRowsResult = {
+  rows: SeaTableRow[];
+  has_more: boolean;
+};
+
+export type SqlResult = {
+  metadata: Record<string, unknown>;
+  results: SeaTableRow[];
+};

--- a/marketplace/plugins/seatable/package.json
+++ b/marketplace/plugins/seatable/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tooljet-marketplace/seatable",
+  "version": "1.0.0",
+  "description": "ToolJet marketplace connector for SeaTable – connect to any SeaTable server and perform CRUD operations.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "ncc build lib/index.ts -o dist",
+    "watch": "ncc build lib/index.ts -o dist --watch",
+    "test": "cd ../.. && npm test"
+  },
+  "dependencies": {
+    "axios": "^1.7.0",
+    "@tooljet-marketplace/common": "^1.0.0"
+  },
+  "devDependencies": {
+    "@vercel/ncc": "^0.38.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/marketplace/plugins/seatable/tsconfig.json
+++ b/marketplace/plugins/seatable/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "lib"
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "__tests__"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a new marketplace plugin for [SeaTable](https://seatable.com), an collaborative database platform
- Supports 7 operations: List Rows, Get Row, Create Row, Update Row, Delete Row, Search Rows (SQL), Get Metadata (schema discovery)
- Works with any SeaTable server — cloud (cloud.seatable.io) or self-hosted
- Authentication uses SeaTable's two-step token exchange (API-Token → Base-Token)
- Includes integration tests (Jest) that run against a real SeaTable instance when env vars are provided

## Plugin structure

```
marketplace/plugins/seatable/
├── package.json
├── tsconfig.json
├── README.md
├── __tests__/
│   └── index.js
└── lib/
    ├── icon.svg
    ├── manifest.json
    ├── operations.json
    ├── index.ts
    ├── query_operations.ts
    ├── seatable_client.ts
    └── types.ts
```

## Test plan

- [x] All 7 operations verified against a real SeaTable instance (15/15 integration tests pass)
- [x] testConnection validates credentials and returns clear error messages
- [x] Error handling for unknown operations, missing required fields, invalid JSON
- [ ] Manual test in ToolJet UI (marketplace install + data source creation)

## More information

- SeaTable website: https://seatable.com
- SeaTable API documentation: https://developer.seatable.com
- Source repository: https://github.com/seatable/tooljet-connector

🤖 Generated with [Claude Code](https://claude.ai/code)