### PR TITLE
feat: add workflow, module, workspace, and custom group counts to telemetry

### DIFF
--- a/server/src/modules/meta/util.service.ts
+++ b/server/src/modules/meta/util.service.ts
@@ -6,7 +6,10 @@ import { User } from 'src/entities/user.entity';
 import { ConfigService } from '@nestjs/config';
 import { InternalTable } from 'src/entities/internal_table.entity';
 import { App } from 'src/entities/app.entity';
+import { Organization } from 'src/entities/organization.entity';
+import { GroupPermissions } from 'src/entities/group_permissions.entity';
 import { DataSource } from 'src/entities/data_source.entity';
+import { APP_TYPES } from '@modules/apps/constants';
 import { LicenseCountsService } from '@modules/licensing/services/count.service';
 import License from '@modules/licensing/configs/License';
 import { MetadataType } from './types';
@@ -129,6 +132,10 @@ export class MetadataUtilService implements IMetaUtilService {
       const totalAppCount = await manager.count(App);
       const totalInternalTableCount = await manager.count(InternalTable);
       const totalDatasourcesByKindCount = await this.fetchDatasourcesByKindCount(manager);
+      const totalWorkflowCount = await manager.count(App, { where: { type: APP_TYPES.WORKFLOW } });
+      const totalModuleCount = await manager.count(App, { where: { type: APP_TYPES.MODULE } });
+      const totalWorkspaceCount = await manager.count(Organization);
+      const totalUserGroupCount = await manager.count(GroupPermissions);
       try {
         return await got('https://hub.tooljet.io/telemetry', {
           method: 'post',
@@ -138,6 +145,10 @@ export class MetadataUtilService implements IMetaUtilService {
             total_editors: totalEditorCount,
             total_viewers: totalViewerCount,
             total_apps: totalAppCount,
+            total_workflows: totalWorkflowCount,
+            total_modules: totalModuleCount,
+            total_workspaces: totalWorkspaceCount,
+            total_user_groups: totalUserGroupCount,
             tooljet_db_table_count: totalInternalTableCount,
             tooljet_version: globalThis.TOOLJET_VERSION,
             data_sources_count: totalDatasourcesByKindCount,

--- a/server/src/modules/meta/util.service.ts
+++ b/server/src/modules/meta/util.service.ts
@@ -10,6 +10,7 @@ import { Organization } from 'src/entities/organization.entity';
 import { GroupPermissions } from 'src/entities/group_permissions.entity';
 import { DataSource } from 'src/entities/data_source.entity';
 import { APP_TYPES } from '@modules/apps/constants';
+import { GROUP_PERMISSIONS_TYPE } from '@modules/group-permissions/constants';
 import { LicenseCountsService } from '@modules/licensing/services/count.service';
 import License from '@modules/licensing/configs/License';
 import { MetadataType } from './types';
@@ -135,7 +136,9 @@ export class MetadataUtilService implements IMetaUtilService {
       const totalWorkflowCount = await manager.count(App, { where: { type: APP_TYPES.WORKFLOW } });
       const totalModuleCount = await manager.count(App, { where: { type: APP_TYPES.MODULE } });
       const totalWorkspaceCount = await manager.count(Organization);
-      const totalUserGroupCount = await manager.count(GroupPermissions);
+      const totalCustomGroupCount = await manager.count(GroupPermissions, {
+        where: { type: GROUP_PERMISSIONS_TYPE.CUSTOM_GROUP },
+      });
       try {
         return await got('https://hub.tooljet.io/telemetry', {
           method: 'post',
@@ -148,7 +151,7 @@ export class MetadataUtilService implements IMetaUtilService {
             total_workflows: totalWorkflowCount,
             total_modules: totalModuleCount,
             total_workspaces: totalWorkspaceCount,
-            total_user_groups: totalUserGroupCount,
+            total_custom_groups: totalCustomGroupCount,
             tooljet_db_table_count: totalInternalTableCount,
             tooljet_version: globalThis.TOOLJET_VERSION,
             data_sources_count: totalDatasourcesByKindCount,


### PR DESCRIPTION
## Summary
- Adds 5 new metrics to the telemetry payload sent to `hub.tooljet.io/telemetry`:
  - `total_workflows` — count of apps with type `workflow`
  - `total_modules` — count of apps with type `module`
  - `total_workspaces` — count of all organizations
  - `total_custom_groups` — count of custom permission groups only (excludes built-in groups like admin, builder, end-user)
- `total_apps` remains unchanged (all apps including workflows/modules) for backward compatibility

## Companion PR
- **Hub**: ToolJet/hub — `feature/telemetry-new-counts` branch (maps new fields to BigQuery)

## Deployment Order
1. BigQuery `ALTER TABLE` to add new INT64 columns
2. Deploy hub Firebase function (companion PR)
3. Deploy this ToolJet server change

## Test plan
- [ ] Verify `sendTelemetryData()` payload includes the new fields with correct integer values
- [ ] Verify `total_custom_groups` only counts groups with `type = 'custom'`
- [ ] Verify hub function handles payload with and without new fields
- [ ] Verify BigQuery rows contain new column values after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)