### PR TITLE
Fix: wrap lazy-loaded PageCanvasHeader and PageCanvasFooter in Suspense boundaries

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/DesktopLayout.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/DesktopLayout.jsx
@@ -1,4 +1,4 @@
-import React, { lazy } from 'react';
+import React, { Suspense, lazy } from 'react';
 import cx from 'classnames';
 
 import { PAGE_CANVAS_HEADER_HEIGHT } from './appCanvasConstants';
@@ -36,7 +36,9 @@ export const DesktopLayout = ({
     className={cx({ 'h-100': isModuleMode })}
     style={{ position: 'relative', display: 'flex', flexDirection: 'column' }}
   >
-    <PageCanvasHeader showCanvasHeader={showCanvasHeader} isMobileLayout={isMobileLayout} currentMode={currentMode} />
+    <Suspense fallback={null}>
+      <PageCanvasHeader showCanvasHeader={showCanvasHeader} isMobileLayout={isMobileLayout} currentMode={currentMode} />
+    </Suspense>
     <div
       className={cx('canvas-wrapper  tw-w-full tw-h-full d-flex', {
         'tw-flex-col': position === 'top' || isPagesSidebarHidden,
@@ -71,6 +73,8 @@ export const DesktopLayout = ({
         {mainCanvasContainer}
       </CanvasContentTail>
     </div>
-    <PageCanvasFooter showCanvasFooter={showCanvasFooter} isMobileLayout={isMobileLayout} currentMode={currentMode} />
+    <Suspense fallback={null}>
+      <PageCanvasFooter showCanvasFooter={showCanvasFooter} isMobileLayout={isMobileLayout} currentMode={currentMode} />
+    </Suspense>
   </div>
 );

--- a/frontend/src/AppBuilder/AppCanvas/MobileLayout.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/MobileLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, lazy } from 'react';
+import React, { Suspense, useRef, lazy } from 'react';
 import cx from 'classnames';
 
 import { PAGE_CANVAS_HEADER_HEIGHT } from './appCanvasConstants';
@@ -42,7 +42,13 @@ export const MobileLayout = ({
         className={cx('tw-absolute tw-inset-0 tw-overflow-hidden tw-pointer-events-none')}
       />
       {/* Canvas header — sticky at top of scroll */}
-      <PageCanvasHeader showCanvasHeader={showCanvasHeader} isMobileLayout={isMobileLayout} currentMode={currentMode} />
+      <Suspense fallback={null}>
+        <PageCanvasHeader
+          showCanvasHeader={showCanvasHeader}
+          isMobileLayout={isMobileLayout}
+          currentMode={currentMode}
+        />
+      </Suspense>
       {/* Mobile nav — sticky below header */}
       {appType !== 'module' && (
         <div
@@ -66,7 +72,13 @@ export const MobileLayout = ({
       <CanvasContentTail currentMode={currentMode} appType={appType} isAppDarkMode={isAppDarkMode}>
         {mainCanvasContainer}
       </CanvasContentTail>
-      <PageCanvasFooter showCanvasFooter={showCanvasFooter} isMobileLayout={isMobileLayout} currentMode={currentMode} />
+      <Suspense fallback={null}>
+        <PageCanvasFooter
+          showCanvasFooter={showCanvasFooter}
+          isMobileLayout={isMobileLayout}
+          currentMode={currentMode}
+        />
+      </Suspense>
     </div>
   );
 };


### PR DESCRIPTION
## 📝 What this does
Fixes a rendering issue where widgets appeared narrower than expected in the viewer, leaving extra space on the right side of the canvas. The root cause was lazy-loaded `PageCanvasHeader` and `PageCanvasFooter` components missing their required `<Suspense>` boundaries, which disrupted the canvas mount sequence and caused `useCanvasResizing` to calculate an incorrect initial width.

## 🔀 Changes
- Wrapped lazy `PageCanvasHeader` and `PageCanvasFooter` in `<Suspense fallback={null}>` in both `DesktopLayout` and `MobileLayout`
- Added `Suspense` to the React imports in both layout components

## 🧪 How to test
- [ ] Open any app in viewer/preview mode with a full-width widget (e.g., Calendar, Table)
- [ ] Verify the widget fills the full canvas width with no extra space on the right
- [ ] Hard-refresh the page (Cmd+Shift+R) to test cold-load behavior
- [ ] Check that page header and footer still render correctly when enabled