### PR TITLE
Remove redundant boxShadow from universalProps and align configs

### DIFF
--- a/frontend/src/AppBuilder/WidgetManager/componentTypes.js
+++ b/frontend/src/AppBuilder/WidgetManager/componentTypes.js
@@ -1,6 +1,69 @@
 import { widgets } from './configs/widgetConfig';
 
+const NEW_REVAMPED_COMPONENTS = [
+  'Text',
+  'TextInput',
+  'PasswordInput',
+  'NumberInput',
+  'EmailInput',
+  'DropdownV2',
+  'Table',
+  'Button',
+  'Checkbox',
+  'Divider',
+  'VerticalDivider',
+  'Link',
+  'Datepicker',
+  'DatePickerV2',
+  'TimePicker',
+  'DatetimePickerV2',
+  'DaterangePicker',
+  'TextArea',
+  'Container',
+  'Tabs',
+  'Form',
+  'Image',
+  'FilePicker',
+  'Icon',
+  'Steps',
+  'Statistics',
+  'StarRating',
+  'Tags',
+  'CircularProgressBar',
+  'Html',
+  'Chat',
+  'CurrencyInput',
+  'PhoneInput',
+  'IFrame',
+  'TreeSelect',
+  'Listview',
+  'ColorPicker',
+  'ButtonGroupV2',
+  'ModalV2',
+  'PopoverMenu',
+];
+
+const newRevampedComponents = new Set(NEW_REVAMPED_COMPONENTS);
+
 const universalProps = {
+  properties: {},
+  general: {
+    tooltip: { type: 'code', displayName: 'Tooltip', validation: { schema: { type: 'string' } } },
+  },
+  others: {},
+  events: {},
+  styles: {},
+  validate: true,
+  generalStyles: {},
+  definition: {
+    others: {},
+    events: [],
+    styles: {},
+    generalStyles: {},
+  },
+};
+
+const legacyUniversalProps = {
   properties: {},
   general: {
     tooltip: { type: 'code', displayName: 'Tooltip', validation: { schema: { type: 'string' } } },
@@ -37,9 +100,10 @@ const combineProperties = (widget, universal, isArray = false) => {
 };
 
 export const componentTypes = widgets.map((widget) => {
+  const baseProps = newRevampedComponents.has(widget.component) ? universalProps : legacyUniversalProps;
   return {
-    ...combineProperties(widget, universalProps),
-    definition: combineProperties(widget.definition, universalProps.definition, true),
+    ...combineProperties(widget, baseProps),
+    definition: combineProperties(widget.definition, baseProps.definition, true),
   };
 });
 


### PR DESCRIPTION
We have either removed the `boxShadow` prop or moved it from `generalStyles` to under `styles` for newly revamped components, and removed it from these components' widget config. However, it still gets added to the widget config under `generalStyles` when adding the component, since this attribute is part of `universalProps` that is appended to every component's config. This attribute is now redundant.

We have also written a migration to remove this prop from imported apps' widget config wherever applicable. This creates a mismatch between an app created directly and the same app exported and imported (which is essentially what git sync is). The first will have `boxShadow` under `generalStyles`, while the second will not. This creates unnecessary diffs when a user edits and commits a newly checked-out version/branch of an app for the first time.
