### PR TITLE
Fix: Undesired changes getting pushed in Git from App builder

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js
+++ b/frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js
@@ -156,8 +156,11 @@ export function addChildrenWidgetsToParent(componentType, parentId, currentLayou
       const height = layout.height ? layout.height : componentMeta.defaultSize.height;
       const top = layout.top ? layout.top : 0;
       const left = layout.left ? layout.left : 0;
-      const newComponentDefinition = {
+      const newComponentProperties = {
         ...componentData.definition.properties,
+      };
+      const newComponentStyles = {
+        ...componentData.definition.styles,
       };
 
       if (_.isArray(properties) && properties.length > 0) {
@@ -166,11 +169,11 @@ export function addChildrenWidgetsToParent(componentType, parentId, currentLayou
             ? `{{${customResolverVariable}.${accessorKey}}}`
             : defaultValue[prop] || '';
 
-          _.set(newComponentDefinition, prop, {
+          _.set(newComponentProperties, prop, {
             value: accessor,
           });
         });
-        _.set(componentData, 'definition.properties', newComponentDefinition);
+        _.set(componentData, 'definition.properties', newComponentProperties);
       }
 
       if (_.isArray(styles) && styles.length > 0) {
@@ -179,11 +182,11 @@ export function addChildrenWidgetsToParent(componentType, parentId, currentLayou
             ? `{{${customResolverVariable}.${accessorKey}}}`
             : defaultValue[prop] || '';
 
-          _.set(newComponentDefinition, prop, {
+          _.set(newComponentStyles, prop, {
             value: accessor,
           });
         });
-        _.set(componentData, 'definition.styles', newComponentDefinition);
+        _.set(componentData, 'definition.styles', newComponentStyles);
       }
 
       if (currentLayout === 'mobile') {

--- a/frontend/src/AppBuilder/WidgetManager/widgets/starrating.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/starrating.js
@@ -338,8 +338,6 @@ export const starratingConfig = {
     styles: {
       textColor: { value: '#EFB82D' },
       labelColor: { value: 'var(--cc-primary-text)' },
-      visibility: { value: '{{true}}' },
-      disabledState: { value: '{{false}}' },
       padding: { value: 'default' },
       boxShadow: { value: '0px 0px 0px 0px #00000040' },
       labelStyle: { value: 'standard' },

--- a/server/src/modules/apps/services/widget-config/index.js
+++ b/server/src/modules/apps/services/widget-config/index.js
@@ -164,7 +164,74 @@ const widgets = {
   buttonGroupV2Config,
 };
 
+const NEW_REVAMPED_COMPONENTS = [
+  'Text',
+  'TextInput',
+  'PasswordInput',
+  'NumberInput',
+  'EmailInput',
+  'DropdownV2',
+  'Table',
+  'Button',
+  'Checkbox',
+  'Divider',
+  'VerticalDivider',
+  'Link',
+  'Datepicker',
+  'DatePickerV2',
+  'TimePicker',
+  'DatetimePickerV2',
+  'DaterangePicker',
+  'TextArea',
+  'Container',
+  'Tabs',
+  'Form',
+  'Image',
+  'FilePicker',
+  'Icon',
+  'Steps',
+  'Statistics',
+  'StarRating',
+  'Tags',
+  'CircularProgressBar',
+  'Html',
+  'Chat',
+  'CurrencyInput',
+  'PhoneInput',
+  'IFrame',
+  'TreeSelect',
+  'Listview',
+  'ColorPicker',
+  'ButtonGroupV2',
+  'ModalV2',
+  'PopoverMenu',
+];
+
+const newRevampedComponents = new Set(NEW_REVAMPED_COMPONENTS);
+
 const universalProps = {
+  properties: {},
+  general: {
+    tooltip: {
+      type: "code",
+      displayName: "Tooltip",
+      validation: { schema: { type: "string" } },
+    },
+  },
+  others: {},
+  events: {},
+  styles: {},
+  validate: true,
+  generalStyles: {},
+  definition: {
+    others: {},
+    events: [],
+    styles: {},
+    generalStyles: {},
+  },
+};
+
+const legacyUniversalProps = {
   properties: {},
   general: {
     tooltip: {
@@ -210,11 +277,12 @@ const combineProperties = (widget, universal, isArray = false) => {
 };
 
 export const componentTypes = Object.values(widgets).map((widget) => {
+  const baseProps = newRevampedComponents.has(widget.component) ? universalProps : legacyUniversalProps;
   return {
-    ...combineProperties(widget, universalProps),
+    ...combineProperties(widget, baseProps),
     definition: combineProperties(
       widget.definition,
-      universalProps.definition,
+      baseProps.definition,
       true,
     ),
   };

--- a/server/src/modules/apps/services/widget-config/starrating.js
+++ b/server/src/modules/apps/services/widget-config/starrating.js
@@ -338,8 +338,6 @@ export const starratingConfig = {
     styles: {
       textColor: { value: '#EFB82D' },
       labelColor: { value: 'var(--cc-primary-text)' },
-      visibility: { value: '{{true}}' },
-      disabledState: { value: '{{false}}' },
       padding: { value: 'default' },
       boxShadow: { value: '0px 0px 0px 0px #00000040' },
       labelStyle: { value: 'standard' },


### PR DESCRIPTION
This pull request introduces improvements to the widget configuration system, particularly to support a new set of "revamped" components with updated universal properties, and cleans up widget property handling in both the frontend and backend. Additionally, it removes redundant style properties from the `StarRating` widget configuration.

**Widget configuration enhancements:**

* Added a list of new revamped components in `server/src/modules/apps/services/widget-config/index.js` and introduced a `newRevampedComponents` set to distinguish between revamped and legacy widgets.
* Updated the universal properties system: created separate `universalProps` for revamped components and `legacyUniversalProps` for older ones, enabling different default structures for each.
* Modified the `componentTypes` export to select the appropriate universal properties based on whether a widget is revamped or legacy, ensuring correct property merging for each widget type.

**Frontend property handling improvements:**

* In `frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js`, refactored how properties and styles are set for child widgets by separating `newComponentProperties` and `newComponentStyles`, improving clarity and maintainability. [[1]](diffhunk://#diff-4d9b8f71297881929b23b0057fede491a7349c002e2ca29317c7d9f226385fe8L159-R176) [[2]](diffhunk://#diff-4d9b8f71297881929b23b0057fede491a7349c002e2ca29317c7d9f226385fe8L182-R189)

**Widget configuration cleanup:**

* Removed unnecessary `visibility` and `disabledState` style properties from the `StarRating` widget configuration in both frontend and backend files, reducing redundancy. [[1]](diffhunk://#diff-8f058a745fcb08ade5a4269cde6e9918be43b1a2e58a6a3be68988029490f2b1L341-L342) [[2]](diffhunk://#diff-8f058a745fcb08ade5a4269cde6e9918be43b1a2e58a6a3be68988029490f2b1L341-L342)