### PR TITLE
Perf: batch Zustand store writes during ListView/Form mount and dynamic-height recursion

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
@@ -62,6 +62,7 @@ export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
   const isPagesSidebarHidden = useStore((state) => state.getPagesSidebarVisibility(moduleId), shallow);
 
   const isMobileLayout = currentLayout === 'mobile';
+  const pageLoader = useStore((state) => state.pageLoader, shallow);
   const [isViewerSidebarPinned, setIsSidebarPinned] = useState(
     localStorage.getItem('isPagesSidebarPinned') === null
       ? false
@@ -261,6 +262,8 @@ export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
                 >
                   {environmentLoadingState !== 'loading' && (
                     <SuspenseCountProvider
+                      key={pageLoader ? 'loading' : currentPageId}
+                      disabled={pageLoader}
                       onAllResolved={handleAllSuspenseResolved}
                       deferCheck={isModuleMode || appType === 'module'}
                     >

--- a/frontend/src/AppBuilder/AppCanvas/SuspenseTracker.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/SuspenseTracker.jsx
@@ -6,19 +6,22 @@ const SuspenseCountContext = createContext();
 
 // Added this to track the number of pending Suspense components
 // deferCheck: When true, defers the resolution check to handle nested lazy loading (e.g., ModuleContainer -> Table)
-export const SuspenseCountProvider = ({ onAllResolved, children, deferCheck = false }) => {
+export const SuspenseCountProvider = ({ onAllResolved, children, deferCheck = false, disabled = false }) => {
   const pendingCount = useRef(0);
   const hasInitialized = useRef(false);
   const hasResolved = useRef(false);
   const [isLoading, setIsLoading] = useState(true);
 
   const checkAndResolve = useCallback(() => {
+    // When disabled (e.g. pageLoader=true, Container hidden), don't fire onAllResolved.
+    // The provider will remount with disabled=false once the Container is shown.
+    if (disabled) return;
     if (pendingCount.current === 0 && hasInitialized.current && !hasResolved.current) {
       hasResolved.current = true;
       setIsLoading(false);
       onAllResolved();
     }
-  }, [onAllResolved]);
+  }, [onAllResolved, disabled]);
 
   const increment = useCallback(() => {
     pendingCount.current += 1;

--- a/frontend/src/AppBuilder/AppCanvas/WidgetWrapper.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/WidgetWrapper.jsx
@@ -47,7 +47,7 @@ const WidgetWrapper = memo(
     }, [subContainerIndex, contextPath]);
 
     const calculateMoveableBoxHeightWithId = useStore((state) => state.calculateMoveableBoxHeightWithId, shallow);
-    const incrementCanvasUpdater = useStore((state) => state.incrementCanvasUpdater, shallow);
+    const debouncedIncrementCanvasUpdater = useStore((state) => state.debouncedIncrementCanvasUpdater, shallow);
     const stylesDefinition = useStore(
       (state) => state.getComponentDefinition(id, moduleId)?.component?.definition?.styles,
       shallow
@@ -106,7 +106,7 @@ const WidgetWrapper = memo(
     });
 
     useEffect(() => {
-      incrementCanvasUpdater();
+      debouncedIncrementCanvasUpdater();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [visibility]);
 

--- a/frontend/src/AppBuilder/Widgets/Form/Form.jsx
+++ b/frontend/src/AppBuilder/Widgets/Form/Form.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useMemo } from 'react';
+import React, { useRef, useState, useEffect, useLayoutEffect, useMemo } from 'react';
 import { Container as SubContainer } from '@/AppBuilder/AppCanvas/Container';
 // eslint-disable-next-line import/no-unresolved
 import _, { debounce, omit } from 'lodash';
@@ -185,6 +185,26 @@ const FormComponent = (props) => {
     });
     return result;
   }, shallow);
+
+  const startExposedValueBatch = useStore((state) => state.startExposedValueBatch, shallow);
+  const flushExposedValueBatch = useStore((state) => state.flushExposedValueBatch, shallow);
+  const prevComponentCountRef = useRef(0);
+
+  // Mirror the ListView pattern: open the exposed-value batch in useLayoutEffect (which fires
+  // before any child useEffect) so all Form children's setExposedVariable calls on mount are
+  // coalesced into a single store write instead of N individual writes.
+  useLayoutEffect(() => {
+    if (componentCount > prevComponentCountRef.current) {
+      startExposedValueBatch();
+    }
+  }, [componentCount]);
+
+  useEffect(() => {
+    if (componentCount > prevComponentCountRef.current) {
+      prevComponentCountRef.current = componentCount;
+      flushExposedValueBatch();
+    }
+  }, [componentCount]);
 
   // Derive childrenData from raw exposed values + component definitions (read imperatively).
   // Only recomputes when childExposedMap actually changes.

--- a/frontend/src/AppBuilder/Widgets/Listview/Listview.jsx
+++ b/frontend/src/AppBuilder/Widgets/Listview/Listview.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useRef, useState, useEffect, useLayoutEffect, useMemo, useCallback } from 'react';
 // import { SubContainer } from '../SubContainer';
 import { Pagination } from '@/_components/Pagination';
 import _ from 'lodash';
