### PR TITLE
Fix: Missing `branch_id` Param For `getForApp` FE Method

### DIFF
--- a/frontend/src/_services/globalDatasource.service.js
+++ b/frontend/src/_services/globalDatasource.service.js
@@ -25,7 +25,9 @@ function getForApp(organizationId, appVersionId, environmentId) {
   const requestOptions = { method: 'GET', headers: authHeader(), credentials: 'include' };
 
   return fetch(
-    `${config.apiUrl}/data-sources/${organizationId}/environments/${environmentId}/versions/${appVersionId}`,
+    appendBranchId(
+      `${config.apiUrl}/data-sources/${organizationId}/environments/${environmentId}/versions/${appVersionId}`
+    ),
     requestOptions
   ).then(handleResponse);
 }


### PR DESCRIPTION
This pull request updates the `getForApp` function in `globalDatasource.service.js` to ensure that API requests include the branch ID as a query parameter. This change improves the accuracy of data source retrieval by scoping requests to the correct branch context.

API request improvements:
* Updated the API endpoint construction in `getForApp` to use the `appendBranchId` utility, ensuring the branch ID is included in the request URL.