### PR TITLE
Fix: Module migration single-target seed with origin restore

### DIFF
--- a/server/data-migrations/1776600000000-SeedPushModulesBranch.ts
+++ b/server/data-migrations/1776600000000-SeedPushModulesBranch.ts
@@ -100,66 +100,57 @@ export class SeedPushModulesBranch1776600000000 implements MigrationInterface {
       where: { organizationId: defaultBranch.organizationId },
     });
 
-    const nonDefaultBranches = await em.find(WorkspaceBranch, {
-      where: { organizationId: defaultBranch.organizationId, isDefault: false },
-    });
-
-    // Step 1: seed module BRANCH versions on every non-default branch. The app
-    // remap pass below depends on these rows existing on the target branch.
+    // Step 1: seed module BRANCH versions on the push-modules branch only.
+    // The app remap pass below depends on these rows existing on that branch.
     for (const moduleApp of modules) {
-      for (const targetBranch of nonDefaultBranches) {
-        await this.cloneVersionToBranch(
-          em,
-          versionsCreate,
-          moduleApp,
-          targetBranch,
-          defaultBranch.organizationId,
-          /* stampModuleReferenceId */ true
-        );
-      }
+      await this.cloneVersionToBranch(
+        em,
+        versionsCreate,
+        moduleApp,
+        branch,
+        defaultBranch.organizationId,
+        /* stampModuleReferenceId */ true
+      );
       if (orgGit) await this.ensureAppGitSyncRow(em, moduleApp, orgGit.id);
     }
 
-    // Step 2: seed BRANCH versions for non-module apps that contain at least one
-    // ModuleViewer. No post-clone pin remap is needed — by the time this runs,
-    // 1776470400000 has already corrected every ModuleViewer pin to either the
-    // default-branch released module_reference_id or '' (unpinned). The clone
-    // copies components verbatim from a stable source via setupNewVersion, so
-    // each new BRANCH version inherits the correct pin without further action.
+    // Step 2: seed a push-modules BRANCH version for non-module apps that contain
+    // at least one ModuleViewer. No post-clone pin remap is needed — by the time
+    // this runs, 1776470400000 has already corrected every ModuleViewer pin to
+    // either the default-branch released module_reference_id or '' (unpinned).
+    // The clone copies components verbatim from a stable source via
+    // setupNewVersion, so the new BRANCH version inherits the correct pin
+    // without further action.
     const appsWithModuleViewers = await this.findAppsWithModuleViewers(em, defaultBranch.organizationId);
     for (const app of appsWithModuleViewers) {
-      // Lock the source version ONCE per app, before the per-branch loop. Without
-      // this, after iter 1 creates a BRANCH version, the per-branch helper's
-      // "latest by created_at" fallback in cloneVersionToBranch would pick up that
-      // fresh BRANCH row as the source. The locked source guarantees every clone
-      // is built from the same default-branch row.
+      // Resolve a stable default-branch source so cloneVersionToBranch's
+      // "latest by created_at" fallback can't accidentally pick up an
+      // existing BRANCH row.
       const lockedSource = await this.findStableAppSource(em, app, defaultBranch.id);
-      for (const targetBranch of nonDefaultBranches) {
-        await this.cloneVersionToBranch(
-          em,
-          versionsCreate,
-          app,
-          targetBranch,
-          defaultBranch.organizationId,
-          /* stampModuleReferenceId */ false,
-          lockedSource
-        );
-      }
+      await this.cloneVersionToBranch(
+        em,
+        versionsCreate,
+        app,
+        branch,
+        defaultBranch.organizationId,
+        /* stampModuleReferenceId */ false,
+        lockedSource
+      );
     }
   }
 
   /**
-   * Resolve the source version to clone from, locked to a stable choice that won't
-   * shift across loop iterations even as new BRANCH rows are created.
+   * Resolve a stable default-branch source version to clone from, so that
+   * cloneVersionToBranch's "latest by created_at" fallback can't accidentally
+   * pick up a pre-existing BRANCH row as the source.
    *
    * Order:
    *   1. Default-branch VERSION-type row (status irrelevant — even DRAFT is correct)
    *   2. App.currentVersionId, if set (normally points at the released VERSION row)
-   *   3. OLDEST version on the app — never "latest", because the loop creates new
-   *      BRANCH rows each iteration; picking "latest" would bind the next clone
-   *      to a freshly-created BRANCH row that may have a different shape (e.g.
-   *      different home page, different content) than the canonical default-branch
-   *      version we want every clone to match.
+   *   3. OLDEST version on the app — never "latest", because picking "latest"
+   *      could bind the clone to a pre-existing BRANCH row that may have a
+   *      different shape (e.g. different home page, different content) than the
+   *      canonical default-branch version we want the clone to match.
    *
    * Returns null if the app has no version at all (skip cloning entirely).
    */
