### PR TITLE
Fix: [ButtonGroupV2] Mandatory property not working on component drop

### DIFF
--- a/frontend/src/AppBuilder/WidgetManager/widgets/buttonGroupV2.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/buttonGroupV2.js
@@ -331,6 +331,10 @@ export const buttonGroupV2Config = {
       showOnDesktop: { value: '{{true}}' },
       showOnMobile: { value: '{{false}}' },
     },
+    validation: {
+      mandatory: { value: '{{false}}' },
+      customRule: { value: null },
+    },
     properties: {
       label: { value: `Label` },
       advanced: { value: '{{false}}' },

--- a/server/src/modules/apps/services/widget-config/buttonGroupV2.js
+++ b/server/src/modules/apps/services/widget-config/buttonGroupV2.js
@@ -331,6 +331,10 @@ export const buttonGroupV2Config = {
       showOnDesktop: { value: '{{true}}' },
       showOnMobile: { value: '{{false}}' },
     },
+    validation: {
+      mandatory: { value: '{{false}}' },
+      customRule: { value: null },
+    },
     properties: {
       label: { value: `Label` },
       advanced: { value: '{{false}}' },


### PR DESCRIPTION
This pull request adds a new validation configuration to the `buttonGroupV2` widget in both the frontend and server codebases. The new `validation` property allows for specifying whether the button group is mandatory and for defining a custom validation rule.

**Widget Validation Enhancements:**

* Added a `validation` property to the `buttonGroupV2Config` in `frontend/src/AppBuilder/WidgetManager/widgets/buttonGroupV2.js`, enabling configuration of mandatory status and custom validation rules.
* Added the same `validation` property to the backend config in `server/src/modules/apps/services/widget-config/buttonGroupV2.js` for consistency and backend support.