### PR TITLE
fix: Datepicker - portal regression inside module canvas

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/CanvasContentTail.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/CanvasContentTail.jsx
@@ -9,7 +9,6 @@ export const CanvasContentTail = ({ currentMode, appType, isAppDarkMode, childre
     {currentMode === 'view' && appType !== 'module' && <SuspenseLoadingOverlay darkMode={isAppDarkMode} />}
     {children}
     {currentMode === 'edit' && <DragResizeGhostWidget />}
-    <div id="component-portal" />
     {appType !== 'module' && <div id="component-portal" />}
   </>
 );


### PR DESCRIPTION
closes: https://github.com/ToolJet/tj-ee/issues/5026
Embedded module renders a nested AppCanvas whose CanvasContentTail emitted an unconditional <div id="component-portal" /> inside the module-container's overflow:hidden wrapper. Date widgets' getElementById lookup hit that nested div first, so the popup clipped to module bounds. Re-applies the appType !== 'module' guard from #15608, lost in the layout refactor.