### PR TITLE
Feature: Add WORKSPACE_GIT_CONFIGS env var as primary source for workspace git sync config

### DIFF
--- a/server/test/modules/organization-env/unit/registry.service.spec.ts
+++ b/server/test/modules/organization-env/unit/registry.service.spec.ts
@@ -98,4 +98,68 @@ describe('OrganizationEnvRegistryService', () => {
       expect(result.has('workspace-a')).toBe(false);
     });
   });
+
+  describe('initialize() — source priority and overlay', () => {
+    const ORG_UUID_A = '11111111-1111-1111-1111-111111111111';
+    const ORG_UUID_B = '22222222-2222-2222-2222-222222222222';
+
+    beforeEach(() => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+    });
+
+    it('env var workspace wins entirely over matching file workspace', async () => {
+      process.env.WORKSPACE_GIT_CONFIGS = JSON.stringify({
+        [ORG_UUID_A]: { GITHUB_URL: 'env-url' },
+      });
+      (fs.promises.readdir as jest.Mock).mockResolvedValue([`.tj_env.${ORG_UUID_A}`]);
+      (fs.promises.readFile as jest.Mock).mockResolvedValue(`GITHUB_URL=file-url\nGITHUB_BRANCH=main`);
+
+      const { service } = makeService();
+      await service.initialize();
+
+      expect(await service.get(ORG_UUID_A, 'GITHUB_URL')).toBe('env-url');
+      // file key not in env var entry is discarded — full replace, no merge
+      expect(await service.get(ORG_UUID_A, 'GITHUB_BRANCH')).toBeUndefined();
+    });
+
+    it('file workspace used as fallback when not present in env var', async () => {
+      process.env.WORKSPACE_GIT_CONFIGS = JSON.stringify({
+        [ORG_UUID_A]: { GITHUB_URL: 'env-url' },
+      });
+      (fs.promises.readdir as jest.Mock).mockResolvedValue([
+        `.tj_env.${ORG_UUID_A}`,
+        `.tj_env.${ORG_UUID_B}`,
+      ]);
+      (fs.promises.readFile as jest.Mock)
+        .mockResolvedValueOnce(`GITHUB_URL=file-url-a`)
+        .mockResolvedValueOnce(`GITHUB_URL=file-url-b`);
+
+      const { service } = makeService();
+      await service.initialize();
+
+      expect(await service.get(ORG_UUID_B, 'GITHUB_URL')).toBe('file-url-b');
+    });
+
+    it('only env var workspaces present when no files exist', async () => {
+      process.env.WORKSPACE_GIT_CONFIGS = JSON.stringify({
+        [ORG_UUID_A]: { GITHUB_URL: 'env-url' },
+      });
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      const { service } = makeService();
+      await service.initialize();
+
+      expect(await service.get(ORG_UUID_A, 'GITHUB_URL')).toBe('env-url');
+    });
+
+    it('only file workspaces present when WORKSPACE_GIT_CONFIGS is not set', async () => {
+      (fs.promises.readdir as jest.Mock).mockResolvedValue([`.tj_env.${ORG_UUID_A}`]);
+      (fs.promises.readFile as jest.Mock).mockResolvedValue(`GITHUB_URL=file-url`);
+
+      const { service } = makeService();
+      await service.initialize();
+
+      expect(await service.get(ORG_UUID_A, 'GITHUB_URL')).toBe('file-url');
+    });
+  });
 });

