### PR TITLE
Fix CodeQL default branch checkout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       branch:
         description: "Branch to scan"
-        default: "main"
+        default: "develop"
 
 jobs:
   analyze:
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch || 'main' }}
+          ref: ${{ github.event.inputs.branch || github.event.repository.default_branch }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
## Summary

ToolJet's default branch is `develop`, but the CodeQL workflow still defaulted manual dispatches and fallback checkouts to `main`.

This updates the workflow so:

- the manual `branch` input defaults to `develop`
- the checkout fallback uses `github.event.repository.default_branch`

That keeps scheduled/manual CodeQL scans aligned with the repository's actual default branch while still allowing a manually supplied branch to be scanned.

## Tests

- `git diff --check`
- Parsed `.github/workflows/codeql.yml` with Ruby `YAML.load_file`
- Verified the workflow contains the updated default and fallback expressions
