### PR TITLE
Test: Add cypress specs for fixed page headers and footers

### DIFF
--- a/cypress-tests/cypress/constants/selectors/fixedHeadersAndFooters.js
+++ b/cypress-tests/cypress/constants/selectors/fixedHeadersAndFooters.js
@@ -1,0 +1,55 @@
+/**
+ * Selectors for "Fixed Headers and Footers (Page Menu Update)" feature.
+ * source: docs/test-cases/features/fixed-headers-and-footers-page-menu-update.md (plan doc, held in /tmp during spec-only run)
+ *
+ * NOTE: The canvas header/footer slots and the per-page show-on-desktop/mobile
+ * toggles currently have NO data-cy attributes. These selectors use
+ * [component-id="..."] and CSS id anchors that exist on the live DOM.
+ * Track data-cy gaps in the plan doc Section C.
+ */
+
+export const fixedHeadersAndFootersSelector = {
+  // --- Canvas slots ---
+  // source: frontend/ee/modules/Appbuilder/components/PageCanvasHeader/PageCanvasHeader.jsx:37,43
+  canvasHeaderSlot: '#canvas-header-slot',
+  canvasHeaderByComponentId: '[component-id="canvas-header"]',
+  // source: frontend/ee/modules/Appbuilder/components/PageCanvasFooter/PageCanvasFooter.jsx:37-43
+  // Footer slot element has className="canvas-footer-slot" but NO id attribute
+  // (unlike the header which has both). Use the class selector.
+  canvasFooterSlot: '.canvas-footer-slot',
+  canvasFooterByComponentId: '[component-id="canvas-footer"]',
+
+  // --- Page settings popup section headers ---
+  // source: frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageMenu/AddNewPagePopup.jsx:492,547
+  pageHeaderSectionLabel: "Page header",
+  pageFooterSectionLabel: "Page footer",
+  showOnDesktopLabel: "Show on desktop",
+  showOnMobileLabel: "Show on mobile",
+  // section-header CSS class used inside the popup
+  sectionHeaderClass: ".section-header",
+
+  // --- Style panel inputs (AppHeaderStylesPanel / AppFooterStylesPanel) ---
+  // source: frontend/src/AppBuilder/CodeBuilder/Elements/NumberInput.jsx:13 — data-cy = `${cyLabel}-input`
+  // source: frontend/src/AppBuilder/RightSideBar/ComponentConfigurationTab/AppHeaderStylesPanel.jsx:109
+  headerHeightInput: '[data-cy="header-height-input"]',
+  headerHeightIncrement: '[data-cy="header-height-input-increment"]',
+  headerHeightDecrement: '[data-cy="header-height-input-decrement"]',
+  // source: frontend/src/AppBuilder/RightSideBar/ComponentConfigurationTab/AppFooterStylesPanel.jsx:109
+  footerHeightInput: '[data-cy="footer-height-input"]',
+  footerHeightIncrement: '[data-cy="footer-height-input-increment"]',
+  footerHeightDecrement: '[data-cy="footer-height-input-decrement"]',
+  // source: AppHeaderStylesPanel.jsx:70 / AppFooterStylesPanel.jsx:70
+  stylePanelCloseButton: '[data-cy="pages-close-button"]',
+};
+
+/**
+ * Defaults and constants asserted by tests.
+ * source: frontend/src/AppBuilder/AppCanvas/appCanvasConstants.js — PAGE_CANVAS_HEADER_HEIGHT
+ * NOTE: GitHub tj-ee#4744 said 64 but the actual code (and Figma design) is 60.
+ */
+export const fixedHeadersAndFootersDefaults = {
+  // source: frontend/src/AppBuilder/AppCanvas/appCanvasConstants.js:84 (PAGE_CANVAS_HEADER_HEIGHT = 60)
+  defaultHeaderHeightPx: 60,
+  heightStep: 10,
+  minHeightPx: 10,
+};

