### PR TITLE
Fix: event manager name input replays chars on typing pause

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/Inspector/EventManager.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/EventManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 
 import { ArrowRight, Copy, MousePointerClick, Plus, Trash2 } from 'lucide-react';
 import { ActionTypes } from './ActionTypes';
@@ -113,37 +113,9 @@ export const EventManager = ({
     if (_.isEqual(currentEvents, events)) return;
 
     const sortedEvents = (currentEvents || []).slice().sort((a, b) => a.index - b.index);
-
-    // Preserve local `name` when the user has typed ahead of the debounced save —
-    // store may carry a stale name during the debounce/in-flight window.
-    const merged = sortedEvents.map((storeEvent) => {
-      const localEvent = events.find((e) => e.id === storeEvent.id);
-      if (localEvent && localEvent.name !== storeEvent.name) {
-        return { ...storeEvent, name: localEvent.name };
-      }
-      return storeEvent;
-    });
-
-    setEvents(merged, moduleId);
+    setEvents(sortedEvents, moduleId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(currentEvents), moduleId]);
-
-  const eventsRef = useRef(events);
-  useEffect(() => {
-    eventsRef.current = events;
-  }, [events]);
-
-  const debouncedSaveName = useMemo(
-    () =>
-      _.debounce((eventId) => {
-        const current = eventsRef.current.find((e) => e.id === eventId);
-        if (!current) return;
-        updateAppVersionEventHandlers([{ event_id: eventId, diff: current }], 'update', 'name');
-      }, 400),
-    [updateAppVersionEventHandlers]
-  );
-
-  useEffect(() => () => debouncedSaveName.flush(), [debouncedSaveName]);
 
   let groupedOptions = ActionTypes.reduce((acc, action) => {
     const groupName = action.group;
@@ -389,16 +361,6 @@ export const EventManager = ({
     const shouldUpdateEvent = !_.isEmpty(diff(events[index], updatedEvent));
     if (!shouldUpdateEvent) return;
 
-    if (param === 'name') {
-      // Sync local state immediately so the controlled input stays in lockstep
-      // with the user's typing; defer the API call via debounce. The save reads
-      // the freshest event from eventsRef at fire time to avoid clobbering
-      // changes to other params made during the debounce window.
-      setEvents(newEvents);
-      debouncedSaveName(updatedEvent.id);
-      return;
-    }
-
     handleLowPriorityWork(() => {
       updateAppVersionEventHandlers(
         [
@@ -567,9 +529,8 @@ export const EventManager = ({
                 <Input
                   key={eventHandler?.id}
                   type="text"
-                  value={eventHandler?.name ?? ''}
-                  onChange={(e) => handlerChanged(index, 'name', e.target.value)}
-                  onBlur={() => debouncedSaveName.flush()}
+                  defaultValue={eventHandler?.name ?? ''}
+                  onBlur={(e) => handlerChanged(index, 'name', e.target.value)}
                   className="tw-w-full"
                   data-cy="event-name-input"
                 />
@@ -1172,9 +1133,6 @@ export const EventManager = ({
                                 lastFocusedEventIndex.current = index;
                               } else {
                                 setFocusedEventIndex(null);
-                                // Commit any pending name save before the popover unmounts —
-                                // covers Esc, outside-click, and switching to another event.
-                                debouncedSaveName.flush();
                               }
                               if (typeof popOverCallback === 'function') popOverCallback(showing);
                             }}

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/EventManager.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/EventManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useRef } from 'react';
+import React, { useState, useEffect, useContext, useRef, useMemo } from 'react';
 
 import { ArrowRight, Copy, MousePointerClick, Plus, Trash2 } from 'lucide-react';
 import { ActionTypes } from './ActionTypes';
@@ -112,13 +112,38 @@ export const EventManager = ({
   useEffect(() => {
     if (_.isEqual(currentEvents, events)) return;
 
-    const sortedEvents = currentEvents.sort((a, b) => {
-      return a.index - b.index;
+    const sortedEvents = (currentEvents || []).slice().sort((a, b) => a.index - b.index);
+
+    // Preserve local `name` when the user has typed ahead of the debounced save —
+    // store may carry a stale name during the debounce/in-flight window.
+    const merged = sortedEvents.map((storeEvent) => {
+      const localEvent = events.find((e) => e.id === storeEvent.id);
+      if (localEvent && localEvent.name !== storeEvent.name) {
+        return { ...storeEvent, name: localEvent.name };
+      }
+      return storeEvent;
     });
 
-    setEvents(sortedEvents || [], moduleId);
+    setEvents(merged, moduleId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(currentEvents), moduleId]);
+
+  const eventsRef = useRef(events);
+  useEffect(() => {
+    eventsRef.current = events;
+  }, [events]);
+
+  const debouncedSaveName = useMemo(
+    () =>
+      _.debounce((eventId) => {
+        const current = eventsRef.current.find((e) => e.id === eventId);
+        if (!current) return;
+        updateAppVersionEventHandlers([{ event_id: eventId, diff: current }], 'update', 'name');
+      }, 400),
+    [updateAppVersionEventHandlers]
+  );
+
+  useEffect(() => () => debouncedSaveName.flush(), [debouncedSaveName]);
 
   let groupedOptions = ActionTypes.reduce((acc, action) => {
     const groupName = action.group;
@@ -364,6 +389,16 @@ export const EventManager = ({
     const shouldUpdateEvent = !_.isEmpty(diff(events[index], updatedEvent));
     if (!shouldUpdateEvent) return;
 
+    if (param === 'name') {
+      // Sync local state immediately so the controlled input stays in lockstep
+      // with the user's typing; defer the API call via debounce. The save reads
+      // the freshest event from eventsRef at fire time to avoid clobbering
+      // changes to other params made during the debounce window.
+      setEvents(newEvents);
+      debouncedSaveName(updatedEvent.id);
+      return;
+    }
+
     handleLowPriorityWork(() => {
       updateAppVersionEventHandlers(
         [
@@ -532,8 +567,9 @@ export const EventManager = ({
                 <Input
                   key={eventHandler?.id}
                   type="text"
-                  defaultValue={eventHandler?.name ?? ''}
+                  value={eventHandler?.name ?? ''}
                   onChange={(e) => handlerChanged(index, 'name', e.target.value)}
+                  onBlur={() => debouncedSaveName.flush()}
                   className="tw-w-full"
                   data-cy="event-name-input"
                 />
@@ -1136,6 +1172,9 @@ export const EventManager = ({
                                 lastFocusedEventIndex.current = index;
                               } else {
                                 setFocusedEventIndex(null);
+                                // Commit any pending name save before the popover unmounts —
+                                // covers Esc, outside-click, and switching to another event.
+                                debouncedSaveName.flush();
                               }
                               if (typeof popOverCallback === 'function') popOverCallback(showing);
                             }}

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/EventManager.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/EventManager.jsx
@@ -530,8 +530,9 @@ export const EventManager = ({
               </FieldRow>
               <FieldRow label={t('editor.inspector.eventManager.eventName', 'Event name')} dataCy="event-name-label">
                 <Input
+                  key={eventHandler?.id}
                   type="text"
-                  value={eventHandler?.name ?? ''}
+                  defaultValue={eventHandler?.name ?? ''}
                   onChange={(e) => handlerChanged(index, 'name', e.target.value)}
                   className="tw-w-full"
                   data-cy="event-name-input"


### PR DESCRIPTION
## 📝 What this does
Stops the event-name input in the inspector popover from going blank and replaying characters back into itself when the user pauses typing. Bug shipped in #16016.

Relates to: #16016

## 🔀 Changes
Keeps the popover event-name `Input` controlled (`value` + `onChange`) but moves the API write off the keystroke path:
- `handlerChanged` for `param === 'name'` updates local state synchronously, then schedules a 400ms debounced save (other params keep the existing `handleLowPriorityWork` path).
- The debounced save reads the latest event from an `eventsRef` at fire time, so a name typed at T=0 plus an action picked at T=100 doesn't get clobbered when the debounce fires at T=400.
- The store-sync `useEffect` merges store events but preserves local `name` when it differs, so the in-flight/debounce window doesn't overwrite the user's typing with a stale store value.
- Pending saves are flushed on input `onBlur`, popover `onOpenChange(false)` (covers Esc, outside-click, switching events), and EventManager unmount.
- `key={eventHandler?.id}` on the input as a defensive remount when switching events.

### Why not the simpler `defaultValue` + `key` fix
An earlier attempt made the input uncontrolled. It removed the visible replay but had two regressions: every keystroke still hit the API, and Esc / popover-close lost in-flight edits. The controlled + debounced shape preserves data on every close path and dedupes the API write.

## 🧪 How to test
- [ ] Open any component's Events panel, click an event row to open the popover
- [ ] Type rapidly into Event name, then stop — value stays put, no character replay
- [ ] Type into Event name, close popover (click outside / Esc), reopen — input shows the new name
- [ ] Type a name, then immediately pick a different action from the action dropdown — both changes persist (debounce shouldn't revert the action)
- [ ] Switch between two event handlers' popovers mid-typing — each popover shows its own name, neither pending save is dropped
- [ ] Duplicate a handler — duplicate's popover shows ` copy` suffix correctly