### PR TITLE
Fix: Lazy nested Listview child resolution inside expandable Table rows

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -2487,6 +2487,17 @@ export const createComponentsSlice = (set, get) => ({
               if (source && Array.isArray(source)) {
                 source = source[0];
               }
+              if (!source) {
+                // No local sibling available (e.g. fresh Table expanded-row slot) — walk the
+                // deepest [0] chain from the root entity to reuse the original resolved shape.
+                let temp = state.resolvedStore.modules[moduleId][entityType][entityId];
+                while (Array.isArray(temp) && temp[0] !== undefined) {
+                  temp = temp[0];
+                }
+                if (temp && typeof temp === 'object' && !Array.isArray(temp)) {
+                  source = temp;
+                }
+              }
               current[lastIdx] = source
                 ? { ...source, [type]: { ...(source[type] || {}), [key]: value } }
                 : { ...DEFAULT_COMPONENT_STRUCTURE, [type]: { [key]: value } };

--- a/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
@@ -555,6 +555,17 @@ export const createResolvedSlice = (set, get) => ({
             const sibling = current[0];
             template = Array.isArray(sibling) ? sibling[0] : sibling;
           }
+          if (!template) {
+            // No sibling available (e.g. fresh Table expanded-row slot) — walk deepest [0] chain
+            // from root entity to get the original fully-resolved structure (with styles, etc.)
+            let temp = state.resolvedStore.modules[moduleId].components[componentId];
+            while (Array.isArray(temp) && temp[0] !== undefined) {
+              temp = temp[0];
+            }
+            if (temp && typeof temp === 'object' && !Array.isArray(temp)) {
+              template = temp;
+            }
+          }
           for (let i = 0; i < length; i++) {
             if (!nested[i]) {
               nested[i] = template ? { ...template } : { ...DEFAULT_COMPONENT_STRUCTURE };


### PR DESCRIPTION
This pull request improves how the app handles cases where a new slot (such as an expanded row in a Table) is created without a local sibling to copy structure from. The changes ensure that, in these scenarios, the code walks up the data structure to find and reuse the original resolved shape, preserving styles and other properties.

Enhancements to fallback logic for new slots/components:

* In `componentsSlice.js`, updated the logic so that if no local sibling is available, the code walks the deepest `[0]` chain from the root entity to reuse the original resolved component shape. This helps ensure new slots get a fully resolved structure when inserted.
* In `resolvedSlice.js`, added similar logic for cases where no sibling template is available, walking the deepest `[0]` chain from the root to obtain the original fully-resolved structure (including styles) for new components.

### Cause

- Lazy expandable table rows created deeper nested branches out of order.
- Template lookup in nested resolved-store writes relied on the immediate local sibling (current[0]).
- In the failing path, that sibling was missing because the branch had just been created.
- The code then fell back to DEFAULT_COMPONENT_STRUCTURE, which dropped resolved metadata required for rendering.
- As a result, deeply nested child widgets had valid data but incomplete resolved shape, causing render guards to hide them.

### Fix

This change updates both nested child-array initialization and nested dependency-driven writes to recover a real resolved template from the deepest available [0] branch before falling back to DEFAULT_COMPONENT_STRUCTURE.

That means:

- if a local sibling template exists, we continue using it
- if it does not exist, we now walk the root resolved branch through index 0 to find the original fully resolved component structure
- only if no real template can be found do we fall back to the default empty structure
- This preserves the complete resolved shape, including `others.showOnDesktop `/ `showOnMobile`, for lazily created nested rows and ensures deeply nested ListView children render consistently across all expanded table rows.

### Performance Impact

Expected performance impact is minimal.

- The additional lookup only runs when a nested row entry is being initialized and no immediate sibling template is available.
- This is part of store update logic, not the normal render path.
- The fallback walk follows the [0] chain of a single component’s resolved tree and is bounded by the nesting depth, which is small in practice.
- Existing behavior is unchanged for the common case where a local sibling template is already available.