@@ -206,9 +197,9 @@ export class SeedPushModulesBranch1776600000000 implements MigrationInterface {
    * regular apps (the column only carries meaning for module versions).
    *
    * presetSourceVersion: when supplied, use this row as the clone source instead of
-   * resolving via currentVersionId / latest-by-created_at. Step 2 (apps loop) passes
-   * a stable, default-branch-locked source so subsequent loop iterations don't pick
-   * up the freshly-created BRANCH rows we're emitting.
+   * resolving via currentVersionId / latest-by-created_at. Step 2 (apps with
+   * ModuleViewers) passes a default-branch-locked source so the fallback can't
+   * pick up a pre-existing BRANCH row.
    */
   private async cloneVersionToBranch(
     em: EntityManager,

--- a/server/data-migrations/1776600000000-SeedPushModulesBranch.ts
+++ b/server/data-migrations/1776600000000-SeedPushModulesBranch.ts
@@ -58,6 +58,11 @@ export class SeedPushModulesBranch1776600000000 implements MigrationInterface {
         }
         progress.show();
       }
+
+      // 1776470400000 created this staging table to pass module origin
+      // branch_ids across the migration boundary. Drop it now that all orgs
+      // have been processed.
+      await em.query(`DROP TABLE IF EXISTS module_origin_branch_staging`);
     } finally {
       await nestApp.close();
     }
@@ -112,6 +117,34 @@ export class SeedPushModulesBranch1776600000000 implements MigrationInterface {
         /* stampModuleReferenceId */ true
       );
       if (orgGit) await this.ensureAppGitSyncRow(em, moduleApp, orgGit.id);
+    }
+
+    // Step 1b: restore module BRANCH presence on each module's origin feature
+    // branch. 1776470400000 captured these origins before normalizing the
+    // VERSION-row branch_id to default. Cloning here means users who created
+    // a module on a feature branch still see it when opening that branch.
+    // cloneVersionToBranch is idempotent — if a BRANCH row already exists on
+    // the origin branch, this is a no-op.
+    const originRows: Array<{ app_id: string; origin_branch_id: string }> = await em.query(
+      `SELECT mobs.app_id, mobs.origin_branch_id
+       FROM module_origin_branch_staging mobs
+       JOIN apps a ON a.id = mobs.app_id
+       WHERE a.organization_id = $1`,
+      [defaultBranch.organizationId]
+    );
+    for (const { app_id, origin_branch_id } of originRows) {
+      const moduleApp = modules.find((m) => m.id === app_id);
+      if (!moduleApp) continue;
+      const originBranch = await em.findOne(WorkspaceBranch, { where: { id: origin_branch_id } });
+      if (!originBranch) continue;
+      await this.cloneVersionToBranch(
+        em,
+        versionsCreate,
+        moduleApp,
+        originBranch,
+        defaultBranch.organizationId,
+        /* stampModuleReferenceId */ true
+      );
     }
 
     // Step 2: seed a push-modules BRANCH version for non-module apps that contain

