### PR TITLE
fix: Dropping a module after a module search

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Modal.jsx
+++ b/frontend/src/AppBuilder/Widgets/Modal.jsx
@@ -175,7 +175,6 @@ export const Modal = function Modal({
       backgroundColor:
         ['#fff', '#ffffffff'].includes(headerBackgroundColor) && darkMode ? '#1F2837' : headerBackgroundColor,
       color: ['#000', '#000000', '#000000ff'].includes(headerTextColor) && darkMode ? '#fff' : headerTextColor,
-      overflowX: 'hidden',
     },
     buttonStyles: {
       backgroundColor: triggerButtonBackgroundColor,

--- a/frontend/src/AppBuilder/Widgets/ModalV2/helpers/stylesFactory.js
+++ b/frontend/src/AppBuilder/Widgets/ModalV2/helpers/stylesFactory.js
@@ -33,6 +33,7 @@ export function createModalStyles({
         ['#fff', '#ffffffff'].includes(headerBackgroundColor) && darkMode ? '#1F2837' : headerBackgroundColor,
       overflowY: isDisabledModal ? 'hidden' : 'auto',
       '--cc-modal-header-divider-color': headerDividerColor,
+      overflowX: 'hidden',
     },
     modalFooter: {
       backgroundColor:


### PR DESCRIPTION
This pull request updates the `DragLayer` component in the App Builder to improve its reactivity and ensure consistent props are passed to child components. The main changes involve updating dependencies in a React hook and adjusting how props are passed to `ModuleWidgetBox`.

**React hook improvements:**
* The dependency array for the hook now includes `component.moduleId` in addition to `component.component`, ensuring the effect re-runs when either changes.

**Component rendering consistency:**
* The `ModuleWidgetBox` now receives both `index` and `module` props, aligning its usage with `WidgetBox` and improving prop consistency.