### PR TITLE
fix: CheckboxV2 - keep mandatory * indicator visible when checked

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Checkbox.jsx
+++ b/frontend/src/AppBuilder/Widgets/Checkbox.jsx
@@ -260,9 +260,7 @@ export const Checkbox = ({
             >
               <label htmlFor={inputId}>
                 {label}
-                {isMandatory && !checked && (
-                  <span style={{ color: 'var(--cc-error-systemStatus)', marginLeft: '1px' }}>{'*'}</span>
-                )}
+                {isMandatory && <span style={{ color: 'var(--cc-error-systemStatus)', marginLeft: '1px' }}>{'*'}</span>}
               </label>
             </OverflowTooltip>
           </>


### PR DESCRIPTION
closes: https://github.com/ToolJet/tj-ee/issues/5014