@@ -35,6 +35,8 @@ export const Listview = function Listview({
   const childComponentCount = useStore((state) => (state.containerChildrenMapping?.[id] || []).length);
   const updateCustomResolvables = useStore((state) => state.updateCustomResolvables, shallow);
   const initExposedValueArrayForChildren = useStore((state) => state.initExposedValueArrayForChildren, shallow);
+  const startExposedValueBatch = useStore((state) => state.startExposedValueBatch, shallow);
+  const flushExposedValueBatch = useStore((state) => state.flushExposedValueBatch, shallow);
   const fallbackProperties = { height: 100, showBorder: false, data: [] };
   const isWidgetInContainerDragging = useStore(
     (state) => state.containerChildrenMapping?.[id]?.includes(state?.draggingComponentId),
@@ -125,6 +127,8 @@ export const Listview = function Listview({
     } else setPositiveColumns(columns);
   }, [columns]);
 
+  const prevRenderedRowCount = useRef(0);
+
   const [currentPage, setCurrentPage] = useState(1);
   const pageChanged = (page) => {
     setCurrentPage(page);
@@ -165,6 +169,25 @@ export const Listview = function Listview({
       initExposedValueArrayForChildren(id, filteredData.length, moduleId, parentIndices);
     }
   }
+
+  const renderedRowCount = filteredData.length;
+
+  // Start a batch before children's mount useEffects fire (useLayoutEffect runs before any useEffect)
+  // so that all setExposedValuePerRow calls from newly mounted children are coalesced into one
+  // store write instead of N×M individual writes.
+  useLayoutEffect(() => {
+    if (renderedRowCount > prevRenderedRowCount.current) {
+      startExposedValueBatch();
+    }
+  }, [renderedRowCount]);
+
+  useEffect(() => {
+    if (renderedRowCount > prevRenderedRowCount.current) {
+      prevRenderedRowCount.current = renderedRowCount;
+      flushExposedValueBatch();
+    }
+  }, [renderedRowCount]);
+
   return (
     <div
       data-disabled={disabledState}

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -118,6 +118,8 @@ const useAppData = (
   const setJsLibraryRegistry = useStore((state) => state.setJsLibraryRegistry);
   const setJsLibraryLoading = useStore((state) => state.setJsLibraryLoading);
   const isLicenseFetched = useStore((state) => state.isLicenseFetched);
+  const startExposedValueBatch = useStore((state) => state.startExposedValueBatch);
+  const flushExposedValueBatch = useStore((state) => state.flushExposedValueBatch);
 
   const setModulesIsLoading = useStore((state) => state?.setModulesIsLoading ?? noop);
   const setModulesList = useStore((state) => state?.setModulesList ?? noop);
@@ -175,6 +177,7 @@ const useAppData = (
 
   const initialLoadRef = useRef(true);
   const promptSentRef = useRef(false);
+  const isPageSwitchRef = useRef(false);
 
   const appTypeRef = useRef(null);
   const { isReleasedVersionId } = useStore(
@@ -209,15 +212,10 @@ const useAppData = (
 
   useEffect(() => {
     if (pageSwitchInProgress && !moduleMode) {
-      const currentPageEvents = events.filter((event) => event.target === 'page' && event.sourceId === currentPageId);
+      isPageSwitchRef.current = true;
       setPageSwitchInProgress(false);
-      setTimeout(() => {
-        handleEvent('onPageLoad', currentPageEvents, {});
-        // Rebuild all suggestion segments for the new page's components/queries/variables
-        mode === 'edit' && initSuggestions(moduleId);
-      }, 0);
     }
-  }, [pageSwitchInProgress, currentPageId, moduleMode, mode]);
+  }, [pageSwitchInProgress, moduleMode]);
 
   useEffect(() => {
     const subscription = authenticationService.currentSession
@@ -595,6 +593,7 @@ const useAppData = (
           updateReleasedVersionId(appData.current_version_id);
         }
 
+        startExposedValueBatch();
         setEditorLoading(false, moduleId);
         initialLoadRef.current = false;
       })
@@ -614,6 +613,7 @@ const useAppData = (
 
   useEffect(() => {
     if (isComponentLayoutReady && isLicenseFetched) {
+      flushExposedValueBatch();
       mode === 'edit' && initSuggestions(moduleId);
 
       const loadLibrariesAndRun = async () => {
@@ -641,9 +641,21 @@ const useAppData = (
           }
         }
 
-        await runOnLoadQueries(moduleId);
         const currentPageEvents = events.filter((event) => event.target === 'page' && event.sourceId === currentPageId);
-        handleEvent('onPageLoad', currentPageEvents, {});
+        if (isPageSwitchRef.current) {
+          // Page switch: skip runOnLoadQueries and only fire onPageLoad.
+          // Running runOnLoadQueries here would create an infinite loop if any
+          // runOnPageLoad query has a success/failure event that navigates to another
+          // page — each navigation would re-trigger queries which re-trigger navigation.
+          // Apps that need data refresh on navigation should trigger queries from the
+          // onPageLoad event instead of relying on runOnPageLoad.
+          isPageSwitchRef.current = false;
+          handleEvent('onPageLoad', currentPageEvents, {});
+        } else {
+          runOnLoadQueries(moduleId).then(() => {
+            handleEvent('onPageLoad', currentPageEvents, {});
+          });
+        }
       };
 
       loadLibrariesAndRun();

--- a/frontend/src/AppBuilder/_hooks/useExposedValueBatch.js
+++ b/frontend/src/AppBuilder/_hooks/useExposedValueBatch.js
@@ -1,0 +1,42 @@
+import { useRef, useEffect, useLayoutEffect } from 'react';
+import useStore from '@/AppBuilder/_stores/store';
+import { shallow } from 'zustand/shallow';
+
+/**
+ * Opens an exposed-value batch before children's mount useEffects fire, then flushes
+ * after they complete. Prevents N individual set() calls when child count increases.
+ *
+ * Usage: useExposedValueBatch(renderedRowCount) or useExposedValueBatch(componentCount)
+ */
+export const useExposedValueBatch = (count) => {
+  const startExposedValueBatch = useStore((s) => s.startExposedValueBatch, shallow);
+  const flushExposedValueBatch = useStore((s) => s.flushExposedValueBatch, shallow);
+  const isExposedValueBatching = useStore((s) => s.isExposedValueBatching, shallow);
+  const prevCountRef = useRef(count);
+
+  // useLayoutEffect fires after all children's layout effects but before any useEffect —
+  // the right moment to open the batch before children's mount effects write exposed values.
+  useLayoutEffect(() => {
+    if (count > prevCountRef.current) {
+      startExposedValueBatch();
+    }
+  }, [count]);
+
+  // No cleanup here — a cleanup on [count] runs AFTER the new useLayoutEffect opens the
+  // batch but BEFORE newly mounted children's useEffects buffer their writes, causing a
+  // premature flush that empties the batch before children can use it.
+  useEffect(() => {
+    if (count > prevCountRef.current) {
+      prevCountRef.current = count;
+      flushExposedValueBatch();
+    }
+  }, [count]);
+
+  // Separate unmount-only safety: if the component is removed after startExposedValueBatch
+  // but before flushExposedValueBatch fires, flush to prevent the batch staying open forever.
+  useEffect(() => {
+    return () => {
+      if (isExposedValueBatching()) flushExposedValueBatch();
+    };
+  }, []);
+};

--- a/frontend/src/AppBuilder/_stores/batchManager.ts
+++ b/frontend/src/AppBuilder/_stores/batchManager.ts
@@ -1,0 +1,124 @@
+/**
+ * Creates a ref-counted batch manager for Zustand stores with Immer.
+ * Buffers mutations and dependency paths, applies them in a single set() on flush.
+ * Supports nested start/flush — only the outermost flush applies.
+ *
+ * Options:
+ *   useShallowReturn {boolean} — when true, the flush set() returns { ...state } after
+ *     applying mutations. Required when mutations touch class instances (e.g. DependencyGraph)
+ *     that Immer cannot track, so Zustand must be notified via a returned object rather than
+ *     draft patches. Dep path cascade is skipped when this is set (graph construction only).
+ */
+
+type Mutation<S> = (state: S) => void;
+
+interface DepPath {
+  path: string;
+  moduleId: string;
+}
+
+interface BatchManagerOptions {
+  useShallowReturn?: boolean;
+}
+
+interface StoreWithDependencies {
+  updateDependencyValues: (path: string, moduleId: string) => void;
+}
+
+type ImmerSet<S> = (
+  updater: (state: S) => S | Partial<S> | void,
+  replace?: boolean,
+  actionName?: string
+) => void;
+
+type StoreGet<S> = () => S;
+
+export function createBatchManager<S extends StoreWithDependencies>(
+  set: ImmerSet<S>,
+  get: StoreGet<S>,
+  options: BatchManagerOptions = {}
+) {
+  const { useShallowReturn = false } = options;
+  let _depth = 0;
+  let _mutations: Mutation<S>[] = [];
+  let _depPaths: DepPath[] = [];
+  // Post-flush callbacks: keyed for deduplication (same key → only first callback registered).
+  let _postFlushKeys: Set<string> = new Set();
+  let _postFlushCallbacks: Array<() => void> = [];
+
+  return {
+    isBatching: () => _depth > 0,
+
+    startBatch: () => {
+      _depth++;
+      if (_depth === 1) {
+        _mutations = [];
+        _depPaths = [];
+        _postFlushKeys = new Set();
+        _postFlushCallbacks = [];
+      }
+    },
+
+    bufferMutation: (mutation: Mutation<S>, depPaths?: DepPath[]) => {
+      _mutations.push(mutation);
+      if (depPaths?.length) _depPaths.push(...depPaths);
+    },
+
+    // Register a callback to run after the outermost flush completes.
+    // dedupeKey: if provided, only the first registration with that key is kept.
+    bufferPostFlushCallback: (cb: () => void, dedupeKey?: string) => {
+      if (dedupeKey !== undefined) {
+        if (_postFlushKeys.has(dedupeKey)) return;
+        _postFlushKeys.add(dedupeKey);
+      }
+      _postFlushCallbacks.push(cb);
+    },
+
+    flush: (actionName = 'batchFlush') => {
+      _depth--;
+      if (_depth > 0) return;
+      _depth = 0;
+
+      const mutations = _mutations;
+      const depPaths = _depPaths;
+      const postFlushCallbacks = _postFlushCallbacks;
+      _mutations = [];
+      _depPaths = [];
+      _postFlushKeys = new Set();
+      _postFlushCallbacks = [];
+
+      if (mutations.length === 0) {
+        postFlushCallbacks.forEach((cb) => cb());
+        return;
+      }
+
+      set(
+        (state) => {
+          mutations.forEach((m) => m(state));
+          if (useShallowReturn) return { ...state };
+        },
+        false,
+        actionName
+      );
+
+      if (useShallowReturn) return;
+
+      const seen = new Set<string>();
+      depPaths.forEach(({ path, moduleId }) => {
+        const key = `${path}|${moduleId}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        get().updateDependencyValues(path, moduleId);
+      });
+
+      postFlushCallbacks.forEach((cb) => cb());
+    },
+  };
+}
+
+declare const scheduler: { yield(): Promise<void> } | undefined;
+
+export const yieldToMain = (): Promise<void> =>
+  typeof scheduler !== 'undefined' && 'yield' in scheduler
+    ? scheduler.yield()
+    : new Promise((resolve) => setTimeout(resolve, 0));

--- a/frontend/src/AppBuilder/_stores/slices/appSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/appSlice.js
@@ -9,12 +9,14 @@ import { replaceEntityReferencesWithIds, baseTheme } from '../utils';
 import _, { isEmpty, has } from 'lodash';
 import { getSubpath } from '@/_helpers/routes';
 import { v4 as uuidv4 } from 'uuid';
+import { yieldToMain } from '../batchManager';
 
 const initialState = {
   isSaving: false,
   globalSettings: {
     theme: baseTheme,
   },
+  pageLoader: false,
   pageSwitchInProgress: false,
   isTJDarkMode: localStorage.getItem('darkMode') === 'true',
   isViewer: false,
@@ -231,89 +233,111 @@ export const createAppSlice = (set, get) => ({
   switchPage: (pageId, handle, queryParams = [], moduleId = 'canvas', isBackOrForward = false) => {
     get().debugger.resetUnreadErrorCount();
 
-    // reset stores
     if (get().pageSwitchInProgress) {
       toast('Please wait, page switch in progress', {
         icon: '⚠️',
       });
       return;
     }
-    const {
-      setCurrentPageId,
-      setComponentNameIdMapping,
-      initDependencyGraph,
-      setQueryMapping,
-      cleanUpStore,
-      setResolvedGlobals,
-      setResolvedPageConstants,
-      setPageSwitchInProgress,
-      getCurrentPageId,
-      license,
-      modules: {
-        canvas: { pages },
-      },
-      getCurrentMode,
-    } = get();
-    const isPreview = getCurrentMode(moduleId) !== 'edit';
-    //!TODO clear all queued tasks
-    cleanUpStore(true);
-    get().clearTemporaryLayouts();
-    setCurrentPageId(pageId, moduleId);
-    setComponentNameIdMapping(moduleId);
-    setQueryMapping(moduleId);
 
-    const isLicenseValid =
-      !_.get(license, 'featureAccess.licenseStatus.isExpired', true) &&
-      _.get(license, 'featureAccess.licenseStatus.isLicenseValid', false);
-
-    const appId = get().appStore.modules[moduleId].app.appId;
-    const filteredQueryParams = queryParams.filter(([key, value]) => {
-      if (!value) return false;
-      if (key === 'env' && !isLicenseValid) return false;
-      return true;
-    });
-    const currentPageId = getCurrentPageId(moduleId);
-    const isSamePage = currentPageId === pageId;
-
-    if (isSamePage) {
-      set((state) => {
-        state.pageKey = uuidv4();
-      });
-    }
-
-    const queryParamsString = filteredQueryParams.map(([key, value]) => `${key}=${value}`).join('&');
-    const slug = get().appStore.modules[moduleId].app.slug;
-    const subpath = getSubpath();
-    let toNavigate = '';
-
-    if (!isBackOrForward) {
-      toNavigate = `${subpath ? `${subpath}` : ''}/${isPreview ? 'applications' : `${getWorkspaceId() + '/apps'}`}/${
-        slug ?? appId
-      }/${handle}?${queryParamsString}`;
-      navigate(toNavigate, {
-        state: {
-          isSwitchingPage: true,
-          id: pageId,
-          handle: handle,
+    const doSwitch = async () => {
+      const {
+        setCurrentPageId,
+        setComponentNameIdMapping,
+        initDependencyGraph,
+        setQueryMapping,
+        cleanUpStore,
+        setResolvedGlobals,
+        setResolvedPageConstants,
+        setPageSwitchInProgress,
+        setIsComponentLayoutReady,
+        getCurrentPageId,
+        startExposedValueBatch,
+        license,
+        modules: {
+          canvas: { pages },
         },
-      });
-    }
+        getCurrentMode,
+        setPageLoader,
+      } = get();
+      const isPreview = getCurrentMode(moduleId) !== 'edit';
 
-    const newPage = pages.find((p) => p.id === pageId);
-    setResolvedPageConstants(
-      {
-        id: newPage?.id,
-        handle: newPage?.handle,
-        name: newPage?.name,
-      },
-      moduleId
-    );
-    setResolvedGlobals('urlparams', JSON.parse(JSON.stringify(queryString.parse(queryParamsString))));
-    initDependencyGraph('canvas');
-    setPageSwitchInProgress(true);
+      setPageLoader(true);
+      await yieldToMain(); // Paint the loader before doing heavy work
+
+      // Capture the current page BEFORE updating so isSamePage is correct.
+      // Reading getCurrentPageId after setCurrentPageId would always return pageId
+      // (same-page), making the check always true.
+      const previousPageId = getCurrentPageId(moduleId);
+      const isSamePage = previousPageId === pageId;
+
+      cleanUpStore(true);
+      get().clearTemporaryLayouts();
+      setCurrentPageId(pageId, moduleId);
+      setComponentNameIdMapping(moduleId);
+      setQueryMapping(moduleId);
+
+      const isLicenseValid =
+        !_.get(license, 'featureAccess.licenseStatus.isExpired', true) &&
+        _.get(license, 'featureAccess.licenseStatus.isLicenseValid', false);
+
+      const appId = get().appStore.modules[moduleId].app.appId;
+      const filteredQueryParams = queryParams.filter(([key, value]) => {
+        if (!value) return false;
+        if (key === 'env' && !isLicenseValid) return false;
+        return true;
+      });
+
+      if (isSamePage) {
+        set((state) => {
+          state.pageKey = uuidv4();
+        });
+      }
+
+      const queryParamsString = filteredQueryParams.map(([key, value]) => `${key}=${value}`).join('&');
+      const slug = get().appStore.modules[moduleId].app.slug;
+      const subpath = getSubpath();
+
+      if (!isBackOrForward) {
+        const toNavigate = `${subpath ? `${subpath}` : ''}/${
+          isPreview ? 'applications' : `${getWorkspaceId() + '/apps'}`
+        }/${slug ?? appId}/${handle}?${queryParamsString}`;
+        navigate(toNavigate, {
+          state: {
+            isSwitchingPage: true,
+            id: pageId,
+            handle: handle,
+          },
+        });
+      }
+
+      const newPage = pages.find((p) => p.id === pageId);
+      setResolvedPageConstants(
+        {
+          id: newPage?.id,
+          handle: newPage?.handle,
+          name: newPage?.name,
+        },
+        moduleId
+      );
+      setResolvedGlobals('urlparams', JSON.parse(JSON.stringify(queryString.parse(queryParamsString))));
+      initDependencyGraph('canvas');
+      setPageSwitchInProgress(true);
+      setIsComponentLayoutReady(false, moduleId);
+      await yieldToMain(); // Let React commit all state changes before showing the Container
+
+      startExposedValueBatch();
+      setPageLoader(false);
+    };
+
+    doSwitch().catch((error) => {
+      console.error('Page switch failed:', error);
+      get().setPageLoader(false);
+    });
   },
   setPageSwitchInProgress: (isInProgress) =>
     set(() => ({ pageSwitchInProgress: isInProgress }), false, 'setPageSwitchInProgress'),
+  setPageLoader: (isInProgress) => set(() => ({ pageLoader: isInProgress }), false, 'setPageLoader'),
 
   cleanUpStore: (isPageSwitch = false, moduleId) => {
     const { resetUndoRedoStack, initModules, clearSelectedComponents } = get();

--- a/frontend/src/AppBuilder/_stores/slices/componentSlices/listViewComponentSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentSlices/listViewComponentSlice.js
@@ -6,6 +6,39 @@ export const listViewComponentSlice = (set, get) => ({
   // Per-row exposed value write for ListView children.
   // After writing, derives the parent ListView's children/data directly in the store.
   setExposedValuePerRow: (componentId, property, value, indices, moduleId = 'canvas') => {
+    if (typeof value !== 'function' && get().isExposedValueBatching()) {
+      get().bufferExposedValueMutation(
+        (state) => {
+          const components = state.resolvedStore.modules[moduleId].exposedValues.components;
+          if (!Array.isArray(components[componentId])) components[componentId] = [];
+          let current = components[componentId];
+          for (let i = 0; i < indices.length - 1; i++) {
+            const idx = indices[i];
+            if (!current[idx]) current[idx] = [];
+            else if (!Array.isArray(current[idx])) current[idx] = [current[idx]];
+            current = current[idx];
+          }
+          const lastIdx = indices[indices.length - 1];
+          if (!current[lastIdx] || typeof current[lastIdx] !== 'object' || Array.isArray(current[lastIdx])) {
+            current[lastIdx] = {};
+          }
+          current[lastIdx][property] = value;
+        },
+        [{ path: `components.${componentId}.${property}`, moduleId }]
+      );
+      // _deriveListviewChain reads from the store — it must run after all buffered mutations
+      // are flushed. Register once per (listview, row) via dedupeKey.
+      const parentId = get().getComponentDefinition(componentId, moduleId)?.component?.parent;
+      const nearestListviewId = parentId ? get().findNearestSubcontainerAncestor(parentId, moduleId) : null;
+      if (nearestListviewId) {
+        get().bufferExposedValuePostFlush(
+          () => get()._deriveListviewChain(nearestListviewId, indices, moduleId),
+          `${nearestListviewId}|${indices.join(',')}|${moduleId}`
+        );
+      }
+      return;
+    }
+
     set(
       (state) => {
         const components = state.resolvedStore.modules[moduleId].exposedValues.components;
@@ -52,6 +85,39 @@ export const listViewComponentSlice = (set, get) => ({
 
   // Batch per-row exposed value write for ListView children.
   setExposedValuesPerRow: (componentId, values, indices, moduleId = 'canvas') => {
+    if (get().isExposedValueBatching()) {
+      const depPaths = Object.keys(values)
+        .filter((key) => typeof values[key] !== 'function')
+        .map((key) => ({ path: `components.${componentId}.${key}`, moduleId }));
+      get().bufferExposedValueMutation((state) => {
+        const components = state.resolvedStore.modules[moduleId].exposedValues.components;
+        if (!Array.isArray(components[componentId])) components[componentId] = [];
+        let current = components[componentId];
+        for (let i = 0; i < indices.length - 1; i++) {
+          const idx = indices[i];
+          if (!current[idx]) current[idx] = [];
+          else if (!Array.isArray(current[idx])) current[idx] = [current[idx]];
+          current = current[idx];
+        }
+        const lastIdx = indices[indices.length - 1];
+        if (!current[lastIdx] || typeof current[lastIdx] !== 'object' || Array.isArray(current[lastIdx])) {
+          current[lastIdx] = {};
+        }
+        Object.entries(values).forEach(([key, value]) => {
+          current[lastIdx][key] = value;
+        });
+      }, depPaths);
+      const parentId = get().getComponentDefinition(componentId, moduleId)?.component?.parent;
+      const nearestListviewId = parentId ? get().findNearestSubcontainerAncestor(parentId, moduleId) : null;
+      if (nearestListviewId) {
+        get().bufferExposedValuePostFlush(
+          () => get()._deriveListviewChain(nearestListviewId, indices, moduleId),
+          `${nearestListviewId}|${indices.join(',')}|${moduleId}`
+        );
+      }
+      return;
+    }
+
     const skipKeys = new Set();
     set(
       (state) => {

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -1,5 +1,5 @@
 import { appVersionService } from '@/_services';
-import { componentTypes } from '@/AppBuilder/WidgetManager';
+import { componentTypes, componentTypeDefinitionMap } from '@/AppBuilder/WidgetManager';
 import {
   resolveDynamicValues,
   checkSubstringRegex,
@@ -866,8 +866,8 @@ export const createComponentsSlice = (set, get) => ({
     moduleId
   ) => {
     const { updateResolvedValues, generateDependencyGraphForRefs } = get();
-    const updatedPropertyValue = cloneDeep(value);
     if (Array.isArray(value)) {
+      const updatedPropertyValue = cloneDeep(value);
       value.forEach((val, index) => {
         //This code assumes that the array always consists of objects the else condition is to handle the case when the value is an array of strings/numbers
         if (val && typeof val === 'object') {
@@ -1001,6 +1001,8 @@ export const createComponentsSlice = (set, get) => ({
       addToDependencyGraph,
       setResolvedComponents,
       resolveOthers,
+      startDependencyBatch,
+      flushDependencyBatch,
       registerQueryDependencies,
     } = get();
     const components = getCurrentPageComponents(moduleId);
@@ -1008,12 +1010,51 @@ export const createComponentsSlice = (set, get) => ({
     //TODO: Replace with object of component types
     let resolvedComponentValues = {};
 
+    startDependencyBatch();
     Object.entries(components).forEach(([componentId, component]) => {
       resolvedComponentValues[componentId] = addToDependencyGraph(moduleId, componentId, component.component);
     });
+    flushDependencyBatch();
+
     setResolvedComponents(resolvedComponentValues, moduleId);
     resolveOthers(moduleId);
 
+    // Pre-populate default exposed values for all components in a single store write.
+    // This prevents 600+ individual set() calls during component mount in RenderWidget
+    // (setDefaultExposedValues will early-return since values already exist).
+    set(
+      (state) => {
+        Object.entries(components).forEach(([componentId, component]) => {
+          const componentType = component.component.component;
+          const parentId = component.component.parent;
+
+          const existing = state.resolvedStore.modules[moduleId].exposedValues.components[componentId];
+          if (existing && Object.keys(existing).length > 0) return;
+
+          const compDef = componentTypeDefinitionMap[componentType];
+          if (!compDef) return;
+
+          // Skip components with a Listview ancestor — they use per-row array storage at runtime
+          // and cannot be pre-populated flat. Form children without a Listview ancestor can be
+          // pre-populated here, eliminating their individual set() calls at mount time.
+          if (parentId) {
+            let cur = components[parentId];
+            while (cur) {
+              if (cur.component.component === 'Listview') return;
+              cur = components[cur.component.parent];
+            }
+          }
+
+          const exposedVariables = compDef.exposedVariables || {};
+          state.resolvedStore.modules[moduleId].exposedValues.components[componentId] = {
+            ...exposedVariables,
+            id: componentId,
+          };
+        });
+      },
+      false,
+      'batchSetDefaultExposedValues'
+    );
     // Register query option dependencies for queries with runOnDependencyChange enabled
     const queries = get().dataQuery?.queries?.modules?.[moduleId] || [];
     queries.forEach((query) => {
@@ -2252,6 +2293,7 @@ export const createComponentsSlice = (set, get) => ({
       getResolvedComponent,
     } = get();
     const dependecies = getDependencies(path, moduleId);
+
     if (dependecies?.length) {
       dependecies.forEach((dependency) => {
         // Handle query options sentinel — trigger re-run instead of resolution

--- a/frontend/src/AppBuilder/_stores/slices/debuggerSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/debuggerSlice.js
@@ -86,17 +86,22 @@ export const createDebuggerSlice = (set, get) => ({
 
     validateComponents: (components, moduleId = 'canvas') => {
       const validateComponent = get().debugger.validateComponent;
+      const allLogs = [];
       const entries = Object.entries(components).map(([id, component]) => {
         // If component is an array, validate each component in the array and return the array
         if (Array.isArray(component)) {
-          return [id, component.map((c) => validateComponent(id, c, moduleId))];
+          return [id, component.map((c) => validateComponent(id, c, moduleId, allLogs))];
         }
-        return [id, validateComponent(id, component, moduleId)];
+        return [id, validateComponent(id, component, moduleId, allLogs)];
       });
+      // Single logMultiple call instead of one per component (avoids N Zustand set() calls)
+      if (allLogs.length > 0) {
+        get().debugger.logMultiple(allLogs);
+      }
       return Object.fromEntries(entries);
     },
 
-    validateComponent: (id, component, moduleId = 'canvas') => {
+    validateComponent: (id, component, moduleId = 'canvas', logAccumulator = null) => {
       const componentDefinition = get().getComponentDefinition(id, moduleId);
       const componentName = componentDefinition.component.name;
       const componentType = componentDefinition.component.component;
@@ -153,7 +158,11 @@ export const createDebuggerSlice = (set, get) => ({
         timestamp: moment().toISOString(),
       }));
 
-      get().debugger.logMultiple(logs);
+      if (logAccumulator !== null) {
+        logAccumulator.push(...logs);
+      } else if (logs.length > 0) {
+        get().debugger.logMultiple(logs);
+      }
 
       return newComponent;
     },

--- a/frontend/src/AppBuilder/_stores/slices/dependencySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dependencySlice.js
@@ -1,4 +1,5 @@
 import DependencyGraph from './DependencyClass';
+import { createBatchManager } from '../batchManager';
 
 const initialState = {
   dependencyGraph: {
@@ -10,63 +11,87 @@ const initialState = {
   },
 };
 
-export const createDependencySlice = (set, get) => ({
-  ...initialState,
-  initializeDependencySlice: (moduleId) => {
-    set(
-      (state) => {
-        state.dependencyGraph.modules[moduleId] = {
-          graph: new DependencyGraph(),
-        };
-      },
-      false,
-      'initializeDependencySlice'
-    );
-  },
+export const createDependencySlice = (set, get) => {
+  // useShallowReturn: DependencyGraph is a class instance — Immer can't track its mutations,
+  // so flush must return { ...state } to notify Zustand instead of relying on draft patches.
+  // No dep path cascade needed here (this batch is for graph construction, not runtime updates).
+  const _depBatch = createBatchManager(set, get, { useShallowReturn: true });
 
-  addDependency: (fromPath, toPath, nodeData, moduleId = 'canvas') => {
-    if (!get().checkIfDependencyExists(fromPath, toPath, moduleId)) {
+  return {
+    ...initialState,
+    initializeDependencySlice: (moduleId) => {
+      set(
+        (state) => {
+          state.dependencyGraph.modules[moduleId] = {
+            graph: new DependencyGraph(),
+          };
+        },
+        false,
+        'initializeDependencySlice'
+      );
+    },
+
+    startDependencyBatch: () => _depBatch.startBatch(),
+
+    flushDependencyBatch: () => _depBatch.flush('flushDependencyBatch'),
+
+    addDependency: (fromPath, toPath, nodeData, moduleId = 'canvas') => {
+      if (_depBatch.isBatching()) {
+        _depBatch.bufferMutation((state) => {
+          state.dependencyGraph.modules[moduleId].graph.addDependency(fromPath, toPath, nodeData);
+        });
+        return;
+      }
+      if (!get().checkIfDependencyExists(fromPath, toPath, moduleId)) {
+        set((state) => {
+          state.dependencyGraph.modules[moduleId].graph.addDependency(fromPath, toPath, nodeData);
+          return { ...state };
+        });
+      }
+    },
+
+    updateDependency: (newFromPath, toPath, nodeData, moduleId = 'canvas') => {
+      if (_depBatch.isBatching()) {
+        _depBatch.bufferMutation((state) => {
+          state.dependencyGraph.modules[moduleId].graph.updateDependency(newFromPath, toPath, nodeData);
+        });
+        return;
+      }
       set((state) => {
-        state.dependencyGraph.modules[moduleId].graph.addDependency(fromPath, toPath, nodeData);
+        state.dependencyGraph.modules[moduleId].graph.updateDependency(newFromPath, toPath, nodeData);
         return { ...state };
       });
-    }
-  },
+    },
 
-  updateDependency: (newFromPath, toPath, nodeData, moduleId = 'canvas') =>
-    set((state) => {
-      state.dependencyGraph.modules[moduleId].graph.updateDependency(newFromPath, toPath, nodeData);
-      return { ...state };
-    }),
+    removeDependency: (toPath, clearToPath = false, moduleId = 'canvas') =>
+      set((state) => {
+        state.dependencyGraph.modules[moduleId].graph.removeDependency(toPath, clearToPath);
+        return { ...state };
+      }),
 
-  removeDependency: (toPath, clearToPath = false, moduleId = 'canvas') =>
-    set((state) => {
-      state.dependencyGraph.modules[moduleId].graph.removeDependency(toPath, clearToPath);
-      return { ...state };
-    }),
+    removeNode: (path, moduleId = 'canvas') =>
+      set((state) => {
+        state.dependencyGraph.modules[moduleId].graph.removeNode(path);
+        return { ...state };
+      }),
 
-  removeNode: (path, moduleId = 'canvas') =>
-    set((state) => {
-      state.dependencyGraph.modules[moduleId].graph.removeNode(path);
-      return { ...state };
-    }),
+    getNodeData: (path, moduleId = 'canvas') => get().dependencyGraph.modules[moduleId].graph.getNodeData(path),
 
-  getNodeData: (path, moduleId = 'canvas') => get().dependencyGraph.modules[moduleId].graph.getNodeData(path),
+    getDependencies: (path, moduleId = 'canvas') => get().dependencyGraph.modules[moduleId].graph.getDependencies(path),
 
-  getDependencies: (path, moduleId = 'canvas') => get().dependencyGraph.modules[moduleId].graph.getDependencies(path),
+    getDirectDependencies: (path, moduleId = 'canvas') =>
+      get().dependencyGraph.modules[moduleId].graph.getDirectDependencies(path),
 
-  getDirectDependencies: (path, moduleId = 'canvas') =>
-    get().dependencyGraph.modules[moduleId].graph.getDirectDependencies(path),
+    getDependents: (path, moduleId = 'canvas') => get().dependencyGraph.modules[moduleId].graph.getDependents(path),
 
-  getDependents: (path, moduleId = 'canvas') => get().dependencyGraph.modules[moduleId].graph.getDependents(path),
+    getDirectDependents: (path, moduleId = 'canvas') =>
+      get().dependencyGraph.modules[moduleId].graph.getDirectDependents(path),
 
-  getDirectDependents: (path, moduleId = 'canvas') =>
-    get().dependencyGraph.modules[moduleId].graph.getDirectDependents(path),
+    getOverallOrder: (moduleId = 'canvas') => get().dependencyGraph.modules[moduleId].graph.getOverallOrder(),
 
-  getOverallOrder: (moduleId = 'canvas') => get().dependencyGraph.modules[moduleId].graph.getOverallOrder(),
-
-  checkIfDependencyExists: (fromPath, toPath, moduleId = 'canvas') => {
-    const dependencies = get().getDependencies(fromPath, moduleId);
-    return dependencies.includes(toPath);
-  },
-});
+    checkIfDependencyExists: (fromPath, toPath, moduleId = 'canvas') => {
+      const dependencies = get().getDependencies(fromPath, moduleId);
+      return dependencies.includes(toPath);
+    },
+  };
+};

--- a/frontend/src/AppBuilder/_stores/slices/gridSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/gridSlice.js
@@ -115,19 +115,35 @@ export const createGridSlice = (set, get) => ({
     }
   },
 
-  adjustComponentPositions: (componentId, currentLayout = 'desktop', isContainer = false, subContainerIndex = null) => {
+  adjustComponentPositions: (
+    componentId,
+    currentLayout = 'desktop',
+    isContainer = false,
+    subContainerIndex = null,
+    _pendingLayouts = null
+  ) => {
     const {
       getResolvedValue,
       getCurrentPageComponents,
       setTemporaryLayouts,
       incrementCanvasUpdater,
-      temporaryLayouts,
       adjustComponentPositions,
       getResolvedComponent,
       getComponentTypeFromId,
       getComponentDefinition,
       getExposedPropertyForAdditionalActions,
     } = get();
+
+    // On the outermost call, create the accumulator; inner recursive levels share it.
+    // All layout mutations are collected here and flushed in ONE store write at the end,
+    // replacing the N×(setTemporaryLayouts + incrementCanvasUpdater) calls that previously
+    // fired at every level of the container nesting chain.
+    const isRootCall = _pendingLayouts === null;
+    const pendingLayouts = isRootCall ? {} : _pendingLayouts;
+    // Merge the stored state with any pending-but-not-yet-flushed updates so that each
+    // recursive level sees the full picture (e.g. a parent container reads its child's
+    // already-updated height when computing its own new height).
+    const temporaryLayouts = { ...get().temporaryLayouts, ...pendingLayouts };
 
     try {
       // Getting all the components on the current page
@@ -390,7 +406,9 @@ export const createGridSlice = (set, get) => ({
       // ModalV2 is rendered as an overlay; its body size must not push
       // sibling components of the trigger button on the canvas.
       if (componentType === 'ModalV2' && isContainer) {
-        setTemporaryLayouts(updatedLayouts);
+        Object.assign(pendingLayouts, updatedLayouts);
+        if (isRootCall) setTemporaryLayouts(pendingLayouts);
+        // Intentionally no incrementCanvasUpdater for ModalV2 — preserved from original behaviour.
         return;
       }
 
@@ -499,9 +517,10 @@ export const createGridSlice = (set, get) => ({
         }
       }
 
-      setTemporaryLayouts(updatedLayouts);
-
-      incrementCanvasUpdater();
+      // Accumulate this level's layout changes into the shared pending object.
+      // The store write and canvas increment are deferred to the root call so the entire
+      // chain (widget → Form → Container → …) triggers only ONE set() + ONE re-render.
+      Object.assign(pendingLayouts, updatedLayouts);
 
       if (changedComponent.component?.parent || (componentType === 'Listview' && doesSubContainerIndexExist)) {
         // Bubble the height change up to the parent container.
@@ -519,8 +538,14 @@ export const createGridSlice = (set, get) => ({
           parentComponentId &&
           !(parentComponentId === componentId && parentSubContainerIndex === subContainerIndex)
         ) {
-          adjustComponentPositions(parentComponentId, currentLayout, true, parentSubContainerIndex);
+          adjustComponentPositions(parentComponentId, currentLayout, true, parentSubContainerIndex, pendingLayouts);
         }
+      }
+
+      // Only the root call flushes to the store — all levels have finished accumulating by now.
+      if (isRootCall) {
+        setTemporaryLayouts(pendingLayouts);
+        incrementCanvasUpdater();
       }
 
       return updatedLayouts;

--- a/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
@@ -1,6 +1,7 @@
 import { resolveDynamicValues } from '../utils';
 import { extractAndReplaceReferencesFromString } from '@/AppBuilder/_stores/ast';
 import { componentTypeDefinitionMap } from '@/AppBuilder/WidgetManager';
+import { createBatchManager } from '@/AppBuilder/_stores/batchManager';
 import _ from 'lodash';
 
 const initialState = {
@@ -41,234 +42,256 @@ export const DEFAULT_COMPONENT_STRUCTURE = {
   general: {},
 };
 
-export const createResolvedSlice = (set, get) => ({
-  ...initialState,
-  initializeResolvedSlice: (moduleId) => {
-    set(
-      (state) => {
-        state.resolvedStore.modules[moduleId] = {
-          ...initialState.resolvedStore.modules.canvas,
-        };
-      },
-      false,
-      'initializeResolvedSlice'
-    );
-  },
-  setResolvedGlobals: (objKey, values, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        // Handle object assignment
-        if (!state.resolvedStore.modules[moduleId].exposedValues.globals[objKey]) {
-          state.resolvedStore.modules[moduleId].exposedValues.globals[objKey] = {};
-        }
-        if (Object.keys(values).length === 0) {
-          // Set an empty object
-          state.resolvedStore.modules[moduleId].exposedValues.globals[objKey] = {};
-        } else {
-          // Handle nested object assignment
-          Object.entries(values).forEach(([key, value]) => {
-            state.resolvedStore.modules[moduleId].exposedValues.globals[objKey][key] = value;
-          });
-        }
-      },
-      false,
-      'setResolvedGlobals'
-    );
-    Object.entries(values).forEach(() => {
-      get().updateDependencyValues(`globals.${objKey}`, moduleId);
-    });
-  },
-  setResolvedConstants: (constants = {}, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        Object.entries(constants).forEach(([key, value]) => {
-          state.resolvedStore.modules[moduleId].exposedValues.constants[key] = value;
-        });
-      },
-      false,
-      'setResolvedConstants'
-    );
-    Object.entries(constants).forEach(([key, value]) => {
-      get().updateDependencyValues(`constants.${key}`, moduleId);
-    });
-  },
+export const createResolvedSlice = (set, get) => {
+  const _exposedValueBatch = createBatchManager(set, get);
 
-  setSecrets: (secrets = {}, moduleId = 'canvas') => {
-    set((state) => {
-      Object.entries(secrets).forEach(([key, value]) => {
-        state.resolvedStore.modules[moduleId].secrets[key] = value;
+  return {
+    ...initialState,
+    initializeResolvedSlice: (moduleId) => {
+      set(
+        (state) => {
+          state.resolvedStore.modules[moduleId] = {
+            ...initialState.resolvedStore.modules.canvas,
+          };
+        },
+        false,
+        'initializeResolvedSlice'
+      );
+    },
+
+    startExposedValueBatch: () => {
+      _exposedValueBatch.startBatch();
+    },
+
+    flushExposedValueBatch: () => {
+      _exposedValueBatch.flush('flushExposedValueBatch');
+    },
+
+    isExposedValueBatching: () => _exposedValueBatch.isBatching(),
+
+    bufferExposedValueMutation: (mutation, depPaths) => {
+      _exposedValueBatch.bufferMutation(mutation, depPaths);
+    },
+
+    bufferExposedValuePostFlush: (cb, dedupeKey) => {
+      _exposedValueBatch.bufferPostFlushCallback(cb, dedupeKey);
+    },
+
+    setResolvedGlobals: (objKey, values, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          // Handle object assignment
+          if (!state.resolvedStore.modules[moduleId].exposedValues.globals[objKey]) {
+            state.resolvedStore.modules[moduleId].exposedValues.globals[objKey] = {};
+          }
+          if (Object.keys(values).length === 0) {
+            // Set an empty object
+            state.resolvedStore.modules[moduleId].exposedValues.globals[objKey] = {};
+          } else {
+            // Handle nested object assignment
+            Object.entries(values).forEach(([key, value]) => {
+              state.resolvedStore.modules[moduleId].exposedValues.globals[objKey][key] = value;
+            });
+          }
+        },
+        false,
+        'setResolvedGlobals'
+      );
+      Object.entries(values).forEach(() => {
+        get().updateDependencyValues(`globals.${objKey}`, moduleId);
       });
-    });
-  },
+    },
+    setResolvedConstants: (constants = {}, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          Object.entries(constants).forEach(([key, value]) => {
+            state.resolvedStore.modules[moduleId].exposedValues.constants[key] = value;
+          });
+        },
+        false,
+        'setResolvedConstants'
+      );
+      Object.entries(constants).forEach(([key, value]) => {
+        get().updateDependencyValues(`constants.${key}`, moduleId);
+      });
+    },
 
-  setResolvedPageConstants: (constants = {}, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        Object.entries(constants).forEach(([key, value]) => {
-          state.resolvedStore.modules[moduleId].exposedValues.page[key] = value;
+    setSecrets: (secrets = {}, moduleId = 'canvas') => {
+      set((state) => {
+        Object.entries(secrets).forEach(([key, value]) => {
+          state.resolvedStore.modules[moduleId].secrets[key] = value;
         });
-      },
-      false,
-      'setResolvedPageConstants'
-    );
-    Object.entries(constants).forEach(([key, value]) => {
-      get().updateDependencyValues(`page.${key}`, moduleId);
-    });
-  },
+      });
+    },
 
-  // variables
-  setVariable: (key, value, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        state.resolvedStore.modules[moduleId].exposedValues.variables[key] = value;
-      },
-      false,
-      'setVariables'
-    );
-    get().updateDependencyValues(`variables.${key}`, moduleId);
-    get().rebuildVariableHints(moduleId);
-  },
+    setResolvedPageConstants: (constants = {}, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          Object.entries(constants).forEach(([key, value]) => {
+            state.resolvedStore.modules[moduleId].exposedValues.page[key] = value;
+          });
+        },
+        false,
+        'setResolvedPageConstants'
+      );
+      Object.entries(constants).forEach(([key, value]) => {
+        get().updateDependencyValues(`page.${key}`, moduleId);
+      });
+    },
 
-  getVariable: (key, moduleId = 'canvas') => {
-    return get().resolvedStore.modules[moduleId].exposedValues.variables[key];
-  },
+    // variables
+    setVariable: (key, value, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          state.resolvedStore.modules[moduleId].exposedValues.variables[key] = value;
+        },
+        false,
+        'setVariables'
+      );
+      get().updateDependencyValues(`variables.${key}`, moduleId);
+      get().rebuildVariableHints(moduleId);
+    },
 
-  unsetVariable: (key, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        delete state.resolvedStore.modules[moduleId].exposedValues.variables[key];
-      },
-      false,
-      'unsetVariable'
-    );
-    get().removeNode(`variables.${key}`, moduleId);
-    get().updateDependencyValues(`variables.${key}`, moduleId);
-    get().rebuildVariableHints(moduleId);
-  },
+    getVariable: (key, moduleId = 'canvas') => {
+      return get().resolvedStore.modules[moduleId].exposedValues.variables[key];
+    },
 
-  unsetAllVariables: (moduleId = 'canvas') => {
-    const variables = get().resolvedStore.modules[moduleId].exposedValues.variables;
-    set(
-      (state) => {
-        state.resolvedStore.modules[moduleId].exposedValues.variables = {};
-      },
-      false,
-      'unsetAllVariables'
-    );
-    Object.keys(variables).forEach((key) => {
-      get().removeNode(`variables.${key}`);
-      get().updateDependencyValues(`variables.${key}`);
-    });
-    get().rebuildVariableHints(moduleId);
-  },
+    unsetVariable: (key, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          delete state.resolvedStore.modules[moduleId].exposedValues.variables[key];
+        },
+        false,
+        'unsetVariable'
+      );
+      get().removeNode(`variables.${key}`, moduleId);
+      get().updateDependencyValues(`variables.${key}`, moduleId);
+      get().rebuildVariableHints(moduleId);
+    },
 
-  // page.variables
-  setPageVariable: (key, value, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        state.resolvedStore.modules[moduleId].exposedValues.page.variables[key] = value;
-      },
-      false,
-      'setPageVariable'
-    );
-    get().updateDependencyValues(`page.variables.${key}`, moduleId);
-    get().rebuildVariableHints(moduleId);
-  },
+    unsetAllVariables: (moduleId = 'canvas') => {
+      const variables = get().resolvedStore.modules[moduleId].exposedValues.variables;
+      set(
+        (state) => {
+          state.resolvedStore.modules[moduleId].exposedValues.variables = {};
+        },
+        false,
+        'unsetAllVariables'
+      );
+      Object.keys(variables).forEach((key) => {
+        get().removeNode(`variables.${key}`);
+        get().updateDependencyValues(`variables.${key}`);
+      });
+      get().rebuildVariableHints(moduleId);
+    },
 
-  getPageVariable: (key, moduleId = 'canvas') => {
-    return get().resolvedStore.modules[moduleId].exposedValues.page.variables[key];
-  },
-  unsetPageVariable: (key, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        delete state.resolvedStore.modules[moduleId].exposedValues.page.variables[key];
-      },
-      false,
-      'unsetPageVariable'
-    );
-    get().removeNode(`page.variables.${key}`, moduleId);
-    get().updateDependencyValues(`page.variables.${key}`, moduleId);
-    get().rebuildVariableHints(moduleId);
-  },
+    // page.variables
+    setPageVariable: (key, value, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          state.resolvedStore.modules[moduleId].exposedValues.page.variables[key] = value;
+        },
+        false,
+        'setPageVariable'
+      );
+      get().updateDependencyValues(`page.variables.${key}`, moduleId);
+      get().rebuildVariableHints(moduleId);
+    },
 
-  unsetAllPageVariables: (moduleId = 'canvas') => {
-    const pageVariables = get().resolvedStore.modules[moduleId].exposedValues.page.variables;
-    set(
-      (state) => {
-        state.resolvedStore.modules[moduleId].exposedValues.page.variables = {};
-      },
-      false,
-      'unsetAllPageVariables'
-    );
-    Object.keys(pageVariables).forEach((key) => {
-      get().removeNode(`page.variables.${key}`);
-      get().updateDependencyValues(`page.variables.${key}`);
-    });
-    get().rebuildVariableHints(moduleId);
-  },
+    getPageVariable: (key, moduleId = 'canvas') => {
+      return get().resolvedStore.modules[moduleId].exposedValues.page.variables[key];
+    },
+    unsetPageVariable: (key, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          delete state.resolvedStore.modules[moduleId].exposedValues.page.variables[key];
+        },
+        false,
+        'unsetPageVariable'
+      );
+      get().removeNode(`page.variables.${key}`, moduleId);
+      get().updateDependencyValues(`page.variables.${key}`, moduleId);
+      get().rebuildVariableHints(moduleId);
+    },
 
-  setResolvedQuery: (queryId, details, moduleId = 'canvas', replaceObject = false) => {
-    set(
-      (state) => {
-        state.resolvedStore.modules[moduleId].exposedValues.queries[queryId] = {
-          ...(replaceObject ? {} : state.resolvedStore.modules[moduleId]?.exposedValues?.queries?.[queryId]),
-          ...details,
+    unsetAllPageVariables: (moduleId = 'canvas') => {
+      const pageVariables = get().resolvedStore.modules[moduleId].exposedValues.page.variables;
+      set(
+        (state) => {
+          state.resolvedStore.modules[moduleId].exposedValues.page.variables = {};
+        },
+        false,
+        'unsetAllPageVariables'
+      );
+      Object.keys(pageVariables).forEach((key) => {
+        get().removeNode(`page.variables.${key}`);
+        get().updateDependencyValues(`page.variables.${key}`);
+      });
+      get().rebuildVariableHints(moduleId);
+    },
+
+    setResolvedQuery: (queryId, details, moduleId = 'canvas', replaceObject = false) => {
+      set(
+        (state) => {
+          state.resolvedStore.modules[moduleId].exposedValues.queries[queryId] = {
+            ...(replaceObject ? {} : state.resolvedStore.modules[moduleId]?.exposedValues?.queries?.[queryId]),
+            ...details,
+          };
+        },
+        false,
+        'setResolvedQuery'
+      );
+
+      Object.entries(details).forEach(([key, value]) => {
+        if (
+          ['isLoading', 'data', 'rawData', 'request', 'response', 'responseHeaders', 'metadata', 'error'].includes(key)
+        ) {
+          if (typeof value !== 'function') get().updateDependencyValues(`queries.${queryId}.${key}`, moduleId);
+        }
+      });
+      get().rebuildQueryHints(moduleId, queryId);
+    },
+    initialiseResolvedQuery: (querIds, moduleId = 'canvas') => {
+      const defaultObject = {};
+      querIds.forEach((queryId) => {
+        defaultObject[queryId] = {
+          isLoading: false,
+          data: [],
+          rawData: [],
+          id: queryId,
         };
-      },
-      false,
-      'setResolvedQuery'
-    );
+      });
+      set((state) => {
+        state.resolvedStore.modules[moduleId].exposedValues.queries = defaultObject;
+      });
+    },
+    setResolvedComponent: (componentId, data, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          state.resolvedStore.modules[moduleId].components[componentId] = data;
+        },
+        false,
+        {
+          type: 'setResolvedComponent',
+          payload: { componentId, data, moduleId },
+        }
+      );
+    },
+    setResolvedComponents: (components, moduleId = 'canvas') => {
+      const validateComponents = get().debugger.validateComponents;
 
-    Object.entries(details).forEach(([key, value]) => {
-      if (
-        ['isLoading', 'data', 'rawData', 'request', 'response', 'responseHeaders', 'metadata', 'error'].includes(key)
-      ) {
-        if (typeof value !== 'function') get().updateDependencyValues(`queries.${queryId}.${key}`, moduleId);
-      }
-    });
-    get().rebuildQueryHints(moduleId, queryId);
-  },
-  initialiseResolvedQuery: (querIds, moduleId = 'canvas') => {
-    const defaultObject = {};
-    querIds.forEach((queryId) => {
-      defaultObject[queryId] = {
-        isLoading: false,
-        data: [],
-        rawData: [],
-        id: queryId,
-      };
-    });
-    set((state) => {
-      state.resolvedStore.modules[moduleId].exposedValues.queries = defaultObject;
-    });
-  },
-  setResolvedComponent: (componentId, data, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        state.resolvedStore.modules[moduleId].components[componentId] = data;
-      },
-      false,
-      {
-        type: 'setResolvedComponent',
-        payload: { componentId, data, moduleId },
-      }
-    );
-  },
-  setResolvedComponents: (components, moduleId = 'canvas') => {
-    const validateComponents = get().debugger.validateComponents;
+      const validatedComponents = validateComponents(components, moduleId);
 
-    const validatedComponents = validateComponents(components, moduleId);
+      set(
+        (state) => {
+          state.resolvedStore.modules[moduleId].components = validatedComponents;
+        },
+        false,
+        'setResolvedComponents'
+      );
+    },
 
-    set(
-      (state) => {
-        state.resolvedStore.modules[moduleId].components = validatedComponents;
-      },
-      false,
-      'setResolvedComponents'
-    );
-  },
-
-  /*
+    /*
     index - If index is passed, then the component is a child of a listview or kanban
     The structure will be - 
           components: {
@@ -285,597 +308,633 @@ export const createResolvedSlice = (set, get) => ({
               properties: {},
           }
   */
-  setResolvedComponentByProperty: (componentId, type, property, value, index = null, moduleId = 'canvas') => {
-    value = get().debugger.validateProperty(componentId, type, property, value, moduleId);
+    setResolvedComponentByProperty: (componentId, type, property, value, index = null, moduleId = 'canvas') => {
+      value = get().debugger.validateProperty(componentId, type, property, value, moduleId);
 
-    set(
-      (state) => {
-        if (!state.resolvedStore.modules[moduleId]) {
-          state.resolvedStore.modules[moduleId] = { components: {} };
-        }
-
-        if (!state.resolvedStore.modules[moduleId].components[componentId]) {
-          state.resolvedStore.modules[moduleId].components[componentId] = { ...DEFAULT_COMPONENT_STRUCTURE };
-        }
-
-        if (index !== null) {
-          const indices = Array.isArray(index) ? index : [index];
-
-          // Helper function to recursively unwrap nested arrays to get the component object
-          const unwrapToObject = (val) => {
-            let result = val;
-            while (result && Array.isArray(result)) {
-              result = result[0];
-            }
-            return result && typeof result === 'object' ? result : null;
-          };
-
-          // Ensure root is an array (modify state directly, not a local variable)
-          if (!Array.isArray(state.resolvedStore.modules[moduleId].components[componentId])) {
-            const existing = state.resolvedStore.modules[moduleId].components[componentId];
-            const unwrapped = unwrapToObject(existing);
-            state.resolvedStore.modules[moduleId].components[componentId] = unwrapped ? [unwrapped] : [];
+      set(
+        (state) => {
+          if (!state.resolvedStore.modules[moduleId]) {
+            state.resolvedStore.modules[moduleId] = { components: {} };
           }
 
-          // Navigate/create nested arrays for all but the last index
-          // We keep track of parent references to ensure we can fix the state structure
-          let current = state.resolvedStore.modules[moduleId].components[componentId];
-          for (let i = 0; i < indices.length - 1; i++) {
-            const idx = indices[i];
-            if (!current[idx]) {
-              current[idx] = [];
-            } else if (!Array.isArray(current[idx])) {
-              // Transition from flat to nested: wrap existing resolved component in array
-              const unwrapped = unwrapToObject(current[idx]);
-              current[idx] = unwrapped ? [unwrapped] : [];
-            }
-            current = current[idx];
-          }
-
-          const lastIdx = indices[indices.length - 1];
-
-          // Get or create the component object at lastIdx
-          let componentObj = unwrapToObject(current[lastIdx]);
-          if (!componentObj) {
-            // Try to copy structure from index 0 as fallback
-            const source = unwrapToObject(current[0]);
-            componentObj = source ? { ...source } : { ...DEFAULT_COMPONENT_STRUCTURE };
-          } else {
-            // Make a shallow copy to avoid mutating the original directly
-            // This ensures Immer properly tracks the changes
-            componentObj = { ...componentObj };
-          }
-
-          // Ensure we have the type object
-          if (!componentObj[type]) {
-            componentObj[type] = {};
-          } else {
-            componentObj[type] = { ...componentObj[type] };
-          }
-
-          // Set the property
-          componentObj[type][property] = value;
-
-          // Write back to state (this replaces any stale array structure)
-          current[lastIdx] = componentObj;
-        } else {
-          // index is null — component is not inside a ListView/Kanban
-          // If the stored data is still an array (stale from a previous parent), reset it
-          if (Array.isArray(state.resolvedStore.modules[moduleId].components[componentId])) {
+          if (!state.resolvedStore.modules[moduleId].components[componentId]) {
             state.resolvedStore.modules[moduleId].components[componentId] = { ...DEFAULT_COMPONENT_STRUCTURE };
           }
-          state.resolvedStore.modules[moduleId].components[componentId][type] = {
-            ...state.resolvedStore.modules[moduleId].components[componentId][type],
-            [property]: value,
-          };
-        }
-      },
-      false,
-      {
-        type: 'setResolvedComponentByProperty',
-        payload: {
-          componentId,
-          type,
-          property,
-          value,
-          index,
-          moduleId,
-        },
-      }
-    );
-  },
-  setExposedValue: (componentId, property, value, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        const existing = state.resolvedStore.modules[moduleId].exposedValues.components[componentId];
-        // Array.isArray check handles the case where a component was previously inside a subcontainer (ListView/Kanban/Table) — exposed values stored as a per-row array
-        // Stale array must be replaced with a plain object before setting named properties, otherwise Immer throws error.
-        if (existing === undefined || Array.isArray(existing)) {
-          state.resolvedStore.modules[moduleId].exposedValues.components[componentId] = {
-            [property]: value,
-          };
-        } else {
-          existing[property] = value;
-        }
-      },
-      false,
-      {
-        type: 'setExposedValue',
-        payload: { componentId, property, value, moduleId },
-      }
-    );
-    get().updateDependencyValues(`components.${componentId}.${property}`, moduleId);
-  },
 
-  setExposedValues: (id, type, values, moduleId = 'canvas') => {
-    const skipKeys = new Set();
-    set(
-      (state) => {
-        Object.entries(values).forEach(([key, value]) => {
-          const existing = state.resolvedStore.modules[moduleId].exposedValues[type][id];
-          if (existing === undefined || Array.isArray(existing)) {
-            // Initialize as plain object. The Array.isArray check handles the case where a
-            // component was previously inside a ListView (exposed values stored as a per-row
-            // array) and is moved to the canvas — the stale array must be replaced with a
-            // plain object before setting named properties, otherwise Immer throws because
-            // arrays only support numeric indices.
-            state.resolvedStore.modules[moduleId].exposedValues[type][id] = {
-              [key]: value,
+          if (index !== null) {
+            const indices = Array.isArray(index) ? index : [index];
+
+            // Helper function to recursively unwrap nested arrays to get the component object
+            const unwrapToObject = (val) => {
+              let result = val;
+              while (result && Array.isArray(result)) {
+                result = result[0];
+              }
+              return result && typeof result === 'object' ? result : null;
             };
+
+            // Ensure root is an array (modify state directly, not a local variable)
+            if (!Array.isArray(state.resolvedStore.modules[moduleId].components[componentId])) {
+              const existing = state.resolvedStore.modules[moduleId].components[componentId];
+              const unwrapped = unwrapToObject(existing);
+              state.resolvedStore.modules[moduleId].components[componentId] = unwrapped ? [unwrapped] : [];
+            }
+
+            // Navigate/create nested arrays for all but the last index
+            // We keep track of parent references to ensure we can fix the state structure
+            let current = state.resolvedStore.modules[moduleId].components[componentId];
+            for (let i = 0; i < indices.length - 1; i++) {
+              const idx = indices[i];
+              if (!current[idx]) {
+                current[idx] = [];
+              } else if (!Array.isArray(current[idx])) {
+                // Transition from flat to nested: wrap existing resolved component in array
+                const unwrapped = unwrapToObject(current[idx]);
+                current[idx] = unwrapped ? [unwrapped] : [];
+              }
+              current = current[idx];
+            }
+
+            const lastIdx = indices[indices.length - 1];
+
+            // Get or create the component object at lastIdx
+            let componentObj = unwrapToObject(current[lastIdx]);
+            if (!componentObj) {
+              // Try to copy structure from index 0 as fallback
+              const source = unwrapToObject(current[0]);
+              componentObj = source ? { ...source } : { ...DEFAULT_COMPONENT_STRUCTURE };
+            } else {
+              // Make a shallow copy to avoid mutating the original directly
+              // This ensures Immer properly tracks the changes
+              componentObj = { ...componentObj };
+            }
+
+            // Ensure we have the type object
+            if (!componentObj[type]) {
+              componentObj[type] = {};
+            } else {
+              componentObj[type] = { ...componentObj[type] };
+            }
+
+            // Set the property
+            componentObj[type][property] = value;
+
+            // Write back to state (this replaces any stale array structure)
+            current[lastIdx] = componentObj;
           } else {
-            // If the value is equal to the existing value, add the key to the skipKeys set and do not update it
-            // using lodash's isEqual as the state is immer proxy and cannot be compared directly
-            if (_.isEqual(value, existing[key])) {
-              skipKeys.add(key);
-            } else existing[key] = value;
+            // index is null — component is not inside a ListView/Kanban
+            // If the stored data is still an array (stale from a previous parent), reset it
+            if (Array.isArray(state.resolvedStore.modules[moduleId].components[componentId])) {
+              state.resolvedStore.modules[moduleId].components[componentId] = { ...DEFAULT_COMPONENT_STRUCTURE };
+            }
+            state.resolvedStore.modules[moduleId].components[componentId][type] = {
+              ...state.resolvedStore.modules[moduleId].components[componentId][type],
+              [property]: value,
+            };
+          }
+        },
+        false,
+        {
+          type: 'setResolvedComponentByProperty',
+          payload: {
+            componentId,
+            type,
+            property,
+            value,
+            index,
+            moduleId,
+          },
+        }
+      );
+    },
+    setExposedValue: (componentId, property, value, moduleId = 'canvas') => {
+      // Skip if the value is already set to the same value
+      const existing = get().resolvedStore.modules[moduleId].exposedValues.components?.[componentId]?.[property];
+      if (existing !== undefined && _.isEqual(existing, value)) return;
+
+      if (_exposedValueBatch.isBatching()) {
+        _exposedValueBatch.bufferMutation(
+          (state) => {
+            if (state.resolvedStore.modules[moduleId].exposedValues.components[componentId] === undefined)
+              state.resolvedStore.modules[moduleId].exposedValues.components[componentId] = { [property]: value };
+            state.resolvedStore.modules[moduleId].exposedValues.components[componentId][property] = value;
+          },
+          typeof value !== 'function' ? [{ path: `components.${componentId}.${property}`, moduleId }] : []
+        );
+        return;
+      }
+
+      set(
+        (state) => {
+          if (state.resolvedStore.modules[moduleId].exposedValues.components[componentId] === undefined)
+            state.resolvedStore.modules[moduleId].exposedValues.components[componentId] = {
+              [property]: value,
+            };
+          state.resolvedStore.modules[moduleId].exposedValues.components[componentId][property] = value;
+        },
+        false,
+        {
+          type: 'setExposedValue',
+          payload: { componentId, property, value, moduleId },
+        }
+      );
+      get().updateDependencyValues(`components.${componentId}.${property}`, moduleId);
+    },
+
+    setExposedValues: (id, type, values, moduleId = 'canvas') => {
+      if (_exposedValueBatch.isBatching()) {
+        const depPaths = [];
+        Object.entries(values).forEach(([key, value]) => {
+          if (typeof value !== 'function') {
+            depPaths.push({ path: `components.${id}.${key}`, moduleId });
           }
         });
-      },
-      false,
-      {
-        type: 'setExposedValues',
-        payload: { id, type, values, moduleId },
+        _exposedValueBatch.bufferMutation((state) => {
+          Object.entries(values).forEach(([key, value]) => {
+            if (state.resolvedStore.modules[moduleId].exposedValues[type][id] === undefined)
+              state.resolvedStore.modules[moduleId].exposedValues[type][id] = { [key]: value };
+            else state.resolvedStore.modules[moduleId].exposedValues[type][id][key] = value;
+          });
+        }, depPaths);
+        return;
       }
-    );
-    Object.entries(values).forEach(([key, value]) => {
-      if (typeof value !== 'function' && !skipKeys.has(key))
-        get().updateDependencyValues(`components.${id}.${key}`, moduleId);
-    });
-  },
 
-  setDefaultExposedValues: (id, parentId, componentType, moduleId = 'canvas') => {
-    const val = get().resolvedStore.modules[moduleId].exposedValues.components[id];
-    if (val && Object.keys(val).length > 0) return;
-    const component = componentTypeDefinitionMap[componentType];
-    if (!component) return;
-    const parentComponentType = get().getComponentDefinition(parentId, moduleId)?.component?.component;
-    if (['Form', 'Listview'].includes(parentComponentType)) return;
-    const exposedVariables = component.exposedVariables || {};
-    get().setExposedValues(id, 'components', exposedVariables, moduleId);
-    get().rebuildComponentHints(moduleId);
-  },
-
-  updateCustomResolvables: (componentId, data, key, moduleId = 'canvas', parentIndices = []) => {
-    const { updateDependencyValues, updateChildComponentsLength, invalidateContextHintsCache } = get();
-    set((state) => {
-      if (parentIndices.length === 0) {
-        state.resolvedStore.modules[moduleId].customResolvables[componentId] = data;
-      } else {
-        // Store as nested structure indexed by outer indices
-        if (!state.resolvedStore.modules[moduleId].customResolvables[componentId]) {
-          state.resolvedStore.modules[moduleId].customResolvables[componentId] = {};
+      const skipKeys = new Set();
+      set(
+        (state) => {
+          Object.entries(values).forEach(([key, value]) => {
+            const existing = state.resolvedStore.modules[moduleId].exposedValues[type][id];
+            if (existing === undefined || Array.isArray(existing)) {
+              // Initialize as plain object. The Array.isArray check handles the case where a
+              // component was previously inside a ListView (exposed values stored as a per-row
+              // array) and is moved to the canvas — the stale array must be replaced with a
+              // plain object before setting named properties, otherwise Immer throws because
+              // arrays only support numeric indices.
+              state.resolvedStore.modules[moduleId].exposedValues[type][id] = {
+                [key]: value,
+              };
+            } else {
+              // If the value is equal to the existing value, add the key to the skipKeys set and do not update it
+              // using lodash's isEqual as the state is immer proxy and cannot be compared directly
+              if (_.isEqual(value, existing[key])) {
+                skipKeys.add(key);
+              } else existing[key] = value;
+            }
+          });
+        },
+        false,
+        {
+          type: 'setExposedValues',
+          payload: { id, type, values, moduleId },
         }
-        let current = state.resolvedStore.modules[moduleId].customResolvables[componentId];
-        for (let i = 0; i < parentIndices.length - 1; i++) {
-          if (!current[parentIndices[i]]) {
-            current[parentIndices[i]] = {};
-          }
-          current = current[parentIndices[i]];
-        }
-        current[parentIndices[parentIndices.length - 1]] = data;
-      }
-    });
-    updateChildComponentsLength(componentId, data.length, data, moduleId, parentIndices);
-    updateDependencyValues(`components.${componentId}.${key}`, moduleId, parentIndices);
-    invalidateContextHintsCache();
-  },
-
-  // Lazy variant of updateCustomResolvables -
-  // stores data without triggering updateChildComponentsLength or updateDependencyValues.
-  // Currently used by Table expandable rows so that resolution is deferred until a row is actually expanded.
-  updateCustomResolvablesLazy: (componentId, data, moduleId = 'canvas', parentIndices = []) => {
-    const { invalidateContextHintsCache } = get();
-    set((state) => {
-      if (parentIndices.length === 0) {
-        state.resolvedStore.modules[moduleId].customResolvables[componentId] = data;
-      } else {
-        if (!state.resolvedStore.modules[moduleId].customResolvables[componentId]) {
-          state.resolvedStore.modules[moduleId].customResolvables[componentId] = {};
-        }
-        let current = state.resolvedStore.modules[moduleId].customResolvables[componentId];
-        for (let i = 0; i < parentIndices.length - 1; i++) {
-          if (!current[parentIndices[i]]) {
-            current[parentIndices[i]] = {};
-          }
-          current = current[parentIndices[i]];
-        }
-        current[parentIndices[parentIndices.length - 1]] = data;
-      }
-      // Mark as lazy so resolution guards in componentsSlice scope to expanded rows only
-      state.resolvedStore.modules[moduleId].lazyResolvableParents[componentId] = true;
-    });
-    invalidateContextHintsCache();
-  },
-
-  updateChildComponentsLength: (parentId, length, data = [], moduleId = 'canvas', parentIndices = []) => {
-    const { getContainerChildrenMapping, copyResolvedDataFromFirstIndex } = get();
-    const childComponents = getContainerChildrenMapping(parentId, moduleId);
-    if (parentIndices.length === 0) {
-      // Flat case: set length and copy (existing behavior — kept as single set to preserve
-      // the length-check optimization inside copyResolvedDataFromFirstIndex)
-      set((state) => {
-        childComponents.forEach((componentId) => {
-          // Ensure component is an array (might be object if transitioning from non-ListView parent)
-          if (!Array.isArray(state.resolvedStore.modules[moduleId].components[componentId])) {
-            state.resolvedStore.modules[moduleId].components[componentId] = [];
-          }
-          state.resolvedStore.modules[moduleId].components[componentId].length = length;
-          copyResolvedDataFromFirstIndex(componentId, parentId, data, moduleId);
-        });
+      );
+      Object.entries(values).forEach(([key, value]) => {
+        if (typeof value !== 'function' && !skipKeys.has(key))
+          get().updateDependencyValues(`components.${id}.${key}`, moduleId);
       });
-    } else {
-      // Nested case: do everything in ONE set() to avoid nested set() overwrite issues
+    },
+
+    setDefaultExposedValues: (id, parentId, componentType, moduleId = 'canvas') => {
+      const val = get().resolvedStore.modules[moduleId].exposedValues.components[id];
+      if (val && Object.keys(val).length > 0) return;
+      const component = componentTypeDefinitionMap[componentType];
+      if (!component) return;
+      // Skip only if there is a Listview ancestor — those components use per-row array storage.
+      // Form children without a Listview ancestor are now pre-populated by batchSetDefaultExposedValues
+      // and will hit the early-return above, so this path is a safety net for non-pre-populated cases.
+      if (parentId) {
+        let cur = get().getComponentDefinition(parentId, moduleId);
+        while (cur) {
+          if (cur.component.component === 'Listview') return;
+          cur = get().getComponentDefinition(cur.component.parent, moduleId);
+        }
+      }
+      const exposedVariables = component.exposedVariables || {};
+      get().setExposedValues(id, 'components', exposedVariables, moduleId);
+      get().rebuildComponentHints(moduleId);
+    },
+
+    updateCustomResolvables: (componentId, data, key, moduleId = 'canvas', parentIndices = []) => {
+      const { updateDependencyValues, updateChildComponentsLength, invalidateContextHintsCache } = get();
       set((state) => {
-        childComponents.forEach((componentId) => {
-          if (!Array.isArray(state.resolvedStore.modules[moduleId].components[componentId])) {
-            state.resolvedStore.modules[moduleId].components[componentId] = [];
+        if (parentIndices.length === 0) {
+          state.resolvedStore.modules[moduleId].customResolvables[componentId] = data;
+        } else {
+          // Store as nested structure indexed by outer indices
+          if (!state.resolvedStore.modules[moduleId].customResolvables[componentId]) {
+            state.resolvedStore.modules[moduleId].customResolvables[componentId] = {};
           }
-          let current = state.resolvedStore.modules[moduleId].components[componentId];
+          let current = state.resolvedStore.modules[moduleId].customResolvables[componentId];
           for (let i = 0; i < parentIndices.length - 1; i++) {
             if (!current[parentIndices[i]]) {
-              current[parentIndices[i]] = [];
-            } else if (!Array.isArray(current[parentIndices[i]])) {
-              current[parentIndices[i]] = [current[parentIndices[i]]];
+              current[parentIndices[i]] = {};
             }
             current = current[parentIndices[i]];
           }
-          const lastIdx = parentIndices[parentIndices.length - 1];
-          if (!current[lastIdx]) {
-            current[lastIdx] = [];
-          } else if (!Array.isArray(current[lastIdx])) {
-            current[lastIdx] = [current[lastIdx]];
-          }
-          const nested = current[lastIdx];
-          nested.length = length;
-
-          // Populate entries: use nested[0] as template, or fall back to sibling[0]
-          let template = nested[0];
-          if (!template) {
-            // Look for a template from a sibling index that was already set up
-            const sibling = current[0];
-            template = Array.isArray(sibling) ? sibling[0] : sibling;
-          }
-          for (let i = 0; i < length; i++) {
-            if (!nested[i]) {
-              nested[i] = template ? { ...template } : { ...DEFAULT_COMPONENT_STRUCTURE };
-            }
-          }
-        });
+          current[parentIndices[parentIndices.length - 1]] = data;
+        }
       });
-    }
-  },
+      updateChildComponentsLength(componentId, data.length, data, moduleId, parentIndices);
+      updateDependencyValues(`components.${componentId}.${key}`, moduleId, parentIndices);
+      invalidateContextHintsCache();
+    },
 
-  copyResolvedDataFromFirstIndex: (componentId, parentId, data = [], moduleId = 'canvas') => {
-    const dataLength = get().getCustomResolvables(parentId, null, moduleId).length ?? data.length;
-    if (get().resolvedStore.modules[moduleId]['components'][componentId].length === dataLength) return;
-    set((state) => {
-      for (let i = 0; i < dataLength; i++) {
-        if (!state.resolvedStore.modules[moduleId]['components'][componentId][i])
-          state.resolvedStore.modules[moduleId]['components'][componentId][i] = {
-            ...state.resolvedStore.modules[moduleId]['components'][componentId][0],
-          };
-      }
-    });
-  },
-
-  getCustomResolvables: (componentId, index = null, moduleId = 'canvas', parentIndices = []) => {
-    // Strip any row suffix (e.g., 'listview-0' -> 'listview') to get the actual ListView/Kanban ID
-    const baseComponentId = get().getBaseParentId?.(componentId) || componentId;
-    let base = get().resolvedStore.modules[moduleId].customResolvables?.[baseComponentId] || {};
-    // Navigate through parentIndices to reach the correct nested level
-    for (let i = 0; i < parentIndices.length; i++) {
-      base = base?.[parentIndices[i]];
-      if (!base) return index !== null ? {} : {};
-    }
-    if (index !== null) {
-      return base?.[index] || {};
-    }
-    return base || {};
-  },
-
-  getResolvedComponent: (componentId, subContainerIndex = null, moduleId = 'canvas') => {
-    if (subContainerIndex !== null) {
-      const indices = Array.isArray(subContainerIndex) ? subContainerIndex : [subContainerIndex];
-      let current = get().resolvedStore?.modules?.[moduleId]?.components?.[componentId];
-      for (let i = 0; i < indices.length; i++) {
-        // If current is not an array, it's a resolved component leaf — stop navigating
-        if (!Array.isArray(current)) break;
-        const value = current?.[indices[i]];
-        if (value !== undefined) {
-          current = value;
+    // Lazy variant of updateCustomResolvables -
+    // stores data without triggering updateChildComponentsLength or updateDependencyValues.
+    // Currently used by Table expandable rows so that resolution is deferred until a row is actually expanded.
+    updateCustomResolvablesLazy: (componentId, data, moduleId = 'canvas', parentIndices = []) => {
+      const { invalidateContextHintsCache } = get();
+      set((state) => {
+        if (parentIndices.length === 0) {
+          state.resolvedStore.modules[moduleId].customResolvables[componentId] = data;
         } else {
-          // Fallback: use index 0 at this level and continue
-          current = current?.[0];
-          if (current === undefined) break;
+          if (!state.resolvedStore.modules[moduleId].customResolvables[componentId]) {
+            state.resolvedStore.modules[moduleId].customResolvables[componentId] = {};
+          }
+          let current = state.resolvedStore.modules[moduleId].customResolvables[componentId];
+          for (let i = 0; i < parentIndices.length - 1; i++) {
+            if (!current[parentIndices[i]]) {
+              current[parentIndices[i]] = {};
+            }
+            current = current[parentIndices[i]];
+          }
+          current[parentIndices[parentIndices.length - 1]] = data;
         }
-      }
-      return current;
-    }
-    const data = get().resolvedStore?.modules?.[moduleId]?.components?.[componentId];
-    // If index is null but data is still an array (stale from a previous ListView parent), return [0] as fallback
-    if (Array.isArray(data)) {
-      return data[0];
-    }
-    return data;
-  },
-  getExposedValueOfComponent: (componentId, moduleId = 'canvas') => {
-    try {
-      const components = get().getCurrentPageComponents(moduleId);
-      const {
-        component: { parent: parentId, name: componentName },
-      } = components[componentId];
-      if (parentId) {
-        // if parent is form get exposed values from children
-        const { component: parentComopnent } = components?.[parentId] || {};
-        if (parentComopnent?.component === 'Form') {
-          return get().resolvedStore.modules[moduleId].exposedValues.components[parentId].children[componentName] || {};
-        }
-      }
-      return get().resolvedStore.modules[moduleId].exposedValues.components[componentId] || {};
-    } catch (error) {
-      return {};
-    }
-  },
-  getExposedValueOfQuery: (queryId, moduleId = 'canvas') => {
-    return get().resolvedStore.modules[moduleId].exposedValues.queries[queryId] || {};
-  },
-  getAllExposedValues: (moduleId = 'canvas') => {
-    return get().resolvedStore.modules[moduleId].exposedValues;
-  },
-  getResolvedValue: (value, customVariables = {}, moduleId = 'canvas') => {
-    if (typeof value === 'string' && value.includes('{{') && value.includes('}}')) {
-      const re = extractAndReplaceReferencesFromString(
-        value,
-        get().modules[moduleId].componentNameIdMapping,
-        get().modules[moduleId].queryNameIdMapping
-      );
-
-      let result = resolveDynamicValues(
-        re.valueWithBrackets,
-        get().resolvedStore.modules[moduleId].exposedValues,
-        customVariables,
-        false,
-        []
-      );
-      return result;
-    } else {
-      return value;
-    }
-  },
-
-  getCanvasBackgroundColor: (moduleId = 'canvas', darkMode) => {
-    const globalSettingsBackgroundColor = get().globalSettings.canvasBackgroundColor;
-    const canvasBgColor = get().globalSettings.backgroundFxQuery
-      ? get().resolvedStore.modules[moduleId].others.canvasBackgroundColor || globalSettingsBackgroundColor
-      : globalSettingsBackgroundColor;
-    const canvasBackgroundColor = canvasBgColor ? canvasBgColor : 'var(--cc-appBackground-surface)';
-    if (['#2f3c4c', '#edeff5'].includes(canvasBackgroundColor)) {
-      return darkMode ? '#2f3c4c' : '#edeff5';
-    }
-    return canvasBackgroundColor;
-  },
-
-  getSecrets: (moduleId = 'canvas') => {
-    return get().resolvedStore.modules[moduleId].secrets;
-  },
-
-  getPagesSidebarVisibility: (moduleId = 'canvas') => {
-    // Tells whether the navigation items are visible or not (main header can still be visible due to app logo and title)
-    return get().resolvedStore.modules[moduleId].others.isPagesSidebarHidden;
-  },
-
-  getPagesVisibility: (moduleId = 'canvas', id) => {
-    return get().resolvedStore.modules[moduleId].others.pages[id]?.hidden ?? false;
-  },
-
-  setResolvedValueForOthers: (values, moduleId = 'canvas') => {
-    set((state) => {
-      state.resolvedStore.modules[moduleId].others = {
-        ...state.resolvedStore.modules[moduleId].others,
-        ...values,
-      };
-    });
-  },
-
-  resetExposedValues: (moduleId = 'canvas', { resetConstants = true, resetGlobals = true }) => {
-    set((state) => {
-      state.resolvedStore.modules[moduleId].components = {};
-      state.resolvedStore.modules[moduleId].customResolvables = {};
-      state.resolvedStore.modules[moduleId].lazyResolvableParents = {};
-      state.resolvedStore.modules[moduleId].lazyRowIndices = {};
-      state.resolvedStore.modules[moduleId].exposedValues.queries = {};
-      state.resolvedStore.modules[moduleId].exposedValues.components = {};
-      state.resolvedStore.modules[moduleId].exposedValues.variables = {};
-      state.resolvedStore.modules[moduleId].exposedValues.globals = {};
-      if (state.resolvedStore.modules[moduleId].exposedValues.input) {
-        state.resolvedStore.modules[moduleId].exposedValues.input = {};
-      }
-      if (state.resolvedStore.modules[moduleId].exposedValues.page?.variables) {
-        state.resolvedStore.modules[moduleId].exposedValues.page.variables = {};
-      }
-      if (resetConstants) {
-        state.resolvedStore.modules[moduleId].exposedValues.constants = {};
-      }
-      if (resetGlobals) {
-        state.resolvedStore.modules[moduleId].exposedValues.globals = {};
-      }
-      // state.resolvedStore.modules[moduleId] = {
-      //   components: {},
-      //   customResolvables: {},
-      //   exposedValues: {
-      //     queries: {},
-      //     components: {},
-      //     variables: {},
-      //     constants: {
-      //       ...get().resolvedStore.modules[moduleId].exposedValues.constants,
-      //     },
-      //     globals: {},
-      //     page: {
-      //       variables: {},
-      //     },
-      //   },
-      // };
-    });
-  },
-
-  // this function simply replaces the id with name for queries and components inside resolvedStore
-  getResolvedState: (moduleId = 'canvas', key) => {
-    const state = {
-      components: {},
-      queries: {},
-    };
-
-    const addToState = (source, mapping, targetKey) => {
-      const reverseMapping = Object.fromEntries(Object.entries(mapping).map(([name, id]) => [id, name]));
-      Object.entries(source).forEach(([k, v]) => {
-        state[targetKey][reverseMapping[k] || k] = v;
+        // Mark as lazy so resolution guards in componentsSlice scope to expanded rows only
+        state.resolvedStore.modules[moduleId].lazyResolvableParents[componentId] = true;
       });
-    };
+      invalidateContextHintsCache();
+    },
 
-    const exposedValues = get().resolvedStore.modules[moduleId].exposedValues;
+    updateChildComponentsLength: (parentId, length, data = [], moduleId = 'canvas', parentIndices = []) => {
+      const { getContainerChildrenMapping, copyResolvedDataFromFirstIndex } = get();
+      const childComponents = getContainerChildrenMapping(parentId, moduleId);
+      if (parentIndices.length === 0) {
+        // Flat case: set length and copy (existing behavior — kept as single set to preserve
+        // the length-check optimization inside copyResolvedDataFromFirstIndex)
+        set((state) => {
+          childComponents.forEach((componentId) => {
+            // Ensure component is an array (might be object if transitioning from non-ListView parent)
+            if (!Array.isArray(state.resolvedStore.modules[moduleId].components[componentId])) {
+              state.resolvedStore.modules[moduleId].components[componentId] = [];
+            }
+            state.resolvedStore.modules[moduleId].components[componentId].length = length;
+            copyResolvedDataFromFirstIndex(componentId, parentId, data, moduleId);
+          });
+        });
+      } else {
+        // Nested case: do everything in ONE set() to avoid nested set() overwrite issues
+        set((state) => {
+          childComponents.forEach((componentId) => {
+            if (!Array.isArray(state.resolvedStore.modules[moduleId].components[componentId])) {
+              state.resolvedStore.modules[moduleId].components[componentId] = [];
+            }
+            let current = state.resolvedStore.modules[moduleId].components[componentId];
+            for (let i = 0; i < parentIndices.length - 1; i++) {
+              if (!current[parentIndices[i]]) {
+                current[parentIndices[i]] = [];
+              } else if (!Array.isArray(current[parentIndices[i]])) {
+                current[parentIndices[i]] = [current[parentIndices[i]]];
+              }
+              current = current[parentIndices[i]];
+            }
+            const lastIdx = parentIndices[parentIndices.length - 1];
+            if (!current[lastIdx]) {
+              current[lastIdx] = [];
+            } else if (!Array.isArray(current[lastIdx])) {
+              current[lastIdx] = [current[lastIdx]];
+            }
+            const nested = current[lastIdx];
+            nested.length = length;
 
-    if (!key || ['all', 'components'].includes(key)) {
-      addToState(exposedValues.components || {}, get().modules[moduleId].componentNameIdMapping, 'components');
-    }
+            // Populate entries: use nested[0] as template, or fall back to sibling[0]
+            let template = nested[0];
+            if (!template) {
+              // Look for a template from a sibling index that was already set up
+              const sibling = current[0];
+              template = Array.isArray(sibling) ? sibling[0] : sibling;
+            }
+            for (let i = 0; i < length; i++) {
+              if (!nested[i]) {
+                nested[i] = template ? { ...template } : { ...DEFAULT_COMPONENT_STRUCTURE };
+              }
+            }
+          });
+        });
+      }
+    },
 
-    if (!key || ['all', 'queries'].includes(key)) {
-      addToState(exposedValues.queries || {}, get().modules[moduleId].queryNameIdMapping, 'queries');
-    }
+    copyResolvedDataFromFirstIndex: (componentId, parentId, data = [], moduleId = 'canvas') => {
+      const dataLength = get().getCustomResolvables(parentId, null, moduleId).length ?? data.length;
+      if (get().resolvedStore.modules[moduleId]['components'][componentId].length === dataLength) return;
+      set((state) => {
+        for (let i = 0; i < dataLength; i++) {
+          if (!state.resolvedStore.modules[moduleId]['components'][componentId][i])
+            state.resolvedStore.modules[moduleId]['components'][componentId][i] = {
+              ...state.resolvedStore.modules[moduleId]['components'][componentId][0],
+            };
+        }
+      });
+    },
 
-    if (!key || (key + '').trim() === 'all') {
-      return { ...exposedValues, ...state };
-    }
-    return state;
-  },
+    getCustomResolvables: (componentId, index = null, moduleId = 'canvas', parentIndices = []) => {
+      // Strip any row suffix (e.g., 'listview-0' -> 'listview') to get the actual ListView/Kanban ID
+      const baseComponentId = get().getBaseParentId?.(componentId) || componentId;
+      let base = get().resolvedStore.modules[moduleId].customResolvables?.[baseComponentId] || {};
+      // Navigate through parentIndices to reach the correct nested level
+      for (let i = 0; i < parentIndices.length; i++) {
+        base = base?.[parentIndices[i]];
+        if (!base) return index !== null ? {} : {};
+      }
+      if (index !== null) {
+        return base?.[index] || {};
+      }
+      return base || {};
+    },
 
-  resolveReferences: (
-    moduleId = 'canvas',
-    object,
-    _state,
-    defaultValue,
-    customObjects = {},
-    withError = false,
-    forPreviewBox = false
-  ) => {
-    if (object === '{{{}}}') return '';
+    getResolvedComponent: (componentId, subContainerIndex = null, moduleId = 'canvas') => {
+      if (subContainerIndex !== null) {
+        const indices = Array.isArray(subContainerIndex) ? subContainerIndex : [subContainerIndex];
+        let current = get().resolvedStore?.modules?.[moduleId]?.components?.[componentId];
+        for (let i = 0; i < indices.length; i++) {
+          // If current is not an array, it's a resolved component leaf — stop navigating
+          if (!Array.isArray(current)) break;
+          const value = current?.[indices[i]];
+          if (value !== undefined) {
+            current = value;
+          } else {
+            // Fallback: use index 0 at this level and continue
+            current = current?.[0];
+            if (current === undefined) break;
+          }
+        }
+        return current;
+      }
+      const data = get().resolvedStore?.modules?.[moduleId]?.components?.[componentId];
+      // If index is null but data is still an array (stale from a previous ListView parent), return [0] as fallback
+      if (Array.isArray(data)) {
+        return data[0];
+      }
+      return data;
+    },
+    getExposedValueOfComponent: (componentId, moduleId = 'canvas') => {
+      try {
+        const components = get().getCurrentPageComponents(moduleId);
+        const {
+          component: { parent: parentId, name: componentName },
+        } = components[componentId];
+        if (parentId) {
+          // if parent is form get exposed values from children
+          const { component: parentComopnent } = components?.[parentId] || {};
+          if (parentComopnent?.component === 'Form') {
+            return (
+              get().resolvedStore.modules[moduleId].exposedValues.components[parentId].children[componentName] || {}
+            );
+          }
+        }
+        return get().resolvedStore.modules[moduleId].exposedValues.components[componentId] || {};
+      } catch (error) {
+        return {};
+      }
+    },
+    getExposedValueOfQuery: (queryId, moduleId = 'canvas') => {
+      return get().resolvedStore.modules[moduleId].exposedValues.queries[queryId] || {};
+    },
+    getAllExposedValues: (moduleId = 'canvas') => {
+      return get().resolvedStore.modules[moduleId].exposedValues;
+    },
+    getResolvedValue: (value, customVariables = {}, moduleId = 'canvas') => {
+      if (typeof value === 'string' && value.includes('{{') && value.includes('}}')) {
+        const re = extractAndReplaceReferencesFromString(
+          value,
+          get().modules[moduleId].componentNameIdMapping,
+          get().modules[moduleId].queryNameIdMapping
+        );
 
-    object = _.clone(object);
-    const objectType = typeof object;
-    let error;
+        let result = resolveDynamicValues(
+          re.valueWithBrackets,
+          get().resolvedStore.modules[moduleId].exposedValues,
+          customVariables,
+          false,
+          []
+        );
+        return result;
+      } else {
+        return value;
+      }
+    },
 
-    const state = _state ?? get().getAllExposedValues(moduleId);
+    getCanvasBackgroundColor: (moduleId = 'canvas', darkMode) => {
+      const globalSettingsBackgroundColor = get().globalSettings.canvasBackgroundColor;
+      const canvasBgColor = get().globalSettings.backgroundFxQuery
+        ? get().resolvedStore.modules[moduleId].others.canvasBackgroundColor || globalSettingsBackgroundColor
+        : globalSettingsBackgroundColor;
+      const canvasBackgroundColor = canvasBgColor ? canvasBgColor : 'var(--cc-appBackground-surface)';
+      if (['#2f3c4c', '#edeff5'].includes(canvasBackgroundColor)) {
+        return darkMode ? '#2f3c4c' : '#edeff5';
+      }
+      return canvasBackgroundColor;
+    },
 
-    if (_state?.parameters) {
-      state.parameters = { ..._state.parameters };
-    }
+    getSecrets: (moduleId = 'canvas') => {
+      return get().resolvedStore.modules[moduleId].secrets;
+    },
 
-    switch (objectType) {
-      case 'string': {
-        return get().getResolvedValue(object, customObjects, moduleId);
+    getPagesSidebarVisibility: (moduleId = 'canvas') => {
+      // Tells whether the navigation items are visible or not (main header can still be visible due to app logo and title)
+      return get().resolvedStore.modules[moduleId].others.isPagesSidebarHidden;
+    },
+
+    getPagesVisibility: (moduleId = 'canvas', id) => {
+      return get().resolvedStore.modules[moduleId].others.pages[id]?.hidden ?? false;
+    },
+
+    setResolvedValueForOthers: (values, moduleId = 'canvas') => {
+      set((state) => {
+        state.resolvedStore.modules[moduleId].others = {
+          ...state.resolvedStore.modules[moduleId].others,
+          ...values,
+        };
+      });
+    },
+
+    resetExposedValues: (moduleId = 'canvas', { resetConstants = true, resetGlobals = true }) => {
+      set((state) => {
+        state.resolvedStore.modules[moduleId].components = {};
+        state.resolvedStore.modules[moduleId].customResolvables = {};
+        state.resolvedStore.modules[moduleId].exposedValues.queries = {};
+        state.resolvedStore.modules[moduleId].exposedValues.components = {};
+        state.resolvedStore.modules[moduleId].exposedValues.variables = {};
+        state.resolvedStore.modules[moduleId].exposedValues.globals = {};
+        if (state.resolvedStore.modules[moduleId].exposedValues.input) {
+          state.resolvedStore.modules[moduleId].exposedValues.input = {};
+        }
+        if (state.resolvedStore.modules[moduleId].exposedValues.page?.variables) {
+          state.resolvedStore.modules[moduleId].exposedValues.page.variables = {};
+        }
+        if (resetConstants) {
+          state.resolvedStore.modules[moduleId].exposedValues.constants = {};
+        }
+        if (resetGlobals) {
+          state.resolvedStore.modules[moduleId].exposedValues.globals = {};
+        }
+        // state.resolvedStore.modules[moduleId] = {
+        //   components: {},
+        //   customResolvables: {},
+        //   exposedValues: {
+        //     queries: {},
+        //     components: {},
+        //     variables: {},
+        //     constants: {
+        //       ...get().resolvedStore.modules[moduleId].exposedValues.constants,
+        //     },
+        //     globals: {},
+        //     page: {
+        //       variables: {},
+        //     },
+        //   },
+        // };
+      });
+    },
+
+    // this function simply replaces the id with name for queries and components inside resolvedStore
+    getResolvedState: (moduleId = 'canvas', key) => {
+      const state = {
+        components: {},
+        queries: {},
+      };
+
+      const addToState = (source, mapping, targetKey) => {
+        const reverseMapping = Object.fromEntries(Object.entries(mapping).map(([name, id]) => [id, name]));
+        Object.entries(source).forEach(([k, v]) => {
+          state[targetKey][reverseMapping[k] || k] = v;
+        });
+      };
+
+      const exposedValues = get().resolvedStore.modules[moduleId].exposedValues;
+
+      if (!key || ['all', 'components'].includes(key)) {
+        addToState(exposedValues.components || {}, get().modules[moduleId].componentNameIdMapping, 'components');
       }
 
-      case 'object': {
-        if (Array.isArray(object)) {
-          const new_array = [];
+      if (!key || ['all', 'queries'].includes(key)) {
+        addToState(exposedValues.queries || {}, get().modules[moduleId].queryNameIdMapping, 'queries');
+      }
 
-          object.forEach((element, index) => {
-            const resolved_object = get().resolveReferences(moduleId, element, state);
-            new_array[index] = resolved_object;
-          });
+      if (!key || (key + '').trim() === 'all') {
+        return { ...exposedValues, ...state };
+      }
+      return state;
+    },
 
-          if (withError) return [new_array, error];
-          return new_array;
-        } else if (!_.isEmpty(object)) {
-          Object.keys(object).forEach((key) => {
-            console.log({ key, object });
-            const resolved_object = get().resolveReferences(moduleId, object[key], state);
-            object[key] = resolved_object;
-          });
+    resolveReferences: (
+      moduleId = 'canvas',
+      object,
+      _state,
+      defaultValue,
+      customObjects = {},
+      withError = false,
+      forPreviewBox = false
+    ) => {
+      if (object === '{{{}}}') return '';
+
+      object = _.clone(object);
+      const objectType = typeof object;
+      let error;
+
+      const state = _state ?? get().getAllExposedValues(moduleId);
+
+      if (_state?.parameters) {
+        state.parameters = { ..._state.parameters };
+      }
+
+      switch (objectType) {
+        case 'string': {
+          return get().getResolvedValue(object, customObjects, moduleId);
+        }
+
+        case 'object': {
+          if (Array.isArray(object)) {
+            const new_array = [];
+
+            object.forEach((element, index) => {
+              const resolved_object = get().resolveReferences(moduleId, element, state);
+              new_array[index] = resolved_object;
+            });
+
+            if (withError) return [new_array, error];
+            return new_array;
+          } else if (!_.isEmpty(object)) {
+            Object.keys(object).forEach((key) => {
+              const resolved_object = get().resolveReferences(moduleId, object[key], state);
+              object[key] = resolved_object;
+            });
+            if (withError) return [object, error];
+            return object;
+          }
+        }
+        // eslint-disable-next-line no-fallthrough
+        default: {
           if (withError) return [object, error];
           return object;
         }
       }
-      // eslint-disable-next-line no-fallthrough
-      default: {
-        if (withError) return [object, error];
-        return object;
-      }
-    }
-  },
+    },
 
-  setModuleInputs: (key, value, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        if (!state.resolvedStore.modules[moduleId].exposedValues.input) {
-          state.resolvedStore.modules[moduleId].exposedValues.input = {};
-        }
-        state.resolvedStore.modules[moduleId].exposedValues.input[key] = value;
-      },
-      false,
-      'setModuleInputs'
-    );
-    get().updateDependencyValues(`input.${key}`, moduleId);
-  },
-  setModuleOutputs: (key, value, moduleId = 'canvas') => {
-    set(
-      (state) => {
-        if (!state.resolvedStore.modules[moduleId].exposedValues.output) {
-          state.resolvedStore.modules[moduleId].exposedValues.output = {};
-        }
-        state.resolvedStore.modules[moduleId].exposedValues.output[key] = value;
-      },
-      false,
-      'setModuleOutputs'
-    );
-    get().updateDependencyValues(`output.${key}`, moduleId);
-  },
-  clearModuleInputs: (moduleId = 'canvas') => {
-    set((state) => {
-      state.resolvedStore.modules[moduleId].exposedValues.input = {};
-    });
-  },
-  clearModuleOutputs: (moduleId = 'canvas') => {
-    set((state) => {
-      state.resolvedStore.modules[moduleId].exposedValues.output = {};
-    });
-  },
+    setModuleInputs: (key, value, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          if (!state.resolvedStore.modules[moduleId].exposedValues.input) {
+            state.resolvedStore.modules[moduleId].exposedValues.input = {};
+          }
+          state.resolvedStore.modules[moduleId].exposedValues.input[key] = value;
+        },
+        false,
+        'setModuleInputs'
+      );
+      get().updateDependencyValues(`input.${key}`, moduleId);
+    },
+    setModuleOutputs: (key, value, moduleId = 'canvas') => {
+      set(
+        (state) => {
+          if (!state.resolvedStore.modules[moduleId].exposedValues.output) {
+            state.resolvedStore.modules[moduleId].exposedValues.output = {};
+          }
+          state.resolvedStore.modules[moduleId].exposedValues.output[key] = value;
+        },
+        false,
+        'setModuleOutputs'
+      );
+      get().updateDependencyValues(`output.${key}`, moduleId);
+    },
+    clearModuleInputs: (moduleId = 'canvas') => {
+      set((state) => {
+        state.resolvedStore.modules[moduleId].exposedValues.input = {};
+      });
+    },
+    clearModuleOutputs: (moduleId = 'canvas') => {
+      set((state) => {
+        state.resolvedStore.modules[moduleId].exposedValues.output = {};
+      });
+    },
 
-  // Cleans up all lazy resolution state for a component (customResolvables, lazyResolvableParents, lazyRowIndices)
-  cleanupLazyResolvables: (componentId, moduleId = 'canvas') => {
-    set((state) => {
-      const mod = state.resolvedStore.modules[moduleId];
-      delete mod.customResolvables[componentId];
-      delete mod.lazyResolvableParents[componentId];
-      delete mod.lazyRowIndices[componentId];
-    });
-  },
+    // Cleans up all lazy resolution state for a component (customResolvables, lazyResolvableParents, lazyRowIndices)
+    cleanupLazyResolvables: (componentId, moduleId = 'canvas') => {
+      set((state) => {
+        const mod = state.resolvedStore.modules[moduleId];
+        delete mod.customResolvables[componentId];
+        delete mod.lazyResolvableParents[componentId];
+        delete mod.lazyRowIndices[componentId];
+      });
+    },
 
-  isLazyResolvableParent: (componentId, moduleId = 'canvas') =>
-    !!get().resolvedStore.modules[moduleId].lazyResolvableParents?.[componentId],
+    isLazyResolvableParent: (componentId, moduleId = 'canvas') =>
+      !!get().resolvedStore.modules[moduleId].lazyResolvableParents?.[componentId],
 
-  getLazyRowIndices: (componentId, moduleId = 'canvas', includeZero = false) => {
-    const indices = get().resolvedStore.modules[moduleId].lazyRowIndices?.[componentId] || [];
-    if (includeZero && !indices.includes(0)) return [0, ...indices];
-    return indices;
-  },
-});
+    getLazyRowIndices: (componentId, moduleId = 'canvas', includeZero = false) => {
+      const indices = get().resolvedStore.modules[moduleId].lazyRowIndices?.[componentId] || [];
+      if (includeZero && !indices.includes(0)) return [0, ...indices];
+      return indices;
+    },
+  };
+};


### PR DESCRIPTION
## 📝 What this does
Eliminates hundreds of redundant Zustand store writes that were causing 5-second freezes when a ListView added new rows at runtime. Introduces a ref-counted batch manager so all exposed-value writes during a component mount phase — and all layout mutations across a dynamic-height recursion chain — flush as a single `set()` call instead of N individual ones.

## 🔀 Changes
- Added `batchManager.ts`: ref-counted batch manager for Zustand/Immer — buffers mutations, dep paths, and deduped post-flush callbacks; one flush applies everything
- ListView and Form widgets now open the exposed-value batch in `useLayoutEffect` (before children's `useEffect`s) and flush in `useEffect`, coalescing all child `setExposedVariable` calls on mount into one store write
- `setExposedValuePerRow` / `setExposedValuesPerRow` in `listViewComponentSlice` check `isExposedValueBatching()` and buffer when a batch is active; `_deriveListviewChain` is registered as a deduped post-flush callback so it runs once per (listview, row) after all mutations are committed
- `batchSetDefaultExposedValues` and `setDefaultExposedValues` skip condition narrowed from "direct parent is Form or Listview" to "has a Listview ancestor" — standalone Form children are now pre-populated in the initial batch
- `adjustComponentPositions` accumulates all layout mutations across the full recursion chain into a single `_pendingLayouts` object and flushes once at the root call, reducing N×2 store writes to 1×2 per dynamic-height change
- Fixed `isSamePage` in `switchPage` — previous page ID is now captured before `setCurrentPageId` so same-page reloads are detected correctly
- Restored `isPageSwitchRef` guard in `useAppData` to prevent infinite query loops when `runOnPageLoad` queries trigger page navigation

## 🧪 How to test
- [ ] Open an app with a ListView containing many components (e.g. 80+ widgets across rows) and trigger a row addition — confirm no visible freeze
- [ ] Open an app with a Form containing 60+ child components — confirm initial load is fast and all field values are correct
- [ ] Navigate between pages — confirm `onPageLoad` events fire and the app does not enter an infinite query loop
- [ ] Verify same-page reload (navigate to the current page) still remounts the canvas
- [ ] Confirm dynamic-height containers (Form, Container, Accordion nested inside each other) still resize correctly