### PR TITLE
Fix: Module pull spawns phantom v1_<timestamp> + slug/isPublic drift

### DIFF
--- a/frontend/src/modules/dataSources/components/DataSourceManager/DataSourceManager.jsx
+++ b/frontend/src/modules/dataSources/components/DataSourceManager/DataSourceManager.jsx
@@ -970,10 +970,15 @@ class DataSourceManagerComponent extends React.Component {
       },
       { ...(selectedDataSource?.options ?? {}) }
     );
-    const isSaveDisabled = selectedDataSource
-      ? deepEqual(options, normalizedSavedOptions, ['encrypted', 'credential_id']) &&
-        selectedDataSource?.name === datasourceName
-      : true;
+    // Sample datasources are read-only (no DynamicForm, no save button), so they're never "editing".
+    // Without this guard, normalizedSavedOptions gets defaults added that state.options never receives
+    // (since DynamicForm which fills defaults isn't rendered for sample dbs), causing a false mismatch.
+    const isSaveDisabled =
+      isSampleDb ||
+      (selectedDataSource
+        ? deepEqual(options, normalizedSavedOptions, ['encrypted', 'credential_id']) &&
+          selectedDataSource?.name === datasourceName
+        : true);
     this.props.setGlobalDataSourceStatus({ isEditing: !isSaveDisabled });
     const docLink = isSampleDb
       ? 'https://docs.tooljet.com/docs/data-sources/sample-data-sources'

