### PR TITLE
Fix: resolve cellValue, rowData, and ListView siblings in CodeHinter preview

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
@@ -72,7 +72,7 @@ const MultiLineCodeEditor = (props) => {
   // Context-aware hints for components inside ListView/Kanban and table columns
   const getContextHints = useStore((state) => state.getContextHints, shallow);
   const getTableColumnContextHints = useStore((state) => state.getTableColumnContextHints, shallow);
-  const tableColumnComponentId = useContext(TableColumnContext); // Set at ColumnPopover level
+  const tableColumnComponentId = useContext(TableColumnContext)?.tableId; // Set at ColumnPopover level
   const getServerSideGlobalResolveSuggestions = useStore(
     (state) => state.getServerSideGlobalResolveSuggestions,
     shallow

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -48,10 +48,19 @@ const SingleLineCodeEditor = ({ componentName, fieldMeta = {}, componentId, modu
   const [cursorInsidePreview, setCursorInsidePreview] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(true);
   const validationFn = restProps?.validationFn;
-  const componentDefinition = useStore((state) => state.getComponentDefinition(componentId, moduleId), shallow);
-  const parentId = componentDefinition?.component?.parent;
-  const customResolvables = useStore((state) => state.resolvedStore.modules.canvas?.customResolvables, shallow);
-  const baseCustomVariables = customResolvables?.[parentId]?.[0] || {};
+  const baseCustomVariables = useStore((state) => {
+    if (!componentId) return {};
+    const componentDef = state.getComponentDefinition(componentId, moduleId);
+    const parentId = componentDef?.component?.parent;
+    if (!parentId) return {};
+    // Walk up the ancestor chain to find the nearest ListView/Kanban, since
+    // customResolvables is keyed by the subcontainer's UUID — not by intermediate
+    // containers (e.g., text → Container → ListView needs to find the ListView).
+    const nearestAncestorId = state.findNearestSubcontainerAncestor(parentId, moduleId);
+    if (!nearestAncestorId) return {};
+    const customResolvables = state.resolvedStore.modules[moduleId]?.customResolvables || {};
+    return customResolvables[nearestAncestorId]?.[0] || {};
+  }, shallow);
 
   // Table column context: inject cellValue/rowData for preview resolution
   const tableColumnContext = useContext(TableColumnContext);

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -51,7 +51,24 @@ const SingleLineCodeEditor = ({ componentName, fieldMeta = {}, componentId, modu
   const componentDefinition = useStore((state) => state.getComponentDefinition(componentId, moduleId), shallow);
   const parentId = componentDefinition?.component?.parent;
   const customResolvables = useStore((state) => state.resolvedStore.modules.canvas?.customResolvables, shallow);
-  const customVariables = customResolvables?.[parentId]?.[0] || {};
+  const baseCustomVariables = customResolvables?.[parentId]?.[0] || {};
+
+  // Table column context: inject cellValue/rowData for preview resolution
+  const tableColumnContext = useContext(TableColumnContext);
+  const tableCurrentData = useStore((state) => {
+    if (!tableColumnContext?.tableId) return null;
+    return state.resolvedStore.modules[moduleId]?.exposedValues?.components?.[tableColumnContext.tableId]?.currentData;
+  }, shallow);
+
+  const customVariables = useMemo(() => {
+    if (!Array.isArray(tableCurrentData) || tableCurrentData.length === 0) return baseCustomVariables;
+    const firstRow = tableCurrentData[0];
+    return {
+      ...baseCustomVariables,
+      rowData: firstRow,
+      cellValue: tableColumnContext?.columnKey != null ? firstRow?.[tableColumnContext.columnKey] : undefined,
+    };
+  }, [baseCustomVariables, tableCurrentData, tableColumnContext?.columnKey]);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -257,7 +274,8 @@ const EditorInput = ({
   const codeHinterContext = useContext(CodeHinterContext);
   // TableColumnContext provides the table component ID for rowData/cellValue hints.
   // Set once at ColumnPopover level, consumed automatically by all nested CodeHinters.
-  const tableColumnComponentId = useContext(TableColumnContext);
+  const tableColumnContext = useContext(TableColumnContext);
+  const tableColumnComponentId = tableColumnContext?.tableId;
   const { suggestionList: paramHints } = createReferencesLookup(codeHinterContext, true);
   const { handleTogglePopupExapand, isOpen, setIsOpen, forceUpdate } = portalProps;
 

--- a/frontend/src/AppBuilder/CodeEditor/utils.js
+++ b/frontend/src/AppBuilder/CodeEditor/utils.js
@@ -146,6 +146,21 @@ function resolveCode(code, customObjects = {}, withError = false, reservedKeywor
   } else {
     try {
       const state = useStore.getState().getResolvedState();
+
+      // ListView children have per-row arrays in exposedValues.components.
+      // Flatten to row 0 so the preview can resolve sibling references
+      // like {{components.button1.text}} without hitting an array.
+      let components = state?.components;
+      if (isJsCode && components) {
+        const hasArrayEntry = Object.values(components).some(Array.isArray);
+        if (hasArrayEntry) {
+          components = {};
+          for (const [name, value] of Object.entries(state.components)) {
+            components[name] = Array.isArray(value) ? value[0] || {} : value;
+          }
+        }
+      }
+
       const evalFunction = Function(
         [
           'variables',
@@ -164,7 +179,7 @@ function resolveCode(code, customObjects = {}, withError = false, reservedKeywor
       );
       result = evalFunction(
         isJsCode ? state?.variables : undefined,
-        isJsCode ? state?.components : undefined,
+        isJsCode ? components : undefined,
         isJsCode ? state?.queries : undefined,
         isJsCode ? state?.globals : undefined,
         isJsCode ? state?.page : undefined,

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/ColumnManager/ColumnPopover.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/ColumnManager/ColumnPopover.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import Popover from 'react-bootstrap/Popover';
 import { StylesTabElements } from './StylesTabElements';
 import { PropertiesTabElements } from './PropertiesTabElements';
@@ -105,13 +105,18 @@ export const ColumnPopoverContent = ({
     }
   };
 
+  const tableColumnContextValue = useMemo(
+    () => ({ tableId: component?.id, columnKey: column?.key }),
+    [component?.id, column?.key]
+  );
+
   {
-    /* TableColumnContext provides the table's component ID to all nested CodeHinters,
-        enabling rowData/cellValue autocomplete hints in column editors (properties, styles, etc.).
-        This avoids threading a tableColumnComponentId prop through every intermediate component. */
+    /* TableColumnContext provides the table's component ID and active column key to all
+        nested CodeHinters, enabling rowData/cellValue autocomplete hints and preview
+        resolution in column editors (properties, styles, etc.). */
   }
   return (
-    <TableColumnContext.Provider value={component?.id}>
+    <TableColumnContext.Provider value={tableColumnContextValue}>
       <Popover.Header style={{ padding: '8px 16px 0 16px' }}>
         <div className="d-flex align-items-center justify-content-between">
           <div className="d-flex custom-gap-6 flex-row items-center justify-start">

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/ColumnManager/TableColumnContext.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/ColumnManager/TableColumnContext.js
@@ -1,5 +1,7 @@
 import { createContext } from 'react';
 
-// Provides the table component ID to all CodeHinter instances inside a column popover,
-// so they can show rowData/cellValue context hints without manual prop threading.
+// Provides the table component ID and active column key to all CodeHinter instances
+// inside a column popover. Used for:
+//   - rowData/cellValue autocomplete hints (via codeHinterSlice)
+//   - rowData/cellValue preview resolution (via SingleLineCodeEditor customVariables)
 export const TableColumnContext = createContext(null);


### PR DESCRIPTION
## 📝 What this does

Resolves https://github.com/ToolJet/tj-ee/issues/4938
Fixes the CodeHinter preview failing to resolve context variables (`cellValue`, `rowData`) in table column editors and sibling component references (`{{components.button1.text}}`) inside ListView.

## 🔀 Changes
- Expanded `TableColumnContext` to carry both `tableId` and `columnKey` so the preview can resolve `cellValue` and `rowData` from the table's first row
- Injected table column custom variables into `SingleLineCodeEditor` for preview resolution
- Flattened ListView per-row arrays to row-0 values in `resolveCode` so sibling references resolve instead of hitting raw arrays
- Updated `MultiLineCodeEditor` to extract `tableId` from the new context shape

## 🧪 How to test
- [ ] Add a Table with data, open a column's Transformation field, type `{{cellValue}}` — preview should show the first row's value
- [ ] Add a ListView with a TextInput and Button inside, reference `{{components.textinput1.value}}` from the Button's text property — preview should resolve without error
- [ ] Verify autocomplete still suggests `cellValue`, `rowData` in table column editors