### PR TITLE
Fix: Prioritize columnSize property for width over UI changes

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.js
@@ -99,7 +99,7 @@ export default function generateColumnsData({
     .map((column) => {
       if (!column) return null;
 
-      const columnSize = columnSizes[column?.id] || columnSizes[column?.name] || column.columnSize;
+      const columnSize = column.columnSize || columnSizes[column?.id] || columnSizes[column?.name];
       const columnType = column?.columnType;
 
       // Process column options for select types


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/4633

This pull request makes a minor adjustment to the column sizing logic in the `generateColumnsData` utility. The priority for determining a column's size now checks the column's own `columnSize` property before falling back to the `columnSizes` mapping.

* Changed the order of precedence so that `column.columnSize` is used before checking `columnSizes` by `id` or `name` in `generateColumnsData.js` (`generateColumnsData`).