### PR TITLE
Fix: resolve listItem for components nested inside Form within ListView

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -2516,16 +2516,15 @@ export const createComponentsSlice = (set, get) => ({
     }
 
     // If the component is inside a ListView, use the ListView's data length
-    // so that all rows are resolved even if this component's array hasn't
-    // been fully sized yet (e.g. grandchildren on page refresh).
-    if (Array.isArray(data)) {
-      const parentId = getParentIdFromDependency(dependency, moduleId);
-      const nearestListviewId = parentId ? findNearestSubcontainerAncestor(parentId, moduleId) : null;
-      if (nearestListviewId) {
-        const customResolvables = getCustomResolvables(nearestListviewId, null, moduleId, parentIndices);
-        const lvLength = Array.isArray(customResolvables) ? customResolvables.length : 0;
-        if (lvLength > 0) return lvLength;
-      }
+    // so all rows are resolved even when this component's resolved value is
+    // still flat/non-array (common for nested descendants like
+    // ListView -> Container/Form -> Text on initial pass).
+    const parentId = getParentIdFromDependency(dependency, moduleId);
+    const nearestListviewId = parentId ? findNearestSubcontainerAncestor(parentId, moduleId) : null;
+    if (nearestListviewId) {
+      const customResolvables = getCustomResolvables(nearestListviewId, null, moduleId, parentIndices);
+      const lvLength = Array.isArray(customResolvables) ? customResolvables.length : 0;
+      if (lvLength > 0) return lvLength;
     }
 
     return data?.length;


### PR DESCRIPTION
## 📝 What this does
Fixes `{{listItem}}` not resolving for components (e.g. Text) placed inside a Form that is itself inside a ListView. The resolution logic now always checks for the nearest ListView ancestor, regardless of whether the component's current resolved value is already an array.

## 🔀 Changes
- Removed `Array.isArray(data)` guard in `getEntityResolvedValueLength` so ListView row count is used for all nested descendants, not just those already resolved as arrays

## 🧪 How to test
- [ ] Create a ListView with a Form inside it, and a Text component inside the Form
- [ ] Set the Text value to `{{listItem.someField}}` — verify it resolves correctly per row
- [ ] Verify `listView1 → listView2 → Text` still works as before
- [ ] Verify `listView1 → listView2 → Form → Text` now resolves `{{listItem}}` correctly