### PR TITLE
Fix: mode from plugin queries (e.g. Snowflake) leaking into unrelated queries (e.g. RestAPI) on switch

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -46,7 +46,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
     */
   const [selectedQueryId, setSelectedQueryId] = useState(selectedQuery?.id);
   const queryName = selectedQuery?.name ?? '';
-  const sourcecomponentName = selectedDataSource?.kind?.charAt(0).toUpperCase() + selectedDataSource?.kind?.slice(1);
+  const sourcecomponentName = selectedQuery?.kind?.charAt(0).toUpperCase() + selectedQuery?.kind?.slice(1);
 
   // Dummy DS = stub options + maybe no plugin relation. Mounting editor crashes:
   // built-ins read undefined options.X.value, unbundled kinds → allSources[Kind] = undefined.
@@ -54,7 +54,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
   const isDummyDataSource = selectedDataSource?.is_dummy === true;
   const ElementToRender = isDummyDataSource
     ? null
-    : selectedDataSource?.plugin_id
+    : selectedQuery?.plugin_id
     ? source
     : allSources[sourcecomponentName];
   const defaultOptions = useRef({});
@@ -239,7 +239,9 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
           <ElementToRender
             renderCopilot={(props) => renderCopilot({ ...props, selectedDataSource })}
             key={selectedQuery?.id}
-            pluginSchema={selectedDataSource?.plugin?.operations_file?.data}
+            pluginSchema={
+              selectedDataSource?.plugin?.operations_file?.data ?? selectedQuery?.plugin?.operations_file?.data
+            }
             selectedDataSource={selectedDataSource}
             options={selectedQuery?.options}
             optionsChanged={optionsChanged}

--- a/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
@@ -106,6 +106,7 @@ export const createDataQuerySlice = (set, get) => ({
         state.dataQuery.queries.modules[moduleId] = [
           {
             ...cleanSelectedQuery,
+            plugin_id: selectedDataSource.pluginId || selectedDataSource.plugin_id || null,
             data_source_id: dataSourceId,
             app_version_id: appVersionId,
             options,


### PR DESCRIPTION
Fix: mode from plugin queries (e.g. Snowflake) leaking into unrelated queries (e.g. RestAPI) on switch
Root cause — two bugs interact:

1. plugin_id contamination in createDataQuery
When creating a new query, ...cleanSelectedQuery spread the previous query's properties into the temp object. All fields like options, kind, plugin were explicitly overridden — but plugin_id was not. A new RestAPI query created while Snowflake was selected would inherit plugin_id: 'snowflake-uuid'.

2. Stale selectedDataSource during first render
selectedDataSource is updated via a useEffect in QueryManager.jsx, so it always lags one render behind selectedQuery. On the first render after any query switch, selectedDataSource still points to the previous plugin (Snowflake). ElementToRender was derived from selectedDataSource?.plugin_id — truthy (Snowflake) — so DynamicForm mounted with Snowflake's operations schema but the new query's options. DynamicForm's useLayoutEffect detected mode missing from those options (it's in Snowflake's schema defaults) and called optionsChanged({ ...newOptions, mode: 'sql' }). The stale-write guard in validateNewOptions passed because both query IDs already matched — permanently writing mode: 'sql' into the wrong query's options.

Fixes:

dataQuerySlice.js: Explicitly override plugin_id in createDataQuery using selectedDataSource.pluginId || selectedDataSource.plugin_id || null.
QueryManagerBody.jsx: Derive sourcecomponentName and ElementToRender from selectedQuery (always current) rather than the stale selectedDataSource. Add selectedQuery?.plugin?.operations_file?.data as a fallback for pluginSchema so plugin editors still receive the correct schema during the stale render.