### PR TITLE
feat: Show go back to modules instead of go back to apps action on Module Builder page's logo popup menu

### DIFF
--- a/frontend/src/AppBuilder/AppBuilder.jsx
+++ b/frontend/src/AppBuilder/AppBuilder.jsx
@@ -61,7 +61,7 @@ export const Editor = ({ id: appId, darkMode, moduleId = 'canvas', switchDarkMod
       <ErrorBoundary>
         <ModuleProvider moduleId={moduleId} appType={appType} isModuleMode={false} isModuleEditor={isModuleEditor}>
           <Suspense fallback={<div>Loading...</div>}>
-            <EditorHeader darkMode={darkMode} />
+            <EditorHeader darkMode={darkMode} appType={appType} />
 
             <LeftSidebar switchDarkMode={changeToDarkMode} darkMode={darkMode} />
           </Suspense>

--- a/frontend/src/AppBuilder/Header/EditorHeader.jsx
+++ b/frontend/src/AppBuilder/Header/EditorHeader.jsx
@@ -14,7 +14,7 @@ import './styles/style.scss';
 
 import SaveIndicator from './SaveIndicator';
 
-export const EditorHeader = ({ darkMode }) => {
+export const EditorHeader = ({ darkMode, appType }) => {
   const { moduleId, isModuleEditor } = useModuleContext();
   const { isSaving, saveError, isVersionReleased } = useStore(
     (state) => ({
@@ -48,7 +48,7 @@ export const EditorHeader = ({ darkMode }) => {
                 >
                   <div className="global-settings-app-wrapper p-0 m-0 ">
                     <h1 className="navbar-brand d-none-navbar-horizontal p-0 tw-shrink-0" data-cy="editor-page-logo">
-                      <LogoNavDropdown darkMode={darkMode} />
+                      <LogoNavDropdown darkMode={darkMode} type={appType} />
                     </h1>
                     <div className="d-flex flex-row tw-mr-1">
                       {isModuleEditor && <ModuleEditorBanner />}

--- a/frontend/src/_helpers/routes.js
+++ b/frontend/src/_helpers/routes.js
@@ -7,28 +7,28 @@ import _ from 'lodash';
 import { eraseCookie, getCookie } from '.';
 import { fetchEdition } from '@/modules/common/helpers/utils';
 
-export const getPrivateRoute = (page, params = {}) => {
-  const routes = {
-    dashboard: '/',
-    editor: '/apps/:slug/:pageHandle',
-    preview: '/applications/:slug/versions/:versionId/:pageHandle',
-    launch: '/applications/:slug/:pageHandle',
-    workspace_settings: '/workspace-settings/users',
-    workspace_settings_builder: '/workspace-settings/themes',
-    settings: '/settings',
-    database: '/database',
-    integrations: '/integrations/marketplace',
-    data_sources: '/data-sources',
-    audit_logs: '/audit-logs',
-    home: '/home',
-    workflows: '/workflows',
-    workspace_constants: '/workspace-constants',
-    profile_settings: '/profile-settings',
-    modules: '/modules',
-    subscription: '/settings/subscription',
-    license: '/settings/license',
-  };
+export const routes = {
+  dashboard: '/',
+  editor: '/apps/:slug/:pageHandle',
+  preview: '/applications/:slug/versions/:versionId/:pageHandle',
+  launch: '/applications/:slug/:pageHandle',
+  workspace_settings: '/workspace-settings/users',
+  workspace_settings_builder: '/workspace-settings/themes',
+  settings: '/settings',
+  database: '/database',
+  integrations: '/integrations/marketplace',
+  data_sources: '/data-sources',
+  audit_logs: '/audit-logs',
+  home: '/home',
+  workflows: '/workflows',
+  workspace_constants: '/workspace-constants',
+  profile_settings: '/profile-settings',
+  modules: '/modules',
+  subscription: '/settings/subscription',
+  license: '/settings/license',
+};
 
+export const getPrivateRoute = (page, params = {}) => {
   let url = routes[page];
   const urlParams = url?.split('/').map((path) => {
     if (path.startsWith(':')) {
@@ -288,11 +288,6 @@ export const eraseRedirectUrl = () => {
   const redirectPath = getCookie('redirectPath');
   redirectPath && eraseCookie('redirectPath');
   return redirectPath;
-};
-
-export const redirectToWorkflows = (data, redirectTo, relativePath = null) => {
-  const workflowUrl = `${dashboardUrl(data, redirectTo, relativePath)}/workflows`;
-  window.location = workflowUrl;
 };
 
 /** Detects whether the app is loaded on a custom domain by comparing

--- a/frontend/src/modules/common/components/BaseLogoNavDropdown/BaseLogoNavDropdown.jsx
+++ b/frontend/src/modules/common/components/BaseLogoNavDropdown/BaseLogoNavDropdown.jsx
@@ -2,24 +2,26 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import { authenticationService } from '@/_services';
-import { getPrivateRoute, redirectToDashboard, redirectToWorkflows } from '@/_helpers/routes';
+import { getPrivateRoute, redirectToDashboard, routes } from '@/_helpers/routes';
 import SolidIcon from '@/_ui/Icon/SolidIcons';
 import AppLogo from '@/_components/AppLogo';
 import { hasBuilderRole } from '@/_helpers/utils';
 import { isWorkflowsFeatureEnabled } from '@/modules/common/helpers/utils';
 
-const BaseLogoNavDropdown = ({ darkMode, showWorkflows = false, type = 'apps' }) => {
+const BaseLogoNavDropdown = ({ darkMode, showWorkflows = false, type = 'front-end' }) => {
   const { admin } = authenticationService?.currentSessionValue ?? {};
-  const isWorkflows = type === 'workflows';
+  const isWorkflows = type === 'workflow';
   const workflowsEnabled = admin && isWorkflowsFeatureEnabled();
+  const goBackRouteKey = type === 'front-end' ? 'dashboard' : `${type}s`;
+  const goBackToPageText = `Back to ${type === 'front-end' ? 'apps' : `${type}s`}`;
 
   const handleBackClick = (e) => {
     e.preventDefault();
     // Force a reload for clearing interval triggers
-    isWorkflows ? redirectToWorkflows() : redirectToDashboard();
+    redirectToDashboard(undefined, routes[goBackRouteKey]);
   };
 
-  const backToLinkProps = { to: getPrivateRoute(isWorkflows ? 'workflows' : 'dashboard') };
+  const backToLinkProps = { to: getPrivateRoute(goBackRouteKey) };
 
   const getOverlay = () => {
     const { admin } = authenticationService?.currentSessionValue ?? {};
@@ -42,7 +44,7 @@ const BaseLogoNavDropdown = ({ darkMode, showWorkflows = false, type = 'apps' })
           {...backToLinkProps}
         >
           <SolidIcon name="arrowbackdown" width="20" viewBox="0 0 20 20" fill="#C1C8CD" />
-          <span>Back to {isWorkflows ? 'workflows' : 'apps'}</span>
+          <span>{goBackToPageText}</span>
         </Link>
         <div className="divider"></div>
         {isWorkflows || !showWorkflows


### PR DESCRIPTION
ee-frontend: https://github.com/ToolJet/ee-frontend/pull/460

## Pull request overview

Updates the App Builder header logo dropdown so the “Back to …” action routes users to the correct listing page based on what they’re editing (apps vs modules vs workflows), specifically fixing Module Builder to go back to Modules instead of Apps.

**Changes:**
- Pass `appType` down to the editor header’s `LogoNavDropdown` so it can render the correct “Back to …” destination.
- Generalize `BaseLogoNavDropdown` to compute both the destination route and label from `type`.
- Refactor `_helpers/routes.js` to export a shared `routes` map and remove the now-unused `redirectToWorkflows` helper.
