### PR TITLE
Feature: Enhance table pagination with page buttons, dots navigation, and centered record count

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/Table.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/Table.jsx
@@ -257,7 +257,10 @@ export const Table = (props) => {
               property="disableActionButton"
               props={action}
               component={component}
-              paramMeta={{ type: 'toggle', displayName: 'Disable action button' }}
+              paramMeta={{
+                type: 'toggle',
+                displayName: 'Disable action button',
+              }}
               paramType="properties"
             />
             <EventManager
@@ -265,7 +268,9 @@ export const Table = (props) => {
               sourceId={component?.id}
               eventSourceType="table_action"
               customEventRefs={actionRef}
-              eventMetaDefinition={{ events: { onClick: { displayName: 'On click' } } }}
+              eventMetaDefinition={{
+                events: { onClick: { displayName: 'On click' } },
+              }}
               currentState={currentState}
               dataQueries={dataQueries}
               components={components}
@@ -414,7 +419,9 @@ export const Table = (props) => {
       'enablePagination',
       ...(enablePagination ? ['serverSidePagination'] : []),
       ...(enablePagination && !serverSidePagination ? ['rowsPerPage'] : []),
-      ...(enablePagination && serverSidePagination ? ['enablePrevButton', 'enableNextButton', 'totalRecords'] : []),
+      ...(enablePagination && serverSidePagination
+        ? ['serverSideRowsPerPage', 'enablePrevButton', 'enableNextButton', 'totalRecords']
+        : []),
     ],
     [enablePagination, serverSidePagination]
   );
@@ -551,9 +558,15 @@ export const Table = (props) => {
                     darkMode={darkMode}
                     callbackFunction={(index, property, value) => setAllColumnsEditable(value)}
                     property="isAllColumnsEditable"
-                    props={{ isAllColumnsEditable: `{{${isAllColumnsEditable}}}` }}
+                    props={{
+                      isAllColumnsEditable: `{{${isAllColumnsEditable}}}`,
+                    }}
                     component={component}
-                    paramMeta={{ type: 'toggle', displayName: 'Make all columns editable', isFxNotRequired: true }}
+                    paramMeta={{
+                      type: 'toggle',
+                      displayName: 'Make all columns editable',
+                      isFxNotRequired: true,
+                    }}
                     paramType="properties"
                   />
                 </div>
@@ -569,7 +582,13 @@ export const Table = (props) => {
             <span>Action buttons</span>
             <ToolTip
               message={
-                <div style={{ padding: '8px 4px', textAlign: 'left', width: '185px' }}>
+                <div
+                  style={{
+                    padding: '8px 4px',
+                    textAlign: 'left',
+                    width: '185px',
+                  }}
+                >
                   These Action buttons are deprecated and will be removed in a future update. Use the new Button column
                   instead by adding a new column and selecting type as a button.
                 </div>

--- a/frontend/src/AppBuilder/WidgetManager/widgets/table.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/table.js
@@ -110,6 +110,10 @@ export const tableConfig = {
         defaultValue: 10,
       },
     },
+    serverSideRowsPerPage: {
+      type: 'code',
+      displayName: 'Number of rows per page',
+    },
     enablePagination: {
       type: 'toggle',
       displayName: 'Enable pagination',

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/Footer/Footer.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/Footer/Footer.jsx
@@ -82,33 +82,37 @@ export const Footer = memo(
             backgroundColor: containerBackgroundColor,
           }}
         >
-          <div className={`table-footer d-flex justify-content-between align-items-center h-100`}>
-            {enablePagination && (
-              <Pagination
-                id={id}
-                tableWidth={width}
-                pageIndex={pageIndex}
-                table={table}
-                pageCount={pageCount}
-                paginationBtnClicked={paginationBtnClicked}
-                darkMode={darkMode}
-                height={height}
-              />
-            )}
-            <div className="d-flex custom-gap-4">
+          <div className={`table-footer d-flex align-items-center h-100`}>
+            <div className="tw-flex-1 d-flex align-items-center h-100">
+              {enablePagination && (
+                <Pagination
+                  id={id}
+                  tableWidth={width}
+                  pageIndex={pageIndex}
+                  table={table}
+                  pageCount={pageCount}
+                  paginationBtnClicked={paginationBtnClicked}
+                  darkMode={darkMode}
+                  height={height}
+                />
+              )}
+            </div>
+            <div className="tw-flex-1 d-flex justify-content-center custom-gap-4">
               {editedRows.size > 0 && showBulkUpdateActions ? renderChangeSetUI() : renderRowCount()}
             </div>
-            <ControlButtons
-              id={id}
-              table={table}
-              darkMode={darkMode}
-              height={height}
-              componentName={componentName}
-              showAddNewRowPopup={showAddNewRowPopup}
-              setShowAddNewRowPopup={setShowAddNewRowPopup}
-              fireEvent={fireEvent}
-              columnVisibility={columnVisibility} // Passed to trigger a re-render when columnVisibility changes
-            />
+            <div className="tw-flex-1 d-flex justify-content-end align-items-center h-100">
+              <ControlButtons
+                id={id}
+                table={table}
+                darkMode={darkMode}
+                height={height}
+                componentName={componentName}
+                showAddNewRowPopup={showAddNewRowPopup}
+                setShowAddNewRowPopup={setShowAddNewRowPopup}
+                fireEvent={fireEvent}
+                columnVisibility={columnVisibility} // Passed to trigger a re-render when columnVisibility changes
+              />
+            </div>
           </div>
         </div>
         {showAddNewRowPopup && (

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/Footer/_components/Pagination/Pagination.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/Footer/_components/Pagination/Pagination.jsx
@@ -65,7 +65,8 @@ export const Pagination = function Pagination({
   };
 
   const pageNumbers = getPageNumbers();
-  const showPagesPopupBtn = !serverSidePagination && ((tableWidth <= 460 && pageCount > 1) || pageCount > 3);
+  const showFirstLastBtns = !serverSidePagination && ((tableWidth <= 460 && pageCount > 1) || pageCount > 3);
+  const showPagesPopupBtn = showFirstLastBtns && !pageNumbers.includes(pageCount);
 
   const PaginationPopoverContent = () => {
     const ref = useRef(null);
@@ -94,21 +95,7 @@ export const Pagination = function Pagination({
 
     return (
       <Popover.Body>
-        <div className="tw-w-full tw-h-[48px] tw-p-[8px] tw-border-0 !tw-border-b tw-border-solid tw-border-[var(--cc-weak-border)] tw-shrink-0">
-          <PaginationButton
-            key={'firstpage'}
-            onClick={(e) => {
-              goToPage(1);
-              e.target.blur(); // To remove focus styling that gets applied after clicking on the button
-            }}
-            dataCy={`first-page-button-option`}
-            currentPageIndex={pageIndex}
-            pageIndex={'First page'}
-            className="!tw-w-full !tw-h-[32px] justify-content-start tw-px-[8px]"
-          />
-        </div>
-
-        <div ref={ref} className="tw-px-[8px] tw-overflow-auto tw-flex-1">
+        <div ref={ref} className="tw-p-[8px] tw-overflow-auto tw-flex-1">
           <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
             {virtualizer.getVirtualItems().map((virtualItem) => {
               const pageNum = virtualItem.index + 1;
@@ -135,20 +122,6 @@ export const Pagination = function Pagination({
             })}
           </div>
         </div>
-
-        <div className="tw-w-full tw-h-[48px] tw-p-[8px] tw-border-0 !tw-border-t tw-border-solid tw-border-[var(--cc-weak-border)] tw-shrink-0">
-          <PaginationButton
-            key={'lastpage'}
-            onClick={(e) => {
-              goToPage(pageCount);
-              e.target.blur(); // To remove focus styling that gets applied after clicking on the button
-            }}
-            dataCy={`last-page-button-option`}
-            currentPageIndex={pageIndex}
-            pageIndex={'Last page'}
-            className="!tw-w-full !tw-h-[32px] justify-content-start tw-px-[8px]"
-          />
-        </div>
       </Popover.Body>
     );
   };
@@ -160,7 +133,7 @@ export const Pagination = function Pagination({
         data-cy="popover-card"
         className={`table-widget-popup pagination-popup ${darkMode && 'dark-theme'}`}
         style={{
-          maxHeight: height - 79 > 128 ? `${height - 79}px` : '128px', // This is to ensure that if table height is small, the popover is still always showing the first, last and a single page buttons
+          maxHeight: height - 79 > 128 ? `${height - 79}px` : '128px',
         }}
         placement="top-end"
       >
@@ -172,6 +145,17 @@ export const Pagination = function Pagination({
   return (
     <div className={'d-flex align-items-center h-100'}>
       <div className="pagination-container d-flex h-100 align-items-center tw-space-x-1" data-cy="pagination-section">
+        {showFirstLastBtns && (
+          <PaginationButton
+            onClick={() => {
+              goToPage(1);
+            }}
+            disabled={pageIndex === 1}
+            icon="IconChevronsLeft"
+            dataCy="pagination-button-to-first"
+          />
+        )}
+
         <PaginationButton
           onClick={() => {
             goToPreviousPage();
@@ -213,6 +197,17 @@ export const Pagination = function Pagination({
           icon="IconChevronRight"
           dataCy="pagination-button-to-next"
         />
+
+        {showFirstLastBtns && (
+          <PaginationButton
+            onClick={() => {
+              goToPage(pageCount);
+            }}
+            disabled={pageIndex === pageCount}
+            icon="IconChevronsRight"
+            dataCy="pagination-button-to-last"
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/Footer/_components/Pagination/Pagination.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/Footer/_components/Pagination/Pagination.jsx
@@ -22,6 +22,17 @@ export const Pagination = function Pagination({
   const serverSidePagination = useTableStore((state) => state.getTableProperties(id)?.serverSidePagination, shallow);
   const enablePrevButton = useTableStore((state) => state.getTableProperties(id)?.enablePrevButton, shallow);
   const enableNextButton = useTableStore((state) => state.getTableProperties(id)?.enableNextButton, shallow);
+  const serverSideRowsPerPage = useTableStore((state) => state.getTableProperties(id)?.serverSideRowsPerPage, shallow);
+  const totalRecords = useTableStore((state) => state.getTableProperties(id)?.totalRecords, shallow);
+
+  const parsedServerSideRowsPerPage = Number(serverSideRowsPerPage);
+  const parsedTotalRecords = Number(totalRecords);
+  const knowTotalPages = serverSidePagination && parsedServerSideRowsPerPage > 0 && parsedTotalRecords > 0;
+  const effectivePageCount = knowTotalPages
+    ? Math.ceil(parsedTotalRecords / parsedServerSideRowsPerPage)
+    : serverSidePagination
+    ? 0
+    : pageCount;
 
   const canGoToNextPage = serverSidePagination ? enableNextButton : table.getCanNextPage();
   const canGoToPreviousPage = serverSidePagination ? enablePrevButton : table.getCanPreviousPage();
@@ -43,9 +54,10 @@ export const Pagination = function Pagination({
 
   const getPageNumbers = () => {
     const currentPage = pageIndex;
-    const totalPages = pageCount;
+    const totalPages = effectivePageCount;
 
-    if (serverSidePagination || tableWidth <= 460) {
+    // Server-side without known totalPages: show only current page
+    if ((serverSidePagination && !knowTotalPages) || tableWidth <= 460) {
       return [currentPage];
     }
 
@@ -65,13 +77,16 @@ export const Pagination = function Pagination({
   };
 
   const pageNumbers = getPageNumbers();
-  const showFirstLastBtns = !serverSidePagination && ((tableWidth <= 460 && pageCount > 1) || pageCount > 3);
-  const showPagesPopupBtn = showFirstLastBtns && !pageNumbers.includes(pageCount);
+  const showFirstLastBtns =
+    serverSidePagination && !knowTotalPages
+      ? false
+      : (tableWidth <= 460 && effectivePageCount > 1) || effectivePageCount > 3;
+  const showPagesPopupBtn = showFirstLastBtns && pageNumbers.length < effectivePageCount;
 
   const PaginationPopoverContent = () => {
     const ref = useRef(null);
     const virtualizer = useVirtualizer({
-      count: pageCount || 0,
+      count: effectivePageCount || 0,
       getScrollElement: () => ref.current,
       estimateSize: () => 32,
       overscan: 15,
@@ -150,7 +165,7 @@ export const Pagination = function Pagination({
             onClick={() => {
               goToPage(1);
             }}
-            disabled={pageIndex === 1}
+            disabled={pageIndex === 1 || (serverSidePagination && !enablePrevButton)}
             icon="IconChevronsLeft"
             dataCy="pagination-button-to-first"
           />
@@ -201,9 +216,9 @@ export const Pagination = function Pagination({
         {showFirstLastBtns && (
           <PaginationButton
             onClick={() => {
-              goToPage(pageCount);
+              goToPage(effectivePageCount);
             }}
-            disabled={pageIndex === pageCount}
+            disabled={pageIndex === effectivePageCount || (serverSidePagination && !enableNextButton)}
             icon="IconChevronsRight"
             dataCy="pagination-button-to-last"
           />

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableContainer/TableContainer.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableContainer/TableContainer.jsx
@@ -38,9 +38,18 @@ export const TableContainer = ({
   const serverSideFilter = useTableStore((state) => state.getTableProperties(id)?.serverSideFilter, shallow);
   const serverSideSearch = useTableStore((state) => state.getTableProperties(id)?.serverSideSearch, shallow);
   const rowsPerPage = useTableStore((state) => state.getTableProperties(id)?.rowsPerPage, shallow);
+  const serverSideRowsPerPage = useTableStore((state) => state.getTableProperties(id)?.serverSideRowsPerPage, shallow);
   const clearEditedRows = useTableStore((state) => state.clearEditedRows, shallow);
 
   const actions = useTableStore((state) => state.getActions(id), shallow);
+
+  const effectiveRowsPerPage = useMemo(() => {
+    if (serverSidePagination) {
+      const parsed = Number(serverSideRowsPerPage);
+      return parsed > 0 ? parsed : rowsPerPage;
+    }
+    return rowsPerPage;
+  }, [serverSidePagination, serverSideRowsPerPage, rowsPerPage]);
 
   const [globalFilter, setGlobalFilter] = useState('');
   const lastClickedRowRef = useRef({});
@@ -97,7 +106,7 @@ export const TableContainer = ({
       serverSidePagination,
       serverSideSort,
       serverSideFilter,
-      rowsPerPage,
+      rowsPerPage: effectiveRowsPerPage,
       globalFilter,
       setGlobalFilter,
     });

--- a/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/initSlice.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/initSlice.js
@@ -48,6 +48,7 @@ export const createInitSlice = (set, get) => ({
         state.components[id].properties.showDownloadButton = properties?.showDownloadButton ?? true;
         state.components[id].properties.showBulkUpdateActions = properties?.showBulkUpdateActions ?? true;
         state.components[id].properties.totalRecords = properties?.totalRecords ?? 10;
+        state.components[id].properties.serverSideRowsPerPage = properties?.serverSideRowsPerPage ?? '';
         state.components[id].properties.enablePrevButton = properties?.enablePrevButton ?? true;
         state.components[id].properties.enableNextButton = properties?.enableNextButton ?? true;
         state.components[id].properties.hideColumnSelectorButton = properties?.hideColumnSelectorButton ?? false;

--- a/server/src/modules/apps/services/widget-config/table.js
+++ b/server/src/modules/apps/services/widget-config/table.js
@@ -110,6 +110,10 @@ export const tableConfig = {
         defaultValue: 10,
       },
     },
+    serverSideRowsPerPage: {
+      type: 'code',
+      displayName: 'Number of rows per page',
+    },
     enablePagination: {
       type: 'toggle',
       displayName: 'Enable pagination',


### PR DESCRIPTION
## 📝 What this does
Replaces the old page-number input field in the table pagination footer with clickable page buttons, a "..." popover for navigating large page counts, first/last page shortcuts, and centers the record count display in the footer.

Closes https://github.com/ToolJet/tj-ee/issues/4922, https://github.com/ToolJet/tj-ee/issues/4598

## 🔀 Changes
- Replaced pagination text input with clickable page number buttons showing a sliding window of 3 pages
- Added first (<<) and last (>>) page navigation buttons
- Added "..." dots button that opens a virtualized popover listing all pages for quick navigation
- Fixed dots button visibility so it appears when navigating near the first or last pages
- Centered the record count ("10 Records") in the footer using a three-column flex layout
- Added `serverSideRowsPerPage` property to support server-side pagination with known total pages
- Added server-side pagination inspector controls (rows per page, total records)

## 🧪 How to test
- [ ] Add a Table component and load data with more than 3 pages
- [ ] Verify page number buttons (1, 2, 3) appear and clicking them navigates correctly
- [ ] Navigate to the last page and confirm the "..." dots button still appears
- [ ] Click the dots button and verify the popover shows all pages with the current page scrolled into view
- [ ] Verify first (<<) and last (>>) buttons navigate to the correct pages
- [ ] Confirm "X Records" text is visually centered in the footer
- [ ] Enable server-side pagination with "Number of rows per page" and "Total records" set — verify page buttons reflect the calculated page count