### PR TITLE
Fix: sibling references break when ListView contains Tabs

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/componentSlices/listViewComponentSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentSlices/listViewComponentSlice.js
@@ -182,17 +182,36 @@ export const listViewComponentSlice = (set, get) => ({
   // Called ONCE before the row loop. Collects descendant IDs and creates the
   // prototype overlay. Returns null if the ListView has no descendants.
   prepareRowScope: (components, listviewId, moduleId = 'canvas') => {
-    const { getContainerChildrenMapping } = get();
+    const { getContainerChildrenMapping, containerChildrenMapping } = get();
+
+    // Pre-build a map from base UUID → children that are stored under slot IDs.
+    // Some containers (e.g. Tabs) render their SubContainer with a slot suffix:
+    //   <SubContainer id={`${id}-${tab.id}`} />
+    // so their children have parent="tabs-uuid-tab0" and are stored in
+    // containerChildrenMapping["tabs-uuid-tab0"], NOT under "tabs-uuid".
+    // This map lets collectDescendants find those children when traversing down.
+    const slotChildrenByBase = {};
+    for (const key of Object.keys(containerChildrenMapping)) {
+      const match = key.match(/([a-fA-F0-9-]{36})-.+/);
+      if (match) {
+        const baseId = match[1];
+        if (!slotChildrenByBase[baseId]) slotChildrenByBase[baseId] = [];
+        slotChildrenByBase[baseId].push(...(containerChildrenMapping[key] || []));
+      }
+    }
 
     // Recursively collect ALL descendant component IDs of this ListView.
-    // This includes components nested inside sub-containers (Form, Container, etc.).
+    // This includes components nested inside sub-containers (Form, Container, Tabs, etc.).
     // Example: ListView → [Checkbox, Button, Form → [TextInput, Dropdown]]
     //   → allDescendants = [Checkbox, Button, Form, TextInput, Dropdown]
     const allDescendants = [];
     const collectDescendants = (containerId) => {
       const children = getContainerChildrenMapping(containerId, moduleId);
-      if (!children) return;
-      for (const childId of children) {
+      const slotChildren = slotChildrenByBase[containerId] || [];
+      // Combine direct children (base ID) and slot-keyed children (e.g. Tabs).
+      // A child can only have one parent so there is no overlap between the two arrays.
+      const allChildren = children.length > 0 ? children : slotChildren;
+      for (const childId of allChildren) {
         allDescendants.push(childId);
         collectDescendants(childId);
       }


### PR DESCRIPTION
## 📝 What this does
Inside a ListView, `{{components.textinput1.value}}` (sibling reference) would silently resolve to `undefined` for any component nested inside a **Tabs** widget — causing wrong values and stalled re-renders. This fixes `prepareRowScope` to correctly collect all descendants regardless of whether an intermediate container uses slot-based IDs.

## 🔀 Changes
- Fixed `collectDescendants` in `prepareRowScope` to also traverse slot-keyed children (e.g. `tabs-uuid-tab0`) that Tabs renders, which were previously invisible to the row-scope overlay
- Pre-built a `slotChildrenByBase` map (one pass over `containerChildrenMapping`) so the traversal stays O(n) rather than scanning all keys per node

## 🧪 How to test
- [ ] Create a ListView with data (e.g. 3 rows)
- [ ] Drop an Accordion inside it, then a Tabs inside the Accordion, then a Form inside a tab, then a TextInput and a Text inside the Form
- [ ] Set the Text's content to `{{components.textinput1.value}}`
- [ ] Type in each row's TextInput — confirm the Text in the same row reflects the typed value
- [ ] Verify the same structure without Tabs (ListView → Accordion → Form → TextInput + Text) still works