### PR TITLE
fix(appCanvasUtils): update modal header padding logic to correctly handle close button visibility

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js
+++ b/frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js
@@ -853,9 +853,9 @@ export const getSubContainerWidthAfterPadding = (canvasWidth, componentType, com
   if (componentType === 'ModalV2') {
     const isModalHeader = componentId?.includes('header');
     if (isModalHeader) {
-      const isModalHeaderCloseBtnEnabled = !useStore.getState().getResolvedComponent(componentId)?.properties
-        ?.hideCloseButton;
-      padding = 2 * (MODAL_CANVAS_PADDING + (isModalHeaderCloseBtnEnabled ? 56 : 0)) + 2 * HOVER_CLICK_OUTLINE_BORDER;
+      const isModalHeaderCloseBtnHidden = useStore.getState().getResolvedComponent(componentId.slice(0, 36))
+        ?.properties?.hideCloseButton;
+      padding = 2 * (MODAL_CANVAS_PADDING + 2 * HOVER_CLICK_OUTLINE_BORDER) + (isModalHeaderCloseBtnHidden ? 0 : 56);
     } else {
       padding = 2 * MODAL_CANVAS_PADDING + 2 * HOVER_CLICK_OUTLINE_BORDER;
     }
@@ -867,6 +867,7 @@ export const getSubContainerWidthAfterPadding = (canvasWidth, componentType, com
     padding =
       2 * TAB_CANVAS_PADDING + 2 * BOX_PADDING + 2 * SUBCONTAINER_CANVAS_BORDER_WIDTH + 2 * HOVER_CLICK_OUTLINE_BORDER;
   }
+
   return canvasWidth - padding;
 };
 


### PR DESCRIPTION
This pull request updates the calculation of padding for modal headers in the `getSubContainerWidthAfterPadding` utility function. The main change corrects how the presence of the close button is determined and adjusts the padding calculation logic accordingly.

**Modal header padding calculation updates:**

* Changed the logic for determining if the modal header's close button is hidden by checking the `hideCloseButton` property on the parent modal component (using the first 36 characters of `componentId`), instead of on the header itself.
* Updated the padding calculation: now, the extra space for the close button (56px) is only added if the close button is not hidden, and the formula for padding has been adjusted for clarity and correctness.

**Other:**

* Minor formatting: added a blank line before the return statement for readability.