### PR TITLE
Fix: Listview children not getting rendered inside Table expanded row

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -347,16 +347,17 @@ export const createComponentsSlice = (set, get) => ({
     let customResolvables = {};
     const parentId = component?.parent;
     const componentDetails = { componentId, paramType, property };
-    const nearestListviewId = findNearestSubcontainerAncestor(parentId, moduleId);
-    let index = nearestListviewId ? 0 : null;
+    // Nearest row-scoped ancestor (Listview / Kanban / Table) — the one whose per-row customResolvables this component resolves against.
+    const nearestRowScopedAncestorId = findNearestSubcontainerAncestor(parentId, moduleId);
+    let index = nearestRowScopedAncestorId ? 0 : null;
     if (index !== null) {
-      // For nested ListViews, we need to build parentIndices by walking up the ancestor chain.
-      // ListView parent IDs don't contain row indices - the row info is only available at render time.
-      // At drop time, we use index 0 for each ListView ancestor as a default for initial resolution.
+      // For components nested inside row-scoped ancestors, build parentIndices by walking up the ancestor chain.
+      // Row-scoped parent IDs don't contain row indices — the row info is only available at render time.
+      // At drop time, we use index 0 for each row-scoped ancestor as a default for initial resolution.
       const parentIndices = [];
 
-      // Walk up the ancestor chain starting from the nearest ListView's parent
-      const nearestDef = getComponentDefinition(nearestListviewId, moduleId);
+      // Walk up the ancestor chain starting from the nearest row-scoped ancestor's parent
+      const nearestDef = getComponentDefinition(nearestRowScopedAncestorId, moduleId);
       let ancestorId = nearestDef?.component?.parent;
       while (ancestorId) {
         const baseAncestorId = getBaseParentId(ancestorId) || ancestorId;
@@ -369,7 +370,7 @@ export const createComponentsSlice = (set, get) => ({
         ancestorId = ancestorDef?.component?.parent;
       }
 
-      customResolvables = getCustomResolvables(nearestListviewId, null, moduleId, parentIndices);
+      customResolvables = getCustomResolvables(nearestRowScopedAncestorId, null, moduleId, parentIndices);
     }
     if (typeof value === 'string' && value?.includes('{{') && value?.includes('}}')) {
       let valueWithId, allRefs, valueWithBrackets;
@@ -2587,7 +2588,7 @@ export const createComponentsSlice = (set, get) => ({
     return refs;
   },
 
-  // Walk up from startParentId through component.parent links to find the nearest per-row subcontainer ancestor (ListView or Kanban).
+  // Walk up from startParentId through component.parent links to find the nearest row-scoped ancestor whose widget type is included in ROW_SCOPED_WIDGET_TYPES.
   // Returns the base UUID of that ancestor, or null if none found.
   findNearestSubcontainerAncestor: (startParentId, moduleId) => {
     const { getBaseParentId, getComponentDefinition } = get();

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -362,8 +362,8 @@ export const createComponentsSlice = (set, get) => ({
         const baseAncestorId = getBaseParentId(ancestorId) || ancestorId;
         const ancestorDef = getComponentDefinition(baseAncestorId, moduleId);
         const ancestorType = ancestorDef?.component?.component;
-        if (ancestorType === 'Listview' || ancestorType === 'Kanban') {
-          // Add 0 at the beginning for each ListView/Kanban ancestor (outer-most first)
+        if (ROW_SCOPED_WIDGET_TYPES.includes(ancestorType)) {
+          // Add 0 at the beginning for each row-scoped ancestor (outer-most first)
           parentIndices.unshift(0);
         }
         ancestorId = ancestorDef?.component?.parent;
@@ -1243,27 +1243,21 @@ export const createComponentsSlice = (set, get) => ({
         // For ListView, initialize customResolvables immediately after processing
         // so that child components processed later can access them
         if (newComponent.component.component === 'Listview') {
-          const {
-            getResolvedComponent,
-            updateCustomResolvables,
-            checkIfParentIsListviewOrKanban,
-            getBaseParentId,
-            getComponentDefinition,
-          } = get();
+          const { getResolvedComponent, updateCustomResolvables, getBaseParentId, getComponentDefinition } = get();
           const resolvedComponent = getResolvedComponent(newComponent.id, null, moduleId);
           const data = resolvedComponent?.properties?.data;
           if (Array.isArray(data) && data.length > 0) {
-            // Build parentIndices for nested ListView case
+            // Build parentIndices for each row-scoped ancestor (outer-most first)
             const parentIndices = [];
             const componentParentId = newComponent.component.parent;
             if (componentParentId) {
               let ancestorId = componentParentId;
               while (ancestorId) {
                 const baseAncestorId = getBaseParentId(ancestorId);
-                if (checkIfParentIsListviewOrKanban(baseAncestorId, moduleId)) {
+                const ancestorDef = getComponentDefinition(baseAncestorId, moduleId);
+                if (ROW_SCOPED_WIDGET_TYPES.includes(ancestorDef?.component?.component)) {
                   parentIndices.unshift(0);
                 }
-                const ancestorDef = getComponentDefinition(baseAncestorId, moduleId);
                 ancestorId = ancestorDef?.component?.parent;
               }
             }
@@ -2591,15 +2585,6 @@ export const createComponentsSlice = (set, get) => ({
     }
 
     return refs;
-  },
-
-  checkIfParentIsListviewOrKanban: (parentId, moduleId) => {
-    const { getParentComponentType } = get();
-    const parentComponentType = getParentComponentType(parentId, moduleId);
-    if (parentComponentType === 'Listview' || parentComponentType === 'Kanban') {
-      return true;
-    }
-    return false;
   },
 
   // Walk up from startParentId through component.parent links to find the nearest per-row subcontainer ancestor (ListView or Kanban).


### PR DESCRIPTION
This pull request refactors how the code determines and handles "row-scoped" ancestor components in the AppBuilder's `componentsSlice`. The main improvement is the generalization of logic previously specific to `Listview` and `Kanban` components, making the code more extensible and maintainable by using a shared constant, `ROW_SCOPED_WIDGET_TYPES`.

**Generalization of row-scoped ancestor logic:**

* Replaced checks for specific component types (`Listview` and `Kanban`) with a generalized check using the `ROW_SCOPED_WIDGET_TYPES` constant when building `parentIndices` in component processing logic. [[1]](diffhunk://#diff-abc6bb316d1fa4f606c614ea7977b97911af8cf27305746e2b63da0ec30dffffL365-R366) [[2]](diffhunk://#diff-abc6bb316d1fa4f606c614ea7977b97911af8cf27305746e2b63da0ec30dffffL1246-L1266)
* Updated the logic for building `parentIndices` during ListView initialization to use the new generalized approach for identifying row-scoped ancestors.

**Code cleanup and simplification:**

* Removed the now-unnecessary `checkIfParentIsListviewOrKanban` helper function, consolidating row-scoped ancestor checks into the new approach.