### PR TITLE
Fix: Radio button and Button Group V2 design review changes

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/PopoverMenu.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/PopoverMenu.jsx
@@ -67,11 +67,11 @@ export const PopoverMenu = ({ componentMeta, darkMode, ...restProps }) => {
         onOptionChange={handleOptionChange}
         onAddOption={handleAddOption}
         onDragEnd={onDragEnd}
+        onDefaultChange={handleDefaultChange}
         getResolvedValue={getResolvedValue}
         getItemStyle={getItemStyle}
-        dataCyPrefix={config.dataCy}
-        popoverFields={config.popoverFields}
-        onDefaultChange={handleDefaultChange}
+        componentType={componentType}
+        config={config}
         {...restProps}
       />
     );

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/components/OptionDetailsPopover.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/components/OptionDetailsPopover.jsx
@@ -11,16 +11,16 @@ const OptionDetailsPopover = forwardRef(
       darkMode,
       onOptionChange,
       onDeleteOption,
+      onDefaultChange,
       getResolvedValue,
-      fields,
-      dataCyPrefix = '',
-      popoverClassName = 'pm-option-popover',
+      config,
       componentType,
       ...restProps
     },
     ref
   ) => {
     const iconVisibility = item?.iconVisibility;
+    const { dataCy: dataCyPrefix, popoverFields, popoverClassName, popoverTitle } = config;
 
     // Common CodeHinter props
     const commonCodeHinterProps = {
@@ -39,7 +39,7 @@ const OptionDetailsPopover = forwardRef(
       type: 'fxEditor',
     };
 
-    const showField = (fieldName) => fields.includes(fieldName);
+    const showField = (fieldName) => popoverFields.includes(fieldName);
 
     return (
       <Popover
@@ -54,7 +54,7 @@ const OptionDetailsPopover = forwardRef(
           <div data-cy={`${dataCyPrefix}-option-details-container`}>
             <div data-cy={`${dataCyPrefix}-option-details-header`} className="pm-option-header">
               <span data-cy={`${dataCyPrefix}-option-details-title`} className="pm-option-header-title">
-                Option details
+                {popoverTitle}
               </span>
               <div data-cy={`${dataCyPrefix}-option-details-actions`} className="pm-option-details-actions">
                 <ButtonComponent
@@ -184,7 +184,7 @@ const OptionDetailsPopover = forwardRef(
                     paramLabel={['ButtonGroupV2'].includes(componentType) ? 'Selected' : 'Default option'}
                     paramName={'optionDefault'}
                     onChange={(value) => {
-                      restProps.onDefaultChange(value, index);
+                      onDefaultChange(value, index);
                     }}
                     onFxPress={(active) => onOptionChange('default.fxActive', active, index)}
                     fxActive={item?.default?.fxActive}

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/components/OptionItem.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/components/OptionItem.jsx
@@ -19,12 +19,12 @@ const OptionItem = ({
   onOptionChange,
   getResolvedValue,
   getItemStyle,
-  // Configurable props for reuse
-  dataCyPrefix = '',
-  popoverFields,
-  popoverClassName,
+  config, // Configurable props for reuse
   ...restProps
 }) => {
+  const { dataCy: dataCyPrefix } = config;
+  const { onDefaultChange, componentType } = restProps;
+
   return (
     <Draggable key={item?.value} draggableId={item?.value} index={index}>
       {(provided, snapshot) => {
@@ -48,12 +48,10 @@ const OptionItem = ({
                   darkMode={darkMode}
                   onOptionChange={onOptionChange}
                   onDeleteOption={onDeleteOption}
+                  onDefaultChange={onDefaultChange}
                   getResolvedValue={getResolvedValue}
-                  fields={popoverFields}
-                  dataCyPrefix={dataCyPrefix}
-                  popoverClassName={popoverClassName}
-                  onDefaultChange={restProps.onDefaultChange}
-                  componentType={restProps?.component?.component?.component}
+                  config={config}
+                  componentType={componentType}
                 />
               }
               onToggle={(isOpen) => {

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/components/OptionsList.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/components/OptionsList.jsx
@@ -16,12 +16,11 @@ const OptionsList = ({
   onDragEnd,
   getResolvedValue,
   getItemStyle,
-  // Configurable props for reuse
-  dataCyPrefix = '',
-  popoverFields,
-  popoverClassName,
+  config, // Configurable props for reuse
   ...restProps
 }) => {
+  const { dataCy: dataCyPrefix, addOptionCtaLabel } = config;
+
   return (
     <List data-cy={`${dataCyPrefix}-options-list`} style={{ marginBottom: '12px' }}>
       <DragDropContext
@@ -46,9 +45,7 @@ const OptionsList = ({
                     onOptionChange={onOptionChange}
                     getResolvedValue={getResolvedValue}
                     getItemStyle={getItemStyle}
-                    dataCyPrefix={dataCyPrefix}
-                    popoverFields={popoverFields}
-                    popoverClassName={popoverClassName}
+                    config={config}
                     {...restProps}
                   />
                 ))}
@@ -59,7 +56,7 @@ const OptionsList = ({
         </Droppable>
       </DragDropContext>
       <AddNewButton onClick={onAddOption} dataCy={`${dataCyPrefix}-add-new-option`} className="mt-0">
-        Add new option
+        {addOptionCtaLabel}
       </AddNewButton>
     </List>
   );

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/constants.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/PopoverMenu/constants.js
@@ -12,8 +12,10 @@ export const COMPONENT_INSPECTOR_CONFIG = {
   ButtonGroupV2: {
     propertiesAccordionTitle: 'Data',
     optionsAccordionTitle: 'Buttons',
+    popoverTitle: 'Edit button',
     popoverFields: ['label', 'value', 'icon', 'default', 'disable'],
     optionLabelPrefix: 'Button',
+    addOptionCtaLabel: 'Add new button',
     singleDataSection: false,
     dataCy: 'inspector-button-group-v2',
   },
@@ -29,7 +31,10 @@ export const COMPONENT_INSPECTOR_CONFIG = {
 export const DEFAULT_CONFIG = {
   propertiesAccordionTitle: 'Properties', // Title for the main properties accordion
   popoverFields: [], // Field names to show in each option's details popover
+  popoverTitle: 'Option details', // Title shown in the option details popover header
+  popoverClassName: 'pm-option-popover', // CSS class applied to the option details popover
   optionLabelPrefix: 'option', // Prefix for new option labels (e.g. "option1", "Card1")
+  addOptionCtaLabel: 'Add new option', // Label for the add-option button
   singleDataSection: false, // If true, one "Data" section; if false, separate "Properties" + "Options"
   dataCy: '', // data-cy prefix for option list and related elements
 };

--- a/frontend/src/AppBuilder/WidgetManager/widgets/buttonGroupV2.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/buttonGroupV2.js
@@ -155,30 +155,6 @@ export const buttonGroupV2Config = {
       ],
       isFxNotRequired: true,
     },
-    widthType: {
-      type: 'select',
-      showLabel: false,
-      options: [
-        { name: 'Of the Component', value: 'ofComponent' },
-        { name: 'Of the Field', value: 'ofField' },
-      ],
-      validation: {
-        schema: { type: 'string' },
-        defaultValue: 'ofComponent',
-      },
-      accordian: 'label',
-      isFxNotRequired: true,
-      conditionallyRender: [
-        {
-          key: 'alignment',
-          value: 'side',
-        },
-        {
-          key: 'auto',
-          value: false,
-        },
-      ],
-    },
     backgroundColor: {
       type: 'colorSwatches',
       displayName: 'Background',
@@ -430,7 +406,6 @@ export const buttonGroupV2Config = {
       auto: { value: '{{true}}' },
       direction: { value: 'left' },
       alignment: { value: 'side' },
-      widthType: { value: 'ofComponent' },
       backgroundColor: { value: 'var(--cc-surface1-surface)' },
       borderColor: { value: 'var(--cc-default-border)' },
       textColor: { value: 'var(--cc-primary-text)' },

--- a/frontend/src/AppBuilder/Widgets/ButtonGroupV2/ButtonGroupV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/ButtonGroupV2/ButtonGroupV2.jsx
@@ -7,10 +7,7 @@ import './buttonGroupV2.scss';
 import TablerIcon from '@/_ui/Icon/TablerIcon';
 // eslint-disable-next-line import/no-unresolved
 import { cx } from 'class-variance-authority';
-import {
-  getLabelWidthOfInput,
-  getWidthTypeOfComponentStyles,
-} from '@/AppBuilder/Widgets/BaseComponents/hooks/useInput';
+import { getWidthTypeOfComponentStyles } from '@/AppBuilder/Widgets/BaseComponents/hooks/useInput';
 import Loader from '@/ToolJetUI/Loader/Loader';
 
 export const ButtonGroupV2 = (props) => {
@@ -36,7 +33,6 @@ export const ButtonGroupV2 = (props) => {
     direction,
     auto: labelAutoWidth,
     labelWidth,
-    widthType,
     backgroundColor,
     hoverBackgroundMode = 'auto',
     hoverBackgroundColor = 'var(--cc-primary-brand)',
@@ -228,7 +224,6 @@ export const ButtonGroupV2 = (props) => {
   // ===== COMPUTED STYLES =====
   const _height = padding === 'default' ? `${height}px` : `${height + 4}px`;
   const justifyContentByAlignment = btnAlignment === 'left' ? 'start' : btnAlignment === 'right' ? 'end' : 'center';
-  const _width = getLabelWidthOfInput(widthType, labelWidth); // Max width which label can go is 70% for better UX calculate width based on this value
 
   const groupStyles = {
     width: layout === 'wrap' ? '100%' : 'max-content',
@@ -240,7 +235,7 @@ export const ButtonGroupV2 = (props) => {
     height: _height,
     ...(layout === 'column' && { justifyContent: justifyContentByAlignment }),
     overflow: layout === 'row' ? 'auto hidden' : 'hidden auto',
-    ...getWidthTypeOfComponentStyles(widthType, labelWidth, labelAutoWidth, alignment),
+    ...getWidthTypeOfComponentStyles('ofComponent', labelWidth, labelAutoWidth, alignment),
   };
 
   const commonStyles = {
@@ -334,8 +329,7 @@ export const ButtonGroupV2 = (props) => {
           direction={direction}
           defaultAlignment={alignment}
           isMandatory={isMandatory}
-          _width={_width}
-          widthType={widthType}
+          _width={labelWidth}
           top={alignment !== 'top' && '9px'}
           id={`${id}-label`}
           dataCy={dataCy}

--- a/frontend/src/AppBuilder/Widgets/RadioButtonV2/RadioButtonV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/RadioButtonV2/RadioButtonV2.jsx
@@ -192,8 +192,9 @@ export const RadioButtonV2 = ({
   const _width = getLabelWidthOfInput(widthType, labelWidth);
 
   const computedLayoutStyles = {
+    height: '100%',
     flexDirection: layout === 'wrap' ? 'row' : layout,
-    ...(layout === 'wrap' && { flexWrap: 'wrap' }),
+    ...(layout === 'wrap' && { flexWrap: 'wrap', maxHeight: '100%', height: 'max-content' }),
     overflow: layout === 'row' ? 'auto hidden' : 'hidden auto',
   };
 
@@ -248,7 +249,7 @@ export const RadioButtonV2 = ({
           <Loader style={{ right: '50%', zIndex: 3, position: 'absolute' }} width="20" />
         ) : (
           <div
-            className="d-flex px-0 h-100"
+            className="d-flex px-0"
             ref={radioBtnRef}
             style={{
               ...computedLayoutStyles,

--- a/server/src/modules/apps/services/widget-config/buttonGroupV2.js
+++ b/server/src/modules/apps/services/widget-config/buttonGroupV2.js
@@ -155,30 +155,6 @@ export const buttonGroupV2Config = {
       ],
       isFxNotRequired: true,
     },
-    widthType: {
-      type: 'select',
-      showLabel: false,
-      options: [
-        { name: 'Of the Component', value: 'ofComponent' },
-        { name: 'Of the Field', value: 'ofField' },
-      ],
-      validation: {
-        schema: { type: 'string' },
-        defaultValue: 'ofComponent',
-      },
-      accordian: 'label',
-      isFxNotRequired: true,
-      conditionallyRender: [
-        {
-          key: 'alignment',
-          value: 'side',
-        },
-        {
-          key: 'auto',
-          value: false,
-        },
-      ],
-    },
     backgroundColor: {
       type: 'colorSwatches',
       displayName: 'Background',
@@ -430,7 +406,6 @@ export const buttonGroupV2Config = {
       auto: { value: '{{true}}' },
       direction: { value: 'left' },
       alignment: { value: 'side' },
-      widthType: { value: 'ofComponent' },
       backgroundColor: { value: 'var(--cc-surface1-surface)' },
       borderColor: { value: 'var(--cc-default-border)' },
       textColor: { value: 'var(--cc-primary-text)' },


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/4911

This pull request refactors and improves the configuration-driven approach for the Popover Menu and related option components in the App Builder's inspector. The changes centralize popover and option UI settings into config objects, streamline prop passing, and remove the now-unnecessary `widthType` property from the ButtonGroupV2 widget. Additionally, it introduces more flexible and customizable UI labels and titles for option-related components.

**Popover Menu & Option Components Refactor:**

- Centralized popover and option UI settings (such as titles, fields, class names, and CTA labels) into the `config` object, reducing prop drilling and making customization easier. Components now extract these values from `config` instead of receiving them as individual props. [[1]](diffhunk://#diff-8e1daaca22236bdb353a94bbc6c8bcc12120a35a31bbed0cb1cf15f86af295c2R70-R74) [[2]](diffhunk://#diff-77ebadf7a5fcdcecdc958df9fabb94709cc228f01eb03a0e07d7f286f0cb1fc0R14-R23) [[3]](diffhunk://#diff-77ebadf7a5fcdcecdc958df9fabb94709cc228f01eb03a0e07d7f286f0cb1fc0L42-R42) [[4]](diffhunk://#diff-77ebadf7a5fcdcecdc958df9fabb94709cc228f01eb03a0e07d7f286f0cb1fc0L57-R57) [[5]](diffhunk://#diff-2e95b88657e2ee99f8611f7169728324a300e6a5f6bd98c33ba8f8e69ee0c6b8L22-R27) [[6]](diffhunk://#diff-2e95b88657e2ee99f8611f7169728324a300e6a5f6bd98c33ba8f8e69ee0c6b8R51-R54) [[7]](diffhunk://#diff-a4e3547a4ed3ce79de6c1401a7a5663615b206397da0fa7b76b60a4fc06d74f5L19-R23) [[8]](diffhunk://#diff-a4e3547a4ed3ce79de6c1401a7a5663615b206397da0fa7b76b60a4fc06d74f5L49-R48) [[9]](diffhunk://#diff-a4e3547a4ed3ce79de6c1401a7a5663615b206397da0fa7b76b60a4fc06d74f5L62-R59)

- Added new configuration options such as `popoverTitle` and `addOptionCtaLabel` to both the default and ButtonGroupV2 configs, enabling more descriptive UI elements and easier future updates. [[1]](diffhunk://#diff-930ba65a8443cf5cb8f29e2d53c1971c55094e23c8461ede2b611a65770bf33aR15-R18) [[2]](diffhunk://#diff-930ba65a8443cf5cb8f29e2d53c1971c55094e23c8461ede2b611a65770bf33aR34-R37)

**ButtonGroupV2 Widget Simplification:**

- Removed the `widthType` property and all related logic from both the frontend and backend configs, as well as from the ButtonGroupV2 widget itself. The widget now always uses `'ofComponent'` for width calculations, simplifying its API and internal logic. [[1]](diffhunk://#diff-ffdd8e42e27fc3edf5bf14a3e4bc2beba109525cebc367e644bb1267615297a3L158-L181) [[2]](diffhunk://#diff-ffdd8e42e27fc3edf5bf14a3e4bc2beba109525cebc367e644bb1267615297a3L433) [[3]](diffhunk://#diff-347bee1211e3d12091edbf11e59151e866c77e745b34661681bf3a62e113b5dcL10-R10) [[4]](diffhunk://#diff-347bee1211e3d12091edbf11e59151e866c77e745b34661681bf3a62e113b5dcL39) [[5]](diffhunk://#diff-347bee1211e3d12091edbf11e59151e866c77e745b34661681bf3a62e113b5dcL231) [[6]](diffhunk://#diff-347bee1211e3d12091edbf11e59151e866c77e745b34661681bf3a62e113b5dcL243-R238) [[7]](diffhunk://#diff-347bee1211e3d12091edbf11e59151e866c77e745b34661681bf3a62e113b5dcL337-R332)

**RadioButtonV2 Layout Fixes:**

- Improved the layout logic and styling for the RadioButtonV2 widget to ensure proper sizing and wrapping, especially when using the `wrap` layout option. [[1]](diffhunk://#diff-7f5b1aa7ae85b883e6ceaa7d0f16adb6ee9522bc1f5f089114dadf0f85dcbd98R195-R197) [[2]](diffhunk://#diff-7f5b1aa7ae85b883e6ceaa7d0f16adb6ee9522bc1f5f089114dadf0f85dcbd98L251-R252)