### PR TITLE
Chore: revive db:seed script for first user setup

### DIFF
--- a/server/scripts/seeds.ts
+++ b/server/scripts/seeds.ts
@@ -3,7 +3,6 @@ import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import got from 'got';
 
-// Load .env the same way other scripts do
 const nodeEnvPath = path.resolve(process.cwd(), process.env.NODE_ENV === 'test' ? '../.env.test' : '../.env');
 const fallbackPath = path.resolve(process.cwd(), '../.env');
 if (fs.existsSync(nodeEnvPath)) {


### PR DESCRIPTION
## 📝 What this does
Revives the `npm run db:seed` command so developers and CI can set up a first super admin user without manual curl commands. Useful for agentic workflows with git worktrees and preview deployments.

## 🔀 Changes
- Replaced stale commented-out seed script with a working HTTP-based implementation
- Calls `POST /api/onboarding/setup-super-admin`
- Added env var overrides (`SEED_EMAIL`, `SEED_PASSWORD`, `SEED_NAME`, `SEED_WORKSPACE`) for CI/preview deployments
- Made the script idempotent — skips gracefully if users already exist
- Requires a running server (no fragile NestJS DI bootstrap)

## 🧪 How to test
- [x] Reset the database: `npm run db:reset`
- [x] Start the server: `npm run start:dev`
- [x] Run the seed: `npm run db:seed`
- [x] Verify login works with `dev@tooljet.com` / `password`
- [x] Run `npm run db:seed` again — should skip with "Database already has users"
- [x] Test with custom credentials: `SEED_EMAIL=test@example.com SEED_PASSWORD=secret npm run db:seed` (after db:reset)