### PR TITLE
fix(Rocket/Switch): tighten track and thumb dimensions

### DIFF
--- a/frontend/src/components/ui/Rocket/Switch/Switch.jsx
+++ b/frontend/src/components/ui/Rocket/Switch/Switch.jsx
@@ -7,7 +7,7 @@ import { Switch as ShadcnSwitch } from '@/components/ui/Rocket/shadcn/switch';
 const switchClasses = [
   // Layout
   'tw-peer tw-inline-flex tw-shrink-0 tw-items-center',
-  'tw-shadow-elevation-none tw-h-5 tw-w-9 tw-rounded-full',
+  'tw-shadow-elevation-none tw-h-4 tw-w-7 tw-rounded-full',
   'tw-border-2 tw-border-solid tw-border-transparent',
   'tw-cursor-pointer',
   'tw-transition-[colors,transform]',
@@ -25,12 +25,12 @@ const switchClasses = [
 
 const switchThumbClasses = [
   'tw-pointer-events-none tw-block tw-rounded-full',
-  'tw-h-4 tw-w-4',
+  'tw-h-3 tw-w-3',
   'tw-bg-switch-tab',
   'tw-shadow-elevation-100 tw-ring-0',
   'tw-transition-transform',
-  'data-[state=unchecked]:-tw-translate-x-1.5',
-  'data-[state=checked]:tw-translate-x-2.5',
+  'data-[state=unchecked]:-tw-translate-x-[5px]',
+  'data-[state=checked]:tw-translate-x-[5px]',
 ];
 
 // ── Switch ───────────────────────────────────────────────────────────────

--- a/frontend/src/components/ui/Rocket/Switch/Switch.spec.md
+++ b/frontend/src/components/ui/Rocket/Switch/Switch.spec.md
@@ -6,6 +6,14 @@
 
 Toggle switch component for binary on/off states. Single-part component (Shape D) wrapping shadcn Switch primitive (Radix `@radix-ui/react-switch`). No visual variants, no size variants — token overrides only.
 
+## Dimensions
+
+| Element | Size | Tailwind |
+|---|---|---|
+| track | 28×16 (inc. 2px transparent border) | `tw-h-4 tw-w-7 tw-border-2` |
+| thumb | 12×12 | `tw-h-3 tw-w-3` |
+| thumb travel | 0 → 12px | `data-[state=unchecked]:tw-translate-x-0` / `data-[state=checked]:tw-translate-x-3` |
+
 ## Props
 
 | Prop | Type | Values | Default |


### PR DESCRIPTION
## Summary
- Track resized 36×20 → 28×16 (`tw-h-4 tw-w-7`)
- Thumb resized 16×16 → 12×12 (`tw-h-3 tw-w-3`)
- Thumb travel normalized to ±5px so the thumb sits flush against the 2px transparent border in both states
- Spec doc updated with a dimensions table

## Test plan
- [ ] Storybook → Rocket/Switch: checked and unchecked states render with new sizes, thumb centered in track
- [ ] Disabled + focus-visible rings still look correct at the smaller size
- [ ] Dark theme unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)