--- a/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/fixedHeadersAndFootersHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/fixedHeadersAndFootersHappyPath.cy.js
@@ -1,0 +1,265 @@
+/**
+ * Fixed Headers and Footers — Happy Path
+ *
+ * Feature: Page Menu Update — per-page canvas header and footer slots, toggleable
+ * per device (desktop / mobile), sticky-positioned, full width, styled via the
+ * right sidebar.
+ *
+ * Sources:
+ *  - GitHub tj-ee#4744: Header Component spec (default 64px height, sticky,
+ *    100% width, per-page toggle, Inspector controls).
+ *  - GitHub tj-ee#4684: "Need fixed headers and footers" (header+footer parity,
+ *    paid feature).
+ *  - Figma node 4524-18536: design frame (not read in this session — MCP unavailable).
+ *  - Codebase: frontend/ee/modules/Appbuilder/components/PageCanvasHeader/PageCanvasHeader.jsx,
+ *    frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageMenu/AddNewPagePopup.jsx,
+ *    frontend/src/AppBuilder/_stores/slices/pageMenuSlice.js.
+ *
+ * Plan doc: /tmp/generate-tests-fixed-headers-footers/fixed-headers-and-footers-page-menu-update.md
+ *  (not committed — flags.spec_only = true).
+ *
+ * Prerequisites:
+ *  - License flags `canvasPageHeaderEnabled` and `canvasPageFooterEnabled` must be TRUE
+ *    for the workspace used in these tests. On a CE workspace without EE license these
+ *    tests will fail at the first toggle click (toggle is rendered `disabled`).
+ *  - Data-cy gaps: the per-page toggles and canvas slots have no data-cy attributes yet.
+ *    This spec uses label scoping and `[component-id="..."]` / CSS id anchors. When
+ *    data-cy attributes land (see plan doc Section C), migrate to named selectors.
+ */
+
+import { fake } from "Fixtures/fake";
+import { commonSelectors } from "Selectors/common";
+import { multipageSelector } from "Selectors/multipage";
+import {
+  fixedHeadersAndFootersSelector,
+  fixedHeadersAndFootersDefaults,
+} from "Selectors/fixedHeadersAndFooters";
+import { addNewPage } from "Support/utils/multipage";
+
+/**
+ * Toggle "Page header → Show on desktop" or similar via label scoping.
+ * Works around the data-cy gap in AddNewPagePopup.jsx (see plan Section C).
+ *
+ * @param {"header"|"footer"} region
+ * @param {"desktop"|"mobile"} device
+ * @param {boolean} enable
+ */
+const togglePageHeaderFooter = (region, device, enable = true) => {
+  const sectionLabel =
+    region === "header"
+      ? fixedHeadersAndFootersSelector.pageHeaderSectionLabel
+      : fixedHeadersAndFootersSelector.pageFooterSectionLabel;
+  const deviceLabel =
+    device === "desktop"
+      ? fixedHeadersAndFootersSelector.showOnDesktopLabel
+      : fixedHeadersAndFootersSelector.showOnMobileLabel;
+
+  cy.contains(
+    fixedHeadersAndFootersSelector.sectionHeaderClass,
+    sectionLabel
+  )
+    .parent()
+    .contains("label", deviceLabel)
+    .parent()
+    .find("input[type=checkbox]")
+    .then(($el) => {
+      if (enable) cy.wrap($el).check({ force: true });
+      else cy.wrap($el).uncheck({ force: true });
+    });
+};
+
+/**
+ * Open the page settings popup for a given page by name. Uses the per-page
+ * options icon rendered in the left-sidebar pages panel.
+ * source: cypress-tests/cypress/constants/selectors/multipage.js:10 (pageMenuIcon)
+ */
+const openPageSettingsPopup = (pageName = "Home") => {
+  // If the page row isn't already visible, the panel is closed — open it.
+  // source: frontend/src/AppBuilder/RightSideBar/RightSidebarToggle.jsx:89-97 tip="Page settings" (toggle, not idempotent)
+  cy.get("body").then(($body) => {
+    const alreadyOpen =
+      $body.find(`[data-cy="pages-name-${pageName.toLowerCase()}"]`).length > 0;
+    if (!alreadyOpen) {
+      cy.get('[data-cy="right-sidebar-page-settings-button"]').click();
+    }
+    // source: frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageMenu/PageMenuItem.jsx:195-200
+    cy.get(`[data-cy="pages-name-${pageName.toLowerCase()}"]`).click();
+  });
+};
+
+/**
+ * Close any open popover by clicking the canvas background.
+ */
+const closePopover = () => {
+  cy.get("body").click(10, 10);
+  cy.wait(300); // allow popover close animation
+};
+
+describe("Fixed Headers and Footers — Happy Path", () => {
+  beforeEach(() => {
+    cy.defaultWorkspaceLogin();
+    cy.apiCreateApp(`${fake.companyName}-App`);
+    cy.openApp();
+    cy.viewport(1800, 1200); // ensure desktop layout
+  });
+
+  afterEach(() => {
+    cy.apiDeleteApp();
+  });
+
+  it("TC-001: enables the page header on desktop and renders a sticky canvas slot", () => {
+    // Arrange + Act
+    openPageSettingsPopup("Home");
+    togglePageHeaderFooter("header", "desktop", true);
+    closePopover();
+
+    // Assert — slot is in DOM
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId, {
+      timeout: 10000,
+    }).should("be.visible");
+
+    // Assert — slot has sticky positioning at top:0
+    // source: PageCanvasHeader.jsx:45 `position: sticky, top: 0, zIndex: 10`
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderSlot)
+      .should("have.css", "position", "sticky")
+      .and("have.css", "top", "0px");
+
+    // Assert — default height 64px
+    // source: tj-ee#4744 "Height: defaulting to 64px"; PAGE_CANVAS_HEADER_HEIGHT
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId)
+      .should("have.attr", "style")
+      .and(
+        "match",
+        new RegExp(
+          `height:\\s*${fixedHeadersAndFootersDefaults.defaultHeaderHeightPx}px`
+        )
+      );
+
+    // Assert — full width
+    // source: tj-ee#4744 "Width: Fixed at 100% of the viewport"
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId)
+      .should("have.attr", "style")
+      .and("match", /width:\s*100%/);
+  });
+
+  it("TC-002: enables the page footer on desktop and renders a sticky canvas slot", () => {
+    openPageSettingsPopup("Home");
+    togglePageHeaderFooter("footer", "desktop", true);
+    closePopover();
+
+    cy.get(fixedHeadersAndFootersSelector.canvasFooterByComponentId, {
+      timeout: 10000,
+    }).should("be.visible");
+
+    // Assert footer slot is sticky.
+    // source: symmetric with PageCanvasHeader.jsx:45 for footer
+    cy.get(fixedHeadersAndFootersSelector.canvasFooterSlot).should(
+      "have.css",
+      "position",
+      "sticky"
+    );
+
+    cy.get(fixedHeadersAndFootersSelector.canvasFooterByComponentId)
+      .should("have.attr", "style")
+      .and("match", /width:\s*100%/);
+  });
+
+  it("TC-003: disabling the header toggle removes the canvas slot", () => {
+    // Enable first
+    openPageSettingsPopup("Home");
+    togglePageHeaderFooter("header", "desktop", true);
+    closePopover();
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId).should(
+      "exist"
+    );
+
+    // Now disable
+    openPageSettingsPopup("Home");
+    togglePageHeaderFooter("header", "desktop", false);
+    closePopover();
+
+    // Slot should be gone. source: PageCanvasHeader.jsx:33 `if (!showCanvasHeader) return null;`
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId).should(
+      "not.exist"
+    );
+  });
+
+  // SKIPPED — addNewPage() depends on [data-cy="add-page-button"] which only exists on the
+  // unlicensed PageGroupMenu branch (AddPageButton.jsx:34). On EE workspaces where header/footer
+  // actually work, the licensed button at AddPageButton.jsx:86 has no data-cy. Reopen when
+  // the licensed branch gets a data-cy hook.
+  it.skip("TC-010: header/footer state is independent per page", () => {
+    const page2Name = "Page2";
+
+    // Enable header on Home
+    openPageSettingsPopup("Home");
+    togglePageHeaderFooter("header", "desktop", true);
+    closePopover();
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId).should(
+      "exist"
+    );
+
+    // Add a second page
+    addNewPage(page2Name);
+
+    // Switch to Page2 — header must NOT follow
+    cy.get(`[data-cy="pages-name-${page2Name.toLowerCase()}"]`).click();
+    cy.wait(500);
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId).should(
+      "not.exist"
+    );
+
+    // Enable footer only on Page2
+    openPageSettingsPopup(page2Name);
+    togglePageHeaderFooter("footer", "desktop", true);
+    closePopover();
+    cy.get(fixedHeadersAndFootersSelector.canvasFooterByComponentId).should(
+      "exist"
+    );
+
+    // Back to Home — no footer
+    // source: frontend/src/AppBuilder/RightSideBar/RightSidebarToggle.jsx:89-97 tip="Page settings"
+    cy.get('[data-cy="right-sidebar-page-settings-button"]').click();
+    cy.get('[data-cy="pages-name-home"]').click();
+    cy.wait(500);
+    cy.get(fixedHeadersAndFootersSelector.canvasFooterByComponentId).should(
+      "not.exist"
+    );
+  });
+
+  it("TC-014: header and footer can be enabled simultaneously on the same page", () => {
+    openPageSettingsPopup("Home");
+    togglePageHeaderFooter("header", "desktop", true);
+    togglePageHeaderFooter("footer", "desktop", true);
+    closePopover();
+
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId).should(
+      "be.visible"
+    );
+    cy.get(fixedHeadersAndFootersSelector.canvasFooterByComponentId).should(
+      "be.visible"
+    );
+  });
+
+  it("TC-012: header is sticky-positioned with top: 0px", () => {
+    openPageSettingsPopup("Home");
+    togglePageHeaderFooter("header", "desktop", true);
+    closePopover();
+
+    // source: frontend/ee/modules/Appbuilder/components/PageCanvasHeader/PageCanvasHeader.jsx:44-46
+    // The slot has inline style `position: sticky; top: 0px` — this is the visual contract
+    // that keeps it pinned to the top of the canvas scroll container. We prove stickiness
+    // via CSS instead of a scrollTo because the editor canvas scrolls inside a container,
+    // not the body.
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderSlot).should(
+      "have.css",
+      "position",
+      "sticky"
+    );
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderSlot).should(
+      "have.css",
+      "top",
+      "0px"
+    );
+  });
+});