--- a/server/migrations/1776470400000-GenerateCoRelationIdForModules.ts
+++ b/server/migrations/1776470400000-GenerateCoRelationIdForModules.ts
@@ -52,6 +52,36 @@ export class GenerateCoRelationIdForModules1776470400000 implements MigrationInt
         AND av.module_reference_id IS NULL;
     `);
 
+    // Capture the origin feature-branch_id of anomalous module VERSION rows
+    // BEFORE the normalize step below moves them to default. 1776600000000
+    // reads this staging table to seed a BRANCH-type row on each module's
+    // origin branch, so users opening that branch still see the module they
+    // created there. NULL branch_id rows (legacy pre-branching shape) are
+    // intentionally excluded — there's no feature branch to restore to.
+    // The staging table is dropped at the end of 1776600000000's up().
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS module_origin_branch_staging (
+        app_id           uuid PRIMARY KEY,
+        origin_branch_id uuid NOT NULL,
+        created_at       timestamp NOT NULL DEFAULT now()
+      );
+    `);
+    await queryRunner.query(`
+      INSERT INTO module_origin_branch_staging (app_id, origin_branch_id)
+      SELECT av.app_id, av.branch_id
+      FROM app_versions av
+      JOIN apps a ON a.id = av.app_id
+      JOIN organization_git_sync_branches default_b
+        ON default_b.organization_id = a.organization_id
+       AND default_b.is_default = true
+      WHERE a.type = 'module'
+        AND av.version_type = 'version'
+        AND av.branch_id IS NOT NULL
+        AND av.branch_id <> default_b.id
+        AND COALESCE(av.is_stub, false) = false
+      ON CONFLICT (app_id) DO NOTHING;
+    `);
+
     // Normalize module VERSION-type rows onto the org's default branch. Older
     // create paths inserted version-type rows with branch_id = active feature
     // branch (a categorical violation: VERSION rows belong on default, BRANCH
@@ -160,6 +190,10 @@ export class GenerateCoRelationIdForModules1776470400000 implements MigrationInt
     // Drop the module_reference_id column + index.
     await queryRunner.query(`DROP INDEX IF EXISTS idx_app_versions_module_ref_branch;`);
     await queryRunner.query(`ALTER TABLE app_versions DROP COLUMN IF EXISTS module_reference_id;`);
+
+    // Drop the origin-branch staging table in case 1776600000000 didn't get
+    // a chance to drop it (e.g., partial run).
+    await queryRunner.query(`DROP TABLE IF EXISTS module_origin_branch_staging;`);
 
     // Restore ModuleViewer component properties to use the DB id instead of co_relation_id
     await queryRunner.query(`


### PR DESCRIPTION
## 📝 What this does
Scopes the module-branching migration to seed only the `push-modules` branch instead of fanning out across every non-default branch, and restores each module's BRANCH presence on the feature branch it was originally created on.

## 🔀 Changes
- SeedPushModulesBranch seeds modules and apps-with-ModuleViewers only on `push-modules` (no cross-branch fan-out)
- GenerateCoRelationIdForModules captures each anomalous module VERSION row's origin `branch_id` into a staging table before normalizing it to default
- SeedPushModulesBranch reads the staging table and seeds a BRANCH-type row on each module's origin feature branch via `cloneVersionToBranch`
- Staging table is dropped after all orgs are processed; defensive drop also added to GenerateCoRelationIdForModules' `down()`

## 🧪 How to test
- [ ] Snapshot the DB pre-migration with modules on a feature branch (e.g. `branch-1`)
- [ ] Run migrations
- [ ] Confirm `push-modules` has one BRANCH row per module and per app-with-ModuleViewer
- [ ] Confirm modules originating on `branch-1` also have a BRANCH row on `branch-1` after migration
- [ ] Confirm no module BRANCH rows landed on unrelated non-default branches
- [ ] Confirm `module_origin_branch_staging` table is gone after migration completes