### PR TITLE
Fix: Import from git fixes

### DIFF
--- a/server/src/helpers/platform-git-pull-registry.ts
+++ b/server/src/helpers/platform-git-pull-registry.ts
@@ -6,7 +6,7 @@
  */
 
 export interface IPlatformGitPullService {
-  hydrateStubApp(stubApp: any, user: any, branchId?: string, tagSha?: string, tagName?: string): Promise<any>;
+  hydrateStubApp(stubApp: any, user: any, branchId?: string, tagSha?: string, tagName?: string, useTagNameOnSubBranch?: boolean): Promise<any>;
   /**
    * Last path segment of an `appPath` like `apps/folder/my-app` → `my-app`, or
    * `modules/my-module` → `my-module`. Used by callers that need to resolve a

--- a/server/src/helpers/platform-git-pull-registry.ts
+++ b/server/src/helpers/platform-git-pull-registry.ts
@@ -6,7 +6,13 @@
  */
 
 export interface IPlatformGitPullService {
-  hydrateStubApp(stubApp: any, user: any, branchId?: string): Promise<any>;
+  hydrateStubApp(stubApp: any, user: any, branchId?: string, tagSha?: string, tagName?: string): Promise<any>;
+  /**
+   * Last path segment of an `appPath` like `apps/folder/my-app` → `my-app`, or
+   * `modules/my-module` → `my-module`. Used by callers that need to resolve a
+   * module/app name from moduleMeta/appMeta entries.
+   */
+  extractAppNameFromPath(appPath: string): string;
   /**
    * Given a parent app already materialised for a branch, look up every
    * ModuleViewer component's moduleAppId.value and hydrate any module that

--- a/server/src/modules/apps/util.service.ts
+++ b/server/src/modules/apps/util.service.ts
@@ -34,9 +34,6 @@ import { AbilityService } from '@modules/ability/interfaces/IService';
 import { IAppsUtilService } from './interfaces/IUtilService';
 import { AppVersionUpdateDto } from '@dto/app-version-update.dto';
 import { APP_TYPES } from './constants';
-import { MODULE_VERSION_AUDIT_KEYS } from '@modules/modules/constants';
-import { RequestContext } from '@modules/request-context/service';
-import { AUDIT_LOGS_REQUEST_CONTEXT_KEY } from '@modules/app/constants';
 import { Component } from 'src/entities/component.entity';
 import { WorkspaceBranch } from '@entities/workspace_branch.entity';
 import { Layout } from 'src/entities/layout.entity';
@@ -882,63 +879,6 @@ export class AppsUtilService implements IAppsUtilService {
   async findByAppId(appId: string, manager?: EntityManager): Promise<App> {
     return dbTransactionWrap((manager: EntityManager) => {
       return this.appRepository.findByAppId(appId, manager);
-    }, manager);
-  }
-
-  /**
-   * Atomically promote a version to the production environment AND mark the app
-   * as released (`apps.current_version_id = versionId`). Writes a release audit
-   * entry matching `AppsService.release`'s shape.
-   *
-   * Skips the per-env promote chain and the release endpoint's multi-env guard
-   * by design — callers that invoke this have already validated whatever
-   * preconditions their flow requires (e.g. external-API autoDeploy accepts
-   * any non-draft version; git-import gates on successful module hydration).
-   *
-   * Used by:
-   *  - `ExternalApisService.autoDeployApp` — "publish latest tag" programmatic flow
-   *  - `AppGitOperationsUtil.createGitApp` — auto-release newly imported app
-   */
-  async releaseVersionToProduction(
-    app: App,
-    user: User,
-    versionId: string,
-    options: { writeAuditLog?: boolean; manager?: EntityManager } = {}
-  ): Promise<App> {
-    const { writeAuditLog = true, manager } = options;
-    return dbTransactionWrap(async (manager: EntityManager) => {
-      const environments = await this.appEnvironmentUtilService.getAllEnvironments(user.organizationId, manager);
-      environments.sort((a, b) => a.priority - b.priority);
-      const prodEnv = environments[environments.length - 1];
-
-      await this.versionRepository.updateVersion(
-        versionId,
-        { currentEnvironmentId: prodEnv.id, status: AppVersionStatus.PUBLISHED, updatedAt: new Date() },
-        manager
-      );
-      await manager.update(App, app.id, { currentVersionId: versionId });
-
-      if (writeAuditLog) {
-        const releasedVersion = await this.versionRepository.findVersion(versionId);
-        RequestContext.setLocals(AUDIT_LOGS_REQUEST_CONTEXT_KEY, {
-          userId: user.id,
-          organizationId: user.organizationId,
-          resourceId: app.id,
-          resourceName: app.name,
-          ...(app.type === APP_TYPES.MODULE && { actionType: MODULE_VERSION_AUDIT_KEYS.RELEASE }),
-          resourceData: {
-            appSlug: app.slug,
-            isPublic: app.isPublic,
-            releasedVersionId: versionId,
-            releasedVersionName: releasedVersion?.name,
-            environmentId: prodEnv.id,
-            environmentName: prodEnv.name,
-          },
-          metadata: { data: { name: 'App Released', versionToBeReleased: versionId } },
-        });
-      }
-
-      return this.appRepository.findByAppId(app.id, manager);
     }, manager);
   }
 

--- a/server/src/modules/apps/util.service.ts
+++ b/server/src/modules/apps/util.service.ts
@@ -34,6 +34,9 @@ import { AbilityService } from '@modules/ability/interfaces/IService';
 import { IAppsUtilService } from './interfaces/IUtilService';
 import { AppVersionUpdateDto } from '@dto/app-version-update.dto';
 import { APP_TYPES } from './constants';
+import { MODULE_VERSION_AUDIT_KEYS } from '@modules/modules/constants';
+import { RequestContext } from '@modules/request-context/service';
+import { AUDIT_LOGS_REQUEST_CONTEXT_KEY } from '@modules/app/constants';
 import { Component } from 'src/entities/component.entity';
 import { WorkspaceBranch } from '@entities/workspace_branch.entity';
 import { Layout } from 'src/entities/layout.entity';
@@ -879,6 +882,63 @@ export class AppsUtilService implements IAppsUtilService {
   async findByAppId(appId: string, manager?: EntityManager): Promise<App> {
     return dbTransactionWrap((manager: EntityManager) => {
       return this.appRepository.findByAppId(appId, manager);
+    }, manager);
+  }
+
+  /**
+   * Atomically promote a version to the production environment AND mark the app
+   * as released (`apps.current_version_id = versionId`). Writes a release audit
+   * entry matching `AppsService.release`'s shape.
+   *
+   * Skips the per-env promote chain and the release endpoint's multi-env guard
+   * by design — callers that invoke this have already validated whatever
+   * preconditions their flow requires (e.g. external-API autoDeploy accepts
+   * any non-draft version; git-import gates on successful module hydration).
+   *
+   * Used by:
+   *  - `ExternalApisService.autoDeployApp` — "publish latest tag" programmatic flow
+   *  - `AppGitOperationsUtil.createGitApp` — auto-release newly imported app
+   */
+  async releaseVersionToProduction(
+    app: App,
+    user: User,
+    versionId: string,
+    options: { writeAuditLog?: boolean; manager?: EntityManager } = {}
+  ): Promise<App> {
+    const { writeAuditLog = true, manager } = options;
+    return dbTransactionWrap(async (manager: EntityManager) => {
+      const environments = await this.appEnvironmentUtilService.getAllEnvironments(user.organizationId, manager);
+      environments.sort((a, b) => a.priority - b.priority);
+      const prodEnv = environments[environments.length - 1];
+
+      await this.versionRepository.updateVersion(
+        versionId,
+        { currentEnvironmentId: prodEnv.id, status: AppVersionStatus.PUBLISHED, updatedAt: new Date() },
+        manager
+      );
+      await manager.update(App, app.id, { currentVersionId: versionId });
+
+      if (writeAuditLog) {
+        const releasedVersion = await this.versionRepository.findVersion(versionId);
+        RequestContext.setLocals(AUDIT_LOGS_REQUEST_CONTEXT_KEY, {
+          userId: user.id,
+          organizationId: user.organizationId,
+          resourceId: app.id,
+          resourceName: app.name,
+          ...(app.type === APP_TYPES.MODULE && { actionType: MODULE_VERSION_AUDIT_KEYS.RELEASE }),
+          resourceData: {
+            appSlug: app.slug,
+            isPublic: app.isPublic,
+            releasedVersionId: versionId,
+            releasedVersionName: releasedVersion?.name,
+            environmentId: prodEnv.id,
+            environmentName: prodEnv.name,
+          },
+          metadata: { data: { name: 'App Released', versionToBeReleased: versionId } },
+        });
+      }
+
+      return this.appRepository.findByAppId(app.id, manager);
     }, manager);
   }
 


### PR DESCRIPTION
## 📝 What this does
Extracts a shared util for atomically promoting a version to production and marking an app released, so git-imported apps/modules can auto-release through the same code path as the external-API autoDeploy flow. Also extends the platform-git-pull interface so module imports can resolve module names from paths and pass tag metadata when hydrating stubs.
- [ee-server](https://github.com/ToolJet/ee-server/pull/479)

## 🔀 Changes
- Added `AppsUtilService.releaseVersionToProduction` — promotes a version to the prod env and sets `apps.current_version_id` in one transaction, with a release audit entry matching `AppsService.release`'s shape
- Added `MODULE_VERSION_AUDIT_KEYS.RELEASE` actionType to the audit entry when the released app is a module
- Extended `IPlatformGitPullService.hydrateStubApp` with optional `tagSha` and `tagName` arguments
- Added `IPlatformGitPullService.extractAppNameFromPath` to the interface for callers resolving names from `moduleMeta`/`appMeta` entries
- Bumped server/ee pointer to include module version hydration and tag resolution

## 🧪 How to test
- [ ] Import an app from Git on a feature branch — the newly imported app should land as released in production
- [ ] Import a module from Git — verify the release audit log uses the module action type
- [ ] External API autoDeploy (publish latest tag) still releases to production as before