### PR TITLE
Fix: Set default 'disabled' and 'hidden' properties for new app pages

### DIFF
--- a/server/src/modules/apps/util.service.ts
+++ b/server/src/modules/apps/util.service.ts
@@ -130,6 +130,8 @@ export class AppsUtilService implements IAppsUtilService {
             handle: 'home',
             appVersionId: branchVersion.id,
             index: 1,
+            disabled: false,
+            hidden: false,
             autoComputeLayout: true,
             appId: app.id,
           })
@@ -191,6 +193,8 @@ export class AppsUtilService implements IAppsUtilService {
             handle: 'home',
             appVersionId: appVersion.id,
             index: 1,
+            disabled: false,
+            hidden: false,
             autoComputeLayout: true,
             appId: app.id,
           })


### PR DESCRIPTION
This pull request makes a small update to the `AppsUtilService` by ensuring that newly created home pages are explicitly set as enabled and visible by default. This is done by setting the `disabled` and `hidden` properties to `false` when creating a home page.

- Default home page properties:
  * Set `disabled: false` and `hidden: false` when creating a home page, ensuring the page is enabled and visible by default. (`server/src/modules/apps/util.service.ts`) [[1]](diffhunk://#diff-ad02584b57469edbe34ea69cae91f2301b0624a996d9ff6f8551aad6e33ecedcR133-R134) [[2]](diffhunk://#diff-ad02584b57469edbe34ea69cae91f2301b0624a996d9ff6f8551aad6e33ecedcR196-R197)