### PR TITLE
Fix permission key logic in defineAppVersionAbility function

### DIFF
--- a/frontend/src/AppBuilder/Header/VersionManager/VersionManagerDropdown.jsx
+++ b/frontend/src/AppBuilder/Header/VersionManager/VersionManagerDropdown.jsx
@@ -78,13 +78,16 @@ const VersionManagerDropdown = ({ darkMode = false, ...props }) => {
   const buttonRef = useRef(null);
   const popoverRef = useRef(null);
 
-  // Sync selectedEnvironmentFilter with global currentEnvironment whenever it changes
-  // This ensures the filter is correct after page reloads from environment switches
+  // Sync selectedEnvironmentFilter with global currentEnvironment whenever it changes.
+  // Also refresh the version list immediately so VersionActionButtons reflect the new
+  // environment state without waiting for the dropdown to open (e.g. after promote).
   useEffect(() => {
-    if (currentEnvironment) {
-      setSelectedEnvironmentFilter(currentEnvironment);
+    if (!currentEnvironment) return;
+    setSelectedEnvironmentFilter(currentEnvironment);
+    if (appId && currentEnvironment.id) {
+      fetchVersionsForEnvironment(appId, currentEnvironment.id);
     }
-  }, [currentEnvironment, setSelectedEnvironmentFilter]);
+  }, [currentEnvironment?.id, appId, setSelectedEnvironmentFilter, fetchVersionsForEnvironment]);
 
   // Fetch development versions on mount to check for draft status
   useEffect(() => {

--- a/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
@@ -46,8 +46,15 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
       // Get app ID from the response (similar to how AppEnvironments.jsx gets it)
       const appId = response.editorVersion?.app?.id || response.editorVersion?.appId;
 
+      const storeState = get();
+      const isModuleApp = storeState.appStore?.modules?.canvas?.app?.appType === 'module';
+      const isWorkflowApp = !!storeState.appStore?.modules?.workflow?.app?.appId;
+      const bypassEnvCheck = isModuleApp || isWorkflowApp;
+
       const hasEditPermission =
-        app_group_permissions?.is_all_editable || (appId && app_group_permissions?.editable_apps_id?.includes(appId));
+        bypassEnvCheck ||
+        app_group_permissions?.is_all_editable ||
+        (appId && app_group_permissions?.editable_apps_id?.includes(appId));
 
       // Check if user is viewer without edit permission
       const isViewOnlyUser = !hasEditPermission;
@@ -96,8 +103,10 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
         }
 
         // Check if user has access to the requested environment
-        // Skip this check if user is owner requesting development
-        const skipAccessCheck = isOwner && requestedEnvName === 'development';
+        // Skip this check if user is owner requesting development, or for module/workflow apps
+        // (module/workflow app IDs are absent from app_group_permissions env access maps, so the
+        // access check always falls back to development even when the backend returned a higher env)
+        const skipAccessCheck = (isOwner && requestedEnvName === 'development') || bypassEnvCheck;
 
         if (!skipAccessCheck && requestedEnvName && !hasEnvironmentAccess(environmentAccess, requestedEnvName)) {
           // User doesn't have access, find the closest available environment

--- a/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
@@ -507,11 +507,13 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
     const hasMultiEnvironmentAccess = get().license?.featureAccess?.multiEnvironment;
     const hasPromotePermission = authenticationService.currentSessionValue?.user_permissions?.app_promote;
     const hasReleasePermission = authenticationService.currentSessionValue?.user_permissions?.app_release;
+    // MODULE apps are not gated by app-level promote/release permissions
+    const isModuleApp = get().appStore?.modules?.canvas?.app?.appType === 'module';
     return {
       canPromote: hasMultiEnvironmentAccess && !isLastEnvironment && !isVersionReleased,
       canRelease: !hasMultiEnvironmentAccess || isLastEnvironment || isVersionReleased,
-      isPromoteVersionEnabled: hasPromotePermission,
-      isReleaseVersionEnabled: hasReleasePermission,
+      isPromoteVersionEnabled: isModuleApp || hasPromotePermission,
+      isReleaseVersionEnabled: isModuleApp || hasReleasePermission,
     };
   },
   createDraftVersionAction: async (appId, selectedVersionId, onSuccess, onFailure) => {

--- a/frontend/src/HomePage/AppMenu.jsx
+++ b/frontend/src/HomePage/AppMenu.jsx
@@ -3,6 +3,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';
 import { useTranslation } from 'react-i18next';
 import { authenticationService } from '@/_services';
+import { hasBuilderRole } from '@/_helpers/utils';
 
 export const AppMenu = function AppMenu({
   appId,
@@ -43,22 +44,31 @@ export const AppMenu = function AppMenu({
   const canEditAnyFolderViaGroup =
     folderGroupPermissions?.is_all_editable || folderGroupPermissions?.editable_folders_id?.length > 0;
 
+  const isBuilder = hasBuilderRole(currentSession?.role ?? {});
+  // Builders have implicit admin-level access to module folders.
+  const isModuleBuilder = appType === 'module' && isBuilder;
+
   // canAddAppToFolder: user can modify the app AND has at least one folder available in the dropdown.
   const hasOwnedFolders = isAppOwner && Array.isArray(ownedFolders) && ownedFolders.length > 0;
 
   const canAddAppToFolder =
-    canModifyApp &&
-    (currentSession?.admin || currentSession?.super_admin || canEditAnyFolderViaGroup || hasOwnedFolders);
+    (canModifyApp || isModuleBuilder) &&
+    (currentSession?.admin ||
+      currentSession?.super_admin ||
+      canEditAnyFolderViaGroup ||
+      hasOwnedFolders ||
+      isModuleBuilder);
 
   // canRemoveFromFolder: only when inside a specific folder AND user has folder-edit access.
   const canRemoveFromFolder =
     !!currentFolder?.id &&
-    canModifyApp &&
+    (canModifyApp || isModuleBuilder) &&
     (currentSession?.admin ||
       currentSession?.super_admin ||
       folderGroupPermissions?.is_all_editable ||
       folderGroupPermissions?.editable_folders_id?.includes(currentFolder.id) ||
-      currentFolder?.created_by === currentUserId);
+      currentFolder?.created_by === currentUserId ||
+      isModuleBuilder);
 
   const Field = ({ text, onClick, customClass }) => {
     const closeMenu = () => {

--- a/frontend/src/HomePage/Folders.jsx
+++ b/frontend/src/HomePage/Folders.jsx
@@ -11,7 +11,7 @@ import { BreadCrumbContext } from '@/App/App';
 import { ButtonSolid } from '@/_ui/AppButton/AppButton';
 import { SearchBox } from '@/_components/SearchBox';
 import _ from 'lodash';
-import { validateName, handleHttpErrorMessages, getWorkspaceId } from '@/_helpers/utils';
+import { validateName, handleHttpErrorMessages, getWorkspaceId, hasBuilderRole } from '@/_helpers/utils';
 import { useNavigate, useLocation } from 'react-router-dom';
 import FolderSkeleton from '@/_ui/FolderSkeleton/FolderSkeleton';
 import { Button } from '@/components/ui/Button/Button';
@@ -53,9 +53,11 @@ export const Folders = function Folders({
   const { updateSidebarNAV } = useContext(BreadCrumbContext);
 
   // Get folder granular permissions from session
-  const folderGroupPermissions = authenticationService.currentSessionValue?.folder_group_permissions;
+  const currentSession = authenticationService.currentSessionValue;
+  const folderGroupPermissions = currentSession?.folder_group_permissions;
   // Get current user ID for ownership check
-  const currentUserId = authenticationService.currentSessionValue?.current_user?.id;
+  const currentUserId = currentSession?.current_user?.id;
+  const isBuilder = hasBuilderRole(currentSession?.role ?? {});
 
   // Check if user can edit a specific folder (granular permission)
   const canEditSpecificFolder = (folderId) => {
@@ -69,9 +71,10 @@ export const Folders = function Folders({
   };
 
   // Determine if user can update/delete a specific folder
-  // Rename: requires granular canEditFolder OR (folderCreate + ownership)
-  // Delete: requires master Delete OR (folderCreate + ownership)
-  const canUpdateSpecificFolder = (folderId, folder) => canEditSpecificFolder(folderId) || isOwnerOfFolder(folder);
+  // Rename: requires granular canEditFolder OR ownership OR (module context + builder)
+  // Delete: requires master Delete OR ownership
+  const canUpdateSpecificFolder = (folderId, folder) =>
+    canEditSpecificFolder(folderId) || isOwnerOfFolder(folder) || (appType === 'module' && isBuilder);
   const canDeleteSpecificFolder = (folderId, folder) => canDeleteFolder || isOwnerOfFolder(folder);
 
   useEffect(() => {

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -2042,6 +2042,9 @@ class HomePageComponent extends React.Component {
                         const currentSession = authenticationService.currentSessionValue;
                         if (currentSession?.super_admin || currentSession?.admin) return true;
 
+                        // Builders have admin-level access to module folders
+                        if (this.props.appType === 'module' && currentSession?.role?.name === 'builder') return true;
+
                         // Check if user has edit permissions for the folder
                         const folderPermissions = currentSession?.user_permissions?.folder;
                         if (folderPermissions?.is_all_editable) return true;

--- a/server/src/modules/ability/util.service.ts
+++ b/server/src/modules/ability/util.service.ts
@@ -11,6 +11,7 @@ import { dbTransactionWrap } from '@helpers/database.helper';
 import { USER_ROLE } from '@modules/group-permissions/constants';
 import { RESOURCE_TO_APP_TYPE_MAP } from './constants';
 import { RolesRepository } from '@modules/roles/repository';
+import { APP_TYPES } from '@modules/apps/constants';
 
 @Injectable()
 export class AbilityUtilService {
@@ -272,6 +273,7 @@ export class AbilityUtilService {
         where: {
           userId: user.id,
           organizationId: user.organizationId,
+          type: APP_TYPES.FRONT_END,
         },
       });
 
@@ -294,6 +296,7 @@ export class AbilityUtilService {
           .innerJoin('folderApp.folder', 'folder')
           .where('folder.createdBy = :userId', { userId: user.id })
           .andWhere('folder.organizationId = :orgId', { orgId: user.organizationId })
+          .andWhere('folder.type = :type', { type: APP_TYPES.FRONT_END })
           .select('folderApp.appId')
           .getMany();
 
@@ -338,6 +341,7 @@ export class AbilityUtilService {
           .createQueryBuilder(FolderApp, 'folderApp')
           .innerJoin('folderApp.folder', 'folder')
           .where('folder.organizationId = :orgId', { orgId: user.organizationId })
+          .andWhere('folder.type = :type', { type: APP_TYPES.FRONT_END })
           .select('folderApp.appId')
           .getMany();
         const allFolderAppIds = allFolderApps.map((fa) => fa.appId);

--- a/server/src/modules/ability/util.service.ts
+++ b/server/src/modules/ability/util.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ResourcePermissionQueryObject, ResourcesItem, UserAppsPermissions, EnvironmentPermissionSet } from './types';
-import { Brackets, EntityManager, In, SelectQueryBuilder } from 'typeorm';
+import { Brackets, EntityManager, SelectQueryBuilder } from 'typeorm';
 import { GroupPermissions } from '@entities/group_permissions.entity';
 import { MODULES } from '@modules/app/constants/modules';
 import { GranularPermissions } from '@entities/granular_permissions.entity';
@@ -273,7 +273,7 @@ export class AbilityUtilService {
         where: {
           userId: user.id,
           organizationId: user.organizationId,
-          type: In([APP_TYPES.FRONT_END, APP_TYPES.MODULE]),
+          type: APP_TYPES.FRONT_END,
         },
       });
 

--- a/server/src/modules/ability/util.service.ts
+++ b/server/src/modules/ability/util.service.ts
@@ -11,7 +11,6 @@ import { dbTransactionWrap } from '@helpers/database.helper';
 import { USER_ROLE } from '@modules/group-permissions/constants';
 import { RESOURCE_TO_APP_TYPE_MAP } from './constants';
 import { RolesRepository } from '@modules/roles/repository';
-import { APP_TYPES } from '@modules/apps/constants';
 
 @Injectable()
 export class AbilityUtilService {
@@ -273,7 +272,6 @@ export class AbilityUtilService {
         where: {
           userId: user.id,
           organizationId: user.organizationId,
-          type: APP_TYPES.FRONT_END,
         },
       });
 
@@ -296,7 +294,6 @@ export class AbilityUtilService {
           .innerJoin('folderApp.folder', 'folder')
           .where('folder.createdBy = :userId', { userId: user.id })
           .andWhere('folder.organizationId = :orgId', { orgId: user.organizationId })
-          .andWhere('folder.type = :type', { type: APP_TYPES.FRONT_END })
           .select('folderApp.appId')
           .getMany();
 
@@ -341,7 +338,6 @@ export class AbilityUtilService {
           .createQueryBuilder(FolderApp, 'folderApp')
           .innerJoin('folderApp.folder', 'folder')
           .where('folder.organizationId = :orgId', { orgId: user.organizationId })
-          .andWhere('folder.type = :type', { type: APP_TYPES.FRONT_END })
           .select('folderApp.appId')
           .getMany();
         const allFolderAppIds = allFolderApps.map((fa) => fa.appId);

--- a/server/src/modules/ability/util.service.ts
+++ b/server/src/modules/ability/util.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ResourcePermissionQueryObject, ResourcesItem, UserAppsPermissions, EnvironmentPermissionSet } from './types';
-import { Brackets, EntityManager, SelectQueryBuilder } from 'typeorm';
+import { Brackets, EntityManager, In, SelectQueryBuilder } from 'typeorm';
 import { GroupPermissions } from '@entities/group_permissions.entity';
 import { MODULES } from '@modules/app/constants/modules';
 import { GranularPermissions } from '@entities/granular_permissions.entity';
@@ -270,7 +270,11 @@ export class AbilityUtilService {
 
     await dbTransactionWrap(async (manager: EntityManager) => {
       const appsOwnedByUser = await manager.find(AppBase, {
-        where: { userId: user.id, organizationId: user.organizationId, type: APP_TYPES.FRONT_END },
+        where: {
+          userId: user.id,
+          organizationId: user.organizationId,
+          type: In([APP_TYPES.FRONT_END, APP_TYPES.MODULE]),
+        },
       });
 
       const appsIdOwnedByUser = appsOwnedByUser.map((app) => app.id);

--- a/server/src/modules/app-git/ability/index.ts
+++ b/server/src/modules/app-git/ability/index.ts
@@ -5,6 +5,7 @@ import { UserAllPermissions } from '@modules/app/types';
 import { FEATURE_KEY } from '../constants';
 import { AppGitSync } from '@entities/app_git_sync.entity';
 import { MODULES } from '@modules/app/constants/modules';
+import { APP_TYPES } from '@modules/apps/constants';
 
 type Subjects = InferSubjects<typeof AppGitSync> | 'all';
 export type AppGitAbility = Ability<[FEATURE_KEY, Subjects]>;
@@ -22,6 +23,7 @@ export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects>
     request?: any
   ): void {
     const appId = request?.tj_resource_id;
+    const appType = request?.tj_app?.type;
     const { superAdmin, isAdmin, userPermission } = UserAllPermissions;
 
     const userAppGitPermissions = userPermission?.[MODULES.APP];
@@ -35,7 +37,7 @@ export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects>
     can(FEATURE_KEY.CREATE_BRANCH, AppGitSync);
     can(FEATURE_KEY.FETCH_PULL_REQUESTS, AppGitSync);
     // Grant feature-level access based on resource actions
-    if (isAdmin || superAdmin) {
+    if (isAdmin || superAdmin || (appType === APP_TYPES.MODULE && UserAllPermissions.isBuilder)) {
       // Admin or Super Admin gets full access to all features
       can(FEATURE_KEY.GIT_CREATE_APP, AppGitSync);
       can(FEATURE_KEY.GIT_UPDATE_APP, AppGitSync);

--- a/server/src/modules/data-queries/ability/app/data-query-app.ability.ts
+++ b/server/src/modules/data-queries/ability/app/data-query-app.ability.ts
@@ -3,6 +3,7 @@ import { UserAllPermissions } from '@modules/app/types';
 import { FEATURE_KEY } from '../../constants';
 import { App } from '@entities/app.entity';
 import { MODULES } from '@modules/app/constants/modules';
+import { APP_TYPES } from '@modules/apps/constants';
 import { FeatureAbility } from './index';
 
 export function defineDataQueryAppAbility(
@@ -17,13 +18,12 @@ export function defineDataQueryAppAbility(
   const isCanCreate = userPermission.appCreate;
   const isCanDelete = userPermission.appDelete;
   const isAllViewable = !!resourcePermissions?.isAllViewable;
-  const resourceType = UserAllPermissions?.resource[0]?.resourceType;
 
   if (app?.isPublic) {
     can([FEATURE_KEY.RUN_VIEWER], App);
   }
 
-  if (isAdmin || superAdmin || (resourceType === MODULES.MODULES && isBuilder)) {
+  if (isAdmin || superAdmin || (app?.type === APP_TYPES.MODULE && isBuilder)) {
     can(
       [
         FEATURE_KEY.CREATE,

--- a/server/src/modules/data-queries/ability/app/data-query-app.ability.ts
+++ b/server/src/modules/data-queries/ability/app/data-query-app.ability.ts
@@ -19,20 +19,6 @@ export function defineDataQueryAppAbility(
   const isCanDelete = userPermission.appDelete;
   const isAllViewable = !!resourcePermissions?.isAllViewable;
 
-  console.log('Defining abilities for app', {
-    appId,
-    isAllEditable,
-    isCanCreate,
-    isCanDelete,
-    isAllViewable,
-    superAdmin,
-    isAdmin,
-    isBuilder,
-    appType: app?.type,
-    editableAppsId: JSON.stringify(resourcePermissions?.editableAppsId),
-    viewableAppsId: JSON.stringify(resourcePermissions?.viewableAppsId),
-  });
-
   if (app?.isPublic) {
     can([FEATURE_KEY.RUN_VIEWER], App);
   }

--- a/server/src/modules/data-queries/ability/app/data-query-app.ability.ts
+++ b/server/src/modules/data-queries/ability/app/data-query-app.ability.ts
@@ -12,12 +12,26 @@ export function defineDataQueryAppAbility(
   app: App
 ): void {
   const appId = app?.id;
-  const { superAdmin, isAdmin, userPermission, isBuilder } = UserAllPermissions;
+  const { superAdmin, isAdmin, userPermission, isBuilder, isEndUser } = UserAllPermissions;
   const resourcePermissions = userPermission?.[MODULES.APP];
   const isAllEditable = !!resourcePermissions?.isAllEditable;
   const isCanCreate = userPermission.appCreate;
   const isCanDelete = userPermission.appDelete;
   const isAllViewable = !!resourcePermissions?.isAllViewable;
+
+  console.log('Defining abilities for app', {
+    appId,
+    isAllEditable,
+    isCanCreate,
+    isCanDelete,
+    isAllViewable,
+    superAdmin,
+    isAdmin,
+    isBuilder,
+    appType: app?.type,
+    editableAppsId: JSON.stringify(resourcePermissions?.editableAppsId),
+    viewableAppsId: JSON.stringify(resourcePermissions?.viewableAppsId),
+  });
 
   if (app?.isPublic) {
     can([FEATURE_KEY.RUN_VIEWER], App);
@@ -83,6 +97,11 @@ export function defineDataQueryAppAbility(
   }
 
   if (resourcePermissions?.viewableAppsId?.length && appId && resourcePermissions?.viewableAppsId?.includes(appId)) {
+    can([FEATURE_KEY.GET, FEATURE_KEY.RUN_VIEWER, FEATURE_KEY.RUN_EDITOR], App);
+    return;
+  }
+
+  if (isEndUser) {
     can([FEATURE_KEY.GET, FEATURE_KEY.RUN_VIEWER, FEATURE_KEY.RUN_EDITOR], App);
     return;
   }

--- a/server/src/modules/data-queries/ability/app/index.ts
+++ b/server/src/modules/data-queries/ability/app/index.ts
@@ -32,7 +32,7 @@ export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects>
         defineDataQueryAppAbility(can, UserAllPermissions, app);
         break;
       case MODULES.MODULES:
-        defineDataQueryAppAbility(can, UserAllPermissions, resourceId);
+        defineDataQueryAppAbility(can, UserAllPermissions, app);
         break;
       case MODULES.WORKFLOWS:
         defineDataQueryWorkflowAbility(can, UserAllPermissions, resourceId);

--- a/server/src/modules/folder-apps/ability/guard.ts
+++ b/server/src/modules/folder-apps/ability/guard.ts
@@ -8,6 +8,7 @@ import { Folder } from '@entities/folder.entity';
 import { App } from '@entities/app.entity';
 import { ResourceDetails } from '@modules/app/types';
 import { MODULES } from '@modules/app/constants/modules';
+import { APP_TYPES } from '@modules/apps/constants';
 import { cloneDeep } from 'lodash';
 import { FEATURE_KEY } from '../constants';
 import { LicenseTermsService } from '@modules/licensing/interfaces/IService';
@@ -58,11 +59,11 @@ export class FeatureAbilityGuard extends AbilityGuard {
       const [folder, app] = await Promise.all([
         this.dataSource.manager.findOne(Folder, {
           where: { id: folderId, organizationId: request.user.organizationId },
-          select: ['id', 'createdBy'],
+          select: ['id', 'createdBy', 'type'],
         }),
         this.dataSource.manager.findOne(App, {
           where: { id: request.body.app_id, organizationId: request.user.organizationId },
-          select: ['id', 'userId'],
+          select: ['id', 'userId', 'type'],
         }),
       ]);
 
@@ -70,6 +71,9 @@ export class FeatureAbilityGuard extends AbilityGuard {
         !!folder && !!app && folder.createdBy === request.user.id && app.userId === request.user.id;
 
       request.tj_allow_owner_folder_app_delete = !!folder && !!app && folder.createdBy === request.user.id;
+
+      request.tj_app_is_module = app?.type === APP_TYPES.MODULE;
+      request.tj_folder_app_type_mismatch = !!(folder?.type && app?.type && folder.type !== app.type);
     }
 
     return super.canActivate(context);

--- a/server/src/modules/folder-apps/ability/index.ts
+++ b/server/src/modules/folder-apps/ability/index.ts
@@ -20,6 +20,10 @@ export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects>
     extractedMetadata: { moduleName: string; features: string[] },
     request?: any
   ): void {
+    if (request?.tj_folder_app_type_mismatch) {
+      return;
+    }
+
     const { superAdmin, userPermission, isAdmin } = UserAllPermissions;
     const folderCreate = userPermission.folderCreate;
     const folderPermissions = userPermission[MODULES.FOLDER];
@@ -37,6 +41,10 @@ export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects>
 
       if (ownerCanDeleteFolderApp) {
         can(FEATURE_KEY.DELETE_FOLDER_APP, FolderApp);
+      }
+
+      if (request?.tj_app_is_module && userPermission.isBuilder) {
+        can([FEATURE_KEY.CREATE_FOLDER_APP, FEATURE_KEY.DELETE_FOLDER_APP], FolderApp);
       }
 
       if (folderPermissions) {

--- a/server/src/modules/folder-apps/service.ts
+++ b/server/src/modules/folder-apps/service.ts
@@ -75,13 +75,20 @@ export class FolderAppsService implements IFolderAppsService {
       const userAppPermissions = userPermissions?.[resourceType] ?? userPermissions?.[MODULES.APP];
       const userFolderPermissions = userPermissions?.[MODULES.FOLDER];
 
+      // Builders have admin-level access to module folders — no app or folder permission checks apply.
+      const isModuleBuilderAccess =
+        type === APP_TYPES.MODULE && (userPermissions?.isBuilder || userPermissions?.isAdmin);
+
       const allFolderList = await this.foldersUtilService.allFolders(user, manager, type);
       if (allFolderList.length === 0) {
         return { folders: [] };
       }
+      const effectiveAppPermissions = isModuleBuilderAccess
+        ? { ...userAppPermissions, isAllEditable: true }
+        : userAppPermissions;
       const folders = await this.folderAppsUtilService.allFoldersWithAppCount(
         user,
-        userAppPermissions,
+        effectiveAppPermissions,
         manager,
         type,
         searchKey,
@@ -102,7 +109,7 @@ export class FolderAppsService implements IFolderAppsService {
       const visibleFolders = this.filterFoldersByPermissions(
         allFolderList,
         user,
-        userPermissions?.isAdmin,
+        isModuleBuilderAccess || userPermissions?.isAdmin,
         userFolderPermissions
       );
 

--- a/server/src/modules/folder-apps/util.service.ts
+++ b/server/src/modules/folder-apps/util.service.ts
@@ -173,6 +173,12 @@ export class FolderAppsUtilService implements IFolderAppsUtilService {
       });
       const userAppPermissions = userPermission?.[MODULES.APP];
 
+      // Builders have admin-level access to modules — skip app-level permission filtering.
+      const isModuleBuilderAccess = type === APP_TYPES.MODULE && (userPermission?.isBuilder || userPermission?.isAdmin);
+      const effectiveAppPermissions = isModuleBuilderAccess
+        ? { ...userAppPermissions, isAllEditable: true }
+        : userAppPermissions;
+
       const folderAppIds = folderApps.map((folderApp) => folderApp.appId);
       if (folderAppIds.length == 0) {
         return {
@@ -182,7 +188,7 @@ export class FolderAppsUtilService implements IFolderAppsUtilService {
       }
 
       const viewableAppsInFolder = this.getBaseAppsQuery(manager, folderAppIds, searchKey, branchId);
-      this.addViewableFrontendFilter(viewableAppsInFolder, folderAppIds, userAppPermissions);
+      this.addViewableFrontendFilter(viewableAppsInFolder, folderAppIds, effectiveAppPermissions);
 
       if (branchId) {
         viewableAppsInFolder.andWhere(

--- a/server/src/modules/folder-apps/util.service.ts
+++ b/server/src/modules/folder-apps/util.service.ts
@@ -182,7 +182,13 @@ export class FolderAppsUtilService implements IFolderAppsUtilService {
       }
 
       const viewableAppsInFolder = this.getBaseAppsQuery(manager, folderAppIds, searchKey, branchId);
-      this.addViewableFrontendFilter(viewableAppsInFolder, folderAppIds, userAppPermissions);
+      if (type === APP_TYPES.MODULE) {
+        // Modules have no permission gate on listing (all org members can see all modules).
+        // Still constrain to this folder's app IDs so we don't return unrelated apps.
+        viewableAppsInFolder.where('apps.id IN (:...folderAppIds)', { folderAppIds });
+      } else {
+        this.addViewableFrontendFilter(viewableAppsInFolder, folderAppIds, userAppPermissions);
+      }
 
       if (branchId) {
         viewableAppsInFolder.andWhere(

--- a/server/src/modules/folder-apps/util.service.ts
+++ b/server/src/modules/folder-apps/util.service.ts
@@ -182,13 +182,7 @@ export class FolderAppsUtilService implements IFolderAppsUtilService {
       }
 
       const viewableAppsInFolder = this.getBaseAppsQuery(manager, folderAppIds, searchKey, branchId);
-      if (type === APP_TYPES.MODULE) {
-        // Modules have no permission gate on listing (all org members can see all modules).
-        // Still constrain to this folder's app IDs so we don't return unrelated apps.
-        viewableAppsInFolder.where('apps.id IN (:...folderAppIds)', { folderAppIds });
-      } else {
-        this.addViewableFrontendFilter(viewableAppsInFolder, folderAppIds, userAppPermissions);
-      }
+      this.addViewableFrontendFilter(viewableAppsInFolder, folderAppIds, userAppPermissions);
 
       if (branchId) {
         viewableAppsInFolder.andWhere(

--- a/server/src/modules/folders/service.ts
+++ b/server/src/modules/folders/service.ts
@@ -12,6 +12,7 @@ import { dbTransactionWrap } from '@helpers/database.helper';
 import { FoldersUtilService } from './util.service';
 import { AbilityService } from '@modules/ability/interfaces/IService';
 import { MODULES } from '@modules/app/constants/modules';
+import { APP_TYPES } from '@modules/apps/constants';
 
 @Injectable()
 export class FoldersService implements IFoldersService {
@@ -114,6 +115,10 @@ export class FoldersService implements IFoldersService {
       if (folderPerms.editableFoldersId?.includes(folder.id)) {
         return;
       }
+    }
+
+    if (action === 'update' && userPermissions.isBuilder && folder.type === APP_TYPES.MODULE) {
+      return;
     }
 
     throw new ForbiddenException('You do not have access to perform this action');

--- a/server/src/modules/versions/ability/app-version.ability.ts
+++ b/server/src/modules/versions/ability/app-version.ability.ts
@@ -15,6 +15,15 @@ export function defineAppVersionAbility(
   const permissionKey = resourceType === MODULES.MODULES ? MODULES.APP : resourceType;
   const userAppPermissions = userPermission?.[permissionKey];
 
+  // For MODULE type apps every authenticated user can read the version --> modules are
+  // fetched as dependencies during app preview and cannot be added to permission groups
+  // (the app_type DB enum has no 'module' value), so the normal viewableAppsId path
+  // can never grant access to them.
+  if (resourceType === MODULES.MODULES && !isAdmin && !superAdmin && !isBuilder) {
+    can([FEATURE_KEY.GET, FEATURE_KEY.GET_ONE, FEATURE_KEY.GET_EVENTS], App);
+    return;
+  }
+
   if (isAdmin || superAdmin || (resourceType === MODULES.MODULES && isBuilder)) {
     can(
       [
@@ -131,5 +140,4 @@ export function defineAppVersionAbility(
   ) {
     can([FEATURE_KEY.GET_EVENTS, FEATURE_KEY.GET_ONE, FEATURE_KEY.GET], App);
   }
-
 }

--- a/server/src/modules/versions/ability/app-version.ability.ts
+++ b/server/src/modules/versions/ability/app-version.ability.ts
@@ -10,7 +10,7 @@ export function defineAppVersionAbility(
   UserAllPermissions: UserAllPermissions,
   resourceId?: string
 ): void {
-  const { superAdmin, isAdmin, userPermission, resource, isBuilder } = UserAllPermissions;
+  const { superAdmin, isAdmin, userPermission, isBuilder } = UserAllPermissions;
   const resourceType = UserAllPermissions?.resource[0]?.resourceType;
   const permissionKey = resourceType === MODULES.MODULES ? MODULES.APP : resourceType;
   const userAppPermissions = userPermission?.[permissionKey];

--- a/server/src/modules/versions/ability/app-version.ability.ts
+++ b/server/src/modules/versions/ability/app-version.ability.ts
@@ -8,11 +8,12 @@ import { MODULES } from '@modules/app/constants/modules';
 export function defineAppVersionAbility(
   can: AbilityBuilder<FeatureAbility>['can'],
   UserAllPermissions: UserAllPermissions,
-  resourceId?: string,
+  resourceId?: string
 ): void {
   const { superAdmin, isAdmin, userPermission, resource, isBuilder } = UserAllPermissions;
-  const userAppPermissions = userPermission?.[resource[0].resourceType];
   const resourceType = UserAllPermissions?.resource[0]?.resourceType;
+  const permissionKey = resourceType === MODULES.MODULES ? MODULES.APP : resourceType;
+  const userAppPermissions = userPermission?.[permissionKey];
 
   if (isAdmin || superAdmin) {
     can(

--- a/server/src/modules/versions/ability/app-version.ability.ts
+++ b/server/src/modules/versions/ability/app-version.ability.ts
@@ -15,7 +15,7 @@ export function defineAppVersionAbility(
   const permissionKey = resourceType === MODULES.MODULES ? MODULES.APP : resourceType;
   const userAppPermissions = userPermission?.[permissionKey];
 
-  if (isAdmin || superAdmin) {
+  if (isAdmin || superAdmin || (resourceType === MODULES.MODULES && isBuilder)) {
     can(
       [
         FEATURE_KEY.GET,
@@ -132,21 +132,4 @@ export function defineAppVersionAbility(
     can([FEATURE_KEY.GET_EVENTS, FEATURE_KEY.GET_ONE, FEATURE_KEY.GET], App);
   }
 
-  if (isBuilder && resourceType === MODULES.MODULES) {
-    //For Modules
-    can(
-      [
-        FEATURE_KEY.UPDATE_COMPONENTS,
-        FEATURE_KEY.CREATE_COMPONENTS,
-        FEATURE_KEY.UPDATE_COMPONENT_LAYOUT,
-        FEATURE_KEY.DELETE_COMPONENTS,
-        FEATURE_KEY.GET_EVENTS,
-        FEATURE_KEY.CREATE_EVENT,
-        FEATURE_KEY.UPDATE_EVENT,
-        FEATURE_KEY.DELETE_EVENT,
-        FEATURE_KEY.GET_ONE,
-      ],
-      App
-    );
-  }
 }

--- a/server/test/modules/folder-apps/e2e/folder-apps.spec.ts
+++ b/server/test/modules/folder-apps/e2e/folder-apps.spec.ts
@@ -1,8 +1,23 @@
 import { INestApplication } from '@nestjs/common';
-import { login, initTestApp, closeTestApp, createUser, createApplication, saveEntity } from 'test-helper';
+import {
+  login,
+  initTestApp,
+  closeTestApp,
+  createUser,
+  createApplication,
+  createApplicationVersion,
+  createFolder,
+  addAppToFolder,
+  saveEntity,
+  findEntity,
+} from 'test-helper';
 import * as request from 'supertest';
 import { Folder } from '@entities/folder.entity';
 import { FolderApp } from '@entities/folder_app.entity';
+import { WorkspaceBranch } from '@entities/workspace_branch.entity';
+import { AppVersion } from '@entities/app_version.entity';
+import { App } from '@entities/app.entity';
+import { APP_TYPES } from '@modules/apps/constants';
 
 async function setupOrganization(nestApp) {
   const adminUserData = await createUser(nestApp, {
@@ -18,7 +33,7 @@ async function setupOrganization(nestApp) {
     isPublic: false,
   });
 
-  return { adminUser, app };
+  return { adminUser, organization, app };
 }
 
 /** @group platform */
@@ -170,6 +185,342 @@ describe('FolderAppsController', () => {
           .send({ app_id: folderApp.appId });
 
         expect(response.statusCode).toBe(200);
+      });
+    });
+
+    // =========================================================================
+    // Module branch-scoped folder listing tests
+    // =========================================================================
+    // Verifies that module apps in folders are properly branch-scoped when
+    // branchId is provided, ensuring cross-branch module leakage is prevented.
+    // =========================================================================
+
+    describe('GET /api/apps (type=module, folder context) | Module branch-scoped listing', () => {
+      it('should return only modules on the specified branch when branchId is provided', async () => {
+        const { adminUser } = await setupOrganization(nestApp);
+        const loggedUser = await login(nestApp);
+
+        // Create workspace branches
+        const branchA = await saveEntity(WorkspaceBranch, {
+          name: 'feature-a',
+          organizationId: adminUser.organizationId,
+          isDefault: false,
+        } as any);
+
+        const branchB = await saveEntity(WorkspaceBranch, {
+          name: 'feature-b',
+          organizationId: adminUser.organizationId,
+          isDefault: false,
+        } as any);
+
+        // Create module apps (skip env creation - already created by setupOrganization)
+        const moduleA = await createApplication(
+          nestApp,
+          {
+            user: adminUser,
+            name: 'Module A',
+            type: APP_TYPES.MODULE,
+          },
+          false
+        );
+
+        const moduleB = await createApplication(
+          nestApp,
+          {
+            user: adminUser,
+            name: 'Module B',
+            type: APP_TYPES.MODULE,
+          },
+          false
+        );
+
+        // Create versions on specific branches
+        const versionA = await createApplicationVersion(nestApp, moduleA, { name: 'v1' });
+        await saveEntity(AppVersion, {
+          id: versionA.id,
+          branchId: branchA.id,
+        } as any);
+
+        const versionB = await createApplicationVersion(nestApp, moduleB, { name: 'v1' });
+        await saveEntity(AppVersion, {
+          id: versionB.id,
+          branchId: branchB.id,
+        } as any);
+
+        // Create a module folder and add modules to it
+        const moduleFolder = await createFolder(nestApp, {
+          name: 'Module Folder',
+          type: APP_TYPES.MODULE,
+          organizationId: adminUser.organizationId,
+        });
+
+        await addAppToFolder(nestApp, moduleA, moduleFolder);
+        await addAppToFolder(nestApp, moduleB, moduleFolder);
+
+        // Fetch modules from folder with branchId=A
+        const responseBranchA = await request(nestApp.getHttpServer())
+          .get('/api/apps')
+          .query({ folder: moduleFolder.id, type: 'module' })
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('x-branch-id', branchA.id)
+          .set('Cookie', loggedUser.tokenCookie);
+
+        expect(responseBranchA.statusCode).toBe(200);
+        const appsBranchA = responseBranchA.body.apps;
+        expect(appsBranchA).toHaveLength(1);
+        expect(appsBranchA[0].id).toBe(moduleA.id);
+        expect(appsBranchA[0].name).toBe('Module A');
+
+        // Fetch modules from folder with branchId=B
+        const responseBranchB = await request(nestApp.getHttpServer())
+          .get('/api/apps')
+          .query({ folder: moduleFolder.id, type: 'module' })
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('x-branch-id', branchB.id)
+          .set('Cookie', loggedUser.tokenCookie);
+
+        expect(responseBranchB.statusCode).toBe(200);
+        const appsBranchB = responseBranchB.body.apps;
+        expect(appsBranchB).toHaveLength(1);
+        expect(appsBranchB[0].id).toBe(moduleB.id);
+        expect(appsBranchB[0].name).toBe('Module B');
+      });
+
+      it('should return empty list when no modules on that branch are in the folder', async () => {
+        const { adminUser } = await setupOrganization(nestApp);
+        const loggedUser = await login(nestApp);
+
+        const branchA = await saveEntity(WorkspaceBranch, {
+          name: 'isolated-branch',
+          organizationId: adminUser.organizationId,
+          isDefault: false,
+        } as any);
+
+        const moduleA = await createApplication(
+          nestApp,
+          {
+            user: adminUser,
+            name: 'Isolated Module',
+            type: APP_TYPES.MODULE,
+          },
+          false
+        );
+
+        const versionA = await createApplicationVersion(nestApp, moduleA, { name: 'v1' });
+        await saveEntity(AppVersion, {
+          id: versionA.id,
+          branchId: branchA.id,
+        } as any);
+
+        const moduleFolder = await createFolder(nestApp, {
+          name: 'Empty Folder',
+          type: APP_TYPES.MODULE,
+          organizationId: adminUser.organizationId,
+        });
+
+        // Add module but query with different branch
+        const branchC = await saveEntity(WorkspaceBranch, {
+          name: 'other-branch',
+          organizationId: adminUser.organizationId,
+          isDefault: false,
+        } as any);
+
+        await addAppToFolder(nestApp, moduleA, moduleFolder);
+
+        const response = await request(nestApp.getHttpServer())
+          .get('/api/apps')
+          .query({ folder: moduleFolder.id, type: 'module' })
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('x-branch-id', branchC.id)
+          .set('Cookie', loggedUser.tokenCookie);
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.apps).toHaveLength(0);
+        expect(response.body.meta.folder_count).toBe(0);
+      });
+
+    describe('Builder permissions on module folders', () => {
+      it('should allow a builder to add a module app to a module folder', async () => {
+        const adminUserData = await createUser(nestApp, {
+          email: 'admin-builder-add@tooljet.io',
+          groups: ['end-user', 'admin'],
+        });
+        const adminUser = adminUserData.user;
+        const organization = adminUserData.organization;
+
+        await createUser(nestApp, { email: 'builder-add@tooljet.io', groups: ['builder'], organization });
+        const { tokenCookie: builderCookie } = await login(nestApp, 'builder-add@tooljet.io', 'password');
+
+        const moduleApp = await createApplication(nestApp, { user: adminUser, name: 'module app', type: APP_TYPES.MODULE }, false);
+
+        const moduleFolder = await createFolder(nestApp, {
+          name: 'module folder',
+          type: APP_TYPES.MODULE,
+          organizationId: adminUser.organizationId,
+        });
+
+        const response = await request(nestApp.getHttpServer())
+          .post('/api/folder-apps')
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('Cookie', builderCookie)
+          .send({ folder_id: moduleFolder.id, app_id: moduleApp.id });
+
+        expect(response.statusCode).toBe(201);
+      });
+
+      it('should allow a builder to remove a module app from a module folder', async () => {
+        const adminUserData = await createUser(nestApp, {
+          email: 'admin-builder-remove@tooljet.io',
+          groups: ['end-user', 'admin'],
+        });
+        const adminUser = adminUserData.user;
+        const organization = adminUserData.organization;
+
+        await createUser(nestApp, { email: 'builder-remove@tooljet.io', groups: ['builder'], organization });
+        const { tokenCookie: builderCookie } = await login(nestApp, 'builder-remove@tooljet.io', 'password');
+
+        const moduleApp = await createApplication(nestApp, { user: adminUser, name: 'module app for removal', type: APP_TYPES.MODULE }, false);
+
+        const moduleFolder = await createFolder(nestApp, {
+          name: 'module folder for removal',
+          type: APP_TYPES.MODULE,
+          organizationId: adminUser.organizationId,
+        });
+
+        await addAppToFolder(nestApp, moduleApp, moduleFolder);
+
+        const response = await request(nestApp.getHttpServer())
+          .put(`/api/folder-apps/${moduleFolder.id}`)
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('Cookie', builderCookie)
+          .send({ app_id: moduleApp.id });
+
+        expect(response.statusCode).toBe(200);
+      });
+
+      it('should not allow a builder to add a front-end app to a front-end folder without explicit permission', async () => {
+        const adminUserData = await createUser(nestApp, {
+          email: 'admin-builder-fe@tooljet.io',
+          groups: ['end-user', 'admin'],
+        });
+        const adminUser = adminUserData.user;
+        const organization = adminUserData.organization;
+
+        await createUser(nestApp, { email: 'builder-frontend@tooljet.io', groups: ['builder'], organization });
+        const { tokenCookie: builderCookie } = await login(nestApp, 'builder-frontend@tooljet.io', 'password');
+
+        const frontEndApp = await createApplication(nestApp, { user: adminUser, name: 'front-end app' }, false);
+
+        const frontEndFolder = await createFolder(nestApp, {
+          name: 'front-end folder',
+          type: APP_TYPES.FRONT_END,
+          organizationId: adminUser.organizationId,
+        });
+
+        const response = await request(nestApp.getHttpServer())
+          .post('/api/folder-apps')
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('Cookie', builderCookie)
+          .send({ folder_id: frontEndFolder.id, app_id: frontEndApp.id });
+
+        expect(response.statusCode).toBe(403);
+      });
+
+      it('should block adding a module app to a front-end folder even for admin', async () => {
+        const { adminUser } = await setupOrganization(nestApp);
+        const loggedUser = await login(nestApp);
+
+        const moduleApp = await createApplication(nestApp, { user: adminUser, name: 'module for mismatch', type: APP_TYPES.MODULE }, false);
+
+        const frontEndFolder = await createFolder(nestApp, {
+          name: 'fe folder for mismatch',
+          type: APP_TYPES.FRONT_END,
+          organizationId: adminUser.organizationId,
+        });
+
+        const response = await request(nestApp.getHttpServer())
+          .post('/api/folder-apps')
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('Cookie', loggedUser.tokenCookie)
+          .send({ folder_id: frontEndFolder.id, app_id: moduleApp.id });
+
+        expect(response.statusCode).toBe(403);
+      });
+
+      it('should block adding a front-end app to a module folder even for admin', async () => {
+        const { adminUser } = await setupOrganization(nestApp);
+        const loggedUser = await login(nestApp);
+
+        const frontEndApp = await createApplication(nestApp, { user: adminUser, name: 'fe app for mismatch' }, false);
+
+        const moduleFolder = await createFolder(nestApp, {
+          name: 'module folder for mismatch',
+          type: APP_TYPES.MODULE,
+          organizationId: adminUser.organizationId,
+        });
+
+        const response = await request(nestApp.getHttpServer())
+          .post('/api/folder-apps')
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('Cookie', loggedUser.tokenCookie)
+          .send({ folder_id: moduleFolder.id, app_id: frontEndApp.id });
+
+        expect(response.statusCode).toBe(403);
+      });
+    });
+
+      it('should align folder count with returned modules across pagination', async () => {
+        const { adminUser } = await setupOrganization(nestApp);
+        const loggedUser = await login(nestApp);
+
+        const branchA = await saveEntity(WorkspaceBranch, {
+          name: 'pagination-branch',
+          organizationId: adminUser.organizationId,
+          isDefault: false,
+        } as any);
+
+        // Create 3 modules, all on branchA
+        const modules = [];
+        for (let i = 0; i < 3; i++) {
+          const mod = await createApplication(
+            nestApp,
+            {
+              user: adminUser,
+              name: `Module ${i + 1}`,
+              type: APP_TYPES.MODULE,
+            },
+            false
+          );
+          const version = await createApplicationVersion(nestApp, mod, { name: 'v1' });
+          await saveEntity(AppVersion, {
+            id: version.id,
+            branchId: branchA.id,
+          } as any);
+          modules.push(mod);
+        }
+
+        const moduleFolder = await createFolder(nestApp, {
+          name: 'Pagination Folder',
+          type: APP_TYPES.MODULE,
+          organizationId: adminUser.organizationId,
+        });
+
+        for (const mod of modules) {
+          await addAppToFolder(nestApp, mod, moduleFolder);
+        }
+
+        // Fetch with page 1 (9 per page, so all 3 should fit)
+        const response = await request(nestApp.getHttpServer())
+          .get('/api/apps')
+          .query({ folder: moduleFolder.id, type: 'module', page: 1 })
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('x-branch-id', branchA.id)
+          .set('Cookie', loggedUser.tokenCookie);
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.apps).toHaveLength(3);
+        expect(response.body.meta.folder_count).toBe(3);
+        expect(response.body.meta.total_pages).toBe(1);
       });
     });
   });

--- a/server/test/modules/group-permissions/e2e/group-permissions.spec.ts
+++ b/server/test/modules/group-permissions/e2e/group-permissions.spec.ts
@@ -6,6 +6,7 @@ import {
   initTestApp,
   closeTestApp,
   createApplication,
+  createFolder,
   login,
   findEntityOrFail,
   findEntity,
@@ -13,6 +14,8 @@ import {
 } from 'test-helper';
 import { GroupPermissions } from 'src/entities/group_permissions.entity';
 import { GroupUsers } from 'src/entities/group_users.entity';
+import { GroupFolders } from 'src/entities/group_folders.entity';
+import { APP_TYPES } from '@modules/apps/constants';
 
 /**
  * V2 Group Permissions API | e2e tests.
@@ -109,7 +112,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('POST /api/v2/group-permissions | Create group', () => {
       it('should not allow non-admin to create a group', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await createGroupViaApi(cookie, defaultUser.defaultOrganizationId, 'avengers');
@@ -117,13 +122,18 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to create a custom group', async () => {
-        const { organization: { adminUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         const response = await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
         expect(response.statusCode).toBe(201);
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
         expect(group).toMatchObject({
           name: 'avengers',
           organizationId: organization.id,
@@ -133,7 +143,9 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should reject duplicate group names within the same organization', async () => {
-        const { organization: { adminUser } } = await setupOrganizations();
+        const {
+          organization: { adminUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         const first = await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
@@ -144,7 +156,10 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow the same group name in different organizations', async () => {
-        const { organization: { adminUser }, anotherOrganization: { anotherAdminUser } } = await setupOrganizations();
+        const {
+          organization: { adminUser },
+          anotherOrganization: { anotherAdminUser },
+        } = await setupOrganizations();
         const adminCookie = await authenticate('admin@tooljet.io');
         const anotherAdminCookie = await authenticate('another_admin@tooljet.io');
 
@@ -162,7 +177,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('GET /api/v2/group-permissions | List groups', () => {
       it('should not allow non-admin to list groups', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await request(nestApp.getHttpServer())
@@ -174,7 +191,9 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to list all groups', async () => {
-        const { organization: { adminUser } } = await setupOrganizations();
+        const {
+          organization: { adminUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         // Create a custom group first
@@ -202,7 +221,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('GET /api/v2/group-permissions/:id | Get group', () => {
       it('should not allow non-admin to get a group', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await request(nestApp.getHttpServer())
@@ -214,12 +235,17 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to get a group by id', async () => {
-        const { organization: { adminUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         const response = await request(nestApp.getHttpServer())
           .get(`/api/v2/group-permissions/${group.id}`)
@@ -234,13 +260,19 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should return 404 for group from another organization', async () => {
-        const { organization: { adminUser, organization }, anotherOrganization: { anotherAdminUser } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+          anotherOrganization: { anotherAdminUser },
+        } = await setupOrganizations();
         const adminCookie = await authenticate('admin@tooljet.io');
         const anotherAdminCookie = await authenticate('another_admin@tooljet.io');
 
         await createGroupViaApi(adminCookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         // Another org's admin should not be able to access
         const response = await request(nestApp.getHttpServer())
@@ -259,7 +291,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('PUT /api/v2/group-permissions/:id | Update group', () => {
       it('should not allow non-admin to update a group', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await request(nestApp.getHttpServer())
@@ -272,12 +306,17 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to rename a custom group', async () => {
-        const { organization: { adminUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         const response = await request(nestApp.getHttpServer())
           .put(`/api/v2/group-permissions/${group.id}`)
@@ -292,12 +331,17 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should reject renaming to an existing group name', async () => {
-        const { organization: { adminUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         // Try to rename to 'admin' which is a default group
         const response = await request(nestApp.getHttpServer())
@@ -310,12 +354,17 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to update group permission flags', async () => {
-        const { organization: { adminUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         const response = await request(nestApp.getHttpServer())
           .put(`/api/v2/group-permissions/${group.id}`)
@@ -339,7 +388,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('DELETE /api/v2/group-permissions/:id | Delete group', () => {
       it('should not allow non-admin to delete a group', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await request(nestApp.getHttpServer())
@@ -351,12 +402,17 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to delete a custom group', async () => {
-        const { organization: { adminUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         const response = await request(nestApp.getHttpServer())
           .delete(`/api/v2/group-permissions/${group.id}`)
@@ -376,7 +432,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('POST /api/v2/group-permissions/:id/users | Add user to group', () => {
       it('should not allow non-admin to add users', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await request(nestApp.getHttpServer())
@@ -389,12 +447,17 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to add users to a custom group', async () => {
-        const { organization: { adminUser, defaultUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, defaultUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         const response = await request(nestApp.getHttpServer())
           .post(`/api/v2/group-permissions/${group.id}/users`)
@@ -416,7 +479,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('GET /api/v2/group-permissions/:id/users | List group users', () => {
       it('should not allow non-admin to list group users', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await request(nestApp.getHttpServer())
@@ -428,11 +493,16 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to list users in a group', async () => {
-        const { organization: { adminUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         // Get the admin default group
-        const adminGroup = await findEntityOrFail(GroupPermissions, { name: 'admin', organizationId: organization.id } as any);
+        const adminGroup = await findEntityOrFail(GroupPermissions, {
+          name: 'admin',
+          organizationId: organization.id,
+        } as any);
 
         const response = await request(nestApp.getHttpServer())
           .get(`/api/v2/group-permissions/${adminGroup.id}/users`)
@@ -452,7 +522,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('DELETE /api/v2/group-permissions/users/:id | Remove user from group', () => {
       it('should not allow non-admin to remove a user from a group', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await request(nestApp.getHttpServer())
@@ -464,12 +536,17 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to remove a user from a custom group', async () => {
-        const { organization: { adminUser, defaultUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, defaultUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         // Add user first
         await request(nestApp.getHttpServer())
@@ -500,7 +577,9 @@ describe('GroupPermissionsControllerV2', () => {
 
     describe('GET /api/v2/group-permissions/:id/users/addable-users | List addable users', () => {
       it('should not allow non-admin to search addable users', async () => {
-        const { organization: { defaultUser } } = await setupOrganizations();
+        const {
+          organization: { defaultUser },
+        } = await setupOrganizations();
         const cookie = await authenticate('developer@tooljet.io');
 
         const response = await request(nestApp.getHttpServer())
@@ -512,12 +591,17 @@ describe('GroupPermissionsControllerV2', () => {
       });
 
       it('should allow admin to search for addable users', async () => {
-        const { organization: { adminUser, organization } } = await setupOrganizations();
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
         const cookie = await authenticate('admin@tooljet.io');
 
         await createGroupViaApi(cookie, adminUser.defaultOrganizationId, 'avengers');
 
-        const group = await findEntityOrFail(GroupPermissions, { organizationId: organization.id, name: 'avengers' } as any);
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'avengers',
+        } as any);
 
         const response = await request(nestApp.getHttpServer())
           .get(`/api/v2/group-permissions/${group.id}/users/addable-users?input=developer`)
@@ -529,6 +613,100 @@ describe('GroupPermissionsControllerV2', () => {
         // developer@tooljet.io should appear as addable
         const emails = users.map((u: any) => u.email);
         expect(emails).toContain('developer@tooljet.io');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // GET /api/v2/group-permissions/granular-permissions/addable-folders
+    // -------------------------------------------------------------------------
+
+    describe('GET /api/v2/group-permissions/granular-permissions/addable-folders | List addable folders', () => {
+      it('should return only front-end folders and hide module folders', async () => {
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
+        const cookie = await authenticate('admin@tooljet.io');
+
+        const appFolder = await createFolder(nestApp, {
+          name: 'App Folder',
+          type: APP_TYPES.FRONT_END,
+          organizationId: organization.id,
+        });
+
+        const moduleFolder = await createFolder(nestApp, {
+          name: 'Module Folder',
+          type: APP_TYPES.MODULE,
+          organizationId: organization.id,
+        });
+
+        const response = await request(nestApp.getHttpServer())
+          .get('/api/v2/group-permissions/granular-permissions/addable-folders')
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('Cookie', cookie);
+
+        expect(response.statusCode).toBe(200);
+
+        const folderIds = response.body.map((folder: any) => folder.id);
+        expect(folderIds).toContain(appFolder.id);
+        expect(folderIds).not.toContain(moduleFolder.id);
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // POST /api/v2/group-permissions/:id/granular-permissions/folder
+    // -------------------------------------------------------------------------
+
+    describe('POST /api/v2/group-permissions/:id/granular-permissions/folder | Create folder granular permissions', () => {
+      it('should still persist module folder ids when sent directly', async () => {
+        const {
+          organization: { adminUser, organization },
+        } = await setupOrganizations();
+        const cookie = await authenticate('admin@tooljet.io');
+
+        const customGroupResponse = await createGroupViaApi(
+          cookie,
+          adminUser.defaultOrganizationId,
+          'module-folder-access'
+        );
+        expect(customGroupResponse.statusCode).toBe(201);
+
+        const group = await findEntityOrFail(GroupPermissions, {
+          organizationId: organization.id,
+          name: 'module-folder-access',
+        } as any);
+
+        const moduleFolder = await createFolder(nestApp, {
+          name: 'Module Folder - direct grant',
+          type: APP_TYPES.MODULE,
+          organizationId: organization.id,
+        });
+
+        const response = await request(nestApp.getHttpServer())
+          .post(`/api/v2/group-permissions/${group.id}/granular-permissions/folder`)
+          .set('tj-workspace-id', adminUser.defaultOrganizationId)
+          .set('Cookie', cookie)
+          .send({
+            name: 'Module Folder Access',
+            groupId: group.id,
+            type: 'folder',
+            isAll: false,
+            createResourcePermissionObject: {
+              canEditFolder: false,
+              canEditApps: false,
+              canViewApps: true,
+              resourcesToAdd: [{ folderId: moduleFolder.id }],
+            },
+          });
+
+        expect(response.statusCode).toBe(201);
+
+        const groupFolders = await findEntities(GroupFolders, {
+          where: {
+            folderId: moduleFolder.id,
+          },
+        });
+
+        expect(groupFolders.length).toBeGreaterThan(0);
       });
     });
   });

--- a/server/test/modules/versions/unit/app-version.ability.spec.ts
+++ b/server/test/modules/versions/unit/app-version.ability.spec.ts
@@ -6,6 +6,10 @@ import { FEATURE_KEY } from '@modules/versions/constants';
 import { MODULES } from '@modules/app/constants/modules';
 import { App } from '@entities/app.entity';
 
+import { UserAllPermissions } from '@modules/app/types';
+import { DEFAULT_USER_PERMISSIONS, DEFAULT_USER_APPS_PERMISSIONS } from '@modules/ability/constants';
+import { User } from '@entities/user.entity';
+
 const makeBuilder = () => new AbilityBuilder<FeatureAbility>(Ability as AbilityClass<FeatureAbility>);
 
 const buildPermissions = (
@@ -21,7 +25,7 @@ const buildPermissions = (
     resourceType?: MODULES;
     appPromote?: boolean;
   } = {}
-) => {
+): UserAllPermissions => {
   const {
     superAdmin = false,
     isAdmin = false,
@@ -40,32 +44,17 @@ const buildPermissions = (
     isAdmin,
     isBuilder,
     isEndUser,
-    user: {} as any,
+    user: {} as User,
     resource: [{ resourceType }],
     userPermission: {
-      isAdmin: false,
-      isSuperAdmin: false,
-      isBuilder: false,
-      isEndUser: false,
-      appCreate: false,
-      appDelete: false,
-      workflowCreate: false,
-      workflowDelete: false,
+      ...DEFAULT_USER_PERMISSIONS,
       appPromote,
-      appRelease: false,
-      dataSourceCreate: false,
-      dataSourceDelete: false,
-      folderCreate: false,
-      folderDelete: false,
-      orgConstantCRUD: false,
-      orgVariableCRUD: false,
       [MODULES.APP]: {
+        ...DEFAULT_USER_APPS_PERMISSIONS,
         isAllEditable,
         isAllViewable,
         editableAppsId,
         viewableAppsId,
-        hiddenAppsId: [],
-        hideAll: false,
       },
     },
   };
@@ -106,7 +95,7 @@ describe('defineAppVersionAbility', () => {
     it('grants all edit actions when isAllEditable is true', () => {
       const perms = buildPermissions({ isAllEditable: true, resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       ALL_ACTIONS.forEach((action) => {
@@ -118,7 +107,7 @@ describe('defineAppVersionAbility', () => {
       const resourceId = 'module-uuid-1';
       const perms = buildPermissions({ editableAppsId: [resourceId], resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any, resourceId);
+      defineAppVersionAbility(can, perms, resourceId);
       const ability = build();
 
       ALL_ACTIONS.forEach((action) => {
@@ -129,7 +118,7 @@ describe('defineAppVersionAbility', () => {
     it('denies edit actions when resourceId is not in editableAppsId', () => {
       const perms = buildPermissions({ editableAppsId: ['other-uuid'], resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any, 'module-uuid-1');
+      defineAppVersionAbility(can, perms, 'module-uuid-1');
       const ability = build();
 
       ALL_ACTIONS.forEach((action) => {
@@ -140,7 +129,7 @@ describe('defineAppVersionAbility', () => {
     it('grants view actions when isAllViewable is true', () => {
       const perms = buildPermissions({ isAllViewable: true, resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       VIEW_ACTIONS.forEach((action) => {
@@ -153,7 +142,7 @@ describe('defineAppVersionAbility', () => {
       const resourceId = 'module-uuid-2';
       const perms = buildPermissions({ viewableAppsId: [resourceId], resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any, resourceId);
+      defineAppVersionAbility(can, perms, resourceId);
       const ability = build();
 
       VIEW_ACTIONS.forEach((action) => {
@@ -165,7 +154,7 @@ describe('defineAppVersionAbility', () => {
     it('grants component/event operations to isBuilder', () => {
       const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(true);
@@ -182,7 +171,7 @@ describe('defineAppVersionAbility', () => {
     it('denies all actions with no permissions', () => {
       const perms = buildPermissions({ resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       ALL_ACTIONS.forEach((action) => {
@@ -195,7 +184,7 @@ describe('defineAppVersionAbility', () => {
     it('grants all edit actions when isAllEditable is true', () => {
       const perms = buildPermissions({ isAllEditable: true, resourceType: MODULES.APP });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       ALL_ACTIONS.forEach((action) => {
@@ -207,7 +196,7 @@ describe('defineAppVersionAbility', () => {
       const resourceId = 'app-uuid-1';
       const perms = buildPermissions({ editableAppsId: [resourceId], resourceType: MODULES.APP });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any, resourceId);
+      defineAppVersionAbility(can, perms, resourceId);
       const ability = build();
 
       ALL_ACTIONS.forEach((action) => {
@@ -220,7 +209,7 @@ describe('defineAppVersionAbility', () => {
     it('denies all actions with no permissions', () => {
       const perms = buildPermissions({ isEndUser: true });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       [...ALL_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
@@ -231,7 +220,7 @@ describe('defineAppVersionAbility', () => {
     it('grants view actions when isAllViewable is true', () => {
       const perms = buildPermissions({ isEndUser: true, isAllViewable: true });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       VIEW_ACTIONS.forEach((action) => {
@@ -242,7 +231,7 @@ describe('defineAppVersionAbility', () => {
     it('denies edit actions even when isAllViewable is true', () => {
       const perms = buildPermissions({ isEndUser: true, isAllViewable: true });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       const editOnlyActions = ALL_ACTIONS.filter((a) => !VIEW_ACTIONS.includes(a));
@@ -255,7 +244,7 @@ describe('defineAppVersionAbility', () => {
       const resourceId = 'app-uuid-end-user';
       const perms = buildPermissions({ isEndUser: true, viewableAppsId: [resourceId] });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any, resourceId);
+      defineAppVersionAbility(can, perms, resourceId);
       const ability = build();
 
       VIEW_ACTIONS.forEach((action) => {
@@ -266,7 +255,7 @@ describe('defineAppVersionAbility', () => {
     it('denies view actions when resourceId is not in viewableAppsId', () => {
       const perms = buildPermissions({ isEndUser: true, viewableAppsId: ['other-uuid'] });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any, 'app-uuid-end-user');
+      defineAppVersionAbility(can, perms, 'app-uuid-end-user');
       const ability = build();
 
       VIEW_ACTIONS.forEach((action) => {
@@ -277,7 +266,7 @@ describe('defineAppVersionAbility', () => {
     it('does not get builder component grant on MODULES resource type', () => {
       const perms = buildPermissions({ isEndUser: true, resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
@@ -288,7 +277,7 @@ describe('defineAppVersionAbility', () => {
       for (const resourceType of [MODULES.APP, MODULES.MODULES]) {
         const perms = buildPermissions({ isEndUser: true, resourceType });
         const { can, build } = makeBuilder();
-        defineAppVersionAbility(can, perms as any);
+        defineAppVersionAbility(can, perms);
         const ability = build();
 
         expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(false);
@@ -301,7 +290,7 @@ describe('defineAppVersionAbility', () => {
       for (const resourceType of [MODULES.APP, MODULES.MODULES]) {
         const perms = buildPermissions({ isAdmin: true, resourceType });
         const { can, build } = makeBuilder();
-        defineAppVersionAbility(can, perms as any);
+        defineAppVersionAbility(can, perms);
         const ability = build();
 
         ALL_ACTIONS.forEach((action) => {
@@ -314,7 +303,7 @@ describe('defineAppVersionAbility', () => {
       for (const resourceType of [MODULES.APP, MODULES.MODULES]) {
         const perms = buildPermissions({ superAdmin: true, resourceType });
         const { can, build } = makeBuilder();
-        defineAppVersionAbility(can, perms as any);
+        defineAppVersionAbility(can, perms);
         const ability = build();
 
         ALL_ACTIONS.forEach((action) => {
@@ -326,7 +315,7 @@ describe('defineAppVersionAbility', () => {
     it('grants PROMOTE to isAdmin', () => {
       const perms = buildPermissions({ isAdmin: true });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(true);
@@ -335,7 +324,7 @@ describe('defineAppVersionAbility', () => {
     it('grants PROMOTE to superAdmin', () => {
       const perms = buildPermissions({ superAdmin: true });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(true);
@@ -345,7 +334,7 @@ describe('defineAppVersionAbility', () => {
       // admin bypasses all permission flag checks via early return
       const perms = buildPermissions({ isAdmin: true, isAllEditable: false, editableAppsId: [] });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       [...ALL_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
@@ -358,7 +347,7 @@ describe('defineAppVersionAbility', () => {
     it('grants PROMOTE when appPromote is true', () => {
       const perms = buildPermissions({ appPromote: true, resourceType: MODULES.APP });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(true);
@@ -367,7 +356,7 @@ describe('defineAppVersionAbility', () => {
     it('denies PROMOTE when appPromote is false', () => {
       const perms = buildPermissions({ appPromote: false, resourceType: MODULES.APP });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(false);
@@ -376,7 +365,7 @@ describe('defineAppVersionAbility', () => {
     it('grants PROMOTE via appPromote on MODULES resource type', () => {
       const perms = buildPermissions({ appPromote: true, resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(true);
@@ -388,7 +377,7 @@ describe('defineAppVersionAbility', () => {
       // isBuilder + MODULES.APP → no special builder grant (only MODULES.MODULES triggers it)
       const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.APP });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       // no edit permissions set, so component actions should be denied
@@ -400,7 +389,7 @@ describe('defineAppVersionAbility', () => {
       // builder MODULES grant only covers component/event ops, not version lifecycle actions
       const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any);
+      defineAppVersionAbility(can, perms);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.APP_VERSION_CREATE, App)).toBe(false);
@@ -416,7 +405,7 @@ describe('defineAppVersionAbility', () => {
       const perms = buildPermissions({ editableAppsId: ['app-uuid-1'] });
       const { can, build } = makeBuilder();
       // no resourceId passed
-      defineAppVersionAbility(can, perms as any, undefined);
+      defineAppVersionAbility(can, perms, undefined);
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
@@ -426,7 +415,7 @@ describe('defineAppVersionAbility', () => {
     it('denies view actions when viewableAppsId is non-empty but resourceId is undefined', () => {
       const perms = buildPermissions({ viewableAppsId: ['app-uuid-1'] });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any, undefined);
+      defineAppVersionAbility(can, perms, undefined);
       const ability = build();
 
       VIEW_ACTIONS.forEach((action) => {
@@ -437,7 +426,7 @@ describe('defineAppVersionAbility', () => {
     it('grants edit actions from isAllEditable even without resourceId', () => {
       const perms = buildPermissions({ isAllEditable: true });
       const { can, build } = makeBuilder();
-      defineAppVersionAbility(can, perms as any, undefined);
+      defineAppVersionAbility(can, perms, undefined);
       const ability = build();
 
       ALL_ACTIONS.forEach((action) => {

--- a/server/test/modules/versions/unit/app-version.ability.spec.ts
+++ b/server/test/modules/versions/unit/app-version.ability.spec.ts
@@ -13,6 +13,7 @@ const buildPermissions = (
     superAdmin?: boolean;
     isAdmin?: boolean;
     isBuilder?: boolean;
+    isEndUser?: boolean;
     isAllEditable?: boolean;
     isAllViewable?: boolean;
     editableAppsId?: string[];
@@ -25,6 +26,7 @@ const buildPermissions = (
     superAdmin = false,
     isAdmin = false,
     isBuilder = false,
+    isEndUser = false,
     isAllEditable = false,
     isAllViewable = false,
     editableAppsId = [],
@@ -37,7 +39,7 @@ const buildPermissions = (
     superAdmin,
     isAdmin,
     isBuilder,
-    isEndUser: false,
+    isEndUser,
     user: {} as any,
     resource: [{ resourceType }],
     userPermission: {
@@ -212,6 +214,86 @@ describe('defineAppVersionAbility', () => {
     });
   });
 
+  describe('end user', () => {
+    it('denies all actions with no permissions', () => {
+      const perms = buildPermissions({ isEndUser: true });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      [...EDIT_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
+    });
+
+    it('grants view actions when isAllViewable is true', () => {
+      const perms = buildPermissions({ isEndUser: true, isAllViewable: true });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+    });
+
+    it('denies edit actions even when isAllViewable is true', () => {
+      const perms = buildPermissions({ isEndUser: true, isAllViewable: true });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      const editOnlyActions = EDIT_ACTIONS.filter((a) => !VIEW_ACTIONS.includes(a));
+      editOnlyActions.forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
+    });
+
+    it('grants view actions when resourceId is in viewableAppsId', () => {
+      const resourceId = 'app-uuid-end-user';
+      const perms = buildPermissions({ isEndUser: true, viewableAppsId: [resourceId] });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any, resourceId);
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+    });
+
+    it('denies view actions when resourceId is not in viewableAppsId', () => {
+      const perms = buildPermissions({ isEndUser: true, viewableAppsId: ['other-uuid'] });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any, 'app-uuid-end-user');
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
+    });
+
+    it('does not get builder component grant on MODULES resource type', () => {
+      const perms = buildPermissions({ isEndUser: true, resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.CREATE_COMPONENTS, App)).toBe(false);
+    });
+
+    it('denies PROMOTE regardless of resource type', () => {
+      for (const resourceType of [MODULES.APP, MODULES.MODULES]) {
+        const perms = buildPermissions({ isEndUser: true, resourceType });
+        const { can, build } = makeBuilder();
+        defineAppVersionAbility(can, perms as any);
+        const ability = build();
+
+        expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(false);
+      }
+    });
+  });
+
   describe('admin / superAdmin bypass', () => {
     it('grants all edit actions for isAdmin regardless of resource type', () => {
       for (const resourceType of [MODULES.APP, MODULES.MODULES]) {
@@ -238,6 +320,36 @@ describe('defineAppVersionAbility', () => {
         });
       }
     });
+
+    it('grants PROMOTE to isAdmin', () => {
+      const perms = buildPermissions({ isAdmin: true });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(true);
+    });
+
+    it('grants PROMOTE to superAdmin', () => {
+      const perms = buildPermissions({ superAdmin: true });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(true);
+    });
+
+    it('grants all actions for admin even with no APP permissions set', () => {
+      // admin bypasses all permission flag checks via early return
+      const perms = buildPermissions({ isAdmin: true, isAllEditable: false, editableAppsId: [] });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      [...EDIT_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+    });
   });
 
   describe('PROMOTE permission', () => {
@@ -257,6 +369,78 @@ describe('defineAppVersionAbility', () => {
       const ability = build();
 
       expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(false);
+    });
+
+    it('grants PROMOTE via appPromote on MODULES resource type', () => {
+      const perms = buildPermissions({ appPromote: true, resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(true);
+    });
+  });
+
+  describe('builder role edge cases', () => {
+    it('does not apply builder component grant on APP resource type', () => {
+      // isBuilder + MODULES.APP → no special builder grant (only MODULES.MODULES triggers it)
+      const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.APP });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      // no edit permissions set, so component actions should be denied
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.CREATE_COMPONENTS, App)).toBe(false);
+    });
+
+    it('does not grant version management actions via the builder grant on MODULES', () => {
+      // builder MODULES grant only covers component/event ops, not version lifecycle actions
+      const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.APP_VERSION_CREATE, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.APP_VERSION_DELETE, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.APP_VERSION_UPDATE, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.DELETE, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.CREATE_PAGES, App)).toBe(false);
+    });
+  });
+
+  describe('granular permission boundary conditions', () => {
+    it('denies edit actions when editableAppsId is non-empty but resourceId is undefined', () => {
+      const perms = buildPermissions({ editableAppsId: ['app-uuid-1'] });
+      const { can, build } = makeBuilder();
+      // no resourceId passed
+      defineAppVersionAbility(can, perms as any, undefined);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.CREATE_PAGES, App)).toBe(false);
+    });
+
+    it('denies view actions when viewableAppsId is non-empty but resourceId is undefined', () => {
+      const perms = buildPermissions({ viewableAppsId: ['app-uuid-1'] });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any, undefined);
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
+    });
+
+    it('grants edit actions from isAllEditable even without resourceId', () => {
+      const perms = buildPermissions({ isAllEditable: true });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any, undefined);
+      const ability = build();
+
+      EDIT_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
     });
   });
 });

--- a/server/test/modules/versions/unit/app-version.ability.spec.ts
+++ b/server/test/modules/versions/unit/app-version.ability.spec.ts
@@ -73,7 +73,7 @@ const buildPermissions = (
 
 /** @group platform */
 describe('defineAppVersionAbility', () => {
-  const EDIT_ACTIONS = [
+  const ALL_ACTIONS = [
     FEATURE_KEY.GET,
     FEATURE_KEY.DELETE,
     FEATURE_KEY.CREATE,
@@ -109,7 +109,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any);
       const ability = build();
 
-      EDIT_ACTIONS.forEach((action) => {
+      ALL_ACTIONS.forEach((action) => {
         expect(ability.can(action, App)).toBe(true);
       });
     });
@@ -121,7 +121,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any, resourceId);
       const ability = build();
 
-      EDIT_ACTIONS.forEach((action) => {
+      ALL_ACTIONS.forEach((action) => {
         expect(ability.can(action, App)).toBe(true);
       });
     });
@@ -132,8 +132,9 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any, 'module-uuid-1');
       const ability = build();
 
-      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
-      expect(ability.can(FEATURE_KEY.CREATE_PAGES, App)).toBe(false);
+      ALL_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
     });
 
     it('grants view actions when isAllViewable is true', () => {
@@ -169,6 +170,7 @@ describe('defineAppVersionAbility', () => {
 
       expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(true);
       expect(ability.can(FEATURE_KEY.CREATE_COMPONENTS, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENT_LAYOUT, App)).toBe(true);
       expect(ability.can(FEATURE_KEY.DELETE_COMPONENTS, App)).toBe(true);
       expect(ability.can(FEATURE_KEY.GET_EVENTS, App)).toBe(true);
       expect(ability.can(FEATURE_KEY.CREATE_EVENT, App)).toBe(true);
@@ -183,7 +185,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any);
       const ability = build();
 
-      EDIT_ACTIONS.forEach((action) => {
+      ALL_ACTIONS.forEach((action) => {
         expect(ability.can(action, App)).toBe(false);
       });
     });
@@ -196,7 +198,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any);
       const ability = build();
 
-      EDIT_ACTIONS.forEach((action) => {
+      ALL_ACTIONS.forEach((action) => {
         expect(ability.can(action, App)).toBe(true);
       });
     });
@@ -208,7 +210,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any, resourceId);
       const ability = build();
 
-      EDIT_ACTIONS.forEach((action) => {
+      ALL_ACTIONS.forEach((action) => {
         expect(ability.can(action, App)).toBe(true);
       });
     });
@@ -221,7 +223,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any);
       const ability = build();
 
-      [...EDIT_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
+      [...ALL_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
         expect(ability.can(action, App)).toBe(false);
       });
     });
@@ -243,7 +245,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any);
       const ability = build();
 
-      const editOnlyActions = EDIT_ACTIONS.filter((a) => !VIEW_ACTIONS.includes(a));
+      const editOnlyActions = ALL_ACTIONS.filter((a) => !VIEW_ACTIONS.includes(a));
       editOnlyActions.forEach((action) => {
         expect(ability.can(action, App)).toBe(false);
       });
@@ -302,7 +304,7 @@ describe('defineAppVersionAbility', () => {
         defineAppVersionAbility(can, perms as any);
         const ability = build();
 
-        EDIT_ACTIONS.forEach((action) => {
+        ALL_ACTIONS.forEach((action) => {
           expect(ability.can(action, App)).toBe(true);
         });
       }
@@ -315,7 +317,7 @@ describe('defineAppVersionAbility', () => {
         defineAppVersionAbility(can, perms as any);
         const ability = build();
 
-        EDIT_ACTIONS.forEach((action) => {
+        ALL_ACTIONS.forEach((action) => {
           expect(ability.can(action, App)).toBe(true);
         });
       }
@@ -346,7 +348,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any);
       const ability = build();
 
-      [...EDIT_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
+      [...ALL_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
         expect(ability.can(action, App)).toBe(true);
       });
     });
@@ -438,7 +440,7 @@ describe('defineAppVersionAbility', () => {
       defineAppVersionAbility(can, perms as any, undefined);
       const ability = build();
 
-      EDIT_ACTIONS.forEach((action) => {
+      ALL_ACTIONS.forEach((action) => {
         expect(ability.can(action, App)).toBe(true);
       });
     });

--- a/server/test/modules/versions/unit/app-version.ability.spec.ts
+++ b/server/test/modules/versions/unit/app-version.ability.spec.ts
@@ -8,17 +8,19 @@ import { App } from '@entities/app.entity';
 
 const makeBuilder = () => new AbilityBuilder<FeatureAbility>(Ability as AbilityClass<FeatureAbility>);
 
-const buildPermissions = (overrides: {
-  superAdmin?: boolean;
-  isAdmin?: boolean;
-  isBuilder?: boolean;
-  isAllEditable?: boolean;
-  isAllViewable?: boolean;
-  editableAppsId?: string[];
-  viewableAppsId?: string[];
-  resourceType?: MODULES;
-  appPromote?: boolean;
-} = {}) => {
+const buildPermissions = (
+  overrides: {
+    superAdmin?: boolean;
+    isAdmin?: boolean;
+    isBuilder?: boolean;
+    isAllEditable?: boolean;
+    isAllViewable?: boolean;
+    editableAppsId?: string[];
+    viewableAppsId?: string[];
+    resourceType?: MODULES;
+    appPromote?: boolean;
+  } = {}
+) => {
   const {
     superAdmin = false,
     isAdmin = false,

--- a/server/test/modules/versions/unit/app-version.ability.spec.ts
+++ b/server/test/modules/versions/unit/app-version.ability.spec.ts
@@ -151,21 +151,15 @@ describe('defineAppVersionAbility', () => {
       expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
     });
 
-    it('grants component/event operations to isBuilder', () => {
+    it('grants all actions to isBuilder via early return', () => {
       const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
       defineAppVersionAbility(can, perms);
       const ability = build();
 
-      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(true);
-      expect(ability.can(FEATURE_KEY.CREATE_COMPONENTS, App)).toBe(true);
-      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENT_LAYOUT, App)).toBe(true);
-      expect(ability.can(FEATURE_KEY.DELETE_COMPONENTS, App)).toBe(true);
-      expect(ability.can(FEATURE_KEY.GET_EVENTS, App)).toBe(true);
-      expect(ability.can(FEATURE_KEY.CREATE_EVENT, App)).toBe(true);
-      expect(ability.can(FEATURE_KEY.UPDATE_EVENT, App)).toBe(true);
-      expect(ability.can(FEATURE_KEY.DELETE_EVENT, App)).toBe(true);
-      expect(ability.can(FEATURE_KEY.GET_ONE, App)).toBe(true);
+      [...ALL_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
     });
 
     it('denies all actions with no permissions', () => {
@@ -385,18 +379,17 @@ describe('defineAppVersionAbility', () => {
       expect(ability.can(FEATURE_KEY.CREATE_COMPONENTS, App)).toBe(false);
     });
 
-    it('does not grant version management actions via the builder grant on MODULES', () => {
-      // builder MODULES grant only covers component/event ops, not version lifecycle actions
+    it('grants version management actions to isBuilder on MODULES', () => {
       const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.MODULES });
       const { can, build } = makeBuilder();
       defineAppVersionAbility(can, perms);
       const ability = build();
 
-      expect(ability.can(FEATURE_KEY.APP_VERSION_CREATE, App)).toBe(false);
-      expect(ability.can(FEATURE_KEY.APP_VERSION_DELETE, App)).toBe(false);
-      expect(ability.can(FEATURE_KEY.APP_VERSION_UPDATE, App)).toBe(false);
-      expect(ability.can(FEATURE_KEY.DELETE, App)).toBe(false);
-      expect(ability.can(FEATURE_KEY.CREATE_PAGES, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.APP_VERSION_CREATE, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.APP_VERSION_DELETE, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.APP_VERSION_UPDATE, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.DELETE, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.CREATE_PAGES, App)).toBe(true);
     });
   });
 

--- a/server/test/modules/versions/unit/app-version.ability.spec.ts
+++ b/server/test/modules/versions/unit/app-version.ability.spec.ts
@@ -1,0 +1,260 @@
+/// <reference types="jest" />
+import { Ability, AbilityBuilder, AbilityClass } from '@casl/ability';
+import { FeatureAbility } from '@modules/versions/ability/index';
+import { defineAppVersionAbility } from '@modules/versions/ability/app-version.ability';
+import { FEATURE_KEY } from '@modules/versions/constants';
+import { MODULES } from '@modules/app/constants/modules';
+import { App } from '@entities/app.entity';
+
+const makeBuilder = () => new AbilityBuilder<FeatureAbility>(Ability as AbilityClass<FeatureAbility>);
+
+const buildPermissions = (overrides: {
+  superAdmin?: boolean;
+  isAdmin?: boolean;
+  isBuilder?: boolean;
+  isAllEditable?: boolean;
+  isAllViewable?: boolean;
+  editableAppsId?: string[];
+  viewableAppsId?: string[];
+  resourceType?: MODULES;
+  appPromote?: boolean;
+} = {}) => {
+  const {
+    superAdmin = false,
+    isAdmin = false,
+    isBuilder = false,
+    isAllEditable = false,
+    isAllViewable = false,
+    editableAppsId = [],
+    viewableAppsId = [],
+    resourceType = MODULES.APP,
+    appPromote = false,
+  } = overrides;
+
+  return {
+    superAdmin,
+    isAdmin,
+    isBuilder,
+    isEndUser: false,
+    user: {} as any,
+    resource: [{ resourceType }],
+    userPermission: {
+      isAdmin: false,
+      isSuperAdmin: false,
+      isBuilder: false,
+      isEndUser: false,
+      appCreate: false,
+      appDelete: false,
+      workflowCreate: false,
+      workflowDelete: false,
+      appPromote,
+      appRelease: false,
+      dataSourceCreate: false,
+      dataSourceDelete: false,
+      folderCreate: false,
+      folderDelete: false,
+      orgConstantCRUD: false,
+      orgVariableCRUD: false,
+      [MODULES.APP]: {
+        isAllEditable,
+        isAllViewable,
+        editableAppsId,
+        viewableAppsId,
+        hiddenAppsId: [],
+        hideAll: false,
+      },
+    },
+  };
+};
+
+/** @group platform */
+describe('defineAppVersionAbility', () => {
+  const EDIT_ACTIONS = [
+    FEATURE_KEY.GET,
+    FEATURE_KEY.DELETE,
+    FEATURE_KEY.CREATE,
+    FEATURE_KEY.GET_ONE,
+    FEATURE_KEY.UPDATE,
+    FEATURE_KEY.UPDATE_SETTINGS,
+    FEATURE_KEY.CREATE_COMPONENTS,
+    FEATURE_KEY.UPDATE_COMPONENTS,
+    FEATURE_KEY.UPDATE_COMPONENT_LAYOUT,
+    FEATURE_KEY.DELETE_COMPONENTS,
+    FEATURE_KEY.CREATE_PAGES,
+    FEATURE_KEY.CLONE_PAGES,
+    FEATURE_KEY.CLONE_GROUP,
+    FEATURE_KEY.UPDATE_PAGES,
+    FEATURE_KEY.DELETE_PAGE,
+    FEATURE_KEY.REORDER_PAGES,
+    FEATURE_KEY.GET_EVENTS,
+    FEATURE_KEY.CREATE_EVENT,
+    FEATURE_KEY.UPDATE_EVENT,
+    FEATURE_KEY.DELETE_EVENT,
+    FEATURE_KEY.APP_VERSION_CREATE,
+    FEATURE_KEY.APP_VERSION_DELETE,
+    FEATURE_KEY.APP_VERSION_UPDATE,
+    FEATURE_KEY.APP_DRAFT_VERSION_CREATE,
+  ];
+
+  const VIEW_ACTIONS = [FEATURE_KEY.GET, FEATURE_KEY.GET_ONE, FEATURE_KEY.GET_EVENTS];
+
+  describe('MODULES resource type', () => {
+    it('grants all edit actions when isAllEditable is true', () => {
+      const perms = buildPermissions({ isAllEditable: true, resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      EDIT_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+    });
+
+    it('grants all edit actions when resourceId is in editableAppsId', () => {
+      const resourceId = 'module-uuid-1';
+      const perms = buildPermissions({ editableAppsId: [resourceId], resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any, resourceId);
+      const ability = build();
+
+      EDIT_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+    });
+
+    it('denies edit actions when resourceId is not in editableAppsId', () => {
+      const perms = buildPermissions({ editableAppsId: ['other-uuid'], resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any, 'module-uuid-1');
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.CREATE_PAGES, App)).toBe(false);
+    });
+
+    it('grants view actions when isAllViewable is true', () => {
+      const perms = buildPermissions({ isAllViewable: true, resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
+    });
+
+    it('grants view actions when resourceId is in viewableAppsId', () => {
+      const resourceId = 'module-uuid-2';
+      const perms = buildPermissions({ viewableAppsId: [resourceId], resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any, resourceId);
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
+    });
+
+    it('grants component/event operations to isBuilder', () => {
+      const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.CREATE_COMPONENTS, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.DELETE_COMPONENTS, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.GET_EVENTS, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.CREATE_EVENT, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.UPDATE_EVENT, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.DELETE_EVENT, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.GET_ONE, App)).toBe(true);
+    });
+
+    it('denies all actions with no permissions', () => {
+      const perms = buildPermissions({ resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      EDIT_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
+    });
+  });
+
+  describe('APP resource type (regression)', () => {
+    it('grants all edit actions when isAllEditable is true', () => {
+      const perms = buildPermissions({ isAllEditable: true, resourceType: MODULES.APP });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      EDIT_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+    });
+
+    it('grants all edit actions when resourceId is in editableAppsId', () => {
+      const resourceId = 'app-uuid-1';
+      const perms = buildPermissions({ editableAppsId: [resourceId], resourceType: MODULES.APP });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any, resourceId);
+      const ability = build();
+
+      EDIT_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+    });
+  });
+
+  describe('admin / superAdmin bypass', () => {
+    it('grants all edit actions for isAdmin regardless of resource type', () => {
+      for (const resourceType of [MODULES.APP, MODULES.MODULES]) {
+        const perms = buildPermissions({ isAdmin: true, resourceType });
+        const { can, build } = makeBuilder();
+        defineAppVersionAbility(can, perms as any);
+        const ability = build();
+
+        EDIT_ACTIONS.forEach((action) => {
+          expect(ability.can(action, App)).toBe(true);
+        });
+      }
+    });
+
+    it('grants all edit actions for superAdmin regardless of resource type', () => {
+      for (const resourceType of [MODULES.APP, MODULES.MODULES]) {
+        const perms = buildPermissions({ superAdmin: true, resourceType });
+        const { can, build } = makeBuilder();
+        defineAppVersionAbility(can, perms as any);
+        const ability = build();
+
+        EDIT_ACTIONS.forEach((action) => {
+          expect(ability.can(action, App)).toBe(true);
+        });
+      }
+    });
+  });
+
+  describe('PROMOTE permission', () => {
+    it('grants PROMOTE when appPromote is true', () => {
+      const perms = buildPermissions({ appPromote: true, resourceType: MODULES.APP });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(true);
+    });
+
+    it('denies PROMOTE when appPromote is false', () => {
+      const perms = buildPermissions({ appPromote: false, resourceType: MODULES.APP });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms as any);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This pull request makes a targeted update to how user permissions are determined in the `defineAppVersionAbility` function. The change ensures that when the `resourceType` is `MODULES.MODULES`, the permission lookup uses `MODULES.APP` as the key, improving accuracy in permission checks for app versions.

- **Permissions Logic Update:**
  - In `app-version.ability.ts`, changed the logic for selecting the permission key so that if the `resourceType` is `MODULES.MODULES`, it uses `MODULES.APP` as the permission key; otherwise, it uses the original `resourceType`. This ensures correct permission mapping for module resources.

[ee-server](https://github.com/ToolJet/ee-server/pull/523)
[ee-frontend](https://github.com/ToolJet/ee-frontend/pull/452)

**QA Checklist** 

- [x] Integration Testing. 
- [x] Smoke Testing. 
- [x] Bug Fixes Verification. 
- [x] Cross browser UI check. (Firefox, safari, chrome)
- [ ] Verify features on Dark and Light mode.
- [ ] Test feature on CE, EE, cloud
- [x] Platform Automation Testing: [Action URL](https://github.com/ToolJet/ToolJet/actions/runs/25430080146?pr=16305), [GitSync check](https://github.com/ToolJet/ToolJet/actions/runs/25476633141?pr=16305)
- [x] Marketplace Automation Testing: [Action URL](https://github.com/ToolJet/ToolJet/actions/runs/25430080175?pr=16305)
- [ ] Migration testing.
- [x] Added tested Label for PR
- [x] Import/Export/GitSync/Cloning
- [ ] Test System Upgrade/Staging Instance(for cloud) (Sanity + Test System Specific. Cases)