### PR TITLE
Fix: Show master branch lock banner in module editor

### DIFF
--- a/frontend/src/AppBuilder/Header/LockedBranchBanner.jsx
+++ b/frontend/src/AppBuilder/Header/LockedBranchBanner.jsx
@@ -10,7 +10,13 @@ import SolidIcon from '@/_ui/Icon/SolidIcons';
  * @param {string} branchName - Name of the locked branch
  * @param {string} reason - Reason why branch is locked (e.g., "merged", "released")
  */
-const LockedBranchBanner = ({ isVisible = false, branchName = '', reason = 'merged', pageContext = '' }) => {
+const LockedBranchBanner = ({
+  isVisible = false,
+  branchName = '',
+  reason = 'merged',
+  pageContext = '',
+  variant = 'inline',
+}) => {
   if (!isVisible) {
     return null;
   }
@@ -24,7 +30,7 @@ const LockedBranchBanner = ({ isVisible = false, branchName = '', reason = 'merg
       : 'This branch has been merged and is now read-only';
 
   return (
-    <div className="locked-branch-banner">
+    <div className={`locked-branch-banner locked-branch-banner--${variant}`}>
       <div className="locked-branch-banner-content">
         {/* <svg
           className="locked-branch-banner-icon"
@@ -41,7 +47,7 @@ const LockedBranchBanner = ({ isVisible = false, branchName = '', reason = 'merg
             strokeWidth="1.2"
           /> 
         </svg> */}
-        <SolidIcon name="lock" width="16" />
+        <SolidIcon name={variant === 'floating' ? 'information' : 'lock'} fill="var(--icon-default)" width="16" />
         <div className="locked-branch-banner-text">
           <span className="locked-branch-banner-message">{reasonText}</span>
           {/* {branchName && (

--- a/frontend/src/_styles/locked-branch-banner.scss
+++ b/frontend/src/_styles/locked-branch-banner.scss
@@ -2,14 +2,28 @@
 // Displays below the editor navigation when branch is locked
 
 .locked-branch-banner {
-    width: 100%;
-    height: 40px;
     display: flex;
     justify-content: center;
-    align-items: center;                                                                                                                                                                                 
-    padding: 12px 20px;                                                                                                                                                                                  
-    background-color: var(--background-surface-layer-03); 
+    align-items: center;
+    padding: 12px 20px;
+    background-color: var(--background-surface-layer-03);
     margin: 0;
+
+  &--inline {
+    width: 100%;
+    height: 40px;
+  }
+
+  &--floating {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    margin-top: 46px;
+    margin-left: 20px;
+    margin-right: 47px;
+    z-index: 2;
+  }
 
   &-content {
     display: flex;

--- a/frontend/src/_ui/WorkspaceLockedBanner/index.jsx
+++ b/frontend/src/_ui/WorkspaceLockedBanner/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useWorkspaceBranchesStore } from '@/_stores/workspaceBranchesStore';
 import LockedBranchBanner from '@/AppBuilder/Header/LockedBranchBanner';
 
-export function WorkspaceLockedBanner({ pageContext = '' }) {
+export function WorkspaceLockedBanner({ pageContext = '', variant = 'inline' }) {
   const { currentBranch, orgGitConfig, isInitialized } = useWorkspaceBranchesStore((state) => ({
     currentBranch: state.currentBranch,
     orgGitConfig: state.orgGitConfig,
@@ -21,6 +21,7 @@ export function WorkspaceLockedBanner({ pageContext = '' }) {
       branchName={currentBranch?.name || ''}
       reason="main_config_branch"
       pageContext={pageContext}
+      variant={variant}
     />
   );
 }


### PR DESCRIPTION
## 📝 What this does
The module editor wasn't showing the "Master is locked" banner when branching was enabled and the user was on the default branch — apps showed it, modules didn't. This wires the banner into the module path and gives it overlay styling that matches the apps' banner.
- [ee-frontend](https://github.com/ToolJet/ee-frontend/pull/442)

## 🔀 Changes
- EE `AppCanvasBanner` now renders `WorkspaceLockedBanner` for module editors instead of returning null.
- Added a `floating` variant to `LockedBranchBanner` / `WorkspaceLockedBanner` for the canvas overlay layout.
- Updated `locked-branch-banner.scss` to support the `floating` overlay (fixed-position, top offset, side gutters) alongside the existing in-flow `inline` variant.
- Switched the floating-variant icon to `information` to match the apps banner; existing inline usage keeps the `lock` icon.

## 🧪 How to test
- [ ] Enable branching at the org level, stay on the default branch, open a module in edit mode → banner appears overlaying the canvas.
- [ ] Switch to a feature branch in the same module → banner disappears.
- [ ] Disable branching → banner doesn't appear in modules.
- [ ] Open an app on the default branch → existing `VersionLockBanner` behavior unchanged.
- [ ] Open the home page / global data sources list while on the default branch → inline banner still renders correctly.