### PR TITLE
Hide preview overlay when currentValue is empty or undefined

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/PreviewBox.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/PreviewBox.jsx
@@ -617,6 +617,7 @@ const PreviewContainer = ({
   );
 
   const initialPlacement = isInsideQueryManager ? 'bottom-start' : previewPlacement || 'left';
+  const hasValue = currentValue !== '' && currentValue !== undefined && currentValue !== null;
 
   return (
     <>
@@ -625,7 +626,7 @@ const PreviewContainer = ({
           key={overlayKey}
           placement={initialPlacement}
           {...(previewRef?.current ? { target: previewRef.current } : {})}
-          show={showPreview}
+          show={showPreview && hasValue}
           rootClose
           shouldUpdatePosition={true}
           container={document.body}


### PR DESCRIPTION
Resolves https://github.com/orgs/ToolJet/projects/26/views/4?filterQuery=sprint%3A%40current+assignee%3A%40me&pane=issue&itemId=179253756&issue=ToolJet%7Ctj-ee%7C4959