### PR TITLE
Fix: scope module save/promote/release gates to caller's org

### DIFF
--- a/server/src/modules/apps/util.service.ts
+++ b/server/src/modules/apps/util.service.ts
@@ -985,6 +985,7 @@ export class AppsUtilService implements IAppsUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )
            OR (
@@ -1000,6 +1001,7 @@ export class AppsUtilService implements IAppsUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )`,
           { orgId: organizationId }

--- a/server/src/modules/versions/util.service.ts
+++ b/server/src/modules/versions/util.service.ts
@@ -286,6 +286,7 @@ export class VersionUtilService implements IVersionUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )
            OR (
@@ -301,6 +302,7 @@ export class VersionUtilService implements IVersionUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )`,
           { orgId: organizationId }
@@ -362,6 +364,7 @@ export class VersionUtilService implements IVersionUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )
            OR (
@@ -377,6 +380,7 @@ export class VersionUtilService implements IVersionUtilService {
                SELECT id FROM apps
                WHERE co_relation_id::text = (component.properties::jsonb -> 'moduleAppId' ->> 'value')
                  AND type = 'module'
+                 AND organization_id = :orgId
              )
            )`,
           { orgId: organizationId }


### PR DESCRIPTION
## 📝 What this does
The three pre-save gates that check a consumer's referenced module versions (`checkDraftModulesInApp`, `checkModulesPromotableToEnvironment`, `checkModulesReleasedInApp`) joined by `co_relation_id` without an `organization_id` filter. Since `co_relation_id` is stable across workspaces by design, rows from *other* orgs' copies of the same module leaked into the join and caused spurious save/promote/release blocks.

## 🔀 Changes
- Added `AND organization_id = :orgId` to the `apps` sub-select in each gate (6 sites across the 3 functions)
- Reused the `:orgId` binding each function already passes for the branch sub-queries — no new params, no signature changes

## 🧪 How to test
- [ ] Reproduce the pre-fix block: two workspaces A and B hold the same module (same `co_relation_id`) at different env priorities. Without the fix, promoting A's consumer app can report that B's module version hasn't been promoted. With the fix, only A's own version is considered.
- [ ] Verify the happy path: a workspace with no sibling copies still promotes/saves/releases normally (no regression).
- [ ] Regression: cross-branch pin lookups within the same org still resolve (the branch sub-queries were already org-scoped).