--- a/server/src/modules/apps/services/app-import-export.service.ts
+++ b/server/src/modules/apps/services/app-import-export.service.ts
@@ -625,8 +625,7 @@ export class AppImportExportService {
       for (const importedModule of appParams.modules) {
         // Prefer passport match (survives renames and cross-lineage name collisions).
         const existingModule =
-          (importedModule?.appV2?.co_relation_id &&
-            existingByCoRel.get(importedModule.appV2.co_relation_id)) ||
+          (importedModule?.appV2?.co_relation_id && existingByCoRel.get(importedModule.appV2.co_relation_id)) ||
           existingByName.get(importedModule?.appV2?.name);
 
         if (existingModule) {
@@ -1721,6 +1720,9 @@ export class AppImportExportService {
           const newFolder = manager.create(DataQueryFolder, {
             name: folder.name,
             appVersionId: newAppVersionId,
+            // git-sync writes co_relation_id into `id` on export, so preserve it here to
+            // keep folder identity stable across push/pull cycles and avoid diff churn.
+            co_relation_id: (folder as any).co_relation_id ?? folder.id ?? uuid(),
           });
           const savedFolder = await manager.save(DataQueryFolder, newFolder);
           savedId = savedFolder.id;
@@ -1759,6 +1761,9 @@ export class AppImportExportService {
           childId: newChildId,
           childType: mapping.childType,
           index: mapping.index,
+          // git-sync writes co_relation_id into `id` on export, so preserve it here to
+          // keep mapping identity stable across push/pull cycles and avoid diff churn.
+          co_relation_id: (mapping as any).co_relation_id ?? mapping.id ?? uuid(),
         });
         await manager.save(DataQueryFolderMapping, newMapping);
       }

--- a/server/src/modules/versions/service.ts
+++ b/server/src/modules/versions/service.ts
@@ -277,7 +277,31 @@ export class VersionService implements IVersionService {
       version = await this.versionRepository.manager.findOne(AppVersion, {
         where: { name: versionName, appId: app.id, branchId, isStub: false },
       });
-      // Attempt 2: unpinned ref on the consumer's branch — latest non-stub version
+      // Attempt 2: consumer is on a feature branch asking for a named saved
+      // version (e.g. "v1") that only exists on the org's default branch.
+      // Saved VERSION rows are authored only on the default branch and represent
+      // canonical, immutable module history, so serving them cross-branch is
+      // safe. Gated to `versionType = VERSION` and the default branch, so
+      // feature-branch working content (DRAFT rows) can never be returned here
+      // — no cross-branch leak of unmerged changes. Runs before attempt 3 so
+      // an explicit pin to "v1" wins over the feature branch's own latest draft.
+      if (!version) {
+        const defaultBranch = await this.versionRepository.manager.findOne(WorkspaceBranch, {
+          where: { organizationId: user.organizationId, isDefault: true },
+        });
+        if (defaultBranch && defaultBranch.id !== branchId) {
+          version = await this.versionRepository.manager.findOne(AppVersion, {
+            where: {
+              name: versionName,
+              appId: app.id,
+              branchId: defaultBranch.id,
+              versionType: AppVersionType.VERSION,
+              isStub: false,
+            },
+          });
+        }
+      }
+      // Attempt 3: unpinned ref on the consumer's branch — latest non-stub version
       // for this module on this branch, regardless of name. Handles the case where
       // the stored moduleVersionId is a foreign branch name (e.g. a merge from a
       // feature branch into master brought "feature-1" along) and we just want the


### PR DESCRIPTION
## 📝 What this does
Two coupled git-sync bugs surface on a module-only pull into `main`: the PR diff carries workspace-local `slug`/`isPublic` noise inside `modules/<name>/app/app.json`, and re-hydrating a released module spawns a phantom `v1_<Date.now()>` DRAFT (often misread as `v1_string`) on every pull. This PR stops serialising those two fields on export and reuses the existing PUBLISHED row as the working copy when a released module is re-hydrated on the default branch.
- [ee-server](https://github.com/ToolJet/ee-server/pull/486)
- [ee-frontend](no changes)

## 🔀 Changes

<details><summary><b>Bug 1 — stop exporting workspace-local <code>slug</code> / <code>isPublic</code></b></summary>

**Where:** `server/ee/git-sync/git-sync-adapter.ts` → `getAppMetadata()`

**What happens:** the exporter wrote `slug` and `isPublic` straight from the live `App` row into `modules/<name>/app/app.json`. Those fields are branch-local: `findOrCreateStubApp` creates each non-default-branch stub with a fresh UUID slug and `isPublic=false`, and the unique-slug constraint blocks overwrite on import. Net effect — pushing from any non-origin branch deterministically flipped both fields in the PR diff even when nothing app-level was edited. Modules are keyed by `co_relation_id` via `.meta/moduleMeta.json`, so neither field is needed to reconstruct state.

</details>

<details><summary><b>Bug 2 — reuse PUBLISHED row on default-branch module hydration (no more <code>v1_&lt;Date.now()&gt;</code>)</b></summary>

**Where:** `server/ee/platform-git-sync/pull.service.ts` → `hydrateStubApp()` `existingDraft` lookup (around L866)

**What happens:** the lookup was strictly `status: DRAFT`. A released module has only PUBLISHED `v1` on `main`, so the lookup returned nothing and the else-branch fell through to `versionName = ``${baseName}_${Date.now()}``` — spawning a new DRAFT on every re-hydration. Added a scoped fallback for `type='module'` on the default branch only: if no DRAFT is found, accept the non-stub PUBLISHED row as the working copy. The swap-in-place body below only touches content fields (`definition`, pages, queries, etc.) and never mutates `status`, so the row stays PUBLISHED. DRAFT-first ordering preserved — an in-progress DRAFT still wins over a stale PUBLISHED. Apps are untouched to respect their explicit release cycle.

</details>

## 🧪 How to test

Needs two ToolJet workspaces (or two branches on one workspace) both git-synced to the same repo, with a module released to `v1` on main.

<details><summary><b>Bug 1 — slug / isPublic drift on module-only PR</b></summary>

- [ ] On workspace A, create a module `m-foo`, release `v1`, push to main.
- [ ] On workspace A, create branch `edit-foo`, edit one component inside the module (no app-level changes), push.
- [ ] Open the resulting PR on GitHub.
- [ ] **Before fix:** `modules/m-foo/app/app.json` shows `slug` and `isPublic` changed (e.g. `slug: a9523366-…` → `e398096f-…`, `isPublic: null` → `false`).
- [ ] **After fix:** `modules/m-foo/app/app.json` has no `slug` / `isPublic` keys at all — only content-bearing metadata (`id`, `name`, `type`, `isMaintenanceOn`, `icon`, etc.) shows up in the diff.

</details>

<details><summary><b>Bug 2 — phantom <code>v1_&lt;timestamp&gt;</code> on module pull</b></summary>

- [ ] Starting state on workspace B: the same git-synced repo, module `m-foo` pulled, released to `v1 PUBLISHED`.
- [ ] Merge the module-edit PR from Bug 1 into `main` on GitHub.
- [ ] On workspace B, click `Pull` (module meta `updatedAt` has bumped) and confirm it succeeds.
- [ ] Open `m-foo` in the module editor.
- [ ] **Before fix:** version dropdown shows a new DRAFT named `v1_1776893243859` (a long timestamp often misread as `v1_string`) next to the released `v1`.
- [ ] **After fix:** dropdown shows only `v1` (PUBLISHED, `pulled_at` bumped); the module's content reflects the pulled edit.
- [ ] DB check: `SELECT name, status FROM app_versions WHERE app_id = '<module-id>';` — exactly one `v1` PUBLISHED row, zero rows matching `name ~ '^v[0-9]+_'`.
- [ ] Regression check: workspace B with an **in-progress DRAFT** on the module — pull still swaps into the DRAFT (status stays DRAFT, id preserved), PUBLISHED is untouched.
- [ ] Regression check: non-default branch — pull on `abcd` still swaps into the branch's DRAFT, never touches PUBLISHED.
- [ ] Regression check: a regular **app** (`type='front-end'`) with PUBLISHED `v1` — pull on main still creates a new DRAFT (apps keep their explicit release cycle; fix is scoped to modules).

</details>