### PR TITLE
Fix: stale-data race when API queries are triggered rapidly

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -9,6 +9,7 @@ import axios from 'axios';
 import { validateMultilineCode } from '@/_helpers/utility';
 import { convertMapSet, getQueryVariables } from '@/AppBuilder/_utils/queryPanel';
 import { deepClone } from '@/_helpers/utilities/utils.helpers';
+import { nextQueryRunId, isLatestQueryRun } from '@/AppBuilder/_utils/queryRunSequence';
 
 const queryManagerPreferences = JSON.parse(localStorage.getItem('queryManagerPreferences')) ?? {};
 
@@ -306,6 +307,9 @@ export const createQueryPanelSlice = (set, get) => ({
     },
     resetQuery: (queryId, moduleId = 'canvas') => {
       const { setResolvedQuery } = get();
+      // Bump the run sequence so any in-flight runQuery for this (moduleId, queryId)
+      // becomes superseded and its async response cannot overwrite this reset.
+      nextQueryRunId(moduleId, queryId);
       setResolvedQuery(
         queryId,
         {
@@ -450,8 +454,26 @@ export const createQueryPanelSlice = (set, get) => ({
         }
       }
 
+      // Tag this invocation so stale async responses can be discarded when the
+      // same query is triggered rapidly multiple times. As soon as a newer
+      // runQuery for this (moduleId, queryId) is issued, every state write
+      // derived from this invocation becomes a no-op — preventing an older
+      // response from overwriting newer widget data in the resolved store.
+      const runId = nextQueryRunId(moduleId, queryId);
+      const setResolvedQueryIfLatest = (qId, details, mId, replaceObject) => {
+        if (!isLatestQueryRun(moduleId, queryId, runId)) return;
+        return setResolvedQuery(qId, details, mId, replaceObject);
+      };
+
       // Handler for transformation and completion of query results
       const processQueryResults = async (data, rawData = null) => {
+        // Drop the response if a newer run has already superseded this one.
+        // We skip the expensive transformation, the debugger log, the state
+        // write and the onDataQuerySuccess event — all the work would be
+        // shadowed by the newer run anyway.
+        if (!isLatestQueryRun(moduleId, queryId, runId)) {
+          return { status: 'superseded' };
+        }
         let finalData = data?.data;
         rawData = rawData || data;
 
@@ -494,7 +516,10 @@ export const createQueryPanelSlice = (set, get) => ({
           errorTarget: 'Queries',
         });
 
-        setResolvedQuery(
+        // Use the latest-run-gated wrapper: between the top-of-function guard
+        // and this write we awaited runTransformation, during which a newer run
+        // could have superseded us. The wrapper drops the write if so.
+        setResolvedQueryIfLatest(
           queryId,
           {
             isLoading: false,
@@ -509,12 +534,22 @@ export const createQueryPanelSlice = (set, get) => ({
           moduleId
         );
 
+        // Skip the success event if a newer run superseded us mid-transformation.
+        if (!isLatestQueryRun(moduleId, queryId, runId)) {
+          return { status: 'superseded' };
+        }
         onEvent('onDataQuerySuccess', queryEvents, {}, mode, moduleId);
         return { status: 'ok', data: finalData };
       };
 
       // Handler for query failures
       const handleFailure = (errorData) => {
+        // Drop the failure if a newer run has already superseded this one.
+        // Otherwise the stale error would clobber the newer run's resolved
+        // state and fire spurious onDataQueryFailure events.
+        if (!isLatestQueryRun(moduleId, queryId, runId)) {
+          return { status: 'superseded' };
+        }
         if (shouldSetPreviewData) {
           setPreviewLoading(false);
           setPreviewData(errorData);
@@ -631,6 +666,14 @@ export const createQueryPanelSlice = (set, get) => ({
 
         queryExecutionPromise
           .then(async (data) => {
+            // If a newer run has superseded us before the request resolved, do
+            // not write to state, do not start an SSE handler, and do not fire
+            // success/failure events. Resolve so awaited chains don't hang.
+            if (!isLatestQueryRun(moduleId, queryId, runId)) {
+              resolve({ status: 'superseded' });
+              return;
+            }
+
             if (data.status === 'needs_oauth') {
               localStorage.setItem('currentAppEnvironmentIdForOauth', selectedEnvironment?.id);
               const url = data.data.auth_url; // Backend generates and return sthe auth url
@@ -642,6 +685,11 @@ export const createQueryPanelSlice = (set, get) => ({
             // Change this conditional to async query type check for other
             // async queries in the future
             if (query.kind === 'workflows' && data?.data?.type !== 'tj-401') {
+              // Pass setResolvedQueryIfLatest so the synchronous jobId write inside
+              // setupAsyncWorkflowHandler AND the SSE onProgress writes inside
+              // createWorkflowAsyncHandler are both gated on this runId. Without
+              // this, a slow superseded workflow's progress ticks would overwrite
+              // the latest run's resolved state.
               const { error, completionPromise } = get().queryPanel.setupAsyncWorkflowHandler({
                 data,
                 queryId,
@@ -649,7 +697,7 @@ export const createQueryPanelSlice = (set, get) => ({
                 handleFailure,
                 shouldSetPreviewData,
                 setPreviewData,
-                setResolvedQuery,
+                setResolvedQuery: setResolvedQueryIfLatest,
               });
 
               if (error) {
@@ -716,6 +764,13 @@ export const createQueryPanelSlice = (set, get) => ({
             }
           })
           .catch((e) => {
+            // If superseded, skip the toast (the user is no longer interested
+            // in this run's error — they fired a newer one) but always resolve
+            // so awaited chains don't hang.
+            if (!isLatestQueryRun(moduleId, queryId, runId)) {
+              resolve({ status: 'superseded' });
+              return;
+            }
             const { error } = e;
             const errorMessage = typeof error === 'string' ? error : error?.message || 'Unknown error';
             if (mode !== 'view') toast.error(errorMessage);

--- a/frontend/src/AppBuilder/_utils/__tests__/queryRunSequence.test.js
+++ b/frontend/src/AppBuilder/_utils/__tests__/queryRunSequence.test.js
@@ -1,0 +1,226 @@
+const {
+  nextQueryRunId,
+  isLatestQueryRun,
+  clearQueryRunSequence,
+  __resetQueryRunSequence,
+} = require('../queryRunSequence');
+
+describe('queryRunSequence helpers', () => {
+  beforeEach(() => {
+    __resetQueryRunSequence();
+  });
+
+  describe('nextQueryRunId', () => {
+    test('returns 1 for the first call on a new (moduleId, queryId) pair', () => {
+      expect(nextQueryRunId('canvas', 'q1')).toBe(1);
+    });
+
+    test('returns monotonically increasing ids for the same pair', () => {
+      expect(nextQueryRunId('canvas', 'q1')).toBe(1);
+      expect(nextQueryRunId('canvas', 'q1')).toBe(2);
+      expect(nextQueryRunId('canvas', 'q1')).toBe(3);
+      expect(nextQueryRunId('canvas', 'q1')).toBe(4);
+    });
+
+    test('keeps independent sequences per queryId within the same module', () => {
+      nextQueryRunId('canvas', 'q1');
+      nextQueryRunId('canvas', 'q1');
+      expect(nextQueryRunId('canvas', 'q2')).toBe(1);
+      expect(nextQueryRunId('canvas', 'q1')).toBe(3);
+    });
+
+    test('keeps independent sequences per moduleId for the same queryId', () => {
+      nextQueryRunId('canvas', 'q1');
+      expect(nextQueryRunId('module-a', 'q1')).toBe(1);
+      expect(nextQueryRunId('canvas', 'q1')).toBe(2);
+    });
+  });
+
+  describe('isLatestQueryRun', () => {
+    test('returns true for the most recently issued id', () => {
+      const r1 = nextQueryRunId('canvas', 'q1');
+      expect(isLatestQueryRun('canvas', 'q1', r1)).toBe(true);
+    });
+
+    test('returns false for any superseded id', () => {
+      const r1 = nextQueryRunId('canvas', 'q1');
+      const r2 = nextQueryRunId('canvas', 'q1');
+      const r3 = nextQueryRunId('canvas', 'q1');
+      expect(isLatestQueryRun('canvas', 'q1', r1)).toBe(false);
+      expect(isLatestQueryRun('canvas', 'q1', r2)).toBe(false);
+      expect(isLatestQueryRun('canvas', 'q1', r3)).toBe(true);
+    });
+
+    test('returns false when no run has ever been issued for the pair', () => {
+      // A caller asking "am I still latest?" with an id of 1 when nothing has
+      // been registered should not be told yes.
+      expect(isLatestQueryRun('canvas', 'never-run', 1)).toBe(false);
+    });
+
+    test('treats moduleId as part of the key (no cross-module leakage)', () => {
+      const r1 = nextQueryRunId('canvas', 'q1');
+      // A newer run in a different module must not invalidate the canvas run.
+      nextQueryRunId('module-a', 'q1');
+      expect(isLatestQueryRun('canvas', 'q1', r1)).toBe(true);
+    });
+  });
+
+  describe('clearQueryRunSequence', () => {
+    test('drops the entry so the next nextQueryRunId restarts at 1', () => {
+      nextQueryRunId('canvas', 'q1');
+      nextQueryRunId('canvas', 'q1');
+      clearQueryRunSequence('canvas', 'q1');
+      expect(nextQueryRunId('canvas', 'q1')).toBe(1);
+    });
+
+    test('is safe to call when no entry exists', () => {
+      expect(() => clearQueryRunSequence('canvas', 'never-run')).not.toThrow();
+    });
+  });
+});
+
+describe('queryRunSequence — race regression: older response cannot overwrite newer', () => {
+  // This test simulates the bug we are fixing. Two `runQuery` calls fire
+  // rapidly for the same query; the first one's slow response would otherwise
+  // arrive AFTER the second's response and overwrite it in the resolved store.
+  // With the sequencer-guarded write, the older response is dropped.
+
+  beforeEach(() => {
+    __resetQueryRunSequence();
+  });
+
+  test('without the sequencer guard, the stale response wins (demonstrates the bug)', async () => {
+    // Naive setStateFromResponse: any caller can write at any time.
+    let store = null;
+    const naiveSetStateFromResponse = (data) => {
+      store = data;
+    };
+
+    // Two responses for the same query. The "old" one is slower than the "new" one.
+    const oldResponse = new Promise((resolve) => setTimeout(() => resolve('old-data'), 30));
+    const newResponse = new Promise((resolve) => setTimeout(() => resolve('new-data'), 5));
+
+    await Promise.all([
+      oldResponse.then(naiveSetStateFromResponse),
+      newResponse.then(naiveSetStateFromResponse),
+    ]);
+
+    // The bug: the older response, arriving last, overwrote the newer one.
+    expect(store).toBe('old-data');
+  });
+
+  test('with the sequencer guard, the newer response wins regardless of arrival order', async () => {
+    let store = null;
+    const moduleId = 'canvas';
+    const queryId = 'qA';
+
+    // Helper that mirrors how runQuery now writes state: capture runId at
+    // request time, drop the write if a newer runId has superseded us.
+    const guardedHandle = (responsePromise) => {
+      const runId = nextQueryRunId(moduleId, queryId);
+      return responsePromise.then((data) => {
+        if (!isLatestQueryRun(moduleId, queryId, runId)) {
+          // Superseded — drop the write, return a sentinel so awaited chains
+          // don't hang.
+          return { status: 'superseded' };
+        }
+        store = data;
+        return { status: 'ok', data };
+      });
+    };
+
+    // Run #1 fires (slow). Then run #2 fires (fast). Run #2's response arrives
+    // first and writes "new-data"; run #1's response arrives second but is
+    // superseded so it does NOT overwrite.
+    const oldResponse = new Promise((resolve) => setTimeout(() => resolve('old-data'), 30));
+    const oldHandle = guardedHandle(oldResponse);
+
+    const newResponse = new Promise((resolve) => setTimeout(() => resolve('new-data'), 5));
+    const newHandle = guardedHandle(newResponse);
+
+    const [oldResult, newResult] = await Promise.all([oldHandle, newHandle]);
+
+    // The newer response is what landed in the store.
+    expect(store).toBe('new-data');
+    // The older run's promise was resolved (so awaited chains don't hang),
+    // but its result is the superseded sentinel rather than a data write.
+    expect(oldResult).toEqual({ status: 'superseded' });
+    expect(newResult).toEqual({ status: 'ok', data: 'new-data' });
+  });
+
+  test('the guard isolates races per (moduleId, queryId) — unrelated queries are unaffected', async () => {
+    let storeA = null;
+    let storeB = null;
+
+    const guardedHandle = (moduleId, queryId, responsePromise, writeTo) => {
+      const runId = nextQueryRunId(moduleId, queryId);
+      return responsePromise.then((data) => {
+        if (!isLatestQueryRun(moduleId, queryId, runId)) {
+          return { status: 'superseded' };
+        }
+        writeTo(data);
+        return { status: 'ok', data };
+      });
+    };
+
+    // queryA: two races. queryB: a single, unrelated run that must NOT be
+    // marked superseded by queryA's later run.
+    const aSlow = guardedHandle(
+      'canvas',
+      'queryA',
+      new Promise((r) => setTimeout(() => r('a-old'), 30)),
+      (d) => (storeA = d)
+    );
+    const bOnly = guardedHandle(
+      'canvas',
+      'queryB',
+      new Promise((r) => setTimeout(() => r('b-only'), 10)),
+      (d) => (storeB = d)
+    );
+    const aFast = guardedHandle(
+      'canvas',
+      'queryA',
+      new Promise((r) => setTimeout(() => r('a-new'), 5)),
+      (d) => (storeA = d)
+    );
+
+    const [aSlowResult, bResult, aFastResult] = await Promise.all([aSlow, bOnly, aFast]);
+
+    expect(storeA).toBe('a-new');
+    expect(storeB).toBe('b-only');
+    expect(aSlowResult).toEqual({ status: 'superseded' });
+    expect(aFastResult).toEqual({ status: 'ok', data: 'a-new' });
+    expect(bResult).toEqual({ status: 'ok', data: 'b-only' });
+  });
+
+  test('a reset (sequence bump) supersedes an in-flight run', async () => {
+    let store = 'before-anything';
+    const moduleId = 'canvas';
+    const queryId = 'qReset';
+
+    const guardedHandle = (responsePromise) => {
+      const runId = nextQueryRunId(moduleId, queryId);
+      return responsePromise.then((data) => {
+        if (!isLatestQueryRun(moduleId, queryId, runId)) {
+          return { status: 'superseded' };
+        }
+        store = data;
+        return { status: 'ok', data };
+      });
+    };
+
+    // Run starts.
+    const inFlight = guardedHandle(new Promise((r) => setTimeout(() => r('run-data'), 20)));
+
+    // User invokes resetQuery, which bumps the sequence and writes the reset
+    // state directly. This mirrors what resetQuery does in queryPanelSlice.js.
+    nextQueryRunId(moduleId, queryId);
+    store = '__reset__';
+
+    const result = await inFlight;
+
+    // The in-flight run's response was dropped — reset state is preserved.
+    expect(store).toBe('__reset__');
+    expect(result).toEqual({ status: 'superseded' });
+  });
+});

--- a/frontend/src/AppBuilder/_utils/queryRunSequence.js
+++ b/frontend/src/AppBuilder/_utils/queryRunSequence.js
@@ -1,0 +1,71 @@
+/**
+ * Per-(moduleId, queryId) monotonic run-sequence helpers used by
+ * `runQuery` in `queryPanelSlice.js` to discard stale async responses.
+ *
+ * When the same query is triggered rapidly multiple times, network and
+ * transform latency can let an older response arrive after a newer one.
+ * Without guarding, the older response would overwrite the newer one in
+ * the resolved store and widgets would render stale data.
+ *
+ * Each `runQuery` invocation captures `nextQueryRunId(moduleId, queryId)`
+ * before issuing the request. State writes derived from that invocation
+ * are gated by `isLatestQueryRun(moduleId, queryId, runId)`: as soon as a
+ * newer invocation supersedes it, all of its callbacks become no-ops.
+ *
+ * The sequence Map is intentionally NOT stored in the Zustand slice — it
+ * is internal bookkeeping that must not trigger React re-renders.
+ */
+
+const queryRunSequence = new Map();
+
+const keyOf = (moduleId, queryId) => `${moduleId}::${queryId}`;
+
+/**
+ * Reserve a fresh run id for the (moduleId, queryId) pair. The first call
+ * for a given pair returns 1, each subsequent call returns the previous
+ * value plus one.
+ *
+ * @param {string} moduleId
+ * @param {string} queryId
+ * @returns {number} the new latest run id for that pair
+ */
+export const nextQueryRunId = (moduleId, queryId) => {
+  const key = keyOf(moduleId, queryId);
+  const next = (queryRunSequence.get(key) ?? 0) + 1;
+  queryRunSequence.set(key, next);
+  return next;
+};
+
+/**
+ * True iff `runId` is still the most recent run id reserved for the
+ * (moduleId, queryId) pair. False once a newer `nextQueryRunId` call has
+ * superseded it.
+ *
+ * @param {string} moduleId
+ * @param {string} queryId
+ * @param {number} runId
+ * @returns {boolean}
+ */
+export const isLatestQueryRun = (moduleId, queryId, runId) => {
+  return queryRunSequence.get(keyOf(moduleId, queryId)) === runId;
+};
+
+/**
+ * Drop the sequence entry for (moduleId, queryId). Intended to be called
+ * from query-deletion paths so the Map does not accumulate dead entries
+ * for queries that no longer exist. Safe to call when no entry exists.
+ *
+ * @param {string} moduleId
+ * @param {string} queryId
+ */
+export const clearQueryRunSequence = (moduleId, queryId) => {
+  queryRunSequence.delete(keyOf(moduleId, queryId));
+};
+
+/**
+ * Test-only helper that wipes the entire sequence Map. Exported so tests
+ * can isolate themselves from each other; not intended for production use.
+ */
+export const __resetQueryRunSequence = () => {
+  queryRunSequence.clear();
+};


### PR DESCRIPTION
## Problem

When the same data query is fired rapidly multiple times from an app page, an older async response can land in the resolved store **after** a newer one and overwrite it, so widgets bound to `queries.<name>.data` render stale data.

`runQuery` in `queryPanelSlice.js` had no per-invocation identity: every concurrent call wrote unconditionally to the same `resolvedStore.modules[moduleId].exposedValues.queries[queryId]` slot, last-writer-wins. On a slow network the last writer is the *oldest* request.

## Fix

Per-`(moduleId, queryId)` monotonic run-sequence stored in a module-scoped `Map` (not Zustand state — it must not trigger React re-renders). Each `runQuery` captures a `runId`; every state-mutating callback gates on "is this still the latest run?". Older runs become no-ops as soon as a newer one is issued. Their pending promises still resolve (with `{ status: 'superseded' }`) so awaited chains in user JS and event handlers don't hang.

Three write paths are covered:

1. `processQueryResults` (success) — guarded at function entry **and** at the `setResolvedQuery` call site (the closure also awaits `runTransformation`, during which a newer run could supersede us).
2. `handleFailure` — guarded at function entry.
3. The async workflow branch — a wrapped `setResolvedQueryIfLatest` is threaded into `setupAsyncWorkflowHandler`, so the synchronous `jobId` write at `setupAsyncWorkflowHandler:1527` and every SSE `onProgress` tick inside `createWorkflowAsyncHandler:261` are also gated.

`resetQuery` bumps the sequence so `queries.foo.reset()` correctly supersedes an in-flight run.

## Documented behavior change

User scripts that do `const result = await queries.foo.run()` will see `result === { status: 'superseded' }` for runs invalidated by a newer trigger. `queries.foo.data` still reflects the newest run's data as before. This is strictly better than the silent stale-data bug it replaces, and matches the pattern used by React Query / SWR.

## Out of scope (deliberate, called out for follow-up)

- `AbortController`-based cancellation of in-flight HTTP requests. Doesn't change correctness once the sequencer is in place; would broaden the surface (`dataqueryService.run` signature, axios threading).
- Same guard for `previewQuery` — it writes to local editor state, not the widget-facing resolved store, so no widget-staleness race.

## Tests

14 new tests in \`frontend/src/AppBuilder/_utils/__tests__/queryRunSequence.test.js\`:

- Helper unit tests (monotonic increment, per-\`(moduleId, queryId)\` isolation, \`isLatestQueryRun\` semantics, \`clearQueryRunSequence\`).
- A **without-guard** test that demonstrates the bug (older response wins when it arrives last).
- A **with-guard** test that proves the fix (newer response wins regardless of arrival order).
- A \`reset\`-supersedes-in-flight-run scenario.
- A per-\`(moduleId, queryId)\` isolation test (unrelated queries are not invalidated by each other).

Run with:

\`\`\`
cd frontend
npx jest src/AppBuilder/_utils/__tests__/queryRunSequence.test.js --testEnvironment=node
\`\`\`

All 14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)