### PR TITLE
fix(mssql): respect statement timeout for long-running queries

### DIFF
--- a/plugins/packages/mssql/lib/index.ts
+++ b/plugins/packages/mssql/lib/index.ts
@@ -357,6 +357,7 @@ private parseConnectionString(connectionString: string): Partial<SourceOptions> 
           encrypt: (finalOptions.azure ?? false) || shouldUseSSL,
           instanceName: finalOptions.instanceName,
           trustServerCertificate: shouldUseSSL && finalOptions.ssl_certificate === 'none',
+          requestTimeout: this.STATEMENT_TIMEOUT,
           ...(shouldUseSSL ? { cryptoCredentialsDetails: sslObject } : {}), // MSSQL uses cryptoCredentialsDetails for TLS
           ...(finalOptions.connection_options && this.sanitizeOptions(finalOptions.connection_options)),
         },


### PR DESCRIPTION
## Problem
MSSQL queries were timing out after 15s regardless of the configured
`STATEMENT_TIMEOUT` (default: 120s).

The `tedious` driver has its own `requestTimeout` that defaults to
15,000ms. This fires before Knex's `.timeout()`, causing premature
ETIMEOUT errors.

Slack thread - https://tooljet.slack.com/archives/C07B74EMNDD/p1774004030645189