### PR TITLE
fix: show correct header in code-hinter for success message field

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx
@@ -16,6 +16,7 @@ export default function SuccessNotificationInputs({ currentState, options, darkM
         <div className="flex-grow-1" style={{ maxWidth: '460px' }}>
           <CodeHinter
             type="basic"
+            componentName="Success Message"
             initialValue={options.successMessage}
             onChange={(value) => optionchanged('successMessage', value)}
             placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}


### PR DESCRIPTION
**Fix:** Show correct header in code-hinter for success message field

---

## Problem

When opening the code-hinter popup for the "Success Message" field in a RunJS query, the popup header displays "Editor" (default value) instead of "Success Message".

## Steps to Reproduce

1. Open a RunJS query in the Query Manager
2. Click the code-hinter icon on the **Success Message** field
3. Observe the popup header shows "Editor" instead of "Success Message"

## Expected Behavior

Popup header should display "Success Message".

## Root Cause

The `componentName` prop was not passed to the `<CodeHinter>` component in `SuccessNotificationInputs.jsx`, causing it to fall back to the default 'Editor' label.

## Fix

Added `componentName="Success Message"` prop to the `<CodeHinter>` component.

## Files Changed

- `frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx`

## Before

```jsx
<CodeHinter
  type="basic"
  initialValue={options.successMessage}
  onChange={(value) => optionchanged('successMessage', value)}
  placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}
  cyLabel={'success-message'}
/>
```

## After

```jsx
<CodeHinter
  type="basic"
  componentName="Success Message"
  initialValue={options.successMessage}
  onChange={(value) => optionchanged('successMessage', value)}
  placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}
  cyLabel={'success-message'}
/>
```

---