### PR TITLE
fix: disable z-index override for Firefox popover styling

### DIFF
--- a/frontend/src/_styles/popover.scss
+++ b/frontend/src/_styles/popover.scss
@@ -59,7 +59,7 @@ div[data-radix-popper-content-wrapper]:has(.PopoverContent.drawer-height) {
 
 @-moz-document url-prefix() {
   div[data-radix-popper-content-wrapper] {
-    z-index: 100 !important;
+    // z-index: 100 !important;
     // left: 1px !important;
   }
 }

--- a/frontend/src/_styles/popover.scss
+++ b/frontend/src/_styles/popover.scss
@@ -57,12 +57,6 @@ div[data-radix-popper-content-wrapper]:has(.PopoverContent.drawer-height) {
   z-index: 2 !important;
 }
 
-@-moz-document url-prefix() {
-  div[data-radix-popper-content-wrapper] {
-    // z-index: 100 !important;
-    // left: 1px !important;
-  }
-}
 
 // Ensure form field popovers have proper overflow handling for dropdowns
 .form-field-popover-body {


### PR DESCRIPTION
Resolves https://github.com/orgs/ToolJet/projects/26/views/4?filterQuery=sprint%3A%40current+assignee%3A%40me&pane=issue&itemId=164327846&issue=ToolJet%7Ctj-ee%7C4795

Issue - adding event handlers to the components in Firefox browser