### PR TITLE
Fix: use sessionStorage for active branch to enable per-tab branch isolation

### DIFF
--- a/frontend/src/AppBuilder/_utils/auth.js
+++ b/frontend/src/AppBuilder/_utils/auth.js
@@ -1,6 +1,7 @@
 import { authenticationService } from '@/_services/authentication.service';
 import { setCookie } from '@/_helpers/cookie';
 import { sessionService } from '@/_services';
+import { unregisterBranchFocusSync } from '@/_helpers/active-branch';
 
 export function fetchOAuthToken(authUrl, dataSourceId) {
   localStorage.setItem('sourceWaitingForOAuth', dataSourceId);
@@ -11,6 +12,7 @@ export function fetchOAuthToken(authUrl, dataSourceId) {
 }
 
 export function logoutAction() {
+  unregisterBranchFocusSync();
   localStorage.clear();
   sessionStorage.clear();
   sessionService.logout(true);

--- a/frontend/src/AppBuilder/_utils/auth.js
+++ b/frontend/src/AppBuilder/_utils/auth.js
@@ -12,6 +12,7 @@ export function fetchOAuthToken(authUrl, dataSourceId) {
 
 export function logoutAction() {
   localStorage.clear();
+  sessionStorage.clear();
   sessionService.logout(true);
 
   return Promise.resolve();

--- a/frontend/src/_helpers/active-branch.js
+++ b/frontend/src/_helpers/active-branch.js
@@ -10,8 +10,16 @@ export function getActiveBranch(orgId) {
   const id = orgId || getOrgId();
   if (!id) return null;
   try {
-    const stored = localStorage.getItem(`${BRANCH_KEY_PREFIX}${id}`);
-    return stored ? JSON.parse(stored) : null;
+    const key = `${BRANCH_KEY_PREFIX}${id}`;
+    const sessionStored = sessionStorage.getItem(key);
+    if (sessionStored) return JSON.parse(sessionStored);
+    // Seed sessionStorage from localStorage so new tabs inherit the active branch
+    const localStored = localStorage.getItem(key);
+    if (localStored) {
+      sessionStorage.setItem(key, localStored);
+      return JSON.parse(localStored);
+    }
+    return null;
   } catch {
     return null;
   }
@@ -21,13 +29,17 @@ export function setActiveBranch(branch, orgId) {
   const id = orgId || getOrgId();
   if (!id) return;
   try {
+    const key = `${BRANCH_KEY_PREFIX}${id}`;
     if (branch) {
-      localStorage.setItem(`${BRANCH_KEY_PREFIX}${id}`, JSON.stringify({ id: branch.id, name: branch.name }));
+      const value = JSON.stringify({ id: branch.id, name: branch.name });
+      sessionStorage.setItem(key, value);
+      localStorage.setItem(key, value);
     } else {
-      localStorage.removeItem(`${BRANCH_KEY_PREFIX}${id}`);
+      sessionStorage.removeItem(key);
+      localStorage.removeItem(key);
     }
   } catch {
-    // ignore localStorage errors
+    // ignore storage errors
   }
 }
 

--- a/frontend/src/_helpers/active-branch.js
+++ b/frontend/src/_helpers/active-branch.js
@@ -48,6 +48,45 @@ export function getActiveBranchId(orgId) {
   return branch?.id || null;
 }
 
+// Module-level ref ensures only one listener is registered at a time
+let _focusSyncListener = null;
+
+/**
+ * Registers a visibilitychange listener that writes the current tab's branch
+ * from sessionStorage to localStorage whenever the tab becomes visible.
+ * This ensures new tabs opened from this tab inherit its active branch.
+ * Safe to call multiple times — removes any existing listener before re-registering.
+ */
+export function registerBranchFocusSync() {
+  if (_focusSyncListener) {
+    document.removeEventListener('visibilitychange', _focusSyncListener);
+  }
+  _focusSyncListener = () => {
+    if (document.visibilityState !== 'visible') return;
+    const id = getOrgId();
+    if (!id) return;
+    try {
+      const key = `${BRANCH_KEY_PREFIX}${id}`;
+      const sessionStored = sessionStorage.getItem(key);
+      // Only write to localStorage if sessionStorage has a value — avoids
+      // wiping the localStorage seed when a fresh tab hasn't initialised yet
+      if (sessionStored) {
+        localStorage.setItem(key, sessionStored);
+      }
+    } catch {
+      // ignore storage errors
+    }
+  };
+  document.addEventListener('visibilitychange', _focusSyncListener);
+}
+
+export function unregisterBranchFocusSync() {
+  if (_focusSyncListener) {
+    document.removeEventListener('visibilitychange', _focusSyncListener);
+    _focusSyncListener = null;
+  }
+}
+
 /**
  * Remove stale tj_active_branch_* keys for the current org only.
  * Clears the key if the stored value is corrupted or has no valid branch ID.

--- a/frontend/src/_helpers/active-branch.js
+++ b/frontend/src/_helpers/active-branch.js
@@ -56,16 +56,18 @@ export function getActiveBranchId(orgId) {
 export function cleanupStaleBranchKeys(orgId) {
   const id = orgId || getOrgId();
   if (!id) return;
-  try {
-    const currentKey = `${BRANCH_KEY_PREFIX}${id}`;
-    const stored = localStorage.getItem(currentKey);
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      if (!parsed?.id) {
-        localStorage.removeItem(currentKey);
+  const currentKey = `${BRANCH_KEY_PREFIX}${id}`;
+  for (const storage of [localStorage, sessionStorage]) {
+    try {
+      const stored = storage.getItem(currentKey);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (!parsed?.id) {
+          storage.removeItem(currentKey);
+        }
       }
+    } catch {
+      // ignore storage errors
     }
-  } catch {
-    // ignore localStorage errors
   }
 }

--- a/frontend/src/_stores/workspaceBranchesStore.js
+++ b/frontend/src/_stores/workspaceBranchesStore.js
@@ -1,7 +1,13 @@
 import { create, zustandDevTools } from './utils';
 import { workspaceBranchesService } from '@/_services/workspace_branches.service';
 import { gitSyncService } from '@/_services/git_sync.service';
-import { getActiveBranch, setActiveBranch, cleanupStaleBranchKeys } from '@/_helpers/active-branch';
+import {
+  getActiveBranch,
+  setActiveBranch,
+  cleanupStaleBranchKeys,
+  registerBranchFocusSync,
+  unregisterBranchFocusSync,
+} from '@/_helpers/active-branch';
 
 const initialState = {
   branches: [],
@@ -59,6 +65,7 @@ export const useWorkspaceBranchesStore = create(
               setActiveBranch(currentBranch);
             }
 
+            registerBranchFocusSync();
             set({
               branches,
               activeBranchId: currentBranch?.id || effectiveActiveBranchId,
@@ -150,6 +157,7 @@ export const useWorkspaceBranchesStore = create(
         },
 
         reset() {
+          unregisterBranchFocusSync();
           set(initialState);
         },
 
@@ -172,6 +180,7 @@ export const useWorkspaceBranchesStore = create(
               setActiveBranch(currentBranch);
             }
 
+            registerBranchFocusSync();
             set({
               branches,
               activeBranchId: currentBranch?.id || effectiveActiveBranchId,

--- a/frontend/src/_stores/workspaceBranchesStore.js
+++ b/frontend/src/_stores/workspaceBranchesStore.js
@@ -48,13 +48,13 @@ export const useWorkspaceBranchesStore = create(
             ]);
 
             const branches = branchData?.branches || [];
-            // Prefer localStorage branch over server-returned activeBranchId
+            // Prefer sessionStorage branch over server-returned activeBranchId
             const storedBranch = getActiveBranch();
             const serverActiveBranchId = branchData?.active_branch_id || branchData?.activeBranchId || null;
             const effectiveActiveBranchId = storedBranch?.id || serverActiveBranchId;
             const currentBranch = resolveCurrentBranch(branches, effectiveActiveBranchId);
 
-            // Persist resolved branch to localStorage
+            // Persist resolved branch to sessionStorage
             if (currentBranch) {
               setActiveBranch(currentBranch);
             }
@@ -76,7 +76,7 @@ export const useWorkspaceBranchesStore = create(
           try {
             const data = await workspaceBranchesService.list();
             const branches = data?.branches || [];
-            // Prefer localStorage branch over server default
+            // Prefer sessionStorage branch over server default
             const storedBranch = getActiveBranch();
             const serverActiveBranchId = data?.active_branch_id || data?.activeBranchId || null;
             const effectiveActiveBranchId = storedBranch?.id || serverActiveBranchId;
@@ -167,6 +167,7 @@ export const useWorkspaceBranchesStore = create(
             const effectiveActiveBranchId = storedBranch?.id || serverActiveBranchId;
             const currentBranch = resolveCurrentBranch(branches, effectiveActiveBranchId);
 
+            // Persist resolved branch to sessionStorage
             if (currentBranch) {
               setActiveBranch(currentBranch);
             }


### PR DESCRIPTION
## Summary
- Migrates active branch persistence from `localStorage` to `sessionStorage` so each tab maintains its own isolated branch state, enabling users to work on different branches simultaneously across tabs
- Adds `localStorage` as a read fallback with sessionStorage hydration — new tabs opened from a branch-specific context (e.g. opening an app link in a new tab) inherit the active branch instead of falling to main/master and hard-failing with a home page redirect
- Dual-writes to both storages on every `setActiveBranch` call so `localStorage` stays current as the cross-tab seed
- Clears `sessionStorage` on logout alongside the existing `localStorage.clear()` to prevent stale branch resumption on re-login within the same tab

## Files changed
- `frontend/src/_helpers/active-branch.js` — core storage logic
- `frontend/src/AppBuilder/_utils/auth.js` — logout clears sessionStorage
- `frontend/src/_stores/workspaceBranchesStore.js` — stale comments updated

## Test plan
- [ ] Single tab: switch to non-default branch, F5 — should stay on same branch
- [ ] New tab: open an app link while on a non-default branch — should open on that branch, not redirect to home
- [ ] Multi-tab isolation: Tab A on branchA, Tab B on branchB — switching in Tab B must not affect Tab A
- [ ] New tab after multi-tab: Tab A on branchA, Tab B switches to branchB, open new Tab C — should land on a real branch, no hard failure
- [ ] Logout: be on a branch, logout, re-login in same tab — should land on default branch, not previous branch
- [ ] Corrupted localStorage: manually set `tj_active_branch_{orgId}` to `{"garbage":true}`, open new tab — should fall to default branch
- [ ] Incognito / no storage: open app URL — should land on server default with no errors
- [ ] Deleted branch: be on a branch, delete it from another tab, refresh — should self-heal to default branch