### PR TITLE
Fix: Preserve module version pin across branches + readability refactor

### DIFF
--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -2,74 +2,214 @@ import { EntityManager } from 'typeorm';
 import { App } from '@entities/app.entity';
 import { AppVersion, AppVersionType } from '@entities/app_version.entity';
 import { WorkspaceBranch } from '@entities/workspace_branch.entity';
+import { APP_TYPES } from '@modules/apps/constants';
 
 /**
- * A module consumer stores a free-form string in `properties.moduleVersionId`.
- * The string does not declare whether it's a pin or a branch marker — the
- * meaning is inferred at read time. This module codifies that inference as a
- * three-way taxonomy so the resolver can't silently conflate the cases:
+ * Module version resolution.
  *
- *   pinned    → explicit reference to a saved version
- *   unpinned  → follow whichever module content lives on the viewer's branch
- *   stale     → neither; the producing branch/version is gone
+ * ─── Why a name, not a UUID ──────────────────────────────────────────────
+ * A parent app references an embedded module through the pair:
+ *
+ *     (moduleAppId: co_relation_id, moduleVersionId: string)
+ *
+ * `co_relation_id` identifies *which module* — it's stable across branches
+ * and across workspaces cloned via git-sync. `moduleVersionId` identifies
+ * *which version of it* — but it's a name, not a UUID. `app_versions.id`
+ * (the PK) is re-minted whenever git-sync hydrates a module into a new
+ * workspace or a new branch, so a UUID FK would snap the moment a parent
+ * app is cloned. A name-based reference survives the hop: `"v1"` means
+ * the same thing on master, on feature-1, and in a git-cloned workspace
+ * as long as there is a version called `"v1"` over there.
+ *
+ * ─── How moduleVersionId is interpreted ──────────────────────────────────
+ * The string carries no type tag. Its meaning is inferred at read time by
+ * checking it against two tables:
+ *
+ *   Lookup A: app_versions                    — saved version on default branch?
+ *   Lookup B: organization_git_sync_branches  — live branch name in this org?
+ *
+ *     A hits    → PINNED    ("v1"):        freeze to that saved version
+ *     B hits    → UNPINNED  ("feature-1"): follow that branch's latest
+ *     neither   → ORPHANED  (deleted branch / cross-org import): best-effort
+ *
+ * Lookup A runs first so a version named after a branch (e.g. a user names
+ * a version "main") still classifies as pinned — explicit user intent wins.
+ *
+ * Resolution is always scoped to the consumer's branchId (from the
+ * x-branch-id header). Fallback to the default branch happens only when
+ * the consumer has no branch context (embedded viewer / public access),
+ * never as a name-matching search across branches. That cross-branch
+ * name match was the bug fixed in d9c4ccf969.
  */
-export type ModuleRef =
-  | { kind: 'pinned'; versionName: string; canonicalVersion: AppVersion }
-  | { kind: 'unpinned'; branchName: string }
-  | { kind: 'stale'; rawValue: string };
 
