### PR TITLE
Fix: Revert module version naming and fix datasource import scope

### DIFF
--- a/server/src/helpers/platform-git-pull-registry.ts
+++ b/server/src/helpers/platform-git-pull-registry.ts
@@ -6,7 +6,7 @@
  */
 
 export interface IPlatformGitPullService {
-  hydrateStubApp(stubApp: any, user: any, branchId?: string, tagSha?: string, tagName?: string, useTagNameOnSubBranch?: boolean): Promise<any>;
+  hydrateStubApp(stubApp: any, user: any, branchId?: string, tagSha?: string, tagName?: string): Promise<any>;
   /**
    * Last path segment of an `appPath` like `apps/folder/my-app` → `my-app`, or
    * `modules/my-module` → `my-module`. Used by callers that need to resolve a


### PR DESCRIPTION
## 📝 What this does
Reverts the module version naming change that broke multi-version module imports and fixes unrelated datasources being imported when pulling an app from git.
- [ee-server](https://github.com/ToolJet/ee-server/pull/485)
- [ee-frontend](no changes)

## 🔀 Changes
- Reverted module version name change; non-default branches use `activeBranch.name` as before, default branch uses tag label or JSON version name
- Removed auto-release of apps on import — users must manually promote and release
- Fixed datasource import always passing a scoped `Set` instead of `undefined`, preventing all workspace datasources from being imported for apps that have no embedded datasources
- Removed unused `useTagNameOnSubBranch` parameter from `IPlatformGitPullService.hydrateStubApp` interface

## 🧪 How to test
- [ ] Configure git sync and import an app that uses a module pinned to a specific version — verify the module version is created with the correct name and no extra datasources appear
- [ ] Import the same app a second time — verify no collision / duplicate datasources
- [ ] Confirm the imported app is NOT auto-released; it stays as a draft