### PR TITLE
Fix: Clicking component config handle inside nested forms refreshes the page

### DIFF
--- a/frontend/src/_components/ConfigHandleButton.jsx
+++ b/frontend/src/_components/ConfigHandleButton.jsx
@@ -21,6 +21,7 @@ const ConfigHandleButton = ({
     <span className={`config-handle-button ${className}`}>
       <ToolTip message={message} show={show} delay={{ show: 500, hide: 50 }}>
         <button
+          type="button"
           style={{
             background: 'var(--background-accent-strong)',
             color: 'var(--text-on-solid)',


### PR DESCRIPTION
This pull request makes a minor update to the `ConfigHandleButton` component by explicitly setting the button's `type` attribute to `"button"`. This helps prevent unintended form submissions when the button is used inside a form.

- Added `type="button"` to the `<button>` element in `ConfigHandleButton` to prevent accidental form submissions.