### PR TITLE
fix: Retain drop position when hydrating a stub module from git

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/Grid/gridUtils.js
+++ b/frontend/src/AppBuilder/AppCanvas/Grid/gridUtils.js
@@ -291,11 +291,13 @@ export const handleWidgetResize = (e, list, boxes, gridWidth) => {
   e.target.style.transform = `translate(${transformX}px, ${transformY}px)`;
 };
 
-export function getMouseDistanceFromParentDiv(event, id, parentWidgetType) {
+export function getMouseDistanceFromParentDiv(event, id, parentWidgetType, frozenTargetRect) {
   let parentDiv = document.getElementById('canvas-' + id) || document.getElementById('real-canvas');
   // Get the bounding rectangle of the parent div.
   const parentDivRect = parentDiv.getBoundingClientRect();
-  const targetDivRect = event.target.getBoundingClientRect();
+  // Use the pre-snapshotted rect when available (e.g. after async stub hydration the
+  // ghost element is already detached and getBoundingClientRect returns all-zeros).
+  const targetDivRect = frozenTargetRect ?? event.target.getBoundingClientRect();
 
   const mouseX = targetDivRect.left - parentDivRect.left;
   const mouseY = targetDivRect.top - parentDivRect.top;

--- a/frontend/src/AppBuilder/AppCanvas/Hooks/useCanvasDropHandler.js
+++ b/frontend/src/AppBuilder/AppCanvas/Hooks/useCanvasDropHandler.js
@@ -94,6 +94,17 @@ export const useCanvasDropHandler = () => {
     // we re-fetch the modules list so module_container / input_items are real.
     let dropComponent = component;
     if (dropComponent?.moduleId && dropComponent?.isStub && dropComponent?.appId) {
+      // Snapshot the drag ghost's bounding rect NOW, while the element is still
+      // mounted. The async hydration below lets the browser complete the drag
+      // lifecycle, which removes the ghost from the DOM. After that,
+      // getBoundingClientRect() on the detached node returns all-zeros, causing
+      // the widget to land at (0,0) instead of the drop position.
+      const ghostPos = useGridStore.getState().getGhostDragPosition();
+      if (ghostPos?.e?.target) {
+        const frozenTargetRect = ghostPos.e.target.getBoundingClientRect();
+        useGridStore.getState().actions.setGhostDragPosition({ ...ghostPos, frozenTargetRect });
+      }
+
       const toastId = toast.loading('Loading module from git…');
       try {
         await appsService.getApp(dropComponent.appId);

--- a/frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js
+++ b/frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js
@@ -42,13 +42,14 @@ export const addNewWidgetToTheEditor = (
   const defaultWidth = componentData.defaultSize.width;
   const defaultHeight = componentData.defaultSize.height;
 
-  const { e } = useGridStore.getState().getGhostDragPosition();
+  const { e, frozenTargetRect } = useGridStore.getState().getGhostDragPosition();
   const subContainerWidth = canvasBoundingRect?.width;
 
   const { left: _left, top: _top } = getMouseDistanceFromParentDiv(
     e,
     parentId === 'canvas' ? 'real-canvas' : parentId,
-    parentCanvasType
+    parentCanvasType,
+    frozenTargetRect
   );
   const scrollTop = realCanvasRef?.scrollTop;
   let [left, top] = snapToGrid(subContainerWidth, _left, _top + scrollTop);


### PR DESCRIPTION
## 📝 What this does
When a git-synced stub module is dropped onto the canvas, the async hydration causes the drag ghost element to be removed from the DOM before position calculation runs — making `getBoundingClientRect()` return all-zeros and placing the module at (0, 0). This fix snapshots the ghost element's bounding rect right before the async work begins so the correct drop position is used after hydration completes.

## 🔀 Changes
- Snapshot the drag ghost's bounding rect in `useCanvasDropHandler` before async stub hydration
- Passed `frozenTargetRect` through to `getMouseDistanceFromParentDiv` as an optional override
- `getMouseDistanceFromParentDiv` falls back to live `getBoundingClientRect()` when no frozen rect is present (no behaviour change for non-stub drops)

## 🧪 How to test
- [ ] Configure git sync and push a module to git on one branch
- [ ] Switch to a different branch that has only the stub (unhydrated) version of the module
- [ ] Drag and drop the stub module onto the app canvas at a non-origin position
- [ ] Confirm the module lands at the drop position, not at the top-left corner
- [ ] Drag and drop a regular (non-stub) component and confirm its position is unaffected