### PR TITLE
Fix: module version dropdown + gate org-scoping

### DIFF
--- a/server/src/modules/apps/util.service.ts
+++ b/server/src/modules/apps/util.service.ts
@@ -985,6 +985,7 @@ export class AppsUtilService implements IAppsUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )
            OR (
@@ -1000,6 +1001,7 @@ export class AppsUtilService implements IAppsUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )`,
           { orgId: organizationId }

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -92,7 +92,6 @@ function findLatestSavedOnDefaultBranch(
   });
 }
 
-/** Plural of findSavedVersionOnDefaultBranch — all pin-target rows. */
 async function listSavedVersionsOnDefaultBranch(
   manager: EntityManager,
   moduleApp: App,

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -92,6 +92,49 @@ function findLatestSavedOnDefaultBranch(
   });
 }
 
+/** Plural of findSavedVersionOnDefaultBranch — all pin-target rows. */
+async function listSavedVersionsOnDefaultBranch(
+  manager: EntityManager,
+  moduleApp: App,
+  organizationId: string
+): Promise<AppVersion[]> {
+  const defaultBranch = await findDefaultBranch(manager, organizationId);
+  if (!defaultBranch) return [];
+  return manager.find(AppVersion, {
+    where: {
+      appId: moduleApp.id,
+      branchId: defaultBranch.id,
+      versionType: AppVersionType.VERSION,
+      isStub: false,
+    },
+    order: { createdAt: 'DESC' },
+  });
+}
+
+/**
+ * Consumer-branch draft (if any) plus saved versions on the default branch.
+ * A pure branchId filter would drop saved versions on feature branches.
+ */
+export async function listModuleVersions(
+  manager: EntityManager,
+  moduleApp: App,
+  branchId: string | undefined,
+  organizationId: string
+): Promise<AppVersion[]> {
+  const savedVersions = await listSavedVersionsOnDefaultBranch(manager, moduleApp, organizationId);
+  const branchDraft = branchId
+    ? await manager.findOne(AppVersion, {
+        where: {
+          appId: moduleApp.id,
+          branchId,
+          versionType: AppVersionType.BRANCH,
+          isStub: false,
+        },
+      })
+    : null;
+  return [branchDraft, ...savedVersions].filter((v): v is AppVersion => !!v);
+}
+
 export async function classifyModuleRef(
   manager: EntityManager,
   moduleApp: App,

--- a/server/src/modules/versions/service.ts
+++ b/server/src/modules/versions/service.ts
@@ -19,7 +19,7 @@ import { LICENSE_FIELD } from '@modules/licensing/constants';
 import { OrganizationThemesUtilService } from '@modules/organization-themes/util.service';
 import { AppVersionUpdateDto } from '@dto/app-version-update.dto';
 import { VersionUtilService } from './util.service';
-import { classifyModuleRef, resolveModuleRef } from './module-ref.util';
+import { classifyModuleRef, listModuleVersions, resolveModuleRef } from './module-ref.util';
 import { AppEnvironment } from '@entities/app_environments.entity';
 import {
   IVersionService,
@@ -126,7 +126,15 @@ export class VersionService implements IVersionService {
     // No-op in CE, EE overrides to capture history
   }
   async getAllVersions(app: App, branchId?: string): Promise<{ versions: Array<AppVersion> }> {
-    const result = await this.versionRepository.getVersionsInApp(app.id, branchId);
+    const result =
+      app.type === APP_TYPES.MODULE
+        ? await listModuleVersions(
+            this.versionRepository.manager,
+            app,
+            branchId,
+            app.organizationId
+          )
+        : await this.versionRepository.getVersionsInApp(app.id, branchId);
 
     if (result?.length) {
       result[0].isCurrentEditingVersion = true;

--- a/server/src/modules/versions/util.service.ts
+++ b/server/src/modules/versions/util.service.ts
@@ -286,6 +286,7 @@ export class VersionUtilService implements IVersionUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )
            OR (
@@ -301,6 +302,7 @@ export class VersionUtilService implements IVersionUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )`,
           { orgId: organizationId }
@@ -362,6 +364,7 @@ export class VersionUtilService implements IVersionUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )
            OR (
@@ -377,6 +380,7 @@ export class VersionUtilService implements IVersionUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )`,
           { orgId: organizationId }


### PR DESCRIPTION
## 📝 What this does
Two fixes in the module-branching area:

1. **Module version dropdown on feature branches** — saved versions (v1, v2...) reappear in the `ModuleViewer` inspector alongside "Current branch". Routes module apps through module-ref.util so pin candidates compose the consumer-branch draft with saved versions on the default branch. Regular apps keep the strict branch filter PR #16066 introduced.
2. **Gate org-scoping** — the three pre-save gates (`checkDraftModulesInApp`, `checkModulesPromotableToEnvironment`, `checkModulesReleasedInApp`) joined by `co_relation_id` without an `organization_id` filter. Since `co_relation_id` is stable across workspaces by design, rows from other orgs' copies of the same module leaked into the join and caused spurious save/promote/release blocks.

- ee-server: no changes
- ee-frontend: no changes

## 🔀 Changes
- Added `listModuleVersions` helper that composes the consumer-branch draft with saved versions on the default branch
- Branched `getAllVersions` on `app.type === MODULE` so only modules take the new path; non-module apps still hit `getVersionsInApp` unchanged
- Kept `isStub: false` scoping from PR #16066, so the export-modal 403 fix stays intact
- Added `AND organization_id = :orgId` to the `apps` sub-select in each of the three gate SQLs (6 sites)

## 🧪 How to test

**Dropdown:**
- [ ] On a feature branch, drop a `ModuleViewer` — open the inspector and confirm v1, v2 appear alongside "Current branch"
- [ ] On the default branch, open the same inspector — confirm v1, v2 plus "Active draft" still render (no regression)
- [ ] Open the left-panel version manager of a regular app on a feature branch — confirm only that branch's versions show (PR #16066 behaviour preserved)
- [ ] Export a non-stub app via the UI — confirm it still exports (no 403 regression)

**Gate org-scoping:**
- [ ] Two workspaces A and B hold the same module (same `co_relation_id`) at different env priorities. Without the fix, promoting A's consumer app can report that B's module version hasn't been promoted. With the fix, only A's own version is considered.
- [ ] Single-workspace happy path: promote/save/release normally (no regression).
- [ ] Cross-branch pin lookups within the same org still resolve (the branch sub-queries were already org-scoped).