### PR TITLE
Fix/export stub access issue

### DIFF
--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -16,6 +16,7 @@ import { validateName, decodeEntities, hasBuilderRole } from '@/_helpers/utils';
 import { getEnvironmentAccessFromPermissions, getDefaultEnvironment } from '@/_helpers/environmentAccess';
 import posthogHelper from '@/modules/common/helpers/posthogHelper';
 import { authenticationService } from '@/_services';
+import { toast } from 'react-hot-toast';
 const { defaultIcon } = configs;
 
 export default function AppCard({
@@ -291,7 +292,16 @@ export default function AppCard({
                     canDeleteApp={canDeleteApp(app)}
                     canUpdateApp={canUpdateApp(app)}
                     deleteApp={() => deleteApp(app)}
-                    exportApp={() => exportApp(app)}
+                    exportApp={() => {
+                      if (isStub) {
+                        toast.error(
+                          'App contents are still syncing from Git. Open the app to finish loading, then try again.',
+                          { position: 'top-center' }
+                        );
+                        return;
+                      }
+                      exportApp(app);
+                    }}
                     isMenuOpen={setMenuOpen}
                     popoverVisible={popoverVisible}
                     setMenuOpen={setMenuOpen}

--- a/server/src/modules/apps/services/app-import-export.service.ts
+++ b/server/src/modules/apps/services/app-import-export.service.ts
@@ -2791,12 +2791,14 @@ export class AppImportExportService {
     // Applies to git-sync, clone, AND device imports on a feature branch (branchId set).
     // Skipped for workflows since they are branch-agnostic.
     let isSubBranch = false;
+    let targetBranchName: string | null = null;
     if (!isWorkflow && branchId && useBranchVersionType) {
       const targetBranch = await manager.findOne(WorkspaceBranch, {
         where: { id: branchId },
-        select: ['id', 'isDefault'],
+        select: ['id', 'isDefault', 'name'],
       });
       isSubBranch = !!targetBranch && !targetBranch.isDefault;
+      if (isSubBranch) targetBranchName = targetBranch.name;
     }
 
     // Find the latest draft version
@@ -2858,10 +2860,11 @@ export class AppImportExportService {
           versionStatus = appVersion.status || AppVersionStatus.DRAFT;
         }
 
+        const isLastVersion = appVersion === appVersions[appVersions.length - 1];
         version = await manager.create(AppVersion, {
           appId: importedApp.id,
           definition: appVersion.definition,
-          name: appVersion.name,
+          name: isSubBranch && isLastVersion && targetBranchName ? targetBranchName : appVersion.name,
           currentEnvironmentId,
           createdAt: new Date(),
           updatedAt: new Date(),

--- a/server/src/modules/versions/controller.ts
+++ b/server/src/modules/versions/controller.ts
@@ -21,8 +21,8 @@ export class VersionController implements IVersionController {
   @InitFeature(FEATURE_KEY.GET)
   @UseGuards(JwtAuthGuard, ValidAppGuard, FeatureAbilityGuard)
   @Get(':id/versions')
-  fetchVersions(@App() app: AppEntity) {
-    return this.versionService.getAllVersions(app);
+  fetchVersions(@App() app: AppEntity, @Headers('x-branch-id') branchId?: string) {
+    return this.versionService.getAllVersions(app, branchId);
   }
 
   @InitFeature(FEATURE_KEY.APP_VERSION_CREATE)

--- a/server/src/modules/versions/interfaces/IController.ts
+++ b/server/src/modules/versions/interfaces/IController.ts
@@ -2,7 +2,7 @@ import { User as UserEntity } from '@entities/user.entity';
 import { App as AppEntity } from '@entities/app.entity';
 import { VersionCreateDto } from '../dto';
 export interface IVersionController {
-  fetchVersions(app: AppEntity): Promise<any>;
+  fetchVersions(app: AppEntity, branchId?: string): Promise<any>;
   createVersion(user: UserEntity, app: AppEntity, versionCreateDto: VersionCreateDto): Promise<any>;
   deleteVersion(user: UserEntity, app: AppEntity): Promise<any>;
 }

--- a/server/src/modules/versions/interfaces/IService.ts
+++ b/server/src/modules/versions/interfaces/IService.ts
@@ -23,7 +23,7 @@ export interface VersionSettingsUpdateContext {
 }
 
 export interface IVersionService {
-  getAllVersions(app: App): Promise<{ versions: Array<AppVersion> }>;
+  getAllVersions(app: App, branchId?: string): Promise<{ versions: Array<AppVersion> }>;
 
   createVersion(app: App, user: User, versionCreateDto: VersionCreateDto): Promise<any>;
 

--- a/server/src/modules/versions/repository.ts
+++ b/server/src/modules/versions/repository.ts
@@ -1,11 +1,11 @@
 import { AppEnvironment } from '@entities/app_environments.entity';
-import { AppVersion, AppVersionStatus } from '@entities/app_version.entity';
+import { AppVersion, AppVersionStatus, AppVersionType } from '@entities/app_version.entity';
 import { DataQuery } from '@entities/data_query.entity';
 import { dbTransactionWrap } from '@helpers/database.helper';
 import { DataBaseConstraints } from '@helpers/db_constraints.constants';
 import { catchDbException } from '@helpers/utils.helper';
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { DataSource, EntityManager, Repository } from 'typeorm';
+import { DataSource, EntityManager, IsNull, Not, Repository } from 'typeorm';
 import { decode } from 'js-base64';
 import { App } from '@entities/app.entity';
 
@@ -178,13 +178,18 @@ export class VersionRepository extends Repository<AppVersion> {
     }, manager || this.manager);
   }
 
-  getVersionsInApp(appId: string, manager?: EntityManager): Promise<AppVersion[]> {
+  getVersionsInApp(appId: string, branchId?: string, manager?: EntityManager): Promise<AppVersion[]> {
     return dbTransactionWrap((manager: EntityManager) => {
+      const where = branchId
+        ? [
+            { appId, branchId, isStub: false },
+            { appId, branchId: IsNull(), versionType: Not(AppVersionType.BRANCH), isStub: false },
+          ]
+        : { appId, isStub: false };
+
       return manager.find(AppVersion, {
-        where: { appId },
-        order: {
-          createdAt: 'DESC',
-        },
+        where,
+        order: { createdAt: 'DESC' },
       });
     }, manager || this.manager);
   }

--- a/server/src/modules/versions/repository.ts
+++ b/server/src/modules/versions/repository.ts
@@ -181,10 +181,7 @@ export class VersionRepository extends Repository<AppVersion> {
   getVersionsInApp(appId: string, branchId?: string, manager?: EntityManager): Promise<AppVersion[]> {
     return dbTransactionWrap((manager: EntityManager) => {
       const where = branchId
-        ? [
-            { appId, branchId, isStub: false },
-            { appId, branchId: IsNull(), versionType: Not(AppVersionType.BRANCH), isStub: false },
-          ]
+        ? { appId, branchId, isStub: false }
         : { appId, isStub: false };
 
       return manager.find(AppVersion, {

--- a/server/src/modules/versions/service.ts
+++ b/server/src/modules/versions/service.ts
@@ -124,8 +124,8 @@ export class VersionService implements IVersionService {
   ): Promise<void> {
     // No-op in CE, EE overrides to capture history
   }
-  async getAllVersions(app: App): Promise<{ versions: Array<AppVersion> }> {
-    const result = await this.versionRepository.getVersionsInApp(app.id);
+  async getAllVersions(app: App, branchId?: string): Promise<{ versions: Array<AppVersion> }> {
+    const result = await this.versionRepository.getVersionsInApp(app.id, branchId);
 
     if (result?.length) {
       result[0].isCurrentEditingVersion = true;


### PR DESCRIPTION
## 🔗 PR
https://github.com/ToolJet/ee-server/pull/490

## 🐛 Issue Summary

Exporting an app was failing with a 403 error when platform git sync and branching were enabled. This was caused by a stub (dummy) version being incorrectly selected during export.

## 🔁 Steps to Reproduce

1. Enable platform git sync and branching
2. Switch to the default branch
3. Pull the workspace (apps get hydrated with VERSION-type versions) [ apps should not be stubed here ]
4. Create a new feature branch (e.g. feat/test)
5. Do not pull the feature branch (leave apps unhydrated) [ keep apps stubed on feature branch ]
[ on builder account ]
7. Switch back to the default branch
8. Open any app in the builder
9. Click Gear Icon → Export App

Result:
403 error and redirect to /error/no-accessible-pages

## ⚠️ What Was Happening

- Creating a feature branch creates a stub (dummy) version of the app
- Stub version:
  - has no pages
  - has the latest timestamp

- While fetching versions:
  - sorted by createdAt DESC
  - stub version comes first

- During export:
  - modal auto-selects the latest version
  - stub version gets selected

- Backend:
  - tries to export stub
  - finds no pages
  - assumes no access
  - throws 403

- UI:
  - modal closes
  - redirects to error page

## ✅ Fix Implemented

1. Filter out stub versions
   - Added isStub: false in getVersionsInApp

2. Branch-aware filtering
   - If branchId exists:
     - return versions for that branch + legacy (no branch)

3. Fix 403 logic
   - Updated condition in getVersion
   - Restrict 403 only to viewer mode

## 🎯 Result

- Stub versions are excluded
- Correct version is selected for export
- No more false 403 errors
- Export works correctly with git sync and branching
