### PR TITLE
Fix: gate JS library loading on license fetch for public and released apps

### DIFF
--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -117,6 +117,7 @@ const useAppData = (
   const setIsPublicAccess = useStore((state) => state.setIsPublicAccess);
   const setJsLibraryRegistry = useStore((state) => state.setJsLibraryRegistry);
   const setJsLibraryLoading = useStore((state) => state.setJsLibraryLoading);
+  const isLicenseFetched = useStore((state) => state.isLicenseFetched);
 
   const setModulesIsLoading = useStore((state) => state?.setModulesIsLoading ?? noop);
   const setModulesList = useStore((state) => state?.setModulesList ?? noop);
@@ -598,7 +599,7 @@ const useAppData = (
   }, [setApp, setEditorLoading, currentSession, mode]);
 
   useEffect(() => {
-    if (isComponentLayoutReady) {
+    if (isComponentLayoutReady && isLicenseFetched) {
       mode === 'edit' && initSuggestions(moduleId);
 
       const loadLibrariesAndRun = async () => {
@@ -633,7 +634,7 @@ const useAppData = (
 
       loadLibrariesAndRun();
     }
-  }, [isComponentLayoutReady, moduleId, mode]);
+  }, [isComponentLayoutReady, isLicenseFetched, moduleId, mode]);
 
   useEffect(() => {
     if (moduleId !== 'canvas') return;

--- a/frontend/src/AppBuilder/_stores/slices/licenseSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/licenseSlice.js
@@ -3,18 +3,37 @@ import _ from 'lodash';
 
 const initialState = {
   license: {},
+  // Tracks whether the license/feature-access fetch has settled (resolved or rejected).
+  // useAppData gates loadLibrariesAndRun on this flag to avoid reading featureAccess
+  // before it arrives — without the gate, JS libraries were silently skipped on public
+  // and released apps because featureAccess?.appJsLibraries was still undefined when
+  // isComponentLayoutReady fired.
+  isLicenseFetched: false,
 };
 
 export const createLicenseSlice = (set, get) => ({
   ...initialState,
   updateFeatureAccess: () => {
-    licenseService.getFeatureAccess().then((data) => {
-      set((state) => {
-        state.license = {
-          featureAccess: data,
-        };
-      });
+    set((state) => {
+      state.isLicenseFetched = false;
     });
+    licenseService
+      .getFeatureAccess()
+      .then((data) => {
+        set((state) => {
+          state.license = {
+            featureAccess: data,
+          };
+          state.isLicenseFetched = true;
+        });
+      })
+      .catch(() => {
+        // For public/unauthenticated apps the license API may be inaccessible.
+        // Still mark as fetched so loadLibrariesAndRun is not blocked indefinitely.
+        set((state) => {
+          state.isLicenseFetched = true;
+        });
+      });
   },
   isLicenseValid: () => {
     const featureAccess = get().license.featureAccess;


### PR DESCRIPTION
## 📝 What this does
JS libraries were silently skipped on public and released apps because `featureAccess?.appJsLibraries` was still `undefined` when `isComponentLayoutReady` fired — the license fetch hadn't completed yet. This introduces an `isLicenseFetched` gate so library loading waits for the fetch to settle before running.

- [ee-server](no changes)
- [ee-frontend](no changes)

## 🔀 Changes
- Added `isLicenseFetched` flag to `licenseSlice` that flips to `true` once the license fetch resolves or rejects
- Added `.catch()` to `updateFeatureAccess` so public/unauthenticated apps don't block indefinitely when the license API is inaccessible
- Gated `loadLibrariesAndRun` effect in `useAppData` on both `isComponentLayoutReady` and `isLicenseFetched`

## 🧪 How to test
- [ ] Open a public app that has JS libraries configured — verify the libraries load correctly
- [ ] Open a released app with JS libraries — verify they load and preloaded JS executes
- [ ] Open the editor — verify normal library loading and on-load queries still work