--- a/server/test/modules/organization-env/unit/registry.service.spec.ts
+++ b/server/test/modules/organization-env/unit/registry.service.spec.ts
@@ -1,0 +1,97 @@
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    existsSync: jest.fn().mockReturnValue(false),
+    promises: {
+      ...actual.promises,
+      readdir: jest.fn().mockResolvedValue([]),
+      readFile: jest.fn(),
+    },
+  };
+});
+
+import * as fs from 'fs';
+import { OrganizationEnvRegistryService } from '@ee/organization-env/service';
+
+function makeService() {
+  const orgRepo = { findOne: jest.fn() };
+  const logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+  const service = new OrganizationEnvRegistryService(orgRepo as any, logger as any);
+  return { service, logger };
+}
+
+describe('OrganizationEnvRegistryService', () => {
+  afterEach(() => {
+    delete process.env.WORKSPACE_GIT_CONFIGS;
+    jest.clearAllMocks();
+  });
+
+  describe('parseWorkspaceGitConfigsVar()', () => {
+    it('returns empty map when WORKSPACE_GIT_CONFIGS is not set', () => {
+      const { service } = makeService();
+      const result = (service as any).parseWorkspaceGitConfigsVar();
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it('parses valid JSON and returns nested maps', () => {
+      const { service } = makeService();
+      process.env.WORKSPACE_GIT_CONFIGS = JSON.stringify({
+        'workspace-a': { GITHUB_URL: 'https://github.com/org/repo', GITHUB_BRANCH: 'main' },
+      });
+      const result = (service as any).parseWorkspaceGitConfigsVar();
+      expect(result.size).toBe(1);
+      expect(result.get('workspace-a').get('GITHUB_URL')).toBe('https://github.com/org/repo');
+      expect(result.get('workspace-a').get('GITHUB_BRANCH')).toBe('main');
+    });
+
+    it('returns empty map and warns when JSON is invalid', () => {
+      const { service, logger } = makeService();
+      process.env.WORKSPACE_GIT_CONFIGS = 'not-valid-json{{{';
+      const result = (service as any).parseWorkspaceGitConfigsVar();
+      expect(result.size).toBe(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'));
+    });
+
+    it('returns empty map and warns when top-level value is an array', () => {
+      const { service, logger } = makeService();
+      process.env.WORKSPACE_GIT_CONFIGS = '[]';
+      const result = (service as any).parseWorkspaceGitConfigsVar();
+      expect(result.size).toBe(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('plain object'));
+    });
+
+    it('skips workspace entry that is not an object and warns', () => {
+      const { service, logger } = makeService();
+      process.env.WORKSPACE_GIT_CONFIGS = JSON.stringify({
+        'bad-workspace': 'not-an-object',
+        'good-workspace': { GITHUB_URL: 'https://github.com/org/repo' },
+      });
+      const result = (service as any).parseWorkspaceGitConfigsVar();
+      expect(result.has('bad-workspace')).toBe(false);
+      expect(result.has('good-workspace')).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('"bad-workspace"'));
+    });
+
+    it('skips individual keys whose values are not strings and warns, but stores remaining keys', () => {
+      const { service, logger } = makeService();
+      process.env.WORKSPACE_GIT_CONFIGS = JSON.stringify({
+        'workspace-a': { GITHUB_URL: 'https://github.com/org/repo', GITHUB_APP_ID: 12345 },
+      });
+      const result = (service as any).parseWorkspaceGitConfigsVar();
+      expect(result.get('workspace-a').get('GITHUB_URL')).toBe('https://github.com/org/repo');
+      expect(result.get('workspace-a').has('GITHUB_APP_ID')).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('workspace-a.GITHUB_APP_ID'));
+    });
+
+    it('does not store workspace entry when all keys are invalid', () => {
+      const { service } = makeService();
+      process.env.WORKSPACE_GIT_CONFIGS = JSON.stringify({
+        'workspace-a': { GITHUB_APP_ID: 12345 },
+      });
+      const result = (service as any).parseWorkspaceGitConfigsVar();
+      expect(result.has('workspace-a')).toBe(false);
+    });
+  });
+});

--- a/server/test/modules/organization-env/unit/registry.service.spec.ts
+++ b/server/test/modules/organization-env/unit/registry.service.spec.ts
@@ -22,6 +22,10 @@ function makeService() {
 }
 
 describe('OrganizationEnvRegistryService', () => {
+  beforeEach(() => {
+    delete process.env.WORKSPACE_GIT_CONFIGS;
+  });
+
   afterEach(() => {
     delete process.env.WORKSPACE_GIT_CONFIGS;
     jest.clearAllMocks();


### PR DESCRIPTION
## 📝 What this does
Adds `WORKSPACE_GIT_CONFIGS` as the primary source for workspace git sync configuration. Customers can now consolidate all workspace configs into a single env var as a JSON blob; `.tj_env.*` files remain as fallback for workspaces not present in the env var.
- [ee-server](https://github.com/ToolJet/ee-server/pull/533)
- [ee-frontend](no changes)

## 🔀 Changes
- Added `WORKSPACE_GIT_CONFIGS` JSON env var parsing with full validation and warn-and-skip error handling
- Env var entries win over filesystem config per workspace — full replace, no key-level merge
- `.tj_env.*` files remain as fallback for workspaces not listed in `WORKSPACE_GIT_CONFIGS`
- Refactored `scanWorkspaceEnvFiles()` to return a map rather than mutate store directly
- Added 11 unit tests covering parser behavior and overlay priority

## 🧪 How to test
- [ ] Set `WORKSPACE_GIT_CONFIGS='{"<workspace-slug>": {"GITHUB_URL": "...", "GITHUB_BRANCH": "main", "GITHUB_APP_ID": "...", "GITHUB_INSTALLATION_ID": "...", "GITHUB_PRIVATE_KEY": "..."}}'` in `.env` and start server — verify workspace git sync uses env var config
- [ ] Add a second workspace via `.tj_env.<slug>` file only (not in env var) — verify it still works as fallback
- [ ] Set `WORKSPACE_GIT_CONFIGS` for the same workspace as a `.tj_env.*` file — verify env var wins, file keys not in env var are absent
- [ ] Set malformed JSON in `WORKSPACE_GIT_CONFIGS` — verify server starts, warning logged, file fallback used