### PR TITLE
feat(modules): enable folder support for modules

### DIFF
--- a/frontend/src/HomePage/AppMenu.jsx
+++ b/frontend/src/HomePage/AppMenu.jsx
@@ -109,13 +109,13 @@ export const AppMenu = function AppMenu({
                     onClick={() => openAppActionModal('change-icon')}
                   />
                 )}
-                {canAddAppToFolder && appType !== 'module' && (
+                {canAddAppToFolder && (
                   <Field
                     text={t('homePage.appCard.addToFolder', 'Add to folder')}
                     onClick={() => openAppActionModal('add-to-folder')}
                   />
                 )}
-                {canRemoveFromFolder && appType !== 'module' && (
+                {canRemoveFromFolder && (
                   <Field
                     text={t('homePage.appCard.removeFromFolder', 'Remove from folder')}
                     onClick={() => openAppActionModal('remove-app-from-folder')}

--- a/frontend/src/HomePage/FolderFilter/index.jsx
+++ b/frontend/src/HomePage/FolderFilter/index.jsx
@@ -17,7 +17,8 @@ export default function FolderFilter({ disabled, options, onChange, value }) {
 
   const updateFolderQuery = (name, id) => {
     const isWorkflow = window.location.pathname.includes('/workflows');
-    const basePath = `/${getWorkspaceId()}${isWorkflow ? '/workflows' : ''}`;
+    const isModule = window.location.pathname.includes('/modules');
+    const basePath = `/${getWorkspaceId()}${isWorkflow ? '/workflows' : isModule ? '/modules' : ''}`;
     const queryParams = id ? `?folder=${name}` : '';
     navigate({ pathname: basePath, search: queryParams }, { replace: true });
   };

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -2108,25 +2108,19 @@ class HomePageComponent extends React.Component {
                   </LicenseTooltip>
                 )}
               </div>
-              {this.props.appType === 'module' ? (
-                <div>
-                  <p></p>
-                </div>
-              ) : (
-                <Folders
-                  foldersLoading={this.state.foldersLoading}
-                  folders={this.state.folders}
-                  currentFolder={currentFolder}
-                  folderChanged={this.folderChanged}
-                  foldersChanged={this.foldersChanged}
-                  canCreateFolder={this.canCreateFolder() && !this.isWorkspaceBranchLocked()}
-                  canDeleteFolder={this.canDeleteFolder() && !this.isWorkspaceBranchLocked()}
-                  canUpdateFolder={this.canUpdateFolder() && !this.isWorkspaceBranchLocked()}
-                  darkMode={this.props.darkMode}
-                  canCreateApp={this.canCreateApp()}
-                  appType={this.props.appType}
-                />
-              )}
+              <Folders
+                foldersLoading={this.state.foldersLoading}
+                folders={this.state.folders}
+                currentFolder={currentFolder}
+                folderChanged={this.folderChanged}
+                foldersChanged={this.foldersChanged}
+                canCreateFolder={this.canCreateFolder() && !this.isWorkspaceBranchLocked()}
+                canDeleteFolder={this.canDeleteFolder() && !this.isWorkspaceBranchLocked()}
+                canUpdateFolder={this.canUpdateFolder() && !this.isWorkspaceBranchLocked()}
+                darkMode={this.props.darkMode}
+                canCreateApp={this.canCreateApp()}
+                appType={this.props.appType}
+              />
               {this.props.appType === 'front-end' && (
                 <LicenseBanner classes="mb-3 small" limits={appsLimit} type="apps" size="small" />
               )}

--- a/server/src/modules/folder-apps/service.ts
+++ b/server/src/modules/folder-apps/service.ts
@@ -71,7 +71,7 @@ export class FolderAppsService implements IFolderAppsService {
         resources: [{ resource: resourceType }, { resource: MODULES.FOLDER }],
         organizationId: user.organizationId,
       });
-      const userAppPermissions = userPermissions?.[resourceType];
+      const userAppPermissions = userPermissions?.[resourceType] ?? userPermissions?.[MODULES.APP];
       const userFolderPermissions = userPermissions?.[MODULES.FOLDER];
 
       const allFolderList = await this.foldersUtilService.allFolders(user, manager, type);


### PR DESCRIPTION
- Remove module restriction from Folders sidebar in HomePage
- Remove appType !== 'module' guards from Add/Remove folder menu items
- Fix FolderFilter redirect bug: correctly stay on /modules path when selecting folders
- Fix folder-apps API for modules: fall back to MODULES.APP permissions since ability service stores module permissions under that key