### PR TITLE
Fix: module import appName applied uniformly to all items in batch

### DIFF
--- a/server/src/modules/external-apis/controllers/modules.controller.ts
+++ b/server/src/modules/external-apis/controllers/modules.controller.ts
@@ -16,7 +16,7 @@ export class ExternalApisModulesController {
     throw new Error('Method not implemented.');
   }
 
-  importModule(workspaceId: string, importresources: ModuleImportRequestDto): Promise<{ message: string }> {
+  importModule(workspaceId: string, importresources: ModuleImportRequestDto): Promise<{ message: string; warnings?: string[] }> {
     throw new Error('Method not implemented.');
   }
 }

--- a/server/src/modules/external-apis/dto/index.ts
+++ b/server/src/modules/external-apis/dto/index.ts
@@ -313,6 +313,10 @@ export class ModuleImportDto {
   @IsDefined()
   @IsObject()
   definition: any;
+
+  @IsOptional()
+  @IsString()
+  appName?: string;
 }
 
 export class ModuleImportRequestDto {

--- a/server/test/modules/external-apis/e2e/modules.spec.ts
+++ b/server/test/modules/external-apis/e2e/modules.spec.ts
@@ -450,6 +450,99 @@ describe('ExternalApisModulesController (EE enterprise)', () => {
         })
         .expect(400);
     });
+
+    it('imports single module using per-item appName — no warning in response', async () => {
+      const { user } = await createUser(app, { email: 'admin@tooljet.io' });
+      const orgId = user.defaultOrganizationId;
+
+      const mod = await createApplication(app, { name: 'Source Module', user, type: APP_TYPES.MODULE });
+      await createApplicationVersion(app, mod);
+      const exportBody = await exportModule(app.getHttpServer(), orgId, mod.id);
+
+      const res = await importModule(app.getHttpServer(), orgId, {
+        tooljet_version: exportBody.tooljet_version,
+        app: [{ ...exportBody.app[0], appName: 'Per-Item Name' }],
+        tooljet_database: exportBody.tooljet_database ?? [],
+      });
+
+      expect(res.message).toBe('Module imported successfully.');
+      expect(res.warnings).toBeUndefined();
+
+      const listing = await listModules(app.getHttpServer(), orgId);
+      const names = listing.modules.map((m: any) => m.name);
+      expect(names).toContain('Per-Item Name');
+    });
+
+    it('imports multiple modules using per-item appName — each gets its own name, no warning', async () => {
+      const { user } = await createUser(app, { email: 'admin@tooljet.io' });
+      const orgId = user.defaultOrganizationId;
+
+      const mod = await createApplication(app, { name: 'Source Module', user, type: APP_TYPES.MODULE });
+      await createApplicationVersion(app, mod);
+      const exportBody = await exportModule(app.getHttpServer(), orgId, mod.id);
+
+      const res = await importModule(app.getHttpServer(), orgId, {
+        tooljet_version: exportBody.tooljet_version,
+        app: [
+          { ...exportBody.app[0], appName: 'Module Alpha' },
+          { ...exportBody.app[0], appName: 'Module Beta' },
+        ],
+        tooljet_database: exportBody.tooljet_database ?? [],
+      });
+
+      expect(res.message).toBe('Module imported successfully.');
+      expect(res.warnings).toBeUndefined();
+
+      const listing = await listModules(app.getHttpServer(), orgId);
+      const names = listing.modules.map((m: any) => m.name);
+      expect(names).toContain('Module Alpha');
+      expect(names).toContain('Module Beta');
+    });
+
+    it('imports single module using top-level appName — returns deprecation warning', async () => {
+      const { user } = await createUser(app, { email: 'admin@tooljet.io' });
+      const orgId = user.defaultOrganizationId;
+
+      const mod = await createApplication(app, { name: 'Source Module', user, type: APP_TYPES.MODULE });
+      await createApplicationVersion(app, mod);
+      const exportBody = await exportModule(app.getHttpServer(), orgId, mod.id);
+
+      const res = await importModule(app.getHttpServer(), orgId, {
+        tooljet_version: exportBody.tooljet_version,
+        appName: 'Legacy Name',
+        app: exportBody.app,
+        tooljet_database: exportBody.tooljet_database ?? [],
+      });
+
+      expect(res.message).toBe('Module imported successfully.');
+      expect(res.warnings).toEqual([
+        'appName at root level is deprecated. Move it inside each item in the app array.',
+      ]);
+
+      const listing = await listModules(app.getHttpServer(), orgId);
+      const names = listing.modules.map((m: any) => m.name);
+      expect(names).toContain('Legacy Name');
+    });
+
+    it('returns 400 when top-level appName is used with multiple items', async () => {
+      const { user } = await createUser(app, { email: 'admin@tooljet.io' });
+      const orgId = user.defaultOrganizationId;
+
+      const mod = await createApplication(app, { name: 'Source Module', user, type: APP_TYPES.MODULE });
+      await createApplicationVersion(app, mod);
+      const exportBody = await exportModule(app.getHttpServer(), orgId, mod.id);
+
+      await request(app.getHttpServer())
+        .post(`/api/ext/import/workspace/${orgId}/modules`)
+        .set('Authorization', getExtAuth())
+        .send({
+          tooljet_version: exportBody.tooljet_version,
+          appName: 'Shared Name',
+          app: [exportBody.app[0], exportBody.app[0]],
+          tooljet_database: exportBody.tooljet_database ?? [],
+        })
+        .expect(400);
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📝 What this does
Fixes a bug in the module import external API (`POST /ext/import/workspace/:workspaceId/modules`) where the root-level `appName` field was applied uniformly to all entries in the `app[]` array. Importing multiple modules in one request always failed with a `ConflictException` on the second item due to the unique-name constraint. `appName` is now supported per item, with root-level kept as a deprecated fallback.

- [ee-server](https://github.com/ToolJet/ee-server/pull/540)
- [ee-frontend](no changes)

## 🔌 API Reference
| Method | Route | Permission | Request | Response |
|--------|-------|------------|---------|----------|
| **POST** | `/api/ext/import/workspace/:workspaceId/modules` | `EXTERNAL_API` | `app[].appName` (new per-item field) | `{ message, warnings? }` |

## 🔀 Changes
- Added optional `appName?: string` to `ModuleImportDto` as a sibling to `definition`
- Root-level `appName` retained as deprecated fallback; emits warning in response body when used
- Root-level `appName` with `app.length > 1` now returns HTTP 400 with actionable message
- Base controller `importModule` return type widened to include `warnings?: string[]`
- Added 4 e2e test cases covering per-item, multi-item, deprecated fallback, and guard paths

## 🧪 How to test
- [ ] `POST /ext/import/workspace/:id/modules` with `app: [{ appName: "A", definition: ... }, { appName: "B", definition: ... }]` — both modules created, no `warnings`
- [ ] Same request with root-level `appName` on a single item — module created, response contains `warnings` array with deprecation string
- [ ] Root-level `appName` with two items in `app[]` — receives HTTP 400
- [ ] Run e2e: `cd server && npm run test:e2e -- --testPathPatterns "external-apis/e2e/modules"`