-/**
- * Classify a raw `moduleVersionId` string. Checks for a pinned version first so
- * a version whose name collides with a branch name (e.g. someone named a version
- * "main") still resolves to the pin. Falls through to branch-name match, then
- * to stale.
- */
-export async function classifyModuleRef(
-  manager: EntityManager,
-  moduleApp: App,
-  rawValue: string,
-  organizationId: string
-): Promise<ModuleRef> {
-  const defaultBranch = await manager.findOne(WorkspaceBranch, {
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export type ModuleRef =
+  | { kind: 'pinned'; versionName: string }
+  | { kind: 'unpinned'; branchName: string }
+  | { kind: 'orphaned'; moduleVersionId: string };
+
+// ─── Named queries ──────────────────────────────────────────────────────
+// Each helper encapsulates one findOne with the load-bearing filters
+// documented in one place. Callers read like domain sentences.
+
+function findDefaultBranch(manager: EntityManager, organizationId: string) {
+  return manager.findOne(WorkspaceBranch, {
     where: { organizationId, isDefault: true },
   });
+}
 
-  if (defaultBranch) {
-    const canonicalVersion = await manager.findOne(AppVersion, {
-      where: {
-        appId: moduleApp.id,
-        name: rawValue,
-        branchId: defaultBranch.id,
-        versionType: AppVersionType.VERSION,
-        isStub: false,
-      },
-    });
-    if (canonicalVersion) {
-      return { kind: 'pinned', versionName: rawValue, canonicalVersion };
-    }
-  }
-
-  const branch = await manager.findOne(WorkspaceBranch, {
-    where: { organizationId, name: rawValue },
+function findBranchByName(manager: EntityManager, organizationId: string, branchName: string) {
+  return manager.findOne(WorkspaceBranch, {
+    where: { organizationId, name: branchName },
   });
-  if (branch) {
-    return { kind: 'unpinned', branchName: rawValue };
-  }
-
-  return { kind: 'stale', rawValue };
 }
 
 /**
- * Resolve a classified ref to a concrete AppVersion given the consumer's branch.
- *
- *   pinned   → prefer a pulled copy on the consumer's branch, else the canonical
- *              version on the default branch. Never drifts to "latest".
- *   unpinned → latest non-stub version for this module on the consumer's branch
- *              (falls back to the default branch when no branchId is supplied,
- *              e.g. embedded viewers / public access).
- *   stale    → latest saved version on the default branch, so orphaned refs
- *              render something reasonable instead of 404-ing.
+ * Saved version = an app_versions row with versionType='version' on the
+ * default branch. The versionType filter is load-bearing: sub-branches
+ * store an editable working copy whose `name` equals the branch name with
+ * versionType='branch' — that row must never be treated as a pin target.
  */
+function findSavedVersionOnDefaultBranch(
+  manager: EntityManager,
+  moduleAppId: string,
+  versionName: string,
+  defaultBranchId: string
+) {
+  return manager.findOne(AppVersion, {
+    where: {
+      appId: moduleAppId,
+      name: versionName,
+      branchId: defaultBranchId,
+      versionType: AppVersionType.VERSION,
+      isStub: false,
+    },
+  });
+}
+
+function findLocalCopyOnBranch(
+  manager: EntityManager,
+  moduleAppId: string,
+  versionName: string,
+  branchId: string
+) {
+  return manager.findOne(AppVersion, {
+    where: { appId: moduleAppId, name: versionName, branchId, isStub: false },
+  });
+}
+
+function findLatestSavedOnDefaultBranch(
+  manager: EntityManager,
+  moduleAppId: string,
+  defaultBranchId: string
+) {
+  return manager.findOne(AppVersion, {
+    where: {
+      appId: moduleAppId,
+      branchId: defaultBranchId,
+      versionType: AppVersionType.VERSION,
+      isStub: false,
+    },
+    order: { createdAt: 'DESC' },
+  });
+}
+
+function findLatestNonStubOnBranch(manager: EntityManager, moduleAppId: string, branchId: string) {
+  return manager.findOne(AppVersion, {
+    where: { appId: moduleAppId, branchId, isStub: false },
+    order: { createdAt: 'DESC' },
+  });
+}
+
+// ─── Classification ─────────────────────────────────────────────────────
+
+export async function classifyModuleRef(
+  manager: EntityManager,
+  moduleApp: App,
+  moduleVersionId: string,
+  organizationId: string
+): Promise<ModuleRef> {
+  // Lookup A — checked first so a version named "main" wins over a branch named "main".
+  const defaultBranch = await findDefaultBranch(manager, organizationId);
+  if (defaultBranch) {
+    const saved = await findSavedVersionOnDefaultBranch(
+      manager,
+      moduleApp.id,
+      moduleVersionId,
+      defaultBranch.id
+    );
+    if (saved) return { kind: 'pinned', versionName: moduleVersionId };
+  }
+
+  // Lookup B
+  const branch = await findBranchByName(manager, organizationId, moduleVersionId);
+  if (branch) return { kind: 'unpinned', branchName: moduleVersionId };
+
+  return { kind: 'orphaned', moduleVersionId };
+}
+
+// ─── Resolvers — one per case, each reads top-to-bottom ─────────────────
+
+async function resolvePinned(
+  manager: EntityManager,
+  moduleApp: App,
+  ref: Extract<ModuleRef, { kind: 'pinned' }>,
+  consumerBranchId: string | undefined,
+  organizationId: string
+): Promise<AppVersion | null> {
+  // Prefer a local copy on the consumer's branch (pulled via git sync);
+  // fall back to the canonical saved version on the default branch. Never
+  // drifts to "latest" — a pin must point at the named version or nothing.
+  if (consumerBranchId) {
+    const local = await findLocalCopyOnBranch(
+      manager,
+      moduleApp.id,
+      ref.versionName,
+      consumerBranchId
+    );
+    if (local) return local;
+  }
+  const defaultBranch = await findDefaultBranch(manager, organizationId);
+  if (!defaultBranch) return null;
+  return findSavedVersionOnDefaultBranch(manager, moduleApp.id, ref.versionName, defaultBranch.id);
+}
+
+async function resolveUnpinned(
+  manager: EntityManager,
+  moduleApp: App,
+  _ref: Extract<ModuleRef, { kind: 'unpinned' }>,
+  consumerBranchId: string | undefined,
+  organizationId: string
+): Promise<AppVersion | null> {
+  // "Follow my branch" — latest non-stub on the consumer's branch. No
+  // branch context (embedded viewer / public access) → follow the default.
+  const targetBranchId =
+    consumerBranchId ?? (await findDefaultBranch(manager, organizationId))?.id;
+  if (!targetBranchId) return null;
+  return findLatestNonStubOnBranch(manager, moduleApp.id, targetBranchId);
+}
+
+async function resolveOrphaned(
+  manager: EntityManager,
+  moduleApp: App,
+  _ref: Extract<ModuleRef, { kind: 'orphaned' }>,
+  _consumerBranchId: string | undefined,
+  organizationId: string
+): Promise<AppVersion | null> {
+  // Orphaned refs can come from a deleted branch, a renamed/deleted
+  // version, or a cross-org import where the name doesn't exist locally.
+  // The conservative recovery is the default branch's latest saved version
+  // — canonical, never surprises the user with merge content on a feature
+  // branch. Cross-branch name matching (the old Attempt 2) is intentionally
+  // NOT resurrected here — see d9c4ccf969 for the leak it caused.
+  const defaultBranch = await findDefaultBranch(manager, organizationId);
+  if (!defaultBranch) return null;
+  return findLatestSavedOnDefaultBranch(manager, moduleApp.id, defaultBranch.id);
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────
+
 export async function resolveModuleRef(
   manager: EntityManager,
   moduleApp: App,
@@ -78,46 +218,99 @@ export async function resolveModuleRef(
   organizationId: string
 ): Promise<AppVersion | null> {
   switch (ref.kind) {
-    case 'pinned': {
-      if (consumerBranchId) {
-        const localCopy = await manager.findOne(AppVersion, {
-          where: {
-            appId: moduleApp.id,
-            name: ref.versionName,
-            branchId: consumerBranchId,
-            isStub: false,
-          },
-        });
-        if (localCopy) return localCopy;
-      }
-      return ref.canonicalVersion;
-    }
+    case 'pinned':
+      return resolvePinned(manager, moduleApp, ref, consumerBranchId, organizationId);
+    case 'unpinned':
+      return resolveUnpinned(manager, moduleApp, ref, consumerBranchId, organizationId);
+    case 'orphaned':
+      return resolveOrphaned(manager, moduleApp, ref, consumerBranchId, organizationId);
+  }
+}
 
-    case 'unpinned': {
-      const targetBranchId =
-        consumerBranchId ??
-        (await manager.findOne(WorkspaceBranch, { where: { organizationId, isDefault: true } }))?.id;
-      if (!targetBranchId) return null;
-      return manager.findOne(AppVersion, {
-        where: { appId: moduleApp.id, branchId: targetBranchId, isStub: false },
-        order: { createdAt: 'DESC' },
-      });
-    }
+// ─── Write-side reconciliation ──────────────────────────────────────────
 
-    case 'stale': {
-      const defaultBranch = await manager.findOne(WorkspaceBranch, {
-        where: { organizationId, isDefault: true },
-      });
-      if (!defaultBranch) return null;
-      return manager.findOne(AppVersion, {
-        where: {
-          appId: moduleApp.id,
-          branchId: defaultBranch.id,
-          versionType: AppVersionType.VERSION,
-          isStub: false,
-        },
-        order: { createdAt: 'DESC' },
-      });
-    }
+/**
+ * After hydrating an app on a non-default branch, inherit pinned
+ * `moduleVersionId` values from the matching component on the default
+ * branch. Without this, branch creation silently drops the user's pin:
+ * the YAML on disk may be stale (pre-pin push) and the default-branch pin
+ * rewrite (pinUnpinnedModuleViewerRefs) never propagates to git, so the
+ * new branch lands with an unpinned ref.
+ *
+ * Matching key: `component.co_relation_id` — the stable cross-branch
+ * identity. Only `pinned` refs on the default branch are copied; unpinned
+ * and orphaned refs are left alone so they keep their branch-following
+ * semantics.
+ */
+export async function reconcileModuleViewerPinsFromDefault(
+  manager: EntityManager,
+  featureBranchVersionId: string,
+  organizationId: string
+): Promise<void> {
+  const featureVersion = await manager.findOne(AppVersion, {
+    where: { id: featureBranchVersionId },
+    select: ['id', 'appId'],
+  });
+  if (!featureVersion) return;
+
+  const defaultBranch = await findDefaultBranch(manager, organizationId);
+  if (!defaultBranch) return;
+
+  const defaultVersion = await findLatestSavedOnDefaultBranch(
+    manager,
+    featureVersion.appId,
+    defaultBranch.id
+  );
+  if (!defaultVersion) return;
+
+  type ViewerRow = {
+    id: string;
+    co_relation_id: string | null;
+    moduleAppId: string | null;
+    moduleVersionId: string | null;
+  };
+
+  const readViewers = (appVersionId: string): Promise<ViewerRow[]> =>
+    manager.query(
+      `SELECT c.id, c.co_relation_id,
+              c.properties->'moduleAppId'->>'value' AS "moduleAppId",
+              c.properties->'moduleVersionId'->>'value' AS "moduleVersionId"
+       FROM components c
+       JOIN pages p ON p.id = c.page_id
+       WHERE p.app_version_id = $1
+         AND c.type = 'ModuleViewer'
+         AND c.co_relation_id IS NOT NULL`,
+      [appVersionId]
+    );
+
+  const featureViewers = await readViewers(featureBranchVersionId);
+  if (featureViewers.length === 0) return;
+
+  const defaultViewers = await readViewers(defaultVersion.id);
+  const defaultByCoRel = new Map(
+    defaultViewers.filter((v) => v.co_relation_id).map((v) => [v.co_relation_id as string, v])
+  );
+
+  for (const feat of featureViewers) {
+    if (!feat.co_relation_id) continue;
+    const def = defaultByCoRel.get(feat.co_relation_id);
+    if (!def?.moduleAppId || !def?.moduleVersionId) continue;
+    if (feat.moduleVersionId === def.moduleVersionId) continue;
+
+    const moduleApp = await manager.findOne(App, {
+      where: { co_relation_id: def.moduleAppId, type: APP_TYPES.MODULE, organizationId },
+      order: { createdAt: 'ASC' },
+    });
+    if (!moduleApp) continue;
+
+    const ref = await classifyModuleRef(manager, moduleApp, def.moduleVersionId, organizationId);
+    if (ref.kind !== 'pinned') continue;
+
+    await manager.query(
+      `UPDATE components
+       SET properties = jsonb_set(properties::jsonb, '{moduleVersionId,value}', to_jsonb($1::text))
+       WHERE id = $2`,
+      [def.moduleVersionId, feat.id]
+    );
   }
 }

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -178,12 +178,20 @@ export async function resolveModuleRef(
 
 /**
  * After hydrating a feature-branch AppVersion, inherit pinned moduleVersionId
- * values from the matching component on the default branch. The YAML on disk
- * can be stale pre-pin (pinUnpinnedModuleViewerRefs never propagates to git),
- * so without this pass branch creation silently drops the pin.
+ * values from the matching component on the default branch. The component JSON
+ * committed to git can be stale pre-pin (pinUnpinnedModuleViewerRefs writes
+ * only to the DB; push is manual), so without this pass the feature branch
+ * lands with whatever ref was last pushed — usually an unpinned branch-name.
  *
- * Match key: component.co_relation_id. Only `pinned` default-branch refs are
- * copied; unpinned/orphaned refs keep their branch-following semantics.
+ * Match key: component.co_relation_id.
+ *
+ * Policy:
+ *   - Only `pinned` default-branch refs are eligible to copy.
+ *   - A feature-branch component that already classifies as `pinned` is left
+ *     alone — the user's explicit pin on this branch wins over main's pin,
+ *     even if they differ.
+ *   - Unpinned/orphaned feature-branch refs are overwritten with the default's
+ *     pin so branch creation doesn't silently drop the pin.
  */
 export async function reconcileModuleViewerPinsFromDefault(
   manager: EntityManager,
@@ -246,8 +254,14 @@ export async function reconcileModuleViewerPinsFromDefault(
     });
     if (!moduleApp) continue;
 
-    const ref = await classifyModuleRef(manager, moduleApp, def.moduleVersionId, organizationId);
-    if (ref.kind !== 'pinned') continue;
+    // Don't overwrite a manual pin already set on the feature branch.
+    if (feat.moduleVersionId) {
+      const featRef = await classifyModuleRef(manager, moduleApp, feat.moduleVersionId, organizationId);
+      if (featRef.kind === 'pinned') continue;
+    }
+
+    const defRef = await classifyModuleRef(manager, moduleApp, def.moduleVersionId, organizationId);
+    if (defRef.kind !== 'pinned') continue;
 
     await manager.query(
       `UPDATE components

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -37,8 +37,10 @@ import { APP_TYPES } from '@modules/apps/constants';
  * UI mapping (ModuleViewerInspector dropdown):
  *   pinned   → "Pinned to <versionName>"
  *   unpinned → "Active draft" on the default branch,
- *              "Current branch" on a sub-branch
- *   orphaned → no dedicated label; shares the unpinned ⚠ banner
+ *              "Current branch" on a sub-branch (⚠ warning icon)
+ *   orphaned → renders as the unpinned option; the inspector treats any
+ *              non-pinned-name ref the same, so orphaned refs share the
+ *              "Current branch"/"Active draft" display and its ⚠ icon.
  */
 export type ModuleRef =
   | { kind: 'pinned'; versionName: string }

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -1,0 +1,123 @@
+import { EntityManager } from 'typeorm';
+import { App } from '@entities/app.entity';
+import { AppVersion, AppVersionType } from '@entities/app_version.entity';
+import { WorkspaceBranch } from '@entities/workspace_branch.entity';
+
+/**
+ * A module consumer stores a free-form string in `properties.moduleVersionId`.
+ * The string does not declare whether it's a pin or a branch marker — the
+ * meaning is inferred at read time. This module codifies that inference as a
+ * three-way taxonomy so the resolver can't silently conflate the cases:
+ *
+ *   pinned    → explicit reference to a saved version
+ *   unpinned  → follow whichever module content lives on the viewer's branch
+ *   stale     → neither; the producing branch/version is gone
+ */
+export type ModuleRef =
+  | { kind: 'pinned'; versionName: string; canonicalVersion: AppVersion }
+  | { kind: 'unpinned'; branchName: string }
+  | { kind: 'stale'; rawValue: string };
+
+/**
+ * Classify a raw `moduleVersionId` string. Checks for a pinned version first so
+ * a version whose name collides with a branch name (e.g. someone named a version
+ * "main") still resolves to the pin. Falls through to branch-name match, then
+ * to stale.
+ */
+export async function classifyModuleRef(
+  manager: EntityManager,
+  moduleApp: App,
+  rawValue: string,
+  organizationId: string
+): Promise<ModuleRef> {
+  const defaultBranch = await manager.findOne(WorkspaceBranch, {
+    where: { organizationId, isDefault: true },
+  });
+
+  if (defaultBranch) {
+    const canonicalVersion = await manager.findOne(AppVersion, {
+      where: {
+        appId: moduleApp.id,
+        name: rawValue,
+        branchId: defaultBranch.id,
+        versionType: AppVersionType.VERSION,
+        isStub: false,
+      },
+    });
+    if (canonicalVersion) {
+      return { kind: 'pinned', versionName: rawValue, canonicalVersion };
+    }
+  }
+
+  const branch = await manager.findOne(WorkspaceBranch, {
+    where: { organizationId, name: rawValue },
+  });
+  if (branch) {
+    return { kind: 'unpinned', branchName: rawValue };
+  }
+
+  return { kind: 'stale', rawValue };
+}
+
+/**
+ * Resolve a classified ref to a concrete AppVersion given the consumer's branch.
+ *
+ *   pinned   → prefer a pulled copy on the consumer's branch, else the canonical
+ *              version on the default branch. Never drifts to "latest".
+ *   unpinned → latest non-stub version for this module on the consumer's branch
+ *              (falls back to the default branch when no branchId is supplied,
+ *              e.g. embedded viewers / public access).
+ *   stale    → latest saved version on the default branch, so orphaned refs
+ *              render something reasonable instead of 404-ing.
+ */
+export async function resolveModuleRef(
+  manager: EntityManager,
+  moduleApp: App,
+  ref: ModuleRef,
+  consumerBranchId: string | undefined,
+  organizationId: string
+): Promise<AppVersion | null> {
+  switch (ref.kind) {
+    case 'pinned': {
+      if (consumerBranchId) {
+        const localCopy = await manager.findOne(AppVersion, {
+          where: {
+            appId: moduleApp.id,
+            name: ref.versionName,
+            branchId: consumerBranchId,
+            isStub: false,
+          },
+        });
+        if (localCopy) return localCopy;
+      }
+      return ref.canonicalVersion;
+    }
+
+    case 'unpinned': {
+      const targetBranchId =
+        consumerBranchId ??
+        (await manager.findOne(WorkspaceBranch, { where: { organizationId, isDefault: true } }))?.id;
+      if (!targetBranchId) return null;
+      return manager.findOne(AppVersion, {
+        where: { appId: moduleApp.id, branchId: targetBranchId, isStub: false },
+        order: { createdAt: 'DESC' },
+      });
+    }
+
+    case 'stale': {
+      const defaultBranch = await manager.findOne(WorkspaceBranch, {
+        where: { organizationId, isDefault: true },
+      });
+      if (!defaultBranch) return null;
+      return manager.findOne(AppVersion, {
+        where: {
+          appId: moduleApp.id,
+          branchId: defaultBranch.id,
+          versionType: AppVersionType.VERSION,
+          isStub: false,
+        },
+        order: { createdAt: 'DESC' },
+      });
+    }
+  }
+}

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -7,10 +7,13 @@ import { APP_TYPES } from '@modules/apps/constants';
 /**
  * Module version resolution.
  *
- * A parent app references an embedded module by (moduleAppId, moduleVersionId).
- * moduleAppId is a co_relation_id (stable across branches and git-cloned
- * workspaces). moduleVersionId is a name, not a UUID: `app_versions.id` is
- * re-minted per workspace/branch, so a UUID FK would snap on clone.
+ * A ModuleViewer stores two strings in its component properties:
+ *   moduleAppId     — the module's co_relation_id; stable across branches
+ *                     and git-cloned workspaces.
+ *   moduleVersionId — the version's *name* (e.g. "v1"), not its DB id.
+ *                     `app_versions.id` is regenerated on each hydrate, so
+ *                     a UUID foreign key would break after a clone; a name
+ *                     survives the hop.
  *
  * The name has no type tag; meaning is inferred at read time:
  *

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -24,10 +24,10 @@ import { APP_TYPES } from '@modules/apps/constants';
  * Lookup A runs first so a version named after a branch (e.g. "main")
  * classifies as pinned — explicit user intent wins.
  *
- * Resolution scopes to the consumer's branchId (from x-branch-id). Default-
- * branch fallback fires only when the consumer has no branch context
- * (embedded viewer / public access) — never as a name-matching search across
- * branches (cross-branch match was the bug fixed in d9c4ccf969).
+ * Resolution is always scoped to the consumer's branchId (from the
+ * x-branch-id header). When the request has no branchId — a public-share
+ * URL or an embedded viewer without an auth session — the resolver falls
+ * back to the default branch.
  */
 
 export type ModuleRef =

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -54,9 +54,10 @@ function findDefaultBranch(manager: EntityManager, organizationId: string) {
 }
 
 /**
- * versionType='version' is load-bearing: sub-branches store an editable copy
- * whose `name` equals the branch name with versionType='branch'. That row
- * must never be treated as a pin target.
+ * Only versionType='version' rows count as pin targets. Sub-branches also
+ * store a row with versionType='branch' whose `name` equals the branch
+ * name (the editable working copy) — without this filter, a ref like
+ * "feature-1" would match that row and be misclassified as pinned.
  */
 function findSavedVersionOnDefaultBranch(
   manager: EntityManager,

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -37,10 +37,10 @@ import { APP_TYPES } from '@modules/apps/constants';
  * UI mapping (ModuleViewerInspector dropdown):
  *   pinned   → "Pinned to <versionName>"
  *   unpinned → "Active draft" on the default branch,
- *              "Current branch" on a sub-branch (⚠ warning icon)
+ *              "Current branch" on a sub-branch
  *   orphaned → renders as the unpinned option; the inspector treats any
  *              non-pinned-name ref the same, so orphaned refs share the
- *              "Current branch"/"Active draft" display and its ⚠ icon.
+ *              "Current branch"/"Active draft" display.
  */
 export type ModuleRef =
   | { kind: 'pinned'; versionName: string }

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -7,23 +7,12 @@ import { APP_TYPES } from '@modules/apps/constants';
 /**
  * Module version resolution.
  *
- * ─── Why a name, not a UUID ──────────────────────────────────────────────
- * A parent app references an embedded module through the pair:
+ * A parent app references an embedded module by (moduleAppId, moduleVersionId).
+ * moduleAppId is a co_relation_id (stable across branches and git-cloned
+ * workspaces). moduleVersionId is a name, not a UUID: `app_versions.id` is
+ * re-minted per workspace/branch, so a UUID FK would snap on clone.
  *
- *     (moduleAppId: co_relation_id, moduleVersionId: string)
- *
- * `co_relation_id` identifies *which module* — it's stable across branches
- * and across workspaces cloned via git-sync. `moduleVersionId` identifies
- * *which version of it* — but it's a name, not a UUID. `app_versions.id`
- * (the PK) is re-minted whenever git-sync hydrates a module into a new
- * workspace or a new branch, so a UUID FK would snap the moment a parent
- * app is cloned. A name-based reference survives the hop: `"v1"` means
- * the same thing on master, on feature-1, and in a git-cloned workspace
- * as long as there is a version called `"v1"` over there.
- *
- * ─── How moduleVersionId is interpreted ──────────────────────────────────
- * The string carries no type tag. Its meaning is inferred at read time by
- * checking it against two tables:
+ * The name has no type tag; meaning is inferred at read time:
  *
  *   Lookup A: app_versions                    — saved version on default branch?
  *   Lookup B: organization_git_sync_branches  — live branch name in this org?
@@ -32,26 +21,19 @@ import { APP_TYPES } from '@modules/apps/constants';
  *     B hits    → UNPINNED  ("feature-1"): follow that branch's latest
  *     neither   → ORPHANED  (deleted branch / cross-org import): best-effort
  *
- * Lookup A runs first so a version named after a branch (e.g. a user names
- * a version "main") still classifies as pinned — explicit user intent wins.
+ * Lookup A runs first so a version named after a branch (e.g. "main")
+ * classifies as pinned — explicit user intent wins.
  *
- * Resolution is always scoped to the consumer's branchId (from the
- * x-branch-id header). Fallback to the default branch happens only when
- * the consumer has no branch context (embedded viewer / public access),
- * never as a name-matching search across branches. That cross-branch
- * name match was the bug fixed in d9c4ccf969.
+ * Resolution scopes to the consumer's branchId (from x-branch-id). Default-
+ * branch fallback fires only when the consumer has no branch context
+ * (embedded viewer / public access) — never as a name-matching search across
+ * branches (cross-branch match was the bug fixed in d9c4ccf969).
  */
-
-// ─── Types ──────────────────────────────────────────────────────────────
 
 export type ModuleRef =
   | { kind: 'pinned'; versionName: string }
   | { kind: 'unpinned'; branchName: string }
   | { kind: 'orphaned'; moduleVersionId: string };
-
-// ─── Named queries ──────────────────────────────────────────────────────
-// Each helper encapsulates one findOne with the load-bearing filters
-// documented in one place. Callers read like domain sentences.
 
 function findDefaultBranch(manager: EntityManager, organizationId: string) {
   return manager.findOne(WorkspaceBranch, {
@@ -59,17 +41,10 @@ function findDefaultBranch(manager: EntityManager, organizationId: string) {
   });
 }
 
-function findBranchByName(manager: EntityManager, organizationId: string, branchName: string) {
-  return manager.findOne(WorkspaceBranch, {
-    where: { organizationId, name: branchName },
-  });
-}
-
 /**
- * Saved version = an app_versions row with versionType='version' on the
- * default branch. The versionType filter is load-bearing: sub-branches
- * store an editable working copy whose `name` equals the branch name with
- * versionType='branch' — that row must never be treated as a pin target.
+ * versionType='version' is load-bearing: sub-branches store an editable copy
+ * whose `name` equals the branch name with versionType='branch'. That row
+ * must never be treated as a pin target.
  */
 function findSavedVersionOnDefaultBranch(
   manager: EntityManager,
@@ -85,17 +60,6 @@ function findSavedVersionOnDefaultBranch(
       versionType: AppVersionType.VERSION,
       isStub: false,
     },
-  });
-}
-
-function findLocalCopyOnBranch(
-  manager: EntityManager,
-  moduleAppId: string,
-  versionName: string,
-  branchId: string
-) {
-  return manager.findOne(AppVersion, {
-    where: { appId: moduleAppId, name: versionName, branchId, isStub: false },
   });
 }
 
@@ -115,22 +79,12 @@ function findLatestSavedOnDefaultBranch(
   });
 }
 
-function findLatestNonStubOnBranch(manager: EntityManager, moduleAppId: string, branchId: string) {
-  return manager.findOne(AppVersion, {
-    where: { appId: moduleAppId, branchId, isStub: false },
-    order: { createdAt: 'DESC' },
-  });
-}
-
-// ─── Classification ─────────────────────────────────────────────────────
-
 export async function classifyModuleRef(
   manager: EntityManager,
   moduleApp: App,
   moduleVersionId: string,
   organizationId: string
 ): Promise<ModuleRef> {
-  // Lookup A — checked first so a version named "main" wins over a branch named "main".
   const defaultBranch = await findDefaultBranch(manager, organizationId);
   if (defaultBranch) {
     const saved = await findSavedVersionOnDefaultBranch(
@@ -142,14 +96,14 @@ export async function classifyModuleRef(
     if (saved) return { kind: 'pinned', versionName: moduleVersionId };
   }
 
-  // Lookup B
-  const branch = await findBranchByName(manager, organizationId, moduleVersionId);
+  // Lookup B — is this string the name of a live branch in this org?
+  const branch = await manager.findOne(WorkspaceBranch, {
+    where: { organizationId, name: moduleVersionId },
+  });
   if (branch) return { kind: 'unpinned', branchName: moduleVersionId };
 
   return { kind: 'orphaned', moduleVersionId };
 }
-
-// ─── Resolvers — one per case, each reads top-to-bottom ─────────────────
 
 async function resolvePinned(
   manager: EntityManager,
@@ -158,16 +112,16 @@ async function resolvePinned(
   consumerBranchId: string | undefined,
   organizationId: string
 ): Promise<AppVersion | null> {
-  // Prefer a local copy on the consumer's branch (pulled via git sync);
-  // fall back to the canonical saved version on the default branch. Never
-  // drifts to "latest" — a pin must point at the named version or nothing.
   if (consumerBranchId) {
-    const local = await findLocalCopyOnBranch(
-      manager,
-      moduleApp.id,
-      ref.versionName,
-      consumerBranchId
-    );
+    // Prefer a local copy on the consumer's branch (pulled via git sync).
+    const local = await manager.findOne(AppVersion, {
+      where: {
+        appId: moduleApp.id,
+        name: ref.versionName,
+        branchId: consumerBranchId,
+        isStub: false,
+      },
+    });
     if (local) return local;
   }
   const defaultBranch = await findDefaultBranch(manager, organizationId);
@@ -182,12 +136,15 @@ async function resolveUnpinned(
   consumerBranchId: string | undefined,
   organizationId: string
 ): Promise<AppVersion | null> {
-  // "Follow my branch" — latest non-stub on the consumer's branch. No
-  // branch context (embedded viewer / public access) → follow the default.
+  // "Follow my branch" — latest non-stub for this module on the consumer's
+  // branch. No branch context (embedded viewer / public access) → default.
   const targetBranchId =
     consumerBranchId ?? (await findDefaultBranch(manager, organizationId))?.id;
   if (!targetBranchId) return null;
-  return findLatestNonStubOnBranch(manager, moduleApp.id, targetBranchId);
+  return manager.findOne(AppVersion, {
+    where: { appId: moduleApp.id, branchId: targetBranchId, isStub: false },
+    order: { createdAt: 'DESC' },
+  });
 }
 
 async function resolveOrphaned(
@@ -197,18 +154,10 @@ async function resolveOrphaned(
   _consumerBranchId: string | undefined,
   organizationId: string
 ): Promise<AppVersion | null> {
-  // Orphaned refs can come from a deleted branch, a renamed/deleted
-  // version, or a cross-org import where the name doesn't exist locally.
-  // The conservative recovery is the default branch's latest saved version
-  // — canonical, never surprises the user with merge content on a feature
-  // branch. Cross-branch name matching (the old Attempt 2) is intentionally
-  // NOT resurrected here — see d9c4ccf969 for the leak it caused.
   const defaultBranch = await findDefaultBranch(manager, organizationId);
   if (!defaultBranch) return null;
   return findLatestSavedOnDefaultBranch(manager, moduleApp.id, defaultBranch.id);
 }
-
-// ─── Entry point ────────────────────────────────────────────────────────
 
 export async function resolveModuleRef(
   manager: EntityManager,
@@ -227,20 +176,14 @@ export async function resolveModuleRef(
   }
 }
 
-// ─── Write-side reconciliation ──────────────────────────────────────────
-
 /**
- * After hydrating an app on a non-default branch, inherit pinned
- * `moduleVersionId` values from the matching component on the default
- * branch. Without this, branch creation silently drops the user's pin:
- * the YAML on disk may be stale (pre-pin push) and the default-branch pin
- * rewrite (pinUnpinnedModuleViewerRefs) never propagates to git, so the
- * new branch lands with an unpinned ref.
+ * After hydrating a feature-branch AppVersion, inherit pinned moduleVersionId
+ * values from the matching component on the default branch. The YAML on disk
+ * can be stale pre-pin (pinUnpinnedModuleViewerRefs never propagates to git),
+ * so without this pass branch creation silently drops the pin.
  *
- * Matching key: `component.co_relation_id` — the stable cross-branch
- * identity. Only `pinned` refs on the default branch are copied; unpinned
- * and orphaned refs are left alone so they keep their branch-following
- * semantics.
+ * Match key: component.co_relation_id. Only `pinned` default-branch refs are
+ * copied; unpinned/orphaned refs keep their branch-following semantics.
  */
 export async function reconcileModuleViewerPinsFromDefault(
   manager: EntityManager,

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -30,6 +30,13 @@ import { APP_TYPES } from '@modules/apps/constants';
  * back to the default branch.
  */
 
+/**
+ * UI mapping (ModuleViewerInspector dropdown):
+ *   pinned   → "Pinned to <versionName>"
+ *   unpinned → "Active draft" on the default branch,
+ *              "Current branch" on a sub-branch
+ *   orphaned → no dedicated label; shares the unpinned ⚠ banner
+ */
 export type ModuleRef =
   | { kind: 'pinned'; versionName: string }
   | { kind: 'unpinned'; branchName: string }

--- a/server/src/modules/versions/service.ts
+++ b/server/src/modules/versions/service.ts
@@ -19,6 +19,7 @@ import { LICENSE_FIELD } from '@modules/licensing/constants';
 import { OrganizationThemesUtilService } from '@modules/organization-themes/util.service';
 import { AppVersionUpdateDto } from '@dto/app-version-update.dto';
 import { VersionUtilService } from './util.service';
+import { classifyModuleRef, resolveModuleRef } from './module-ref.util';
 import { AppEnvironment } from '@entities/app_environments.entity';
 import {
   IVersionService,
@@ -254,68 +255,33 @@ export class VersionService implements IVersionService {
     branchId?: string
   ): Promise<any> {
     // co_relation_id is only unique per-org — multiple orgs can share one after a git-origin clone.
-    const app = await this.versionRepository.manager.findOne(App, {
+    const moduleApp = await this.versionRepository.manager.findOne(App, {
       where: { co_relation_id: coRelationId, type: APP_TYPES.MODULE, organizationId: user.organizationId },
       order: { createdAt: 'ASC' },
     });
-    if (!app) {
+    if (!moduleApp) {
       throw new NotFoundException('Module not found');
     }
-    // Resolution is strictly scoped to the consumer's current branchId. A previous
-    // implementation had a cross-branch name-only fallback that leaked other branches'
-    // module content into the current branch — e.g. an app authored on a feature
-    // branch stores moduleVersionId="feature-1"; after merging to master, the same
-    // stored ref on master would match the feature branch's AppVersion row (which
-    // still exists under its original name until that branch is deleted) and return
-    // feature-branch content while the user is viewing master.
-    let version: AppVersion | null = null;
-    if (branchId) {
-      // Attempt 1: exact name match on the consumer's branch. Covers pinned refs
-      // (versionName is a real version name like "v1") and sub-branch unpinned refs
-      // (versionName equals the branch name, which hydrateStubApp also uses as the
-      // version name on non-default branches).
-      version = await this.versionRepository.manager.findOne(AppVersion, {
-        where: { name: versionName, appId: app.id, branchId, isStub: false },
-      });
-      // Attempt 2: unpinned ref on the consumer's branch — latest non-stub version
-      // for this module on this branch, regardless of name. Handles the case where
-      // the stored moduleVersionId is a foreign branch name (e.g. a merge from a
-      // feature branch into master brought "feature-1" along) and we just want the
-      // module content that belongs to this branch.
-      if (!version) {
-        version = await this.versionRepository.manager.findOne(AppVersion, {
-          where: { appId: app.id, branchId, isStub: false },
-          order: { createdAt: 'DESC' },
-        });
-      }
-    }
+
+    const ref = await classifyModuleRef(
+      this.versionRepository.manager,
+      moduleApp,
+      versionName,
+      user.organizationId
+    );
+    const version = await resolveModuleRef(
+      this.versionRepository.manager,
+      moduleApp,
+      ref,
+      branchId,
+      user.organizationId
+    );
     if (!version) {
-      // Fallback: consumer has no branchId header (embedded viewer, public access,
-      // etc.) or the module has never been pulled to the consumer's branch. Resolve
-      // to the org's default branch so the viewer isn't blank — but never match
-      // across arbitrary branches by name.
-      const defaultBranch = await this.versionRepository.manager.findOne(WorkspaceBranch, {
-        where: { organizationId: user.organizationId, isDefault: true },
-      });
-      if (defaultBranch) {
-        version = await this.versionRepository.manager.findOne(AppVersion, {
-          where: {
-            appId: app.id,
-            branchId: defaultBranch.id,
-            versionType: AppVersionType.VERSION,
-            isStub: false,
-          },
-          order: { createdAt: 'DESC' },
-        });
-      }
-    }
-    if (!version) {
-      // Use NotFoundException (not findOneOrFail) so drift between parent
-      // reference and module state surfaces as 404 instead of 500.
+      // NotFoundException (not findOneOrFail) so drift surfaces as 404, not 500.
       throw new NotFoundException('Module version not found');
     }
-    app.appVersions = [version];
-    return this.getVersion(app, user, mode);
+    moduleApp.appVersions = [version];
+    return this.getVersion(moduleApp, user, mode);
   }
 
   async update(app: App, user: User, appVersionUpdateDto: AppVersionUpdateDto) {


### PR DESCRIPTION
## 📝 What this does
Fixes two related bugs in how ModuleViewer consumers track a module's pinned version across branches, and tightens the shared resolver for readability.

**Issue 2 (resolver)** — pinning a ModuleViewer to a saved version (e.g. `v1`) silently returned the consumer branch's latest module content when that branch hadn't pulled the pinned version. The new classify/resolve split honours pins across branches by falling through to the default-branch canonical version.

**Issue 1 (hydrate)** — creating a new branch from main dropped the pin because the committed JSON on git can be stale pre-pin (`pinUnpinnedModuleViewerRefs` writes DB only, push is manual). `reconcileModuleViewerPinsFromDefault` now runs after feature-branch hydrate and inherits the pin from the default branch's live DB when the default-branch classification is `pinned`. Respects manual pins on the feature branch (re-hydrates won't clobber a user-set pin).

- [ee-server](https://github.com/ToolJet/ee-server/pull/494)
- frontend/ee: no changes

## 🔀 Changes
- Introduced `ModuleRef` tagged union (`pinned` / `unpinned` / `orphaned`) that classifies the stored `moduleVersionId` string before resolution
- Split `getVersionByStableIds` into `classifyModuleRef` + per-case resolvers (`resolvePinned` / `resolveUnpinned` / `resolveOrphaned`), each with its own fallback policy
- Added `reconcileModuleViewerPinsFromDefault` — called from `hydrateStubApp` on non-default branches to inherit pinned refs from main's live DB
- Header doc comment teaches the mental model (Lookup A / Lookup B, pinned/unpinned/orphaned) so future readers don't need to grep

## 🧪 How to test
- [ ] On main: create app1 pinned to module1 v1, branch off to branch1, edit module, merge to main, pull into TJ
- [ ] Create branch2, open app1 — inspector should show "Pinned to v1" (not "Current branch"), v1's content renders
- [ ] Manually switch the dropdown v1 ↔ Current branch — content flips correctly
- [ ] On a feature branch, explicitly pin the dropdown to a different version, force a re-hydrate — the manual pin should survive
- [ ] Regression: drop a brand-new ModuleViewer on a feature branch → `moduleVersionId` stays as the branch name (unpinned by design)