### PR TITLE
fix: invoke handleFailure when runQuery promise rejects

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -719,6 +719,13 @@ export const createQueryPanelSlice = (set, get) => ({
             const { error } = e;
             const errorMessage = typeof error === 'string' ? error : error?.message || 'Unknown error';
             if (mode !== 'view') toast.error(errorMessage);
+            handleFailure({
+              status: 'failed',
+              statusCode: e?.statusCode,
+              message: errorMessage,
+              description: errorMessage,
+              data: e?.data ?? {},
+            });
             resolve({ status: 'failed', message: errorMessage });
           });
       });


### PR DESCRIPTION
Fixes #15709.

The `.catch` in `runQuery` (queryPanelSlice.js) only toasts and resolves with `{ status: 'failed' }`. It never calls `handleFailure`, so on a rejected promise (e.g. a server-side 504 surfaced by `handleResponse` as `Promise.reject({ error, data, statusCode })`):

- `setResolvedQuery` is never called with `isLoading: false`, so the query stays stuck loading in the UI
- `onDataQueryFailure` never fires, so `onFailure` event handlers don't run
- `response` / `request` / error metadata variables stay empty

This matches the issue description: with the timeout set to 0 (default ~30s) and the server returning 504, the query never exits its loading state. Lowering the timeout in the UI takes a different code path that already handles failure, which is why the bug appears to only happen at the higher timeout.

The fix runs `handleFailure` with the data from the rejected promise before resolving, so the same code path as a structured backend error is taken.

### How I tested

- Read through the affected runQuery branch and `handleFailure` to confirm the shape passed in matches what `handleFailure` expects (`statusCode`, `description`, `data.requestObject` / `responseObject` are read defensively).
- Did not run the full app locally for this PR — happy to add an integration test if maintainers prefer.