### PR TITLE
fix(firestore): use collection reference for Add Document operation

### DIFF
--- a/plugins/packages/firestore/lib/operations.json
+++ b/plugins/packages/firestore/lib/operations.json
@@ -181,11 +181,11 @@
         "key": "path",
         "type": "codehinter",
         "lineNumbers": false,
-        "description": "Enter collection",
+        "description": "Enter collection name",
         "width": "320px",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Enter path"
+        "placeholder": "Enter collection name"
       },
       "body": {
         "label": "Body",

--- a/plugins/packages/firestore/lib/operations.ts
+++ b/plugins/packages/firestore/lib/operations.ts
@@ -52,11 +52,11 @@ export async function setDocument(db, path: string, body: string): Promise<objec
   return result;
 }
 
-export async function addDocument(db, path: string, body: string): Promise<object> {
-  const docRef = db.doc(path);
-  const result = await docRef.set(JSON.parse(body));
+export async function addDocument(db, collection: string, body: string): Promise<object> {
+  const collectionRef = db.collection(collection);
+  const result = await collectionRef.add(JSON.parse(body));
 
-  return result;
+  return { id: result.id };
 }
 
 export async function updateDocument(db, path: string, body: string): Promise<object> {


### PR DESCRIPTION
## Summary
Fixes the "Add Document to Collection" operation in the Firestore plugin which currently requires a full document path (`collection/documentId`) instead of just a collection name.

**Root cause:** The `addDocument` function was using `db.doc(path).set(body)`, which is identical to `setDocument` and expects a full document path. For adding a new document to a collection, the correct Firestore API is `db.collection(collectionName).add(body)`, which accepts just the collection name and auto-generates the document ID.

**Changes:**
- `operations.ts`: Changed `addDocument` to use `db.collection(collection).add()` instead of `db.doc(path).set()`. The response now includes the auto-generated document ID.
- `operations.json`: Updated the placeholder text from "Enter path" to "Enter collection name" for consistency with the "Collection" label.

Resolves #15249