### PR TITLE
Fix: Add missing urlJoin import in eventsSlice

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
@@ -3,6 +3,7 @@ import toast from 'react-hot-toast';
 import { debounce, replaceEntityReferencesWithIds } from '../utils';
 import { isQueryRunnable, serializeNestedObjectToQueryParams } from '@/_helpers/utils';
 import { getHostURL } from '@/_helpers/routes';
+import urlJoin from 'url-join';
 import useStore from '@/AppBuilder/_stores/store';
 import _ from 'lodash';
 import { logoutAction } from '@/AppBuilder/_utils/auth';


### PR DESCRIPTION
## 📝 What this does
Adds the missing `urlJoin` import in `eventsSlice.js`, fixing a runtime TypeError when users trigger "Open Webpage" events with relative URLs. This regression was introduced by #15228 (Custom domains support).

## 🔀 Changes
- Added `import urlJoin from 'url-join'` to `eventsSlice.js`

## 🧪 How to test
- [ ] Add a button with an "Open Webpage" event using a relative URL (e.g. `/dashboard`)
- [ ] Click the button and verify the page opens correctly
- [ ] Verify absolute URLs (e.g. `https://example.com`) still work
- [ ] Confirm no console errors when triggering the event