### PR TITLE
Fix: propagate branch_id on data-source invoke for branch-scoped globals

### DIFF
--- a/frontend/src/_services/dataquery.service.js
+++ b/frontend/src/_services/dataquery.service.js
@@ -145,7 +145,11 @@ function invoke(dataSourceId, methodName, environmentId, args) {
     args: args,
   };
 
-  const url = `${config.apiUrl}/data-sources/${dataSourceId}/invoke`;
+  let url = `${config.apiUrl}/data-sources/${dataSourceId}/invoke`;
+  const branchId = getActiveBranchId();
+  if (branchId) {
+    url += `?branch_id=${branchId}`;
+  }
 
   const requestOptions = {
     method: 'POST',


### PR DESCRIPTION
## 📝 What this does
Global data sources on a git-sync feature branch now resolve their branch-scoped `DataSourceVersion` when the query editor invokes plugin helpers (service discovery, dynamic selectors, column lookups). Without this, gRPC (and similar) query editors can't list services on a branch and surface a 403 instead.

## 🔀 Changes
- Appended `?branch_id=<active>` to `dataqueryService.invoke()` so `/data-sources/:id/invoke` receives the branch context its controller already expects.

## 🧪 How to test
- [ ] Enable git-sync; create a feature branch and switch to it
- [ ] Create a global data source on the branch (e.g. gRPCv2 with server reflection)
- [ ] Add a query against it in an app; open the query editor
- [ ] Confirm the services dropdown populates (no "No services found", no 403 on `/invoke` in Network)
- [ ] Run the query and confirm it executes

### Broader audit (follow-up, out of scope for this PR)
`frontend/src/_services/datasource.service.js` has several `/data-sources/*` endpoints (test-connection, fetch by id, CRUD, OAuth base URL) that don't pass `branch_id` even though the backend controllers accept it. Worth a sweep in a separate PR — those paths would hit the same class of bug for global DSes on feature branches.