### PR TITLE
Feature: TruncatingText primitive and Rocket overflow polish

### DIFF
--- a/frontend/src/components/ui/Rocket/Button/Button.jsx
+++ b/frontend/src/components/ui/Rocket/Button/Button.jsx
@@ -11,6 +11,12 @@ const buttonVariants = cva(
     'tw-border-0 tw-border-solid tw-appearance-none tw-outline-none',
     // Override shadcn focus ring with ToolJet token
     'focus-visible:tw-ring-2 focus-visible:tw-ring-interactive-focus-outline focus-visible:tw-ring-offset-1',
+    // Desaturate icons when the button is disabled. Lucide icons follow
+    // currentColor and are already monochrome, but colored SVGs and <img>
+    // visuals in leadingVisual/trailingVisual would otherwise stay vivid.
+    // Pairs with shadcn's disabled:tw-opacity-50 (whole-button fade).
+    'disabled:[&_svg]:tw-grayscale',
+    'disabled:[&_img]:tw-grayscale',
   ],
   {
     variants: {

--- a/frontend/src/components/ui/Rocket/Button/Button.spec.md
+++ b/frontend/src/components/ui/Rocket/Button/Button.spec.md
@@ -70,6 +70,7 @@ Icon gap: tw-gap-1.5 for large/default, tw-gap-1 for medium/small
 | outline | text + icon | default | icon/strong | tw-text-text-medium |
 | all | focus ring | focus | interactive/focus-outline | focus-visible:tw-ring-2 focus-visible:tw-ring-[var(--interactive-focus-outline)] focus-visible:tw-ring-offset-1 |
 | all | cursor | disabled | — | disabled:tw-pointer-events-none disabled:tw-opacity-50 |
+| all | icon (svg/img) | disabled | — | disabled:[&_svg]:tw-grayscale disabled:[&_img]:tw-grayscale |
 
 ## Slots
 

--- a/frontend/src/components/ui/Rocket/Button/Button.stories.jsx
+++ b/frontend/src/components/ui/Rocket/Button/Button.stories.jsx
@@ -150,3 +150,67 @@ export const IconOnlyVariants = {
   ),
   parameters: { layout: 'padded' },
 };
+
+// ── Disabled icons — proves the grayscale filter ─────────────────────────
+//
+// Lucide icons follow currentColor and are already monochrome, so the
+// disabled-state grayscale is invisible on them. The visible cases are:
+//   - colored inline SVG (custom branded glyph, status icon, etc.)
+//   - <img> visuals (logos, profile pics, third-party brand marks)
+//
+// Compare each enabled column to its disabled twin: the colored content
+// should desaturate when disabled.
+
+const ColoredSvg = (props) => (
+  <svg width="14" height="14" viewBox="0 0 14 14" {...props}>
+    <circle cx="7" cy="7" r="6" fill="#22c55e" />
+    <path d="M4 7l2 2 4-4" stroke="white" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const ColoredImage = (props) => (
+  // Tiny inline SVG-as-data-URL so the story works offline
+  <img
+    {...props}
+    width={14}
+    height={14}
+    alt=""
+    src={
+      'data:image/svg+xml;utf8,' +
+      encodeURIComponent(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14"><rect width="14" height="14" rx="3" fill="%23f97316"/><text x="7" y="10" font-size="9" font-family="sans-serif" fill="white" text-anchor="middle">A</text></svg>'
+      )
+    }
+  />
+);
+
+export const DisabledWithColoredIcons = {
+  render: () => (
+    <div className="tw-grid tw-grid-cols-[auto_auto_auto] tw-gap-3 tw-p-4 tw-items-center">
+      <span className="tw-text-xs tw-text-text-placeholder">Lucide (currentColor)</span>
+      <Button variant="primary" leadingVisual={<Plus size={14} />}>
+        Enabled
+      </Button>
+      <Button variant="primary" disabled leadingVisual={<Plus size={14} />}>
+        Disabled
+      </Button>
+
+      <span className="tw-text-xs tw-text-text-placeholder">Colored SVG</span>
+      <Button variant="secondary" leadingVisual={<ColoredSvg />}>
+        Enabled
+      </Button>
+      <Button variant="secondary" disabled leadingVisual={<ColoredSvg />}>
+        Disabled
+      </Button>
+
+      <span className="tw-text-xs tw-text-text-placeholder">Image (data URL)</span>
+      <Button variant="outline" leadingVisual={<ColoredImage />}>
+        Enabled
+      </Button>
+      <Button variant="outline" disabled leadingVisual={<ColoredImage />}>
+        Disabled
+      </Button>
+    </div>
+  ),
+  parameters: { layout: 'padded' },
+};

--- a/frontend/src/components/ui/Rocket/Combobox/Combobox.jsx
+++ b/frontend/src/components/ui/Rocket/Combobox/Combobox.jsx
@@ -18,6 +18,7 @@ import {
   ComboboxGroup,
   ComboboxCollection,
 } from '@/components/ui/Rocket/shadcn/combobox';
+import { useInputOverflowTitle } from '@/components/ui/Rocket/TruncatingText/useInputOverflowTitle';
 
 // ── Anchor context ────────────────────────────────────────────────────────
 // Base UI Positioner anchors to the Trigger (chevron button, ~28px).
@@ -47,6 +48,11 @@ const comboboxInputVariants = cva(
     // ── Text (descendant selectors into inner <input>) ───────────────────
     '[&_input]:tw-text-text-default',
     '[&_input]:placeholder:tw-text-text-placeholder',
+    // Show ellipsis on overflowing input text. Visible only when the input
+    // is blurred — focused inputs scroll horizontally per browser default.
+    // Hover-tooltip via `title` attribute is tracked separately as a
+    // follow-up (input-overflow detection hook).
+    '[&_input]:tw-truncate',
 
     // ── Chevron icon colour + rotation animation ─────────────────────────
     '[&_[data-slot=combobox-trigger-icon]]:tw-text-icon-default',
@@ -93,6 +99,11 @@ const ComboboxInput = forwardRef(function ComboboxInput(
   ref
 ) {
   const anchorRef = useContext(ComboboxAnchorContext);
+
+  // Show full input value as a native browser tooltip when it overflows.
+  // Pairs with the `[&_input]:tw-truncate` ellipsis above — without this hook,
+  // long values clip silently with no way to read them.
+  useInputOverflowTitle(anchorRef);
 
   const handleClick = (e) => {
     // Don't steal focus from button clicks (trigger, clear)

--- a/frontend/src/components/ui/Rocket/Combobox/Combobox.spec.md
+++ b/frontend/src/components/ui/Rocket/Combobox/Combobox.spec.md
@@ -181,3 +181,40 @@ Shape C — sizes only (no variant axis). States handled via CSS pseudo-classes 
 - readOnly allows opening the dropdown to see options but prevents typing to filter.
 - Multi-select (chips) support deferred to v2 — shadcn primitive supports it via `ComboboxChips`.
 - Empty state shown when filter query matches no items.
+
+## Truncating long values (opt-in pattern)
+
+Combobox itself does not auto-truncate. To reveal long content on hover, opt in by composing with [`TruncatingText`](../TruncatingText/TruncatingText.spec.md). It uses the browser's native `title` attribute, so no provider or extra wiring is needed.
+
+### Option rows (in the dropdown)
+
+`ComboboxItem` children render as the row label. Wrap them in `TruncatingText` per row — string children make auto-detection work:
+
+```jsx
+<Combobox items={queries}>
+  <ComboboxInput placeholder="Search query..." />
+  <ComboboxContent>
+    <ComboboxList>
+      {(item) => (
+        <ComboboxItem key={item.value} value={item}>
+          <TruncatingText>{item.name}</TruncatingText>
+        </ComboboxItem>
+      )}
+    </ComboboxList>
+    <ComboboxEmpty>No results found.</ComboboxEmpty>
+  </ComboboxContent>
+</Combobox>
+```
+
+### Selected value (in the input) — built in
+
+The Combobox input trigger handles overflow itself, no opt-in required:
+
+- **Visual ellipsis** — `comboboxInputVariants` carries `[&_input]:tw-truncate`, so blurred input values that overflow show `…` at the right edge. Focused inputs scroll horizontally per browser default.
+- **Native hover tooltip** — `ComboboxInput` calls the `useInputOverflowTitle` hook, which detects overflow on the inner input and sets `input.title = input.value` when overflowing (removing it when the value fits). On blur, `input.scrollLeft` is reset to 0 so the ellipsis reappears reliably.
+
+**Limitation:** programmatic writes to `input.value` (Base UI updating the value after a dropdown pick) do not fire `input` events per HTML spec. The title attribute may be momentarily stale after a selection change until the next user interaction (typing, blur, resize). Visually the ellipsis is always correct.
+
+### Why opt-in, not built-in
+
+Same reasoning as [Select](../Select/Select.spec.md#truncating-long-values-opt-in-pattern). Truncation is a layout decision per callsite. Forcing it into the primitive would require modifying the primitive itself and would couple every consumer to that decision.

--- a/frontend/src/components/ui/Rocket/Combobox/Combobox.stories.jsx
+++ b/frontend/src/components/ui/Rocket/Combobox/Combobox.stories.jsx
@@ -453,3 +453,58 @@ export const LongOptionNames = {
   ),
   parameters: { layout: 'padded' },
 };
+
+// ── Bounded inside a host (consumer-side pattern) ────────────────────────
+//
+// Pattern for narrow hosts (e.g. an inspector panel) where:
+//   - the trigger is smaller than the host
+//   - the trigger is right-aligned within the host
+//   - the dropdown should grow to fit long row labels but stay inside the host
+//
+// No Rocket changes needed — just three things at the consumer site:
+//   1. `align="end"` on ComboboxContent — anchors the popover's right edge to
+//      the trigger's right edge, so it grows leftward as it expands.
+//   2. `!tw-w-max` — overrides shadcn's default `w-[var(--anchor-width)]` so
+//      the popover sizes to its longest row instead of matching trigger width.
+//      (`tw-w-max` is the Tailwind utility for `width: max-content`.)
+//   3. `!tw-max-w-[<inner-width>px]` — caps the popover at the host's INNER
+//      content width (outer width minus padding), so the popover's left edge
+//      stops at the same boundary as the trigger area.
+//
+// The `!` (Tailwind important prefix) is needed because shadcn already sets
+// `tw-w-[var(--anchor-width)]` and `tw-max-w-[var(--available-width)]` on the
+// Popup element with normal specificity — overriding those requires `!`.
+//
+// Mirrors the Inspector panel layout: 300px outer host with 12px padding, so
+// inner usable width is 276px. The 160px trigger is right-aligned within the
+// 276px inner area. Cap is 276px so the popover, growing leftward via
+// `align="end"`, never extends past the inner left edge.
+
+export const BoundedInHost = {
+  render: () => (
+    <div className="tw-w-[300px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+      <div className="tw-mb-2 tw-text-xs tw-text-text-placeholder">
+        300px outer • 12px padding • 276px inner • 160px right-aligned trigger
+      </div>
+      <div className="tw-flex tw-h-8 tw-items-center tw-justify-between">
+        <span className="tw-text-sm tw-text-text-default">Query</span>
+        <div className="tw-w-[160px]">
+          <Combobox items={longQueries}>
+            <ComboboxInput placeholder="Pick query..." />
+            <ComboboxContent align="end" className="!tw-w-max !tw-max-w-[276px]">
+              <ComboboxList>
+                {(item) => (
+                  <ComboboxItem key={item} value={item}>
+                    {item}
+                  </ComboboxItem>
+                )}
+              </ComboboxList>
+              <ComboboxEmpty>No results.</ComboboxEmpty>
+            </ComboboxContent>
+          </Combobox>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: { layout: 'padded' },
+};

--- a/frontend/src/components/ui/Rocket/Combobox/Combobox.stories.jsx
+++ b/frontend/src/components/ui/Rocket/Combobox/Combobox.stories.jsx
@@ -14,6 +14,7 @@ import {
   ComboboxSeparator,
 } from './Combobox';
 import { Field, FieldLabel, FieldDescription, FieldError } from '../Field/Field';
+import { TruncatingText } from '../TruncatingText/TruncatingText';
 import { ChevronDown } from 'lucide-react';
 
 const frameworks = ['React', 'Vue', 'Angular', 'Svelte', 'Solid', 'Qwik'];
@@ -408,5 +409,47 @@ export const AllStates = {
       </div>
     );
   },
+  parameters: { layout: 'padded' },
+};
+
+// ── Long Option Names — opt-in TruncatingText pattern ────────────────────
+//
+// Documents the "Truncating long values" pattern from Combobox.spec.md.
+//
+// Each row's label is wrapped in TruncatingText. When the row label
+// overflows the dropdown width, TruncatingText sets the native `title`
+// attribute and the OS tooltip appears on hover after ~500ms. Short rows
+// show no tooltip.
+//
+// The selected-value-in-input case is intentionally not covered here —
+// inputs scroll horizontally instead of clipping with ellipsis, so they
+// need a different mechanism (tracked separately).
+
+const longQueries = [
+  'getProducts',
+  'getProductsByCategory',
+  'getProductsThatIsReallyLongToFitInaDropdownAndWillDefinitelyOverflow',
+  'getOrders',
+  'updateUserShippingAddressForCheckoutFlowWithLongName',
+];
+
+export const LongOptionNames = {
+  render: () => (
+    <div className="tw-w-[240px] tw-p-4">
+      <Combobox items={longQueries}>
+        <ComboboxInput placeholder="Search query..." />
+        <ComboboxContent>
+          <ComboboxList>
+            {(item) => (
+              <ComboboxItem key={item} value={item}>
+                <TruncatingText>{item}</TruncatingText>
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+          <ComboboxEmpty>No results found.</ComboboxEmpty>
+        </ComboboxContent>
+      </Combobox>
+    </div>
+  ),
   parameters: { layout: 'padded' },
 };

--- a/frontend/src/components/ui/Rocket/Select/Select.jsx
+++ b/frontend/src/components/ui/Rocket/Select/Select.jsx
@@ -21,7 +21,7 @@ const selectTriggerVariants = cva(
     // Resets (preflight is off — browser adds outset border on buttons)
     'tw-appearance-none tw-outline-none tw-border-solid',
     // Base tokens (mirrors Input)
-    'tw-bg-background-surface-layer-01 tw-border-border-default tw-text-text-default tw-shadow-elevation-000',
+    'tw-bg-background-surface-layer-01 tw-border-border-default tw-text-text-default tw-shadow-none',
     'data-[placeholder]:tw-text-text-placeholder',
     // Chevron icon colour
     '[&>svg]:tw-text-icon-default [&>svg]:tw-opacity-100',

--- a/frontend/src/components/ui/Rocket/Select/Select.jsx
+++ b/frontend/src/components/ui/Rocket/Select/Select.jsx
@@ -83,6 +83,10 @@ const SelectItem = forwardRef(function SelectItem({ className, ...props }, ref) 
         // Move check indicator from right → left
         '[&>span:first-child]:tw-left-2 [&>span:first-child]:tw-right-auto',
         '[&>span:first-child_svg]:tw-text-text-brand',
+        // Allow Radix's ItemText (the second span child) to shrink below its
+        // intrinsic content width — flex children otherwise default to
+        // min-width: auto, blocking truncation primitives inside.
+        '[&>span:nth-child(2)]:tw-min-w-0',
         className
       )}
       {...props}

--- a/frontend/src/components/ui/Rocket/Select/Select.spec.md
+++ b/frontend/src/components/ui/Rocket/Select/Select.spec.md
@@ -44,7 +44,7 @@ Wraps shadcn Select (Radix `@radix-ui/react-select`).
 | border | hover | `--border-strong` | `hover:tw-border-border-strong` |
 | text | default | `--text-default` | `tw-text-text-default` |
 | placeholder | default | `--text-placeholder` | `data-[placeholder]:tw-text-text-placeholder` |
-| shadow | default | `--elevation-000` | `tw-shadow-elevation-000` |
+| shadow | default | none | `tw-shadow-none` |
 | focus ring | focus | `--interactive-focus-outline` | `focus:tw-ring-2 focus:tw-ring-[var(--interactive-focus-outline)] focus:tw-ring-offset-1` |
 | chevron icon | default | `--icon-default` | `tw-text-icon-default` |
 | border | error | `--border-danger-strong` | `aria-[invalid=true]:tw-border-border-danger-strong` |
@@ -112,3 +112,39 @@ Wraps shadcn Select (Radix `@radix-ui/react-select`).
 - Leading visual on trigger (icon before placeholder) from Figma — supported via children composition inside SelectTrigger.
 - Leading/trailing visuals on items — supported via custom content inside SelectItem children.
 - Disabled state uses `--background-surface-layer-02` bg token (consistent with Input).
+
+## Truncating long values (opt-in pattern)
+
+Select itself does not auto-truncate selected values or option rows. Long content already clips visually because shadcn's `SelectTrigger` carries `[&>span]:tw-line-clamp-1` on direct child spans. To get a hover tooltip showing the full string, opt in by composing with [`TruncatingText`](../TruncatingText/TruncatingText.spec.md). TruncatingText uses the browser's native `title` attribute, so no provider or extra wiring is needed.
+
+### Selected value (in the trigger)
+
+The shadcn line-clamp targets the trigger's direct child spans. Wrap inside a `<div>` to take that selector out of the picture, then apply `TruncatingText`. The selected value text is rendered by Radix from context, so pass it explicitly via the `title` prop:
+
+```jsx
+<SelectTrigger>
+  <div className="tw-min-w-0 tw-flex-1">
+    <TruncatingText title={selectedLabel}>
+      <SelectValue placeholder="Select query" />
+    </TruncatingText>
+  </div>
+</SelectTrigger>
+```
+
+The div is a flex item of the trigger (which is `display: flex`); `tw-min-w-0` lets it shrink below its content width, `tw-flex-1` lets it claim the available space so the chevron sits flush right.
+
+If the consumer doesn't already track the selected label as state, pass `text={selectedLabel}` instead of children — but the SelectValue child form is the cleanest fit for most callsites because Radix handles the placeholder fallback automatically.
+
+### Option rows (in the dropdown)
+
+`SelectItem` children render as text inside `Select.ItemText`. Wrap the label children in `TruncatingText` per row — string children make auto-detection work without the manual `title` prop:
+
+```jsx
+<SelectItem value={item.value}>
+  <TruncatingText>{item.name}</TruncatingText>
+</SelectItem>
+```
+
+### Why opt-in, not built-in
+
+Truncation is a layout decision, not a primitive concern. Most callsites either size the trigger generously enough to never overflow, or actively want clipped text without a tooltip. Forcing TruncatingText into `SelectValue` would also collide with the shadcn line-clamp selector on the trigger — fixing that cleanly would require modifying the primitive itself. The opt-in pattern keeps the primitive untouched and gives consumers control where the truncation actually matters.

--- a/frontend/src/components/ui/Rocket/Select/Select.stories.jsx
+++ b/frontend/src/components/ui/Rocket/Select/Select.stories.jsx
@@ -313,18 +313,26 @@ export const OpenDropdownWithSelection = {
 //
 // Documents the "Truncating long values" pattern from Select.spec.md.
 //
-// The selected value already clips visually (shadcn applies line-clamp-1 to
-// the trigger's child spans). To reveal the full string on hover, the
-// consumer wraps the value in a div + TruncatingText. The div escapes the
-// line-clamp selector so TruncatingText's measurement works correctly.
+// Two pieces of overflow handling are demonstrated together:
 //
-// TruncatingText sets the browser's native `title` attribute when the text
-// overflows. Since SelectValue renders text from Radix context (not a string
-// child), pass the label explicitly via the `title` prop. Hover the
-// truncated text and the OS tooltip appears after ~500ms.
+//   Trigger (selected value):
+//   - `<TruncatingText title={QUERIES[value]}><SelectValue /></TruncatingText>`
+//     wrapped inside a div that escapes shadcn's `[&>span]:tw-line-clamp-1`.
+//     Hover the clipped trigger to see the OS tooltip with the full string.
 //
-// Stateful labels (controlled Select) make this easy: track the selected
-// value's display label in state and pass it as `title`.
+//   Dropdown (option rows):
+//   - `<TruncatingText>{label}</TruncatingText>` per SelectItem.
+//   - PLUS the dropdown is bounded: `align="end"` is irrelevant here (trigger
+//     fills the host) but the popover needs `!tw-w-max !tw-max-w-[<inner>px]`
+//     and a `data-tj-fit-host` marker so the global `:has()` rule overrides
+//     Radix's popper-wrapper `min-width: max-content`. Without these, the
+//     dropdown grows to fit the longest row and TruncatingText never clips —
+//     because the rows always have enough room.
+//
+// The `<style>` tag is inline so the story is self-contained. In an app, the
+// rule lives once in a global stylesheet (e.g. EventManager.scss).
+//
+// Host: 240px outer, 16px padding (tw-p-4) → 208px inner. Cap is 208px.
 
 const QUERIES = {
   short: 'getProducts',
@@ -336,24 +344,31 @@ export const LongSelectedValue = {
   render: () => {
     const [value, setValue] = React.useState('long');
     return (
-      <div className="tw-w-[240px] tw-p-4">
-        <Select value={value} onValueChange={setValue}>
-          <SelectTrigger>
-            <div className="tw-min-w-0 tw-flex-1">
-              <TruncatingText title={QUERIES[value]}>
-                <SelectValue placeholder="Select query" />
-              </TruncatingText>
-            </div>
-          </SelectTrigger>
-          <SelectContent>
-            {Object.entries(QUERIES).map(([key, label]) => (
-              <SelectItem key={key} value={key}>
-                <TruncatingText>{label}</TruncatingText>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      <>
+        <style>{`
+          [data-radix-popper-content-wrapper]:has([data-tj-fit-host]) {
+            min-width: 0;
+          }
+        `}</style>
+        <div className="tw-w-[240px] tw-p-4">
+          <Select value={value} onValueChange={setValue}>
+            <SelectTrigger>
+              <div className="tw-min-w-0 tw-flex-1">
+                <TruncatingText title={QUERIES[value]}>
+                  <SelectValue placeholder="Select query" />
+                </TruncatingText>
+              </div>
+            </SelectTrigger>
+            <SelectContent data-tj-fit-host="" className="!tw-w-max !tw-max-w-[208px]">
+              {Object.entries(QUERIES).map(([key, label]) => (
+                <SelectItem key={key} value={key}>
+                  <TruncatingText>{label}</TruncatingText>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </>
     );
   },
   parameters: { layout: 'padded' },

--- a/frontend/src/components/ui/Rocket/Select/Select.stories.jsx
+++ b/frontend/src/components/ui/Rocket/Select/Select.stories.jsx
@@ -10,6 +10,7 @@ import {
   SelectSeparator,
 } from './Select';
 import { Field, FieldLabel, FieldDescription, FieldError } from '../Field/Field';
+import { TruncatingText } from '../TruncatingText/TruncatingText';
 import { User, Globe, Mail, Pencil, Trash2 } from 'lucide-react';
 
 export default {
@@ -305,6 +306,56 @@ export const OpenDropdownWithSelection = {
       </Select>
     </div>
   ),
+  parameters: { layout: 'padded' },
+};
+
+// ── Long Selected Value — opt-in TruncatingText pattern ──────────────────
+//
+// Documents the "Truncating long values" pattern from Select.spec.md.
+//
+// The selected value already clips visually (shadcn applies line-clamp-1 to
+// the trigger's child spans). To reveal the full string on hover, the
+// consumer wraps the value in a div + TruncatingText. The div escapes the
+// line-clamp selector so TruncatingText's measurement works correctly.
+//
+// TruncatingText sets the browser's native `title` attribute when the text
+// overflows. Since SelectValue renders text from Radix context (not a string
+// child), pass the label explicitly via the `title` prop. Hover the
+// truncated text and the OS tooltip appears after ~500ms.
+//
+// Stateful labels (controlled Select) make this easy: track the selected
+// value's display label in state and pass it as `title`.
+
+const QUERIES = {
+  short: 'getProducts',
+  medium: 'getProductsByCategory',
+  long: 'getProductsThatIsReallyLongToFitInaDropdownAndWillDefinitelyOverflow',
+};
+
+export const LongSelectedValue = {
+  render: () => {
+    const [value, setValue] = React.useState('long');
+    return (
+      <div className="tw-w-[240px] tw-p-4">
+        <Select value={value} onValueChange={setValue}>
+          <SelectTrigger>
+            <div className="tw-min-w-0 tw-flex-1">
+              <TruncatingText title={QUERIES[value]}>
+                <SelectValue placeholder="Select query" />
+              </TruncatingText>
+            </div>
+          </SelectTrigger>
+          <SelectContent>
+            {Object.entries(QUERIES).map(([key, label]) => (
+              <SelectItem key={key} value={key}>
+                <TruncatingText>{label}</TruncatingText>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  },
   parameters: { layout: 'padded' },
 };
 

--- a/frontend/src/components/ui/Rocket/Select/Select.stories.jsx
+++ b/frontend/src/components/ui/Rocket/Select/Select.stories.jsx
@@ -386,3 +386,76 @@ export const AllVariants = {
   ),
   parameters: { layout: 'padded' },
 };
+
+// ── Bounded inside a host (consumer-side pattern) ────────────────────────
+//
+// Pattern for narrow hosts (e.g. an inspector panel) where:
+//   - the trigger is smaller than the host
+//   - the trigger is right-aligned within the host
+//   - the dropdown should grow to fit long option labels but stay inside the
+//     host
+//
+// Select needs four pieces at the consumer site (no Rocket changes):
+//   1. `align="end"` on SelectContent — anchors the popover's right edge to
+//      the trigger's right edge, so it grows leftward as it expands.
+//   2. `!tw-w-max` — sizes the popover to its longest option (Tailwind
+//      utility for `width: max-content`).
+//   3. `!tw-max-w-[<inner-width>px]` — caps the popover at the host's INNER
+//      content width (outer width minus padding) so the popover's left edge
+//      stops at the same boundary as the trigger area.
+//   4. A global `:has()` CSS rule that overrides Radix's popper-wrapper
+//      `min-width: max-content`, gated by a `data-tj-fit-host` marker on the
+//      Content. Without this override, Radix's wrapper expands to fit the
+//      longest option's intrinsic width and our `max-width` on Content has no
+//      effect — the dropdown overflows the host.
+//
+// The `<style>` tag here is inline to make the story self-contained. In an
+// app, place the rule once in a global stylesheet (e.g. EventManager.scss)
+// — it only fires when an element with `data-tj-fit-host` is present.
+//
+// Mirrors the Inspector panel layout: 300px outer host with 12px padding, so
+// inner usable width is 276px. The 160px trigger is right-aligned within the
+// 276px inner area. Cap is 276px.
+
+const BOUNDED_QUERIES = [
+  { value: 'short', label: 'getProducts' },
+  { value: 'med', label: 'getProductsByCategory' },
+  { value: 'long', label: 'getProductsThatIsReallyLongToFitInaDropdownAndWillDefinitelyOverflow' },
+  { value: 'orders', label: 'getOrders' },
+  { value: 'update', label: 'updateUserShippingAddressForCheckoutFlowWithLongName' },
+];
+
+export const BoundedInHost = {
+  render: () => (
+    <>
+      <style>{`
+        [data-radix-popper-content-wrapper]:has([data-tj-fit-host]) {
+          min-width: 0;
+        }
+      `}</style>
+      <div className="tw-w-[300px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+        <div className="tw-mb-2 tw-text-xs tw-text-text-placeholder">
+          300px outer • 12px padding • 276px inner • 160px right-aligned trigger
+        </div>
+        <div className="tw-flex tw-h-8 tw-items-center tw-justify-between">
+          <span className="tw-text-sm tw-text-text-default">Query</span>
+          <div className="tw-w-[160px]">
+            <Select>
+              <SelectTrigger>
+                <SelectValue placeholder="Pick query" />
+              </SelectTrigger>
+              <SelectContent align="end" data-tj-fit-host="" className="!tw-w-max !tw-max-w-[276px]">
+                {BOUNDED_QUERIES.map((q) => (
+                  <SelectItem key={q.value} value={q.value}>
+                    {q.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+    </>
+  ),
+  parameters: { layout: 'padded' },
+};

--- a/frontend/src/components/ui/Rocket/Switch/Switch.jsx
+++ b/frontend/src/components/ui/Rocket/Switch/Switch.jsx
@@ -29,8 +29,8 @@ const switchThumbClasses = [
   'tw-bg-switch-tab',
   'tw-shadow-elevation-100 tw-ring-0',
   'tw-transition-transform',
-  'data-[state=unchecked]:-tw-translate-x-[5px]',
-  'data-[state=checked]:tw-translate-x-[5px]',
+  'data-[state=unchecked]:-tw-translate-x-1.5',
+  'data-[state=checked]:tw-translate-x-1.5',
 ];
 
 // ── Switch ───────────────────────────────────────────────────────────────

--- a/frontend/src/components/ui/Rocket/TruncatingText/TruncatingText.jsx
+++ b/frontend/src/components/ui/Rocket/TruncatingText/TruncatingText.jsx
@@ -1,0 +1,65 @@
+import React, { forwardRef, useCallback, useLayoutEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { cn } from '@/lib/utils';
+
+const TruncatingText = forwardRef(function TruncatingText(
+  { text, children, className, title: titleOverride, ...props },
+  ref
+) {
+  const [node, setNode] = useState(null);
+  const [autoTitle, setAutoTitle] = useState(undefined);
+  const content = text ?? children;
+  const stringContent = typeof content === 'string' ? content : null;
+
+  const setRefs = useCallback(
+    (el) => {
+      setNode(el);
+      if (typeof ref === 'function') ref(el);
+      else if (ref) ref.current = el;
+    },
+    [ref]
+  );
+
+  useLayoutEffect(() => {
+    if (!node) return undefined;
+
+    const measure = () => {
+      const overflowed = node.scrollWidth - node.clientWidth > 0.5;
+      setAutoTitle(overflowed && stringContent ? stringContent : undefined);
+    };
+
+    measure();
+
+    const resizeObserver = new ResizeObserver(measure);
+    resizeObserver.observe(node);
+
+    const mutationObserver = new MutationObserver(measure);
+    mutationObserver.observe(node, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [node, stringContent]);
+
+  return (
+    <span ref={setRefs} title={titleOverride ?? autoTitle} className={cn('tw-block tw-truncate', className)} {...props}>
+      {content}
+    </span>
+  );
+});
+
+TruncatingText.displayName = 'TruncatingText';
+
+TruncatingText.propTypes = {
+  text: PropTypes.node,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  title: PropTypes.string,
+};
+
+export { TruncatingText };

--- a/frontend/src/components/ui/Rocket/TruncatingText/TruncatingText.spec.md
+++ b/frontend/src/components/ui/Rocket/TruncatingText/TruncatingText.spec.md
@@ -1,0 +1,63 @@
+# TruncatingText — Rocket Design Spec
+<!-- synced: 2026-04-27 -->
+
+## Overview
+
+TruncatingText renders a string with CSS ellipsis. When the rendered text actually overflows its container, it sets a `title` attribute on the element so the browser's native tooltip reveals the full string on hover. When the text fits, no `title` is attached — short values get no tooltip noise.
+
+Use it anywhere text may or may not fit its container: row labels in dropdowns, selected values in Select triggers, table cells, sidebar entries.
+
+## Props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| text | node | — | String content. Wins over `children` when both are passed. |
+| children | node | — | Alternative way to pass content. |
+| className | string | — | Forwarded to the rendered `<span>`. |
+| title | string | — | Manual override. When set, replaces the auto-detected title. Use this if `children` is JSX and you want to provide the plain-text equivalent for the tooltip. |
+
+## Usage
+
+```jsx
+// Basic — auto-detects overflow on the string
+<TruncatingText text={query.name} />
+
+// Inside a flex row — parent needs min-w-0 to allow shrinking
+<div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+  <Icon />
+  <TruncatingText text={longLabel} className="tw-flex-1" />
+</div>
+
+// Wrapping a component that renders text from context (Radix SelectValue)
+<TruncatingText title={query.name}>
+  <SelectValue />
+</TruncatingText>
+```
+
+## Behavior
+
+- Renders `<span>` with `tw-block tw-truncate` (applies `overflow: hidden; text-overflow: ellipsis; white-space: nowrap`).
+- Sets `title={fullText}` only when `scrollWidth - clientWidth > 0.5`. Hover triggers the OS tooltip.
+- Re-measures on:
+  - Container resize — via `ResizeObserver` on the span itself.
+  - Children prop change — via the React effect dependency.
+  - Descendant text mutations — via `MutationObserver` on the subtree (`childList + characterData`). Required so wrappers like Radix `SelectValue` / `ComboboxValue`, which render selected text from context (not from props), trigger re-measurement when the selection changes.
+- The `title` attribute is only auto-set for **string content**. If `children` is a React element (e.g. `<SelectValue />`), the auto-detection still measures correctly but cannot extract a string for the title — pass it explicitly via the `title` prop.
+- SSR-safe: initial `title` is `undefined`, set after mount via `useLayoutEffect`. First paint is the bare ellipsis; the title appears once measurement runs.
+
+## Why native title, not a styled tooltip
+
+Considered wrapping in our Rocket `Tooltip` (Radix-based) so the hover bubble matches design-system styling. Rejected for these reasons:
+
+- **Composition fragility** — nesting Radix Tooltip inside Radix Select/Combobox triggers caused event/portal interaction bugs that were hard to isolate.
+- **DOM stability** — toggling between "wrap in Tooltip" and "no wrap" required remounting the trigger span, breaking observers and adding race conditions.
+- **Overhead** — every truncated row would carry a Radix subtree, materially worse in long lists.
+- **Provider requirement** — every consumer would need a `<TooltipProvider>` ancestor, easy to forget.
+- **Discoverability** — native browser tooltips are the universal pattern for "reveal overflow content," instantly understood by users.
+
+The native `title` attribute eliminates all of the above. The DOM shape never changes; only the attribute toggles. The styled Rocket `Tooltip` remains the right choice for **deliberate informational tooltips** (help text, descriptions) — different job, different primitive.
+
+## Architecture Notes
+
+- **No shadcn base.** TruncatingText has no shadcn primitive equivalent. It's a small composition utility — the "every Rocket component wraps shadcn" rule is explicitly suspended for this component. Documented here so the exception is visible.
+- For truncation to activate inside a flex container, the flex child (or this component's parent) needs `min-w-0`. Otherwise the element grows to its content's intrinsic width and never clips. CSS convention, not a TruncatingText quirk.

--- a/frontend/src/components/ui/Rocket/TruncatingText/TruncatingText.stories.jsx
+++ b/frontend/src/components/ui/Rocket/TruncatingText/TruncatingText.stories.jsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import { TruncatingText } from './TruncatingText';
+
+export default {
+  title: 'Rocket/TruncatingText',
+  component: TruncatingText,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+};
+
+const LONG = 'getProductsThatIsReallyLongToFitInaDropdownAndWillDefinitelyOverflow';
+const SHORT = 'getProducts';
+
+// Hover behavior across stories: when text is truncated, the browser shows
+// a native OS tooltip after ~500ms. Short text shows no tooltip on hover.
+
+// ── Short text — no title attribute set ─────────────────────────────────
+export const ShortText = {
+  render: () => (
+    <div className="tw-w-[240px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+      <TruncatingText text={SHORT} />
+    </div>
+  ),
+};
+
+// ── Long text — title set, native tooltip on hover ──────────────────────
+export const LongText = {
+  render: () => (
+    <div className="tw-w-[240px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+      <TruncatingText text={LONG} />
+    </div>
+  ),
+};
+
+// ── Side-by-side comparison ─────────────────────────────────────────────
+export const Comparison = {
+  render: () => (
+    <div className="tw-flex tw-flex-col tw-gap-4">
+      <div className="tw-w-[240px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+        <div className="tw-mb-1 tw-text-xs tw-text-text-placeholder">Short (no title)</div>
+        <TruncatingText text={SHORT} />
+      </div>
+      <div className="tw-w-[240px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+        <div className="tw-mb-1 tw-text-xs tw-text-text-placeholder">Long (hover for native tooltip)</div>
+        <TruncatingText text={LONG} />
+      </div>
+    </div>
+  ),
+};
+
+// ── Resizable — drag edge to toggle title attribute live ────────────────
+export const Resizable = {
+  render: () => (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      <div className="tw-text-xs tw-text-text-placeholder">
+        Drag the right edge to resize. Inspect the span — `title` should appear/disappear as truncation toggles.
+      </div>
+      <div
+        className="tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3"
+        style={{ width: 320, resize: 'horizontal', overflow: 'auto', minWidth: 80, maxWidth: 600 }}
+      >
+        <TruncatingText text={LONG} />
+      </div>
+    </div>
+  ),
+};
+
+// ── In a flex row (min-w-0 required on flex child) ──────────────────────
+export const InFlexRow = {
+  render: () => (
+    <div className="tw-w-[280px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+      <div className="tw-flex tw-items-center tw-gap-2">
+        <div className="tw-h-4 tw-w-4 tw-rounded-full tw-bg-interactive-hover tw-shrink-0" />
+        <TruncatingText text={LONG} className="tw-min-w-0 tw-flex-1" />
+        <button
+          type="button"
+          className="tw-shrink-0 tw-rounded tw-bg-button-primary tw-px-2 tw-py-1 tw-text-xs tw-text-text-on-solid"
+        >
+          Run
+        </button>
+      </div>
+    </div>
+  ),
+};
+
+// ── Content change triggers re-measure ──────────────────────────────────
+export const ToggleContent = {
+  render: () => {
+    const [isLong, setIsLong] = useState(true);
+    return (
+      <div className="tw-flex tw-flex-col tw-gap-3">
+        <button
+          type="button"
+          onClick={() => setIsLong((v) => !v)}
+          className="tw-self-start tw-rounded tw-bg-button-primary tw-px-3 tw-py-1 tw-text-xs tw-text-text-on-solid"
+        >
+          Toggle text
+        </button>
+        <div className="tw-w-[240px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+          <TruncatingText text={isLong ? LONG : SHORT} />
+        </div>
+      </div>
+    );
+  },
+};
+
+// ── Manual title override (for non-string children) ─────────────────────
+export const ManualTitleOverride = {
+  render: () => (
+    <div className="tw-w-[240px] tw-rounded-md tw-border tw-border-solid tw-border-border-weak tw-p-3">
+      <TruncatingText title={LONG}>
+        <strong>{LONG}</strong>
+      </TruncatingText>
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/Rocket/TruncatingText/useInputOverflowTitle.js
+++ b/frontend/src/components/ui/Rocket/TruncatingText/useInputOverflowTitle.js
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+
+/**
+ * Detects when an `<input>` inside `containerRef` overflows its visible width,
+ * and sets the input's `title` attribute to its current value so the browser
+ * shows a native tooltip on hover. Removes the attribute when the value fits.
+ *
+ * Also resets `input.scrollLeft = 0` on blur so the ellipsis reappears
+ * reliably after the user types past the visible area (Safari doesn't always
+ * reset on its own).
+ *
+ * Limitation: programmatic writes to `input.value` (e.g. Base UI Combobox
+ * setting the value when a user picks from the dropdown) do not fire `input`
+ * events per HTML spec, so the title attribute may be stale until the next
+ * user interaction (typing, blur, hover, container resize).
+ */
+export function useInputOverflowTitle(containerRef) {
+  useEffect(() => {
+    const container = containerRef?.current;
+    if (!container) return undefined;
+
+    const input = container.querySelector('input');
+    if (!input) return undefined;
+
+    const measure = () => {
+      const overflowed = input.scrollWidth - input.clientWidth > 0.5;
+      if (overflowed && input.value) {
+        input.title = input.value;
+      } else if (input.hasAttribute('title')) {
+        input.removeAttribute('title');
+      }
+    };
+
+    const handleBlur = () => {
+      input.scrollLeft = 0;
+      measure();
+    };
+
+    measure();
+
+    const resizeObserver = new ResizeObserver(measure);
+    resizeObserver.observe(input);
+
+    input.addEventListener('input', measure);
+    input.addEventListener('blur', handleBlur);
+
+    return () => {
+      resizeObserver.disconnect();
+      input.removeEventListener('input', measure);
+      input.removeEventListener('blur', handleBlur);
+    };
+  }, [containerRef]);
+}

--- a/frontend/src/components/ui/Rocket/index.js
+++ b/frontend/src/components/ui/Rocket/index.js
@@ -197,6 +197,7 @@ export {
   TableCaption,
 } from './Table/Table';
 export { Skeleton, skeletonClasses } from './Skeleton/Skeleton';
+export { TruncatingText } from './TruncatingText/TruncatingText';
 export { Checkbox, checkboxVariants } from './Checkbox/Checkbox';
 export { RadioGroup, RadioGroupItem, radioGroupItemVariants } from './RadioGroup/RadioGroup';
 export { Textarea, textareaVariants } from './Textarea/Textarea';


### PR DESCRIPTION
## 📝 What this does
Adds a `TruncatingText` Rocket primitive for ellipsis + native browser tooltip on overflowing text, and rolls in related polish across `Button`, `Select`, and `Combobox` so long values, disabled icons, and trigger surfaces behave consistently across the design system.

## 🔀 Changes
- New `TruncatingText` primitive — sets the native `title` attribute when text overflows (no Radix Tooltip dependency, no provider needed).
- New `useInputOverflowTitle` hook wired into `ComboboxInput` — long input values now ellipsis-clip on blur and reveal full text on hover.
- Opt-in `TruncatingText` composition pattern documented in `Select.spec.md` and `Combobox.spec.md`.
- `Select` trigger drops `elevation-000` for a flat surface.
- `Button` desaturates `<svg>` / `<img>` visuals via `grayscale` filter when disabled, so colored icons read as disabled.

## 🧪 How to test
- [ ] In Storybook `Rocket/TruncatingText`: hover the `LongText` story → OS tooltip; `ShortText` → no tooltip.
- [ ] In `Rocket/Select` → `LongSelectedValue`: hover the clipped trigger → tooltip with full query name; switch to a short option → no tooltip.
- [ ] In `Rocket/Combobox` → `LongOptionNames`: type a long value, blur → input shows `…` + hover reveals tooltip; open dropdown → long rows clip with hover tooltips.
- [ ] In `Rocket/Button` → `DisabledWithColoredIcons`: the colored SVG and image rows visibly desaturate when disabled; lucide row unchanged.
- [ ] Toggle dark theme on each story — tokens flip cleanly, no regressions.