### PR TITLE
Fix: module hydration drops all versions when git files are branch-type

### DIFF
--- a/server/src/modules/apps/services/app-import-export.service.ts
+++ b/server/src/modules/apps/services/app-import-export.service.ts
@@ -1225,6 +1225,14 @@ export class AppImportExportService {
           nonStubBranchVersions.length > 0
             ? nonStubBranchVersions
             : importingAppVersions.filter((v: any) => !v.versionType || v.versionType === AppVersionType.VERSION);
+      } else if (isGitApp && branchId) {
+        // Hydrate path: the git folder being imported already represents one branch's
+        // snapshot. Every version file in it belongs here regardless of versionType /
+        // stored branchId — pull.service.ts re-parents and rewrites versionType, name,
+        // branchId on the imported row anyway. Stripping BRANCH-type versions here
+        // (the original cross-workspace-import rule) leaves zero versions and crashes
+        // hydration with "No versions found after import".
+        filteredAppVersions = importingAppVersions;
       } else {
         filteredAppVersions = importingAppVersions.filter(
           (v: any) => !v.versionType || v.versionType === AppVersionType.VERSION


### PR DESCRIPTION
## 📝 What this does
Modules embedded in apps pulled from Git Sync now load on first open instead of rendering blank with a \"Module version not found\" 404.

## 🔀 Changes
- Added an `isGitApp && branchId` clause to the version filter in `setupImportedAppAssociations` so the hydrate path keeps every imported version row instead of stripping BRANCH-type ones
- Cold \"Import App\" and clone behavior unchanged

## 🛡️ Backward compatibility & regression safety

The filter being modified picks which versions to insert when an `import()` is given multiple version rows. Before this PR it had two branches; this PR adds a third. None of the existing branches were touched.

| Caller of `import()` | Flags it passes | Filter branch it lands in | Behavior |
|---|---|---|---|
| Cold \"Import App from JSON\" (uploads, templates) | `cloning=false`, `isGitApp=false` | (existing) strip BRANCH-type rows | unchanged |
| Cloning an app | `cloning=true`, `branchId` set | (existing) keep BRANCH-type rows whose `branchId` matches | unchanged |
| Git Sync hydrate / per-app git pull | `cloning=false`, `isGitApp=true`, `branchId` set | **(NEW)** keep all rows | this PR |

Why it's safe to keep all rows on the new branch: the dangerous fields the cold-import strip rule was protecting against (`branchId`, `versionType`, `name`, `status` — which would dangle if they came from another workspace's UUIDs) are overwritten on every inserted row immediately after by `pull.service.ts:1005-1024` using the destination workspace's local values. So whatever the imported rows say in those fields gets replaced before anything reads them.

Cold-import doesn't have that post-insert overwrite, which is why the strip rule still belongs on its branch.

## 🧪 How to test

The fix is exercised by importing **any** module whose `versions/` folder in git has 2+ JSON files. You don't need to create that state yourself — connect to a repo that already has it.

- [ ] Connect a workspace to a Git Sync repo that has a module with 2+ files in `modules/<name>/versions/`
- [ ] Pull the workspace and open an app that uses that module via the Module component
- [ ] **Without fix:** module renders blank, browser console shows `Module version not found` 404, `apps` table grows `<name>_hydrate_<timestamp>` rows on each open
- [ ] **With fix:** module renders content; no 404; no `_hydrate_` rows accumulate

### Cross-checks (don't regress)
- [ ] Standard Git Sync (single-version module folders) — still works
- [ ] Import App from a JSON export — still works
- [ ] Clone an app — still works

<details>
<summary>📜 Historical context</summary>

- **`58ba6b8563` (PR #15434)** introduced the version filter for the cold \"Import App from JSON\" flow. BRANCH-type rows in that JSON belong to the source workspace's branches, so stripping them is correct for that caller.
- **`41bed36886` (PR #15867)** added a `cloning && branchId` exception when cloning broke under the same rule. The exception was scoped to cloning; the hydrate caller falls through to the unchanged strip clause.
- **This PR** adds a third clause for the hydrate path (`isGitApp && branchId`). The git folder is itself one branch's snapshot, and `pull.service.ts:1005-1023` rewrites `versionType`/`branchId`/`name` on the inserted row — so filtering at insert time was both unnecessary and the cause of \"No versions found after import\".

### Why so few users have hit this
The filter only triggers when `importingAppVersions.length > 1`. A `versions/` folder ends up with 2+ files only when the same module/app has been pushed from multiple workspace branches and the resulting git branches have been merged together. Most Git Sync users push each module once or work on a single branch, so the filter never activates for them. QA flagged it because they were specifically exercising the branching workflow.

</details>