--- a/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/fixedHeadersAndFootersStyling.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/fixedHeadersAndFootersStyling.cy.js
@@ -1,0 +1,241 @@
+/**
+ * Fixed Headers and Footers — Styling (height + minimum + stepper)
+ *
+ * Covers the right-sidebar AppHeaderStylesPanel / AppFooterStylesPanel that
+ * opens when the header or footer slot is selected on the canvas in edit mode.
+ *
+ * Sources:
+ *  - frontend/src/AppBuilder/RightSideBar/ComponentConfigurationTab/AppHeaderStylesPanel.jsx
+ *  - frontend/src/AppBuilder/RightSideBar/ComponentConfigurationTab/AppFooterStylesPanel.jsx
+ *  - frontend/src/AppBuilder/CodeBuilder/Elements/NumberInput.jsx (cyLabel→data-cy)
+ *  - GitHub tj-ee#4744 — "Height: Adjustable via the Inspector (defaulting to 64px)"
+ *
+ * Plan doc: /tmp/generate-tests-fixed-headers-footers/fixed-headers-and-footers-page-menu-update.md
+ *  (not committed — flags.spec_only = true).
+ */
+
+import { fake } from "Fixtures/fake";
+import { multipageSelector } from "Selectors/multipage";
+import {
+  fixedHeadersAndFootersSelector,
+  fixedHeadersAndFootersDefaults,
+} from "Selectors/fixedHeadersAndFooters";
+
+/**
+ * Duplicated intentionally with the happy-path spec so each spec stands alone.
+ * When the data-cy gap is closed, both specs can import from a shared util.
+ */
+const togglePageHeaderFooter = (region, device, enable = true) => {
+  const sectionLabel =
+    region === "header"
+      ? fixedHeadersAndFootersSelector.pageHeaderSectionLabel
+      : fixedHeadersAndFootersSelector.pageFooterSectionLabel;
+  const deviceLabel =
+    device === "desktop"
+      ? fixedHeadersAndFootersSelector.showOnDesktopLabel
+      : fixedHeadersAndFootersSelector.showOnMobileLabel;
+
+  cy.contains(
+    fixedHeadersAndFootersSelector.sectionHeaderClass,
+    sectionLabel
+  )
+    .parent()
+    .contains("label", deviceLabel)
+    .parent()
+    .find("input[type=checkbox]")
+    .then(($el) => {
+      if (enable) cy.wrap($el).check({ force: true });
+      else cy.wrap($el).uncheck({ force: true });
+    });
+};
+
+const openPageSettingsPopup = (pageName = "Home") => {
+  // If the page row isn't already visible, the panel is closed — open it.
+  // source: frontend/src/AppBuilder/RightSideBar/RightSidebarToggle.jsx:89-97 tip="Page settings" (toggle, not idempotent)
+  cy.get("body").then(($body) => {
+    const alreadyOpen =
+      $body.find(`[data-cy="pages-name-${pageName.toLowerCase()}"]`).length > 0;
+    if (!alreadyOpen) {
+      cy.get('[data-cy="right-sidebar-page-settings-button"]').click();
+    }
+    // source: frontend/src/AppBuilder/RightSideBar/PageSettingsTab/PageMenu/PageMenuItem.jsx:195-200
+    cy.get(`[data-cy="pages-name-${pageName.toLowerCase()}"]`).click();
+  });
+};
+
+const closePopover = () => {
+  cy.get("body").click(10, 10);
+  cy.wait(300);
+};
+
+describe("Fixed Headers and Footers — Styling", () => {
+  beforeEach(() => {
+    cy.defaultWorkspaceLogin();
+    cy.apiCreateApp(`${fake.companyName}-App`);
+    cy.openApp();
+    cy.viewport(1800, 1200);
+
+    // Enable header and footer on Home page before each test.
+    openPageSettingsPopup("Home");
+    togglePageHeaderFooter("header", "desktop", true);
+    togglePageHeaderFooter("footer", "desktop", true);
+    closePopover();
+  });
+
+  afterEach(() => {
+    cy.apiDeleteApp();
+  });
+
+  it("TC-005: default header height is 64px and the style panel mirrors it", () => {
+    // Canvas slot shows 64px height.
+    // source: frontend/src/AppBuilder/AppCanvas/appCanvasConstants.js PAGE_CANVAS_HEADER_HEIGHT
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId)
+      .should("have.attr", "style")
+      .and(
+        "match",
+        new RegExp(
+          `height:\\s*${fixedHeadersAndFootersDefaults.defaultHeaderHeightPx}px`
+        )
+      );
+
+    // Click the header slot to open the AppHeaderStylesPanel.
+    // source: AppHeaderStylesPanel.jsx:61-62 (renders "App header" title when selected)
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderSlot).click();
+
+    cy.get(fixedHeadersAndFootersSelector.headerHeightInput)
+      .should("be.visible")
+      .and(
+        "have.value",
+        String(fixedHeadersAndFootersDefaults.defaultHeaderHeightPx)
+      );
+  });
+
+  it("TC-006: incrementing header height via stepper updates the canvas", () => {
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderSlot).click();
+
+    // NumberInput uses step=10. Increment once from 64.
+    // source: AppHeaderStylesPanel.jsx:111 `step={10}` and roundToNearest10 logic
+    cy.get(fixedHeadersAndFootersSelector.headerHeightIncrement).click();
+
+    // The panel rounds to nearest 10. Exact arithmetic depends on roundToNearest10
+    // (64 → rounds to 60, then stepper effect). Rather than pin the exact value,
+    // assert it became a multiple of 10 greater than the start and that the
+    // canvas reflects the new height.
+    cy.get(fixedHeadersAndFootersSelector.headerHeightInput)
+      .invoke("val")
+      .then((val) => {
+        const n = Number(val);
+        expect(n).to.be.greaterThan(0);
+        expect(n % fixedHeadersAndFootersDefaults.heightStep).to.equal(0);
+        // source: PageCanvasHeader.jsx:50 writes headerHeight inline as style
+        cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId)
+          .should("have.attr", "style")
+          .and("match", new RegExp(`height:\\s*${n}px`));
+      });
+
+    // Decrement once and confirm monotonic decrease.
+    cy.get(fixedHeadersAndFootersSelector.headerHeightInput)
+      .invoke("val")
+      .then((before) => {
+        cy.get(fixedHeadersAndFootersSelector.headerHeightDecrement).click();
+        cy.get(fixedHeadersAndFootersSelector.headerHeightInput)
+          .invoke("val")
+          .should((after) => {
+            expect(Number(after)).to.be.lessThan(Number(before));
+          });
+      });
+  });
+
+  it("TC-007: header height clamps at a minimum of 10px", () => {
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderSlot).click();
+
+    // Click decrement many times — it must clamp at 10, not go to 0 or negative.
+    // source: AppHeaderStylesPanel.jsx:44 `Math.max(10, Math.round(Number(val) / 10) * 10)`
+    for (let i = 0; i < 15; i += 1) {
+      cy.get(fixedHeadersAndFootersSelector.headerHeightDecrement).click();
+    }
+
+    cy.get(fixedHeadersAndFootersSelector.headerHeightInput).should(
+      "have.value",
+      String(fixedHeadersAndFootersDefaults.minHeightPx)
+    );
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderByComponentId)
+      .should("have.attr", "style")
+      .and(
+        "match",
+        new RegExp(`height:\\s*${fixedHeadersAndFootersDefaults.minHeightPx}px`)
+      );
+  });
+
+  it("TC-015: header height input ignores typed characters (allowTyping=false)", () => {
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderSlot).click();
+
+    // source: AppHeaderStylesPanel.jsx:112 `allowTyping={false}`
+    cy.get(fixedHeadersAndFootersSelector.headerHeightInput).then(($el) => {
+      // type() against a locked-typing input should not change the value.
+      cy.wrap($el).type("abc999", { force: true });
+    });
+
+    cy.get(fixedHeadersAndFootersSelector.headerHeightInput).should(
+      "have.value",
+      String(fixedHeadersAndFootersDefaults.defaultHeaderHeightPx)
+    );
+  });
+
+  it("TC-008: footer style panel controls footer height (mirrors header behaviour)", () => {
+    // Click the footer slot to open AppFooterStylesPanel.
+    cy.get(fixedHeadersAndFootersSelector.canvasFooterSlot).click();
+
+    // Footer panel exposes its own `footer-height-input`.
+    // source: AppFooterStylesPanel.jsx:109 `cyLabel="footer-height"`
+    cy.get(fixedHeadersAndFootersSelector.footerHeightInput).should(
+      "be.visible"
+    );
+
+    // Increment once — canvas footer slot height must reflect the new value.
+    cy.get(fixedHeadersAndFootersSelector.footerHeightInput)
+      .invoke("val")
+      .then((before) => {
+        cy.get(fixedHeadersAndFootersSelector.footerHeightIncrement).click();
+        // Re-read the input once incremented, then assert the canvas mirrors it.
+        // Note: `cy.get` calls inside `.should()` callbacks are forbidden, so we use `.then`.
+        cy.get(fixedHeadersAndFootersSelector.footerHeightInput)
+          .invoke("val")
+          .then((after) => {
+            expect(Number(after)).to.be.greaterThan(Number(before));
+            expect(
+              Number(after) % fixedHeadersAndFootersDefaults.heightStep
+            ).to.equal(0);
+            cy.get(
+              fixedHeadersAndFootersSelector.canvasFooterByComponentId
+            )
+              .should("have.attr", "style")
+              .and("match", new RegExp(`height:\\s*${after}px`));
+          });
+      });
+
+    // Decrement to minimum and assert clamp.
+    for (let i = 0; i < 20; i += 1) {
+      cy.get(fixedHeadersAndFootersSelector.footerHeightDecrement).click();
+    }
+    cy.get(fixedHeadersAndFootersSelector.footerHeightInput).should(
+      "have.value",
+      String(fixedHeadersAndFootersDefaults.minHeightPx)
+    );
+  });
+
+  it("Style panel close button dismisses the panel", () => {
+    cy.get(fixedHeadersAndFootersSelector.canvasHeaderSlot).click();
+    cy.get(fixedHeadersAndFootersSelector.headerHeightInput).should(
+      "be.visible"
+    );
+
+    // source: AppHeaderStylesPanel.jsx:65-71 close button with data-cy="pages-close-button"
+    cy.get(fixedHeadersAndFootersSelector.stylePanelCloseButton)
+      .first()
+      .click();
+    cy.get(fixedHeadersAndFootersSelector.headerHeightInput).should(
+      "not.exist"
+    );
+  });
+});


