### PR TITLE
chore: add migration usage comments to service functions

### DIFF
--- a/server/src/modules/data-sources/interfaces/IUtilService.ts
+++ b/server/src/modules/data-sources/interfaces/IUtilService.ts
@@ -8,6 +8,10 @@ export interface IDataSourcesUtilService {
 
   getServiceAndRpcNames(protoDefinition: any): { [key: string]: string[] };
 
+  /**
+   * IMPORTANT: Do not modify this function signature - it is used in data migrations.
+   * Used in: 1639734070615-BackfillDataSourcesAndQueriesForAppVersions.ts
+   */
   parseOptionsForCreate(options: Array<object>, resetSecureData?: boolean, manager?: EntityManager): Promise<any>;
 
   parseOptionsForUpdate(

--- a/server/src/modules/data-sources/services/sample-ds.service.ts
+++ b/server/src/modules/data-sources/services/sample-ds.service.ts
@@ -29,6 +29,13 @@ export class SampleDataSourceService {
     }, manager);
   }
 
+  /**
+   * IMPORTANT: Do not modify this function signature - it is used in data migrations.
+   *
+   * Used in migrations:
+   * - 1726649944702-AddConnectionTypeToSampleDataSources.ts
+   * - 1731279588337-ReplaceTheSampleDBConnectionValues.ts
+   */
   async updateSampleDs(manager?: EntityManager) {
     const options = [
       {

--- a/server/src/modules/data-sources/util.service.ts
+++ b/server/src/modules/data-sources/util.service.ts
@@ -155,7 +155,15 @@ export class DataSourcesUtilService implements IDataSourcesUtilService {
     return serviceNamesAndMethods;
   }
 
-  // IMPORTANT: Should not do any changes on this function. Its used in migrations
+  /**
+   * IMPORTANT: Do not modify this function - it is used in data migrations.
+   *
+   * Used in migrations:
+   * - 1639734070615-BackfillDataSourcesAndQueriesForAppVersions.ts
+   *
+   * This function internally calls:
+   * - CredentialsService.create()
+   */
   async parseOptionsForCreate(options: Array<object>, resetSecureData = false, manager?: EntityManager) {
     if (!options) return {};
     return await dbTransactionWrap(async (entityManager: EntityManager) => {

--- a/server/src/modules/encryption/interfaces/IService.ts
+++ b/server/src/modules/encryption/interfaces/IService.ts
@@ -1,4 +1,8 @@
 export interface IEncryptionService {
+  /**
+   * IMPORTANT: Do not modify this function signature - it is used in data migrations.
+   * Used in: 1669054493160, 1706024347284, 1650485473528, 1716551121164, 1681463532466, 1683022868045
+   */
   encryptColumnValue(table: string, column: string, text: string): Promise<string>;
   decryptColumnValue(table: string, column: string, cipherText: string): Promise<string>;
 }

--- a/server/src/modules/encryption/service.ts
+++ b/server/src/modules/encryption/service.ts
@@ -16,6 +16,8 @@ export class EncryptionService implements IEncryptionService {
    * - 1716551121164-addSMTPConfigsToTable.ts
    * - 1681463532466-addMultipleEnvForCEcreatedApps.ts (via filterEncryptedFromOptions helper)
    * - 1683022868045-environmentDataSourceMappingFix.ts (via filterEncryptedFromOptions helper)
+   * - 1709618105785-EncryptValuesForExistingOrganizationConstants.ts
+   * - 1721236971725-MoveToolJetDatabaseTablesFromPublicToTenantSchema.ts
    */
   async encryptColumnValue(table: string, column: string, text: string): Promise<string> {
     const derivedKey = this.#computeAttributeKey(table, column);

--- a/server/src/modules/encryption/service.ts
+++ b/server/src/modules/encryption/service.ts
@@ -6,6 +6,17 @@ const crypto = require('crypto');
 
 @Injectable()
 export class EncryptionService implements IEncryptionService {
+  /**
+   * IMPORTANT: Do not modify this function signature - it is used in data migrations.
+   *
+   * Used in migrations:
+   * - 1669054493160-moveDataSourceOptionsToEnvironment.ts
+   * - 1706024347284-AddInstanceLevelSSOInSSOConfigs.ts
+   * - 1650485473528-PopulateSSOConfigs.ts
+   * - 1716551121164-addSMTPConfigsToTable.ts
+   * - 1681463532466-addMultipleEnvForCEcreatedApps.ts (via filterEncryptedFromOptions helper)
+   * - 1683022868045-environmentDataSourceMappingFix.ts (via filterEncryptedFromOptions helper)
+   */
   async encryptColumnValue(table: string, column: string, text: string): Promise<string> {
     const derivedKey = this.#computeAttributeKey(table, column);
     return this.#encrypt(text, derivedKey);

--- a/server/src/modules/encryption/services/credentials.service.ts
+++ b/server/src/modules/encryption/services/credentials.service.ts
@@ -8,6 +8,16 @@ import { Credential } from '@entities/credential.entity';
 export class CredentialsService {
   constructor(protected readonly encryptionService: EncryptionService) {}
 
+  /**
+   * IMPORTANT: Do not modify this function signature - it is used in data migrations.
+   *
+   * Used in migrations:
+   * - 1752749046662-EncrpyGoogleCalendarClientSecret.ts
+   * - 1681463532466-addMultipleEnvForCEcreatedApps.ts (via filterEncryptedFromOptions helper)
+   *
+   * This function internally calls:
+   * - EncryptionService.encryptColumnValue()
+   */
   async create(value: string, manager?: EntityManager): Promise<Credential> {
     return await dbTransactionWrap(async (manager: EntityManager) => {
       const newCredential = manager.create(Credential, {

--- a/server/src/modules/licensing/interfaces/IService.ts
+++ b/server/src/modules/licensing/interfaces/IService.ts
@@ -27,7 +27,10 @@ export interface ILicenseOrganizationService {
 export abstract class LicenseInitService {
   /**
    * IMPORTANT: Do not modify this function signature - it is used in data migrations.
-   * Used in: 1720434737529, 1742369617678, 1720352990850
+   * Used in migrations:
+   * - 1720434737529-MigrateCustomGroupToNewUserGroup.ts
+   * - 1742369617678-EnforceNewBasicPlanLimits.ts
+   * - 1720352990850-CreateDefaultGroupInExistingWorkspace.ts
    */
   abstract initForMigration(manager?: EntityManager): Promise<{ isValid: boolean }>;
   abstract init(): Promise<void>;

--- a/server/src/modules/licensing/interfaces/IService.ts
+++ b/server/src/modules/licensing/interfaces/IService.ts
@@ -25,6 +25,10 @@ export interface ILicenseOrganizationService {
 }
 
 export abstract class LicenseInitService {
+  /**
+   * IMPORTANT: Do not modify this function signature - it is used in data migrations.
+   * Used in: 1720434737529, 1742369617678, 1720352990850
+   */
   abstract initForMigration(manager?: EntityManager): Promise<{ isValid: boolean }>;
   abstract init(): Promise<void>;
   abstract initForCloud(): Promise<void>;

--- a/server/src/modules/licensing/services/init.service.ts
+++ b/server/src/modules/licensing/services/init.service.ts
@@ -8,6 +8,14 @@ import LicenseBase from '../configs/LicenseBase';
 
 @Injectable()
 export class LicenseInitService extends ILicenseInitService {
+  /**
+   * IMPORTANT: Do not modify this function signature - it is used in data migrations.
+   *
+   * Used in migrations:
+   * - 1720434737529-MigrateCustomGroupToNewUserGroup.ts
+   * - 1742369617678-EnforceNewBasicPlanLimits.ts
+   * - 1720352990850-CreateDefaultGroupInExistingWorkspace.ts
+   */
   async initForMigration(manager?: EntityManager): Promise<{ isValid: boolean }> {
     License.Reload('', new Date());
     return { isValid: false };


### PR DESCRIPTION
## Summary
Added JSDoc comments to service functions that are used in data migrations to prevent accidental breaking changes.

## Changes
- Added migration usage comments to the following service functions:
  - `DataSourcesUtilService.parseOptionsForCreate()`
  - `EncryptionService.encryptColumnValue()`
  - `CredentialsService.create()`
  - `LicenseInitService.initForMigration()`
  - `SampleDataSourceService.updateSampleDs()`

- Updated corresponding interfaces:
  - `IDataSourcesUtilService`
  - `IEncryptionService`
  - `LicenseInitService` (abstract class)

Each comment includes:
- Warning not to modify the function signature
- List of migration files that use the function
- Internal function calls (where applicable)