### PR TITLE
fix: Handle ALTER ROLE permission denied on fly.io PostgreSQL

### DIFF
--- a/server/src/modules/tooljet-db/helper.ts
+++ b/server/src/modules/tooljet-db/helper.ts
@@ -1,8 +1,12 @@
-import { EntityManager } from 'typeorm';
+import { EntityManager } from "typeorm";
 
 export async function reconfigurePostgrest(
   tooljetDbManager: EntityManager,
-  options: { user: string; enableAggregates: boolean; statementTimeoutInSecs: number }
+  options: {
+    user: string;
+    enableAggregates: boolean;
+    statementTimeoutInSecs: number;
+  },
 ) {
   const maxRetries = 3;
   const retryDelay = 1000; // 1 second
@@ -10,26 +14,33 @@ export async function reconfigurePostgrest(
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       // Use advisory locks outside of transaction to prevent concurrent execution
-      await tooljetDbManager.query('SELECT pg_advisory_lock(123456788)');
+      await tooljetDbManager.query("SELECT pg_advisory_lock(123456788)");
 
       try {
-        await tooljetDbManager.transaction(async (transactionalEntityManager) => {
-          await transactionalEntityManager.queryRunner.query('CREATE SCHEMA IF NOT EXISTS postgrest');
+        await tooljetDbManager.transaction(
+          async (transactionalEntityManager) => {
+            await transactionalEntityManager.queryRunner.query(
+              "CREATE SCHEMA IF NOT EXISTS postgrest",
+            );
 
-          // Check if the grant already exists before applying it
-          const grantExists = await transactionalEntityManager.queryRunner.query(
-            `
+            // Check if the grant already exists before applying it
+            const grantExists =
+              await transactionalEntityManager.queryRunner.query(
+                `
             SELECT 1 FROM information_schema.usage_privileges 
             WHERE grantee = $1 AND object_schema = 'postgrest' AND privilege_type = 'USAGE'
           `,
-            [options.user]
-          );
+                [options.user],
+              );
 
-          if (!grantExists || grantExists.length === 0) {
-            await transactionalEntityManager.queryRunner.query(`GRANT USAGE ON SCHEMA postgrest to ${options.user}`);
-          }
+            if (!grantExists || grantExists.length === 0) {
+              await transactionalEntityManager.queryRunner.query(
+                `GRANT USAGE ON SCHEMA postgrest to ${options.user}`,
+              );
+            }
 
-          await transactionalEntityManager.queryRunner.query(`create or replace function postgrest.pre_config()
+            await transactionalEntityManager.queryRunner
+              .query(`create or replace function postgrest.pre_config()
       returns void as $$
         select
           set_config('pgrst.db_aggregates_enabled', '${options.enableAggregates}', false);
@@ -39,31 +50,54 @@ export async function reconfigurePostgrest(
         where nspname like 'workspace_%';
       $$ language sql;
       `);
-          await transactionalEntityManager.queryRunner.query(
-            `ALTER ROLE ${options.user} SET statement_timeout TO '${options.statementTimeoutInSecs}s'`
-          );
-        });
+
+            // await transactionalEntityManager.queryRunner.query(
+            //   `ALTER ROLE ${options.user} SET statement_timeout TO '${options.statementTimeoutInSecs}s'`
+            // );
+
+            try {
+              await transactionalEntityManager.queryRunner.query(
+                `ALTER ROLE ${options.user} SET statement_timeout TO '${options.statementTimeoutInSecs}s'`,
+              );
+            } catch (error) {
+              if ((error as any).code === "42501") {
+                console.warn(
+                  `No permission to ALTER ROLE ${options.user}. Skipping statement_timeout setting.`,
+                );
+              } else {
+                throw error;
+              }
+            }
+          },
+        );
       } finally {
         // Always release the advisory lock (outside of transaction)
         try {
-          await tooljetDbManager.query('SELECT pg_advisory_unlock(123456788)');
+          await tooljetDbManager.query("SELECT pg_advisory_unlock(123456788)");
         } catch (unlockError) {
-          console.warn('Failed to release advisory lock:', unlockError);
+          console.warn("Failed to release advisory lock:", unlockError);
         }
       }
 
       // If we reach here, the operation was successful
       return;
     } catch (error) {
-      console.error(`The tooljet database reconfiguration process encountered an error on attempt ${attempt}:`, error);
+      console.error(
+        `The tooljet database reconfiguration process encountered an error on attempt ${attempt}:`,
+        error,
+      );
 
       // Check if it's a concurrency error or transaction abort
       if (
-        (error.code === 'XX000' && error.message?.includes('tuple concurrently updated')) ||
-        (error.code === '25P02' && error.message?.includes('current transaction is aborted'))
+        (error.code === "XX000" &&
+          error.message?.includes("tuple concurrently updated")) ||
+        (error.code === "25P02" &&
+          error.message?.includes("current transaction is aborted"))
       ) {
         if (attempt < maxRetries) {
-          console.log(`Retrying in ${retryDelay}ms... (attempt ${attempt + 1}/${maxRetries})`);
+          console.log(
+            `Retrying in ${retryDelay}ms... (attempt ${attempt + 1}/${maxRetries})`,
+          );
           await new Promise((resolve) => setTimeout(resolve, retryDelay));
           continue;
         }
@@ -81,7 +115,11 @@ export async function reconfigurePostgrest(
  */
 export async function reconfigurePostgrestWithoutSchemaSync(
   tooljetDbManager: EntityManager,
-  options: { user: string; enableAggregates: boolean; statementTimeoutInSecs: number }
+  options: {
+    user: string;
+    enableAggregates: boolean;
+    statementTimeoutInSecs: number;
+  },
 ) {
   const maxRetries = 3;
   const retryDelay = 1000; // 1 second
@@ -89,57 +127,86 @@ export async function reconfigurePostgrestWithoutSchemaSync(
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       // Use advisory locks outside of transaction to prevent concurrent execution
-      await tooljetDbManager.query('SELECT pg_advisory_lock(123456789)');
+      await tooljetDbManager.query("SELECT pg_advisory_lock(123456789)");
 
       try {
-        await tooljetDbManager.transaction(async (transactionalEntityManager) => {
-          await transactionalEntityManager.queryRunner.query('CREATE SCHEMA IF NOT EXISTS postgrest');
+        await tooljetDbManager.transaction(
+          async (transactionalEntityManager) => {
+            await transactionalEntityManager.queryRunner.query(
+              "CREATE SCHEMA IF NOT EXISTS postgrest",
+            );
 
-          // Check if the grant already exists before applying it
-          const grantExists = await transactionalEntityManager.queryRunner.query(
-            `
+            // Check if the grant already exists before applying it
+            const grantExists =
+              await transactionalEntityManager.queryRunner.query(
+                `
             SELECT 1 FROM information_schema.usage_privileges 
             WHERE grantee = $1 AND object_schema = 'postgrest' AND privilege_type = 'USAGE'
           `,
-            [options.user]
-          );
+                [options.user],
+              );
 
-          if (!grantExists || grantExists.length === 0) {
-            await transactionalEntityManager.queryRunner.query(`GRANT USAGE ON SCHEMA postgrest to ${options.user}`);
-          }
+            if (!grantExists || grantExists.length === 0) {
+              await transactionalEntityManager.queryRunner.query(
+                `GRANT USAGE ON SCHEMA postgrest to ${options.user}`,
+              );
+            }
 
-          await transactionalEntityManager.queryRunner.query(`create or replace function postgrest.pre_config()
+            await transactionalEntityManager.queryRunner
+              .query(`create or replace function postgrest.pre_config()
           returns void as $$
             select
               set_config('pgrst.db_aggregates_enabled', '${options.enableAggregates}', false);
           $$ language sql;
           `);
 
-          await transactionalEntityManager.queryRunner.query(
-            `ALTER ROLE ${options.user} SET statement_timeout TO '${options.statementTimeoutInSecs}s'`
-          );
-        });
+            // await transactionalEntityManager.queryRunner.query(
+            //   `ALTER ROLE ${options.user} SET statement_timeout TO '${options.statementTimeoutInSecs}s'`,
+            // );
+
+            try {
+              await transactionalEntityManager.queryRunner.query(
+                `ALTER ROLE ${options.user} SET statement_timeout TO '${options.statementTimeoutInSecs}s'`,
+              );
+            } catch (error) {
+              if ((error as any).code === "42501") {
+                console.warn(
+                  ` No permission to ALTER ROLE ${options.user}. Skipping statement_timeout setting.`,
+                );
+              } else {
+                throw error;
+              }
+            }
+          },
+        );
       } finally {
         // Always release the advisory lock (outside of transaction)
         try {
-          await tooljetDbManager.query('SELECT pg_advisory_unlock(123456789)');
+          await tooljetDbManager.query("SELECT pg_advisory_unlock(123456789)");
         } catch (unlockError) {
-          console.warn('Failed to release advisory lock:', unlockError);
+          console.warn("Failed to release advisory lock:", unlockError);
         }
       }
 
       // If we reach here, the operation was successful
       return;
     } catch (error) {
-      console.error(`The tooljet database reconfiguration process encountered an error on attempt ${attempt}:`, error);
+      console.error(
+        `The tooljet database reconfiguration process encountered an error on attempt ${attempt}:`,
+        error,
+      );
 
       // Check if it's a concurrency error or transaction abort
       if (
-        (error.code === 'XX000' && error.message?.includes('tuple concurrently updated')) ||
-        (error.code === '25P02' && error.message?.includes('current transaction is aborted'))
+        (error.code === "XX000" &&
+          error.message?.includes("tuple concurrently updated")) ||
+        (error.code === "25P02" &&
+          error.message?.includes("current transaction is aborted"))
       ) {
         if (attempt < maxRetries) {
-          console.log(`Retrying in ${retryDelay}ms... (attempt ${attempt + 1}/${maxRetries})`);
+          console.log(
+            `Retrying in ${retryDelay}ms... (attempt ${attempt + 1}/${maxRetries})`,
+          );
           await new Promise((resolve) => setTimeout(resolve, retryDelay));
           continue;
         }


### PR DESCRIPTION
## Fixes #16430

### Problem
ToolJet fails to run on fly.io managed PostgreSQL because it tries to execute `ALTER ROLE` without proper permissions (error code 42501).

### Solution
Wrap the `ALTER ROLE` query in a try-catch block. If permission denied error occurs, log a warning and skip.

### Changes
- Added try-catch around ALTER ROLE query in both functions
- Handle PostgreSQL error code 42501 gracefully