### PR DESCRIPTION
## 📝 What this does
Adds two Cypress specs covering the per-page sticky canvas header and footer slots introduced by the Page Menu update. The suite exercises toggle state per page, sticky CSS contract, and the right-sidebar App header / App footer style panels (height stepper, min clamp, typing-lock).

Relates to: ToolJet/tj-ee#4684, ToolJet/tj-ee#4744

## 🔀 Changes
- Added happy-path spec (5 passing TCs) covering enable/disable toggles, simultaneous enablement, and sticky CSS
- Added styling spec (6 passing TCs) covering default height, stepper increment/decrement, min-height clamp, typing lock, footer panel mirror
- Added `fixedHeadersAndFooters.js` selectors constants with inline source citations
- Skipped TC-010 (per-page independence) pending data-cy hook on the licensed `AddPageButton` branch

## 🧪 How to test
- [ ] `cd cypress-tests && npx cypress run --spec "cypress/e2e/happyPath/platform/commonTestcases/fixedHeadersAndFootersHappyPath.cy.js,cypress/e2e/happyPath/platform/commonTestcases/fixedHeadersAndFootersStyling.cy.js"`
- [ ] Expect 11 passing, 1 skipped, 0 failing
- [ ] Run against a workspace with `canvasPageHeaderEnabled` and `canvasPageFooterEnabled` flags on (EE license required)