### PR TITLE
fix: show correct header in code-hinter for success message field

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx
@@ -19,6 +19,7 @@ export default function SuccessNotificationInputs({ currentState, options, darkM
             initialValue={options.successMessage}
             onChange={(value) => optionchanged('successMessage', value)}
             placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}
+            componentName="Success Message"
             cyLabel={'success-message'}
           />
         </div>


### PR DESCRIPTION
## Summary

When opening the code-hinter popup from the **Success Message** input field in a RunJS query, the popup header shows `Editor` (the fallback) instead of `Success Message`.

**Root cause:** The `componentName` prop was not being passed to the `<CodeHinter>` component in `SuccessNotificationInputs.jsx`, causing the portal to fall back to the default `'Editor'` label.

**Fix:** Added `componentName="Success Message"` to the `<CodeHinter>` in `AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx`.

## Changes

- `frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx` — 1-line fix

## Test plan

- [ ] Open a RunJS query in the query manager
- [ ] Click the code-hinter icon on the **Success Message** field
- [ ] Verify the popup header now shows `Success Message` instead of `Editor`

Fixes #6655