### PR TITLE
Add cypress E2E spec for inviteUrl

### DIFF
--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js
@@ -162,7 +162,7 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
   // POST inviteUrl depends only on user.invitationToken (non-null for invited users).
   // GET inviteUrl additionally checks ou.status — if active, returns null.
 
-  it("invited user with workspace status active: POST inviteUrl non-null, GET inviteUrl null", () => {
+  it("invited user with workspace status active: POST inviteUrl null, GET inviteUrl null", () => {
     cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
       // invited + no password + ws active
       createUser({
@@ -172,7 +172,7 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
       }).then((response) => {
         expect(response.status).to.eq(201);
         expect(response.body.status).to.eq("invited");
-        expect(response.body.workspaces[0].inviteUrl).to.exist;
+        expect(response.body.workspaces[0].inviteUrl).to.be.null;
 
         getUser(response.body.id).then((getResponse) => {
           expect(getResponse.status).to.eq(200);
@@ -188,7 +188,7 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
         workspaces: [{ id: workspaceId, status: "active" }],
       }).then((response) => {
         expect(response.status).to.eq(201);
-        expect(response.body.workspaces[0].inviteUrl).to.exist;
+        expect(response.body.workspaces[0].inviteUrl).to.be.null;
       });
     });
   });
@@ -440,7 +440,7 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
       }).then((response) => {
         expect(response.status).to.eq(201);
         expect(response.body.status).to.eq("invited");
-        expect(response.body.workspaces[0].inviteUrl).to.exist;
+        expect(response.body.workspaces[0].inviteUrl).to.be.null;
 
         cy.apiLogout();
         cy.visit("/");
@@ -626,8 +626,7 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
       }).then((response) => {
         expect(response.status).to.eq(201);
         expect(response.body.status).to.eq("invited");
-        expect(response.body.workspaces[0].inviteUrl).to.exist;
-        expect(response.body.workspaces[0].inviteUrl).to.include("/invitations/");
+        expect(response.body.workspaces[0].inviteUrl).to.be.null;
 
         cy.apiLogout();
         cy.visit("/");

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js
@@ -1,6 +1,7 @@
 import {
   createUser,
   getUser,
+  getAllUsers,
 } from "Support/utils/externalApi";
 import { fake } from "Fixtures/fake";
 import { sanitize } from "Support/utils/common";
@@ -22,94 +23,208 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
     );
   });
 
-  // afterEach(() => {
-  //   cy.apiDeleteAllWorkspaces();
-  // });
+  // ── SECTION 1: Invited user (default status) ─────────────────────────────────
 
-  it("should validate inviteUrl presence and workspace assignment in POST /ext/users", () => {
-    const workspaceId = Cypress.env("workspaceId");
+  it("invited user: default status is invited, inviteUrl is non-null and contains correct oid", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("invited");
+        expect(response.body.workspaces).to.have.length(1);
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl, "inviteUrl should be non-null").to.exist;
+        expect(inviteUrl).to.include(`oid=${workspaceId}`);
 
-    // Case 1: Response includes a non-null inviteUrl per workspace
-    createUser({
-      name: "Vendor One",
-      email: `${sanitize(fake.lastName)}@example.com`,
-      workspaces: [{ id: workspaceId }],
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-      expect(response.body.workspaces).to.be.an("array").and.have.length(1);
-      expect(
-        response.body.workspaces[0].inviteUrl,
-        "inviteUrl should be present and non-null"
-      ).to.exist;
-    });
-
-    // Case 2: inviteUrl contains correct oid query param matching the workspace id
-    createUser({
-      name: "Vendor Two",
-      email: `${sanitize(fake.lastName)}@example.com`,
-      workspaces: [{ id: workspaceId }],
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-      const inviteUrl = response.body.workspaces[0].inviteUrl;
-      expect(inviteUrl, "inviteUrl should contain oid matching workspace id").to.include(
-        `oid=${workspaceId}`
-      );
+        // GET should also return non-null inviteUrl for an invited user with ws invited
+        getUser(response.body.id).then((getResponse) => {
+          expect(getResponse.status).to.eq(200);
+          expect(getResponse.body.workspaces[0].inviteUrl).to.exist;
+        });
+      });
     });
   });
 
-  it("should validate multi-workspace user creation in POST /ext/users", () => {
+  // ── SECTION 2: Active user — inviteUrl behavior by workspace status ──────────
+  //
+  // When status=active, User.invitationToken is null at creation time so the full
+  // invite URL (/invitations/{userToken}/workspaces/{ouToken}) cannot be generated.
+  // Instead, a workspace-only org-invite URL (/organization-invitations/{ouToken})
+  // is returned when the workspace membership is not yet active.
+  // When workspace status is also active, no URL is generated at all (null).
+
+  it("active user + ws invited: POST inviteUrl is an org-invite URL (not a full invite URL)", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      // active + no password + ws invited (default)
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        status: "active",
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("active");
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl).to.exist;
+        expect(inviteUrl).to.include("organization-invitations");
+        expect(inviteUrl).to.not.include("/invitations/");
+
+        // GET also returns org-invite URL: ou.status is not active, ou.invitationToken is set,
+        // user.invitationToken is null → org-invite URL format
+        getUser(response.body.id).then((getResponse) => {
+          expect(getResponse.status).to.eq(200);
+          const getInviteUrl = getResponse.body.workspaces[0].inviteUrl;
+          expect(getInviteUrl).to.exist;
+          expect(getInviteUrl).to.include("organization-invitations");
+        });
+      });
+
+      // active + with password + ws invited (default)
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        status: "active",
+        password: "Password",
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl).to.exist;
+        expect(inviteUrl).to.include("organization-invitations");
+      });
+    });
+  });
+
+  it("archived user: POST inviteUrl is non-null (tokens generated unconditionally at creation)", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        status: "archived",
+        workspaces: [{ id: workspaceId, status: "archived" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("archived");
+        expect(response.body.workspaces[0].inviteUrl).to.exist;
+      });
+    });
+  });
+
+  it("active user + ws active: POST inviteUrl is null (no URL when workspace membership is already active)", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      // active + no password + ws active
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        status: "active",
+        workspaces: [{ id: workspaceId, status: "active" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.workspaces[0].inviteUrl).to.be.null;
+      });
+
+      // active + with password + ws active
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        status: "active",
+        password: "Password",
+        workspaces: [{ id: workspaceId, status: "active" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.workspaces[0].inviteUrl).to.be.null;
+      });
+    });
+  });
+
+  // ── SECTION 3: Workspace status active — POST vs GET inviteUrl difference ────
+  //
+  // POST inviteUrl depends only on user.invitationToken (non-null for invited users).
+  // GET inviteUrl additionally checks ou.status — if active, returns null.
+
+  it("invited user with workspace status active: POST inviteUrl non-null, GET inviteUrl null", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      // invited + no password + ws active
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        workspaces: [{ id: workspaceId, status: "active" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("invited");
+        expect(response.body.workspaces[0].inviteUrl).to.exist;
+
+        getUser(response.body.id).then((getResponse) => {
+          expect(getResponse.status).to.eq(200);
+          expect(getResponse.body.workspaces[0].inviteUrl).to.be.null;
+        });
+      });
+
+      // invited + with password + ws active
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        password: "Password",
+        workspaces: [{ id: workspaceId, status: "active" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.workspaces[0].inviteUrl).to.exist;
+      });
+    });
+  });
+
+  // ── SECTION 4: Multi-workspace, roles, and custom groups ─────────────────────
+
+  it("should create user in all requested workspaces with per-workspace inviteUrls", () => {
     cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
       const ts2 = Date.now();
-      data.workspaceName2 = `${sanitize(fake.lastName)}${ts2}`;
-      data.workspaceSlug2 = `${sanitize(fake.lastName)}${ts2}`;
-      cy.apiCreateWorkspace(data.workspaceName2, data.workspaceSlug2).then(
-        (wsResponse) => {
-          const secondWorkspaceId = wsResponse.body.organization_id;
-
-          // Case 3: Creates the user in every requested workspace
-          createUser({
-            name: "Vendor Multi",
-            email: `${sanitize(fake.lastName)}@example.com`,
-            workspaces: [
-              { id: workspaceId },
-              { id: secondWorkspaceId },
-            ],
-          }).then((response) => {
-            expect(response.status).to.eq(201);
-            expect(response.body.workspaces).to.be.an("array").and.have.length(2);
-            const returnedIds = response.body.workspaces.map((ws) => ws.id);
-            expect(returnedIds).to.include(workspaceId);
-            expect(returnedIds).to.include(secondWorkspaceId);
-          });
-        }
-      );
-    });
-  });
-
-  it("should validate role assignment via POST /ext/users", () => {
-    const workspaceId = Cypress.env("workspaceId");
-
-    // Case 4: Assigns the specified role to the user in the workspace
-    createUser({
-      name: "Builder User",
-      email: `${sanitize(fake.lastName)}@example.com`,
-      workspaces: [{ id: workspaceId, role: "builder" }],
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-      const groupNames = response.body.userGroups.map((g) => g.name);
-      expect(groupNames).to.include("builder");
-    });
-
-    // Case 5: Assigns different roles across multiple workspaces
-    const ts3 = Date.now();
-    data.workspaceName2 = `${sanitize(fake.lastName)}${ts3}`;
-    data.workspaceSlug2 = `${sanitize(fake.lastName)}${ts3}`;
-    cy.apiCreateWorkspace(data.workspaceName2, data.workspaceSlug2).then(
-      (wsResponse) => {
+      cy.apiCreateWorkspace(
+        `${sanitize(fake.lastName)}${ts2}`,
+        `${sanitize(fake.lastName)}${ts2}`
+      ).then((wsResponse) => {
         const secondWorkspaceId = wsResponse.body.organization_id;
 
         createUser({
-          name: "Multi Role User",
+          name: fake.firstName,
+          email: `${sanitize(fake.lastName)}@example.com`,
+          workspaces: [{ id: workspaceId }, { id: secondWorkspaceId }],
+        }).then((response) => {
+          expect(response.status).to.eq(201);
+          expect(response.body.workspaces).to.have.length(2);
+          const returnedIds = response.body.workspaces.map((ws) => ws.id);
+          expect(returnedIds).to.include(workspaceId);
+          expect(returnedIds).to.include(secondWorkspaceId);
+          response.body.workspaces.forEach((ws) => {
+            expect(ws.inviteUrl).to.exist;
+          });
+        });
+      });
+    });
+  });
+
+  it("should assign specified roles across single and multiple workspaces", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        workspaces: [{ id: workspaceId, role: "builder" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        const groupNames = response.body.userGroups.map((g) => g.name);
+        expect(groupNames).to.include("builder");
+      });
+
+      const ts3 = Date.now();
+      cy.apiCreateWorkspace(
+        `${sanitize(fake.lastName)}${ts3}`,
+        `${sanitize(fake.lastName)}${ts3}`
+      ).then((wsResponse) => {
+        const secondWorkspaceId = wsResponse.body.organization_id;
+        createUser({
+          name: fake.firstName,
           email: `${sanitize(fake.lastName)}@example.com`,
           workspaces: [
             { id: workspaceId, role: "builder" },
@@ -117,244 +232,315 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
           ],
         }).then((response) => {
           expect(response.status).to.eq(201);
-          expect(response.body.workspaces).to.have.length(2);
           const groupNames = response.body.userGroups.map((g) => g.name);
           expect(groupNames).to.include("builder");
           expect(groupNames).to.include("end-user");
         });
-      }
-    );
+      });
+    });
   });
 
-  it("should validate custom group assignment in POST /ext/users", () => {
-    const workspaceId = Cypress.env("workspaceId");
-
-    // Create two custom groups in the workspace via the internal API
-    cy.getAuthHeaders().then((headers) => {
-      cy.request({
-        method: "POST",
-        url: `${Cypress.env("server_host")}/api/v2/group-permissions`,
-        headers: headers,
-        body: { name: "Viewer Group A" },
-        failOnStatusCode: false,
-      }).then((groupAResponse) => {
-        expect(groupAResponse.status).to.eq(201);
-
+  it("should add user to multiple custom groups in a workspace", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      cy.getAuthHeaders().then((headers) => {
         cy.request({
           method: "POST",
           url: `${Cypress.env("server_host")}/api/v2/group-permissions`,
-          headers: headers,
-          body: { name: "Viewer Group B" },
+          headers,
+          body: { name: "Viewer Group A" },
           failOnStatusCode: false,
-        }).then((groupBResponse) => {
-          expect(groupBResponse.status).to.eq(201);
-
-          // Case 6: Adds user to multiple custom groups in a workspace
-          createUser({
-            name: "Multi Group User",
-            email: `${sanitize(fake.lastName)}@example.com`,
-            workspaces: [
-              {
-                id: workspaceId,
-                groups: [
-                  { name: "Viewer Group A" },
-                  { name: "Viewer Group B" },
-                ],
-              },
-            ],
-          }).then((response) => {
-            expect(response.status).to.eq(201);
-            const groupNames = response.body.userGroups.map((g) => g.name);
-            expect(groupNames).to.include("Viewer Group A");
-            expect(groupNames).to.include("Viewer Group B");
+        }).then(() => {
+          cy.request({
+            method: "POST",
+            url: `${Cypress.env("server_host")}/api/v2/group-permissions`,
+            headers,
+            body: { name: "Viewer Group B" },
+            failOnStatusCode: false,
+          }).then(() => {
+            createUser({
+              name: fake.firstName,
+              email: `${sanitize(fake.lastName)}@example.com`,
+              workspaces: [
+                {
+                  id: workspaceId,
+                  groups: [
+                    { name: "Viewer Group A" },
+                    { name: "Viewer Group B" },
+                  ],
+                },
+              ],
+            }).then((response) => {
+              expect(response.status).to.eq(201);
+              const groupNames = response.body.userGroups.map((g) => g.name);
+              expect(groupNames).to.include("Viewer Group A");
+              expect(groupNames).to.include("Viewer Group B");
+            });
           });
         });
       });
     });
   });
 
-  it("should validate failing conditions in POST /ext/users", () => {
-    const workspaceId = Cypress.env("workspaceId");
-    const sharedEmail = `${sanitize(fake.lastName)}@example.com`;
+  // ── SECTION 5: Error / validation ────────────────────────────────────────────
 
-    // Case 7: Returns 400 when email already exists
-    createUser({
-      name: "Duplicate Vendor",
-      email: sharedEmail,
-      workspaces: [{ id: workspaceId }],
-    }).then((firstResponse) => {
-      expect(firstResponse.status).to.eq(201);
+  it("should return 400 for validation failures", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const sharedEmail = `${sanitize(fake.lastName)}@example.com`;
 
+      // duplicate email
       createUser({
         name: "Duplicate Vendor",
         email: sharedEmail,
         workspaces: [{ id: workspaceId }],
+      }).then((firstResponse) => {
+        expect(firstResponse.status).to.eq(201);
+        createUser({
+          name: "Duplicate Vendor",
+          email: sharedEmail,
+          workspaces: [{ id: workspaceId }],
+        }).then((response) => {
+          expect(response.status).to.eq(400);
+          expect(response.body.message).to.include("already exists");
+        });
+      });
+
+      // non-existent workspace id
+      createUser({
+        name: "Ghost Vendor",
+        email: `${sanitize(fake.lastName)}@example.com`,
+        workspaces: [{ id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d" }],
       }).then((response) => {
         expect(response.status).to.eq(400);
-        expect(response.body.message).to.include("already exists");
+        expect(response.body.message).to.include("do not exist");
       });
-    });
 
-    // Case 8: Returns 400 when workspace id does not exist
-    createUser({
-      name: "Ghost Vendor",
-      email: `${sanitize(fake.lastName)}@example.com`,
-      workspaces: [{ id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d" }],
-    }).then((response) => {
-      expect(response.status).to.eq(400);
-      expect(response.body.message).to.include("do not exist");
-    });
+      // default group name in groups field (use role field instead)
+      createUser({
+        name: "Invalid Group Vendor",
+        email: `${sanitize(fake.lastName)}@example.com`,
+        workspaces: [{ id: workspaceId, groups: [{ name: "builder" }] }],
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.message).to.include("role field");
+      });
 
-    // Case 9: Returns 400 when a default group name is passed in the groups field
-    createUser({
-      name: "Invalid Group Vendor",
-      email: `${sanitize(fake.lastName)}@example.com`,
-      workspaces: [{ id: workspaceId, groups: [{ name: "builder" }] }],
-    }).then((response) => {
-      expect(response.status).to.eq(400);
-      expect(response.body.message).to.include("role field");
-    });
-
-    // Case 10: Returns 400 when a custom group does not exist in the workspace
-    createUser({
-      name: "Bad Group Vendor",
-      email: `${sanitize(fake.lastName)}@example.com`,
-      workspaces: [
-        { id: workspaceId, groups: [{ name: "non-existent-custom-group" }] },
-      ],
-    }).then((response) => {
-      expect(response.status).to.eq(400);
-      expect(response.body.message).to.include(
-        "Group permission id or name not found"
-      );
+      // non-existent custom group
+      createUser({
+        name: "Bad Group Vendor",
+        email: `${sanitize(fake.lastName)}@example.com`,
+        workspaces: [
+          { id: workspaceId, groups: [{ name: "non-existent-custom-group" }] },
+        ],
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.message).to.include(
+          "Group permission id or name not found"
+        );
+      });
     });
   });
 
-  it("should validate conflicting-permissions error in POST /ext/users", () => {
-    const workspaceId = Cypress.env("workspaceId");
-
-    // Create a builder-level custom group (appCreate: true) via internal API
-    cy.getAuthHeaders().then((headers) => {
-      cy.request({
-        method: "POST",
-        url: `${Cypress.env("server_host")}/api/v2/group-permissions`,
-        headers: headers,
-        body: { name: "Elevated Builders" },
-        failOnStatusCode: false,
-      }).then((groupResponse) => {
-        expect(groupResponse.status).to.eq(201);
-        const groupId = groupResponse.body.id;
-
-        // Update the group to have builder-level (appCreate) permissions
+  it("should return 400 when end-user is added to a builder-level custom group", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      cy.getAuthHeaders().then((headers) => {
         cy.request({
-          method: "PUT",
-          url: `${Cypress.env("server_host")}/api/v2/group-permissions/${groupId}`,
-          headers: headers,
-          body: { appCreate: true },
+          method: "POST",
+          url: `${Cypress.env("server_host")}/api/v2/group-permissions`,
+          headers,
+          body: { name: "Elevated Builders" },
           failOnStatusCode: false,
-        }).then(() => {
-          // Case 11: Returns 400 when end-user is added to a builder-level custom group
-          createUser({
-            name: "Conflict Vendor",
-            email: `${sanitize(fake.lastName)}@example.com`,
-            workspaces: [
-              {
-                id: workspaceId,
-                role: "end-user",
-                groups: [{ name: "Elevated Builders" }],
-              },
-            ],
-          }).then((response) => {
-            expect(response.status).to.eq(400);
-            expect(response.body.message).to.be.an("object");
-            expect(response.body.message.title).to.eq("Conflicting permissions");
+        }).then((groupResponse) => {
+          const groupId = groupResponse.body.id;
+          cy.request({
+            method: "PUT",
+            url: `${Cypress.env("server_host")}/api/v2/group-permissions/${groupId}`,
+            headers,
+            body: { appCreate: true },
+            failOnStatusCode: false,
+          }).then(() => {
+            createUser({
+              name: "Conflict Vendor",
+              email: `${sanitize(fake.lastName)}@example.com`,
+              workspaces: [
+                {
+                  id: workspaceId,
+                  role: "end-user",
+                  groups: [{ name: "Elevated Builders" }],
+                },
+              ],
+            }).then((response) => {
+              expect(response.status).to.eq(400);
+              expect(response.body.message).to.be.an("object");
+              expect(response.body.message.title).to.eq("Conflicting permissions");
+            });
           });
         });
       });
     });
   });
 
-  it("should complete onboarding via inviteUrl for an invited user", () => {
-    const workspaceId = Cypress.env("workspaceId");
-    const email = `${sanitize(fake.lastName)}@example.com`;
+  // ── SECTION 6: UI end-to-end flows ───────────────────────────────────────────
 
-    createUser({
-      name: fake.firstName,
-      email,
-      workspaces: [{ id: workspaceId }],
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-      const inviteUrl = response.body.workspaces[0].inviteUrl;
-      expect(inviteUrl).to.exist;
+  it("invited user with no password: visit inviteUrl → set password → accept invite", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const email = `${sanitize(fake.lastName)}@example.com`;
 
-      cy.apiLogout();
-      cy.visit(inviteUrl);
+      createUser({
+        name: fake.firstName,
+        email,
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl).to.exist;
 
-      cy.clearAndType(onboardingSelectors.loginPasswordInput, "password");
-      cy.get(commonSelectors.signUpButton).click();
-      cy.get(commonSelectors.acceptInviteButton).click();
-      cy.get(commonSelectors.workspaceName).should(
-        "have.text",
-        data.workspaceName
-      );
+        cy.apiLogout();
+        cy.visit(inviteUrl);
 
-      // Clear all cookies then re-login as admin so that afterEach cleanup
-      // (apiDeleteAllWorkspaces) uses the admin credentials. Without clearing,
-      // cy.getCookie("tj_auth_token") returns the invited user's cookie that was
-      // set by cy.visit(inviteUrl), causing 401 in apiArchiveWorkspace.
-      cy.clearCookies();
-      cy.apiLogin();
+        cy.clearAndType(onboardingSelectors.loginPasswordInput, "password");
+        cy.get(commonSelectors.signUpButton).click();
+        cy.get(commonSelectors.acceptInviteButton).click();
+        cy.get(commonSelectors.workspaceName).should(
+          "have.text",
+          data.workspaceName
+        );
+
+        cy.clearCookies();
+        cy.apiLogin();
+      });
     });
   });
 
-  it("should allow direct login for an active user created with a password", () => {
-    const workspaceId = Cypress.env("workspaceId");
-    const email = `${sanitize(fake.lastName)}@example.com`;
-    const password = "password";
+  it("invited user with no password and workspace status active: visit inviteUrl → set password → workspace loads", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const email = `${sanitize(fake.lastName)}@example.com`;
 
-    createUser({
-      name: fake.firstName,
-      email,
-      status: "active",
-      password,
-      workspaces: [{ id: workspaceId }],
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-      expect(response.body.status).to.eq("active");
+      createUser({
+        name: fake.firstName,
+        email,
+        workspaces: [{ id: workspaceId, status: "active" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("invited");
+        // POST: non-null (user.invitationToken is set for invited users)
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl).to.exist;
 
-      cy.apiLogout();
-      cy.visit("/");
-      cy.clearAndType(onboardingSelectors.signupEmailInput, email);
-      cy.clearAndType(onboardingSelectors.loginPasswordInput, password);
-      cy.get(onboardingSelectors.signInButton).click();
-      cy.visit("/" + data.workspaceSlug);
-      cy.get(commonSelectors.workspaceName, { timeout: 20000 }).should(
-        "be.visible"
-      );
-      cy.clearCookies();
-      cy.apiLogin();
+        cy.apiLogout();
+        cy.visit(inviteUrl);
+
+        cy.clearAndType(onboardingSelectors.loginPasswordInput, "password");
+        cy.get(commonSelectors.signUpButton).click();
+        cy.get(commonSelectors.acceptInviteButton, { timeout: 10000 }).click();
+        cy.get(commonSelectors.workspaceName, { timeout: 20000 }).should(
+          "be.visible"
+        );
+
+        cy.clearCookies();
+        cy.apiLogin();
+      });
     });
   });
 
-  it("should validate GET /ext/user/:id returns inviteUrl null for users without invitation tokens", () => {
-    // Case 12: GET /ext/user/:id returns inviteUrl: null for users without invitation tokens
-    // The admin user (dev@tooljet.io) was created via internal path and never gets an invitationToken,
-    // so their workspaces should have inviteUrl: null.
+  it("active user with password: POST returns org-invite URL — direct login to workspace", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const email = `${sanitize(fake.lastName)}@example.com`;
+      const password = "Password";
 
-    // Get any user id from the users list
-    cy.request({
-      method: "GET",
-      url: `${Cypress.env("API_URL")}/ext/users`,
-      headers: {
-        Authorization: Cypress.env("AUTH_TOKEN"),
-        "Content-Type": "application/json",
-      },
-      failOnStatusCode: false,
-    }).then((listResponse) => {
+      createUser({
+        name: fake.firstName,
+        email,
+        status: "active",
+        password,
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("active");
+        // Active users have no User.invitationToken, so a workspace-only org-invite URL is
+        // returned instead of the full invite URL. The user logs in directly with their password.
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl).to.exist;
+        expect(inviteUrl).to.include("organization-invitations");
+
+        cy.apiLogout();
+        cy.visit("/");
+        cy.clearAndType(onboardingSelectors.signupEmailInput, email);
+        cy.clearAndType(onboardingSelectors.loginPasswordInput, password);
+        cy.get(onboardingSelectors.signInButton).click();
+        cy.visit("/" + data.workspaceSlug);
+        cy.get(commonSelectors.workspaceName, { timeout: 20000 }).should(
+          "be.visible"
+        );
+
+        cy.clearCookies();
+        cy.apiLogin();
+      });
+    });
+  });
+
+  it("active user with no password: POST returns org-invite URL — reset password via DB token then login", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const email = `${sanitize(fake.lastName)}@example.com`;
+      const newPassword = "Password";
+
+      createUser({
+        name: fake.firstName,
+        email,
+        status: "active",
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("active");
+        // Active users have no User.invitationToken — a workspace-only org-invite URL is
+        // returned. No password is set, so the user must reset via forgot-password first.
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl).to.exist;
+        expect(inviteUrl).to.include("organization-invitations");
+
+        cy.apiLogout();
+        cy.visit("/");
+
+        cy.get(commonSelectors.forgotPasswordLink).click();
+        cy.clearAndType('[data-cy="email-input-field-input"]', email);
+        cy.get(commonSelectors.resetPasswordLinkButton).click();
+
+        // Fetch reset token directly from DB to avoid email dependency
+        cy.task("dbConnection", {
+          dbconfig: Cypress.env("app_db"),
+          sql: `select forgot_password_token from users where email='${email}';`,
+        }).then((resp) => {
+          const token = resp.rows[0].forgot_password_token;
+          cy.visit(`/reset-password/${token}`);
+
+          cy.get(commonSelectors.newPasswordInputField).type(newPassword);
+          cy.get(commonSelectors.confirmPasswordInputField).type(newPassword);
+          cy.get(commonSelectors.resetPasswordButton).click();
+
+          cy.get(commonSelectors.backToLoginButton).click();
+          cy.clearAndType(onboardingSelectors.signupEmailInput, email);
+          cy.clearAndType(onboardingSelectors.loginPasswordInput, newPassword);
+          cy.get(onboardingSelectors.signInButton).click();
+
+          cy.visit("/" + data.workspaceSlug);
+          cy.get(commonSelectors.workspaceName, { timeout: 20000 }).should(
+            "be.visible"
+          );
+
+          cy.clearCookies();
+          cy.apiLogin();
+        });
+      });
+    });
+  });
+
+  // ── SECTION 7: GET /ext/user/:id ─────────────────────────────────────────────
+
+  it("GET /ext/user/:id returns inviteUrl null for pre-existing users without invitation tokens", () => {
+    getAllUsers().then((listResponse) => {
       expect(listResponse.status).to.eq(200);
       expect(listResponse.body).to.be.an("array").and.not.be.empty;
 
-      // Use the first user (admin, created via internal path — no invitationToken)
+      // Admin user was created via internal path — no invitationToken is ever set
       const adminUserId = listResponse.body[0].id;
 
       getUser(adminUserId).then((response) => {
@@ -363,7 +549,7 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
         response.body.workspaces.forEach((ws) => {
           expect(
             ws.inviteUrl,
-            `workspace ${ws.id} inviteUrl should be null for admin user`
+            `workspace ${ws.id} should have null inviteUrl for admin user`
           ).to.be.null;
         });
       });

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js
@@ -1,0 +1,372 @@
+import {
+  createUser,
+  getUser,
+} from "Support/utils/externalApi";
+import { fake } from "Fixtures/fake";
+import { sanitize } from "Support/utils/common";
+import { commonSelectors } from "Selectors/common";
+import { onboardingSelectors } from "Selectors/onboarding";
+
+describe("ToolJet: Create User — inviteUrl API Validation", () => {
+  const data = {};
+
+  beforeEach(() => {
+    const ts = Date.now();
+    data.workspaceName = `${sanitize(fake.lastName)}${ts}`;
+    data.workspaceSlug = `${sanitize(fake.lastName)}${ts}`;
+    cy.apiLogin();
+    cy.apiCreateWorkspace(data.workspaceName, data.workspaceSlug).then(
+      (response) => {
+        Cypress.env("workspaceId", response.body.organization_id);
+      }
+    );
+  });
+
+  // afterEach(() => {
+  //   cy.apiDeleteAllWorkspaces();
+  // });
+
+  it("should validate inviteUrl presence and workspace assignment in POST /ext/users", () => {
+    const workspaceId = Cypress.env("workspaceId");
+
+    // Case 1: Response includes a non-null inviteUrl per workspace
+    createUser({
+      name: "Vendor One",
+      email: `${sanitize(fake.lastName)}@example.com`,
+      workspaces: [{ id: workspaceId }],
+    }).then((response) => {
+      expect(response.status).to.eq(201);
+      expect(response.body.workspaces).to.be.an("array").and.have.length(1);
+      expect(
+        response.body.workspaces[0].inviteUrl,
+        "inviteUrl should be present and non-null"
+      ).to.exist;
+    });
+
+    // Case 2: inviteUrl contains correct oid query param matching the workspace id
+    createUser({
+      name: "Vendor Two",
+      email: `${sanitize(fake.lastName)}@example.com`,
+      workspaces: [{ id: workspaceId }],
+    }).then((response) => {
+      expect(response.status).to.eq(201);
+      const inviteUrl = response.body.workspaces[0].inviteUrl;
+      expect(inviteUrl, "inviteUrl should contain oid matching workspace id").to.include(
+        `oid=${workspaceId}`
+      );
+    });
+  });
+
+  it("should validate multi-workspace user creation in POST /ext/users", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const ts2 = Date.now();
+      data.workspaceName2 = `${sanitize(fake.lastName)}${ts2}`;
+      data.workspaceSlug2 = `${sanitize(fake.lastName)}${ts2}`;
+      cy.apiCreateWorkspace(data.workspaceName2, data.workspaceSlug2).then(
+        (wsResponse) => {
+          const secondWorkspaceId = wsResponse.body.organization_id;
+
+          // Case 3: Creates the user in every requested workspace
+          createUser({
+            name: "Vendor Multi",
+            email: `${sanitize(fake.lastName)}@example.com`,
+            workspaces: [
+              { id: workspaceId },
+              { id: secondWorkspaceId },
+            ],
+          }).then((response) => {
+            expect(response.status).to.eq(201);
+            expect(response.body.workspaces).to.be.an("array").and.have.length(2);
+            const returnedIds = response.body.workspaces.map((ws) => ws.id);
+            expect(returnedIds).to.include(workspaceId);
+            expect(returnedIds).to.include(secondWorkspaceId);
+          });
+        }
+      );
+    });
+  });
+
+  it("should validate role assignment via POST /ext/users", () => {
+    const workspaceId = Cypress.env("workspaceId");
+
+    // Case 4: Assigns the specified role to the user in the workspace
+    createUser({
+      name: "Builder User",
+      email: `${sanitize(fake.lastName)}@example.com`,
+      workspaces: [{ id: workspaceId, role: "builder" }],
+    }).then((response) => {
+      expect(response.status).to.eq(201);
+      const groupNames = response.body.userGroups.map((g) => g.name);
+      expect(groupNames).to.include("builder");
+    });
+
+    // Case 5: Assigns different roles across multiple workspaces
+    const ts3 = Date.now();
+    data.workspaceName2 = `${sanitize(fake.lastName)}${ts3}`;
+    data.workspaceSlug2 = `${sanitize(fake.lastName)}${ts3}`;
+    cy.apiCreateWorkspace(data.workspaceName2, data.workspaceSlug2).then(
+      (wsResponse) => {
+        const secondWorkspaceId = wsResponse.body.organization_id;
+
+        createUser({
+          name: "Multi Role User",
+          email: `${sanitize(fake.lastName)}@example.com`,
+          workspaces: [
+            { id: workspaceId, role: "builder" },
+            { id: secondWorkspaceId, role: "end-user" },
+          ],
+        }).then((response) => {
+          expect(response.status).to.eq(201);
+          expect(response.body.workspaces).to.have.length(2);
+          const groupNames = response.body.userGroups.map((g) => g.name);
+          expect(groupNames).to.include("builder");
+          expect(groupNames).to.include("end-user");
+        });
+      }
+    );
+  });
+
+  it("should validate custom group assignment in POST /ext/users", () => {
+    const workspaceId = Cypress.env("workspaceId");
+
+    // Create two custom groups in the workspace via the internal API
+    cy.getAuthHeaders().then((headers) => {
+      cy.request({
+        method: "POST",
+        url: `${Cypress.env("server_host")}/api/v2/group-permissions`,
+        headers: headers,
+        body: { name: "Viewer Group A" },
+        failOnStatusCode: false,
+      }).then((groupAResponse) => {
+        expect(groupAResponse.status).to.eq(201);
+
+        cy.request({
+          method: "POST",
+          url: `${Cypress.env("server_host")}/api/v2/group-permissions`,
+          headers: headers,
+          body: { name: "Viewer Group B" },
+          failOnStatusCode: false,
+        }).then((groupBResponse) => {
+          expect(groupBResponse.status).to.eq(201);
+
+          // Case 6: Adds user to multiple custom groups in a workspace
+          createUser({
+            name: "Multi Group User",
+            email: `${sanitize(fake.lastName)}@example.com`,
+            workspaces: [
+              {
+                id: workspaceId,
+                groups: [
+                  { name: "Viewer Group A" },
+                  { name: "Viewer Group B" },
+                ],
+              },
+            ],
+          }).then((response) => {
+            expect(response.status).to.eq(201);
+            const groupNames = response.body.userGroups.map((g) => g.name);
+            expect(groupNames).to.include("Viewer Group A");
+            expect(groupNames).to.include("Viewer Group B");
+          });
+        });
+      });
+    });
+  });
+
+  it("should validate failing conditions in POST /ext/users", () => {
+    const workspaceId = Cypress.env("workspaceId");
+    const sharedEmail = `${sanitize(fake.lastName)}@example.com`;
+
+    // Case 7: Returns 400 when email already exists
+    createUser({
+      name: "Duplicate Vendor",
+      email: sharedEmail,
+      workspaces: [{ id: workspaceId }],
+    }).then((firstResponse) => {
+      expect(firstResponse.status).to.eq(201);
+
+      createUser({
+        name: "Duplicate Vendor",
+        email: sharedEmail,
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+        expect(response.body.message).to.include("already exists");
+      });
+    });
+
+    // Case 8: Returns 400 when workspace id does not exist
+    createUser({
+      name: "Ghost Vendor",
+      email: `${sanitize(fake.lastName)}@example.com`,
+      workspaces: [{ id: "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d" }],
+    }).then((response) => {
+      expect(response.status).to.eq(400);
+      expect(response.body.message).to.include("do not exist");
+    });
+
+    // Case 9: Returns 400 when a default group name is passed in the groups field
+    createUser({
+      name: "Invalid Group Vendor",
+      email: `${sanitize(fake.lastName)}@example.com`,
+      workspaces: [{ id: workspaceId, groups: [{ name: "builder" }] }],
+    }).then((response) => {
+      expect(response.status).to.eq(400);
+      expect(response.body.message).to.include("role field");
+    });
+
+    // Case 10: Returns 400 when a custom group does not exist in the workspace
+    createUser({
+      name: "Bad Group Vendor",
+      email: `${sanitize(fake.lastName)}@example.com`,
+      workspaces: [
+        { id: workspaceId, groups: [{ name: "non-existent-custom-group" }] },
+      ],
+    }).then((response) => {
+      expect(response.status).to.eq(400);
+      expect(response.body.message).to.include(
+        "Group permission id or name not found"
+      );
+    });
+  });
+
+  it("should validate conflicting-permissions error in POST /ext/users", () => {
+    const workspaceId = Cypress.env("workspaceId");
+
+    // Create a builder-level custom group (appCreate: true) via internal API
+    cy.getAuthHeaders().then((headers) => {
+      cy.request({
+        method: "POST",
+        url: `${Cypress.env("server_host")}/api/v2/group-permissions`,
+        headers: headers,
+        body: { name: "Elevated Builders" },
+        failOnStatusCode: false,
+      }).then((groupResponse) => {
+        expect(groupResponse.status).to.eq(201);
+        const groupId = groupResponse.body.id;
+
+        // Update the group to have builder-level (appCreate) permissions
+        cy.request({
+          method: "PUT",
+          url: `${Cypress.env("server_host")}/api/v2/group-permissions/${groupId}`,
+          headers: headers,
+          body: { appCreate: true },
+          failOnStatusCode: false,
+        }).then(() => {
+          // Case 11: Returns 400 when end-user is added to a builder-level custom group
+          createUser({
+            name: "Conflict Vendor",
+            email: `${sanitize(fake.lastName)}@example.com`,
+            workspaces: [
+              {
+                id: workspaceId,
+                role: "end-user",
+                groups: [{ name: "Elevated Builders" }],
+              },
+            ],
+          }).then((response) => {
+            expect(response.status).to.eq(400);
+            expect(response.body.message).to.be.an("object");
+            expect(response.body.message.title).to.eq("Conflicting permissions");
+          });
+        });
+      });
+    });
+  });
+
+  it("should complete onboarding via inviteUrl for an invited user", () => {
+    const workspaceId = Cypress.env("workspaceId");
+    const email = `${sanitize(fake.lastName)}@example.com`;
+
+    createUser({
+      name: fake.firstName,
+      email,
+      workspaces: [{ id: workspaceId }],
+    }).then((response) => {
+      expect(response.status).to.eq(201);
+      const inviteUrl = response.body.workspaces[0].inviteUrl;
+      expect(inviteUrl).to.exist;
+
+      cy.apiLogout();
+      cy.visit(inviteUrl);
+
+      cy.clearAndType(onboardingSelectors.loginPasswordInput, "password");
+      cy.get(commonSelectors.signUpButton).click();
+      cy.get(commonSelectors.acceptInviteButton).click();
+      cy.get(commonSelectors.workspaceName).should(
+        "have.text",
+        data.workspaceName
+      );
+
+      // Clear all cookies then re-login as admin so that afterEach cleanup
+      // (apiDeleteAllWorkspaces) uses the admin credentials. Without clearing,
+      // cy.getCookie("tj_auth_token") returns the invited user's cookie that was
+      // set by cy.visit(inviteUrl), causing 401 in apiArchiveWorkspace.
+      cy.clearCookies();
+      cy.apiLogin();
+    });
+  });
+
+  it("should allow direct login for an active user created with a password", () => {
+    const workspaceId = Cypress.env("workspaceId");
+    const email = `${sanitize(fake.lastName)}@example.com`;
+    const password = "password";
+
+    createUser({
+      name: fake.firstName,
+      email,
+      status: "active",
+      password,
+      workspaces: [{ id: workspaceId }],
+    }).then((response) => {
+      expect(response.status).to.eq(201);
+      expect(response.body.status).to.eq("active");
+
+      cy.apiLogout();
+      cy.visit("/");
+      cy.clearAndType(onboardingSelectors.signupEmailInput, email);
+      cy.clearAndType(onboardingSelectors.loginPasswordInput, password);
+      cy.get(onboardingSelectors.signInButton).click();
+      cy.visit("/" + data.workspaceSlug);
+      cy.get(commonSelectors.workspaceName, { timeout: 20000 }).should(
+        "be.visible"
+      );
+      cy.clearCookies();
+      cy.apiLogin();
+    });
+  });
+
+  it("should validate GET /ext/user/:id returns inviteUrl null for users without invitation tokens", () => {
+    // Case 12: GET /ext/user/:id returns inviteUrl: null for users without invitation tokens
+    // The admin user (dev@tooljet.io) was created via internal path and never gets an invitationToken,
+    // so their workspaces should have inviteUrl: null.
+
+    // Get any user id from the users list
+    cy.request({
+      method: "GET",
+      url: `${Cypress.env("API_URL")}/ext/users`,
+      headers: {
+        Authorization: Cypress.env("AUTH_TOKEN"),
+        "Content-Type": "application/json",
+      },
+      failOnStatusCode: false,
+    }).then((listResponse) => {
+      expect(listResponse.status).to.eq(200);
+      expect(listResponse.body).to.be.an("array").and.not.be.empty;
+
+      // Use the first user (admin, created via internal path — no invitationToken)
+      const adminUserId = listResponse.body[0].id;
+
+      getUser(adminUserId).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.workspaces).to.be.an("array");
+        response.body.workspaces.forEach((ws) => {
+          expect(
+            ws.inviteUrl,
+            `workspace ${ws.id} inviteUrl should be null for admin user`
+          ).to.be.null;
+        });
+      });
+    });
+  });
+});

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js
@@ -27,6 +27,7 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
 
   it("invited user: default status is invited, inviteUrl is non-null and contains correct oid", () => {
     cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      // invited + no password + ws invited (default)
       createUser({
         name: fake.firstName,
         email: `${sanitize(fake.lastName)}@example.com`,
@@ -37,6 +38,7 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
         expect(response.body.workspaces).to.have.length(1);
         const inviteUrl = response.body.workspaces[0].inviteUrl;
         expect(inviteUrl, "inviteUrl should be non-null").to.exist;
+        expect(inviteUrl).to.include("/invitations/");
         expect(inviteUrl).to.include(`oid=${workspaceId}`);
 
         // GET should also return non-null inviteUrl for an invited user with ws invited
@@ -44,6 +46,21 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
           expect(getResponse.status).to.eq(200);
           expect(getResponse.body.workspaces[0].inviteUrl).to.exist;
         });
+      });
+
+      // invited + with password + ws invited — password does not affect URL generation
+      createUser({
+        name: fake.firstName,
+        email: `${sanitize(fake.lastName)}@example.com`,
+        password: "Password",
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("invited");
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl).to.exist;
+        expect(inviteUrl).to.include("/invitations/");
+        expect(inviteUrl).to.include(`oid=${workspaceId}`);
       });
     });
   });
@@ -411,9 +428,10 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
     });
   });
 
-  it("invited user with no password and workspace status active: visit inviteUrl → set password → workspace loads", () => {
+  it("invited user with no password and workspace status active: reset password → login → not-active error", () => {
     cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
       const email = `${sanitize(fake.lastName)}@example.com`;
+      const newPassword = "Password";
 
       createUser({
         name: fake.firstName,
@@ -422,22 +440,44 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
       }).then((response) => {
         expect(response.status).to.eq(201);
         expect(response.body.status).to.eq("invited");
-        // POST: non-null (user.invitationToken is set for invited users)
-        const inviteUrl = response.body.workspaces[0].inviteUrl;
-        expect(inviteUrl).to.exist;
+        expect(response.body.workspaces[0].inviteUrl).to.exist;
 
         cy.apiLogout();
-        cy.visit(inviteUrl);
+        cy.visit("/");
 
-        cy.clearAndType(onboardingSelectors.loginPasswordInput, "password");
-        cy.get(commonSelectors.signUpButton).click();
-        cy.get(commonSelectors.acceptInviteButton, { timeout: 10000 }).click();
-        cy.get(commonSelectors.workspaceName, { timeout: 20000 }).should(
-          "be.visible"
-        );
+        cy.get(commonSelectors.forgotPasswordLink).click();
+        cy.clearAndType('[data-cy="email-input-field-input"]', email);
+        cy.get(commonSelectors.resetPasswordLinkButton).click();
 
-        cy.clearCookies();
-        cy.apiLogin();
+        cy.task("dbConnection", {
+          dbconfig: Cypress.env("app_db"),
+          sql: `select forgot_password_token from users where email='${email}';`,
+        }).then((resp) => {
+          const token = resp.rows[0].forgot_password_token;
+          cy.intercept("GET", "**/api/metadata").as("resetMeta");
+          cy.intercept("GET", "**/api/white-labelling").as("resetWhiteLabel");
+          cy.visit(`/reset-password/${token}`);
+          cy.wait(["@resetMeta", "@resetWhiteLabel"]);
+
+          cy.get(commonSelectors.newPasswordInputField).should("be.visible");
+          cy.clearAndType(commonSelectors.newPasswordInputField, newPassword);
+          cy.get(commonSelectors.confirmPasswordInputField).should("be.visible");
+          cy.clearAndType(commonSelectors.confirmPasswordInputField, newPassword);
+          cy.get(commonSelectors.resetPasswordButton).click();
+
+          cy.get(commonSelectors.backToLoginButton).click();
+          cy.url().should("not.include", "reset-password");
+          cy.clearAndType(onboardingSelectors.signupEmailInput, email);
+          cy.clearAndType(onboardingSelectors.loginPasswordInput, newPassword);
+          cy.get(onboardingSelectors.signInButton).click();
+
+          cy.contains(
+            "The user is not active, please use the invite link shared to activate"
+          ).should("be.visible");
+
+          cy.clearCookies();
+          cy.apiLogin();
+        });
       });
     });
   });
@@ -510,13 +550,176 @@ describe("ToolJet: Create User — inviteUrl API Validation", () => {
           sql: `select forgot_password_token from users where email='${email}';`,
         }).then((resp) => {
           const token = resp.rows[0].forgot_password_token;
+          cy.intercept("GET", "**/api/metadata").as("resetMeta");
+          cy.intercept("GET", "**/api/white-labelling").as("resetWhiteLabel");
           cy.visit(`/reset-password/${token}`);
+          cy.wait(["@resetMeta", "@resetWhiteLabel"]);
 
-          cy.get(commonSelectors.newPasswordInputField).type(newPassword);
-          cy.get(commonSelectors.confirmPasswordInputField).type(newPassword);
+          cy.get(commonSelectors.newPasswordInputField).should("be.visible");
+          cy.clearAndType(commonSelectors.newPasswordInputField, newPassword);
+          cy.get(commonSelectors.confirmPasswordInputField).should("be.visible");
+          cy.clearAndType(commonSelectors.confirmPasswordInputField, newPassword);
+          cy.get(commonSelectors.resetPasswordButton).click();
+
+          // Visit the org-invite URL from the POST response and login to accept the workspace invite
+          cy.visit(inviteUrl);
+          cy.clearAndType(onboardingSelectors.signupEmailInput, email);
+          cy.clearAndType(onboardingSelectors.loginPasswordInput, newPassword);
+          cy.get(onboardingSelectors.signInButton).click();
+          cy.get(commonSelectors.acceptInviteButton).click();
+          cy.get(commonSelectors.workspaceName).should(
+            "have.text",
+            data.workspaceName
+          );
+
+          cy.clearCookies();
+          cy.apiLogin();
+        });
+      });
+    });
+  });
+
+  it("invited user with password: visit inviteUrl → enter password → accept invite → workspace loads", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const email = `${sanitize(fake.lastName)}@example.com`;
+      const password = "Password";
+
+      createUser({
+        name: fake.firstName,
+        email,
+        password,
+        workspaces: [{ id: workspaceId }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("invited");
+        const inviteUrl = response.body.workspaces[0].inviteUrl;
+        expect(inviteUrl).to.exist;
+        expect(inviteUrl).to.include("/invitations/");
+
+        cy.apiLogout();
+        cy.visit(inviteUrl);
+
+        cy.clearAndType(onboardingSelectors.loginPasswordInput, password);
+        cy.get(commonSelectors.signUpButton).click();
+        cy.get(commonSelectors.acceptInviteButton).click();
+        cy.get(commonSelectors.workspaceName).should(
+          "have.text",
+          data.workspaceName
+        );
+
+        cy.clearCookies();
+        cy.apiLogin();
+      });
+    });
+  });
+
+  it("invited user with password and workspace status active: login → not-active error", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const email = `${sanitize(fake.lastName)}@example.com`;
+      const password = "Password";
+
+      createUser({
+        name: fake.firstName,
+        email,
+        password,
+        workspaces: [{ id: workspaceId, status: "active" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("invited");
+        expect(response.body.workspaces[0].inviteUrl).to.exist;
+        expect(response.body.workspaces[0].inviteUrl).to.include("/invitations/");
+
+        cy.apiLogout();
+        cy.visit("/");
+        cy.clearAndType(onboardingSelectors.signupEmailInput, email);
+        cy.clearAndType(onboardingSelectors.loginPasswordInput, password);
+        cy.get(onboardingSelectors.signInButton).click();
+
+        cy.contains(
+          "The user is not active, please use the invite link shared to activate"
+        ).should("be.visible");
+
+        cy.clearCookies();
+        cy.apiLogin();
+      });
+    });
+  });
+
+  it("active user with password and workspace status active: inviteUrl is null — login directly to workspace", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const email = `${sanitize(fake.lastName)}@example.com`;
+      const password = "Password";
+
+      createUser({
+        name: fake.firstName,
+        email,
+        status: "active",
+        password,
+        workspaces: [{ id: workspaceId, status: "active" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("active");
+        expect(response.body.workspaces[0].inviteUrl).to.be.null;
+
+        cy.apiLogout();
+        cy.visit("/");
+        cy.clearAndType(onboardingSelectors.signupEmailInput, email);
+        cy.clearAndType(onboardingSelectors.loginPasswordInput, password);
+        cy.get(onboardingSelectors.signInButton).click();
+        cy.visit("/" + data.workspaceSlug);
+        cy.get(commonSelectors.workspaceName, { timeout: 20000 }).should(
+          "be.visible"
+        );
+
+        cy.clearCookies();
+        cy.apiLogin();
+      });
+    });
+  });
+
+  it("active user with no password and workspace status active: inviteUrl is null — reset password then login", () => {
+    cy.then(() => Cypress.env("workspaceId")).then((workspaceId) => {
+      const email = `${sanitize(fake.lastName)}@example.com`;
+      const newPassword = "Password";
+
+      createUser({
+        name: fake.firstName,
+        email,
+        status: "active",
+        workspaces: [{ id: workspaceId, status: "active" }],
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.status).to.eq("active");
+        expect(response.body.workspaces[0].inviteUrl).to.be.null;
+
+        cy.apiLogout();
+        cy.visit("/");
+
+        cy.get(commonSelectors.forgotPasswordLink).click();
+        cy.clearAndType('[data-cy="email-input-field-input"]', email);
+        cy.get(commonSelectors.resetPasswordLinkButton).click();
+
+        cy.task("dbConnection", {
+          dbconfig: Cypress.env("app_db"),
+          sql: `select forgot_password_token from users where email='${email}';`,
+        }).then((resp) => {
+          const token = resp.rows[0].forgot_password_token;
+          cy.intercept("GET", "**/api/metadata").as("resetMeta");
+          cy.intercept("GET", "**/api/white-labelling").as("resetWhiteLabel");
+          cy.visit(`/reset-password/${token}`);
+          cy.wait(["@resetMeta", "@resetWhiteLabel"]);
+
+          cy.get(commonSelectors.newPasswordInputField).should("be.visible");
+          cy.clearAndType(commonSelectors.newPasswordInputField, newPassword);
+          cy.get(commonSelectors.confirmPasswordInputField).should("be.visible");
+          cy.clearAndType(
+            commonSelectors.confirmPasswordInputField,
+            newPassword
+          );
           cy.get(commonSelectors.resetPasswordButton).click();
 
           cy.get(commonSelectors.backToLoginButton).click();
+          cy.url().should("not.include", "reset-password");
           cy.clearAndType(onboardingSelectors.signupEmailInput, email);
           cy.clearAndType(onboardingSelectors.loginPasswordInput, newPassword);
           cy.get(onboardingSelectors.signInButton).click();

--- a/server/src/modules/external-apis/dto/index.ts
+++ b/server/src/modules/external-apis/dto/index.ts
@@ -23,6 +23,7 @@ import { ValidateTooljetDatabaseImportSchema } from '@dto/validators/tooljet-dat
 export enum Status {
   ACTIVE = 'active',
   ARCHIVED = 'archived',
+  INVITED = 'invited',
 }
 
 export class GroupDto {
@@ -54,7 +55,7 @@ export class WorkspaceDto {
 
   @IsEnum(Status)
   @IsOptional()
-  status?: Status = Status.ARCHIVED;
+  status?: Status = Status.INVITED;
 
   @IsArray()
   @ValidateNested({ each: true })
@@ -98,7 +99,7 @@ export class CreateUserDto {
 
   @IsEnum(Status)
   @IsOptional()
-  status?: Status = Status.ARCHIVED;
+  status?: Status = Status.INVITED;
 
   @IsString()
   @IsOptional()
@@ -128,6 +129,10 @@ export class UpdateUserDto {
   @IsEnum(Status)
   @IsOptional()
   status?: Status;
+
+  @IsString()
+  @IsOptional()
+  defaultOrganizationId?: string;
 }
 
 export class UpdateUserWorkspaceDto {

--- a/server/src/modules/session/guards/invited-user-session.guard.ts
+++ b/server/src/modules/session/guards/invited-user-session.guard.ts
@@ -140,8 +140,9 @@ export class InvitedUserSessionAuthGuard extends AuthGuard('jwt') {
   }
 
   async onInvalidSession(invitedUser: any, accountToken: string) {
-    const { status, source: organizationUserSource } = invitedUser;
-    if (accountToken && [USER_STATUS.INVITED, USER_STATUS.VERIFIED].includes(status as USER_STATUS)) {
+    const { source: organizationUserSource } = invitedUser;
+    const userStatus = invitedUser.user?.status;
+    if (accountToken && [USER_STATUS.INVITED, USER_STATUS.VERIFIED].includes(userStatus as USER_STATUS)) {
       /* User doesn't have a valid session & User didn't activate account yet */
       return invitedUser;
     } else {

--- a/server/test/helpers/seed.ts
+++ b/server/test/helpers/seed.ts
@@ -237,6 +237,7 @@ async function maybeCreateDefaultGroupPermissions(nestApp: INestApplication, org
 
   const defaultGroups = [
     { name: 'admin', isAdmin: true },
+    { name: 'builder', isAdmin: true },
     { name: 'end-user', isAdmin: false },
   ];
 

--- a/server/test/modules/external-apis/e2e/users.spec.ts
+++ b/server/test/modules/external-apis/e2e/users.spec.ts
@@ -128,6 +128,46 @@ describe('ExternalApisUsersController (EE enterprise)', () => {
       expect(groupNames).toContain('end-user');
     });
 
+    it('should return an org-invite URL (not a full invite URL) when user status is active', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin-active-user@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Active User Vendor',
+          email: 'active-user-vendor@example.com',
+          status: 'active',
+          workspaces: [{ id: orgId }],
+        })
+        .expect(201);
+
+      const inviteUrl: string = res.body.workspaces[0].inviteUrl;
+      expect(inviteUrl).toBeTruthy();
+      // Active users have no invitationToken — workspace-only invite URL is returned.
+      expect(inviteUrl).toContain('organization-invitations');
+      expect(inviteUrl).not.toContain('/invitations/');
+    });
+
+    it('should return inviteUrl as null when workspace status is active', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin-active-ws@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Active WS Vendor',
+          email: 'active-ws-vendor@example.com',
+          status: 'active',
+          workspaces: [{ id: orgId, status: 'active' }],
+        })
+        .expect(201);
+
+      expect(res.body.workspaces[0].inviteUrl).toBeNull();
+    });
+
     it('should return a non-null inviteUrl even when user and workspace status are archived', async () => {
       const { user: adminUser } = await createUser(app, { email: 'admin-archived@tooljet.io' });
       const orgId = adminUser.defaultOrganizationId;

--- a/server/test/modules/external-apis/e2e/users.spec.ts
+++ b/server/test/modules/external-apis/e2e/users.spec.ts
@@ -4,7 +4,7 @@
 
 import * as request from 'supertest';
 import { INestApplication } from '@nestjs/common';
-import { createUser, initTestApp, closeTestApp } from 'test-helper';
+import { createUser, initTestApp, closeTestApp, createGroupPermission } from 'test-helper';
 
 jest.setTimeout(120_000);
 
@@ -44,6 +44,26 @@ describe('ExternalApisUsersController (EE enterprise)', () => {
       expect(res.body.workspaces[0].inviteUrl).toBeTruthy();
     });
 
+    it('should create the user in every requested workspace', async () => {
+      const { user: adminUserOne } = await createUser(app, { email: 'admin4@tooljet.io' });
+      const { user: adminUserTwo } = await createUser(app, { email: 'admin5@tooljet.io' });
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Vendor Multi',
+          email: 'vendor-multi@example.com',
+          workspaces: [{ id: adminUserOne.defaultOrganizationId }, { id: adminUserTwo.defaultOrganizationId }],
+        })
+        .expect(201);
+
+      expect(res.body.workspaces).toHaveLength(2);
+      expect(res.body.workspaces.map((workspace: { id: string }) => workspace.id)).toEqual(
+        expect.arrayContaining([adminUserOne.defaultOrganizationId, adminUserTwo.defaultOrganizationId])
+      );
+    });
+
     it('inviteUrl should contain the correct oid query param matching the workspace id', async () => {
       const { user: adminUser } = await createUser(app, { email: 'admin2@tooljet.io' });
       const orgId = adminUser.defaultOrganizationId;
@@ -60,6 +80,161 @@ describe('ExternalApisUsersController (EE enterprise)', () => {
 
       const inviteUrl: string = res.body.workspaces[0].inviteUrl;
       expect(inviteUrl).toContain(`oid=${orgId}`);
+    });
+
+    it('should assign the specified role to the user in the workspace', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin6@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Builder User',
+          email: 'builder1@example.com',
+          workspaces: [{ id: orgId, role: 'builder' }],
+        })
+        .expect(201);
+
+      const groupNames = res.body.userGroups.map((g: { name: string }) => g.name);
+      expect(groupNames).toContain('builder');
+    });
+
+    it('should assign different roles across multiple workspaces', async () => {
+      const { user: orgOneAdmin } = await createUser(app, { email: 'admin7@tooljet.io' });
+      const { user: orgTwoAdmin } = await createUser(app, { email: 'admin8@tooljet.io' });
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Multi Role User',
+          email: 'multi-role@example.com',
+          workspaces: [
+            { id: orgOneAdmin.defaultOrganizationId, role: 'builder' },
+            { id: orgTwoAdmin.defaultOrganizationId, role: 'end-user' },
+          ],
+        })
+        .expect(201);
+
+      expect(res.body.workspaces).toHaveLength(2);
+      const groupNames = res.body.userGroups.map((g: { name: string }) => g.name);
+      expect(groupNames).toContain('builder');
+      expect(groupNames).toContain('end-user');
+    });
+
+    it('should add user to multiple custom groups in a workspace', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin9@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const groupA = await createGroupPermission(app, { name: 'Viewer Group A', organizationId: orgId });
+      const groupB = await createGroupPermission(app, { name: 'Viewer Group B', organizationId: orgId });
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Multi Group User',
+          email: 'multi-group@example.com',
+          workspaces: [{ id: orgId, groups: [{ name: groupA.name }, { name: groupB.name }] }],
+        })
+        .expect(201);
+
+      const groupNames = res.body.userGroups.map((g: { name: string }) => g.name);
+      expect(groupNames).toContain('Viewer Group A');
+      expect(groupNames).toContain('Viewer Group B');
+    });
+  });
+
+  describe('POST /api/ext/users — failing conditions', () => {
+    it('should return 400 when the email already exists', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin10@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({ name: 'Duplicate Vendor', email: 'duplicate@example.com', workspaces: [{ id: orgId }] })
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({ name: 'Duplicate Vendor', email: 'duplicate@example.com', workspaces: [{ id: orgId }] })
+        .expect(400);
+
+      expect(res.body.message).toContain('already exists');
+    });
+
+    it('should return 400 when a workspace id does not exist', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Ghost Vendor',
+          email: 'ghost@example.com',
+          workspaces: [{ id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d' }],
+        })
+        .expect(400);
+
+      expect(res.body.message).toContain('do not exist');
+    });
+
+    it('should return 400 when a default group name is passed in the groups field', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin11@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Invalid Group Vendor',
+          email: 'invalid-group@example.com',
+          workspaces: [{ id: orgId, groups: [{ name: 'builder' }] }],
+        })
+        .expect(400);
+
+      expect(res.body.message).toContain('role field');
+    });
+
+    it('should return 400 when a custom group does not exist in the workspace', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin12@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Bad Group Vendor',
+          email: 'bad-group@example.com',
+          workspaces: [{ id: orgId, groups: [{ name: 'non-existent-custom-group' }] }],
+        })
+        .expect(400);
+
+      expect(res.body.message).toContain('Group permission id or name not found');
+    });
+
+    it('should return 400 when an end-user is added to a builder-level custom group', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin13@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const elevatedGroup = await createGroupPermission(app, {
+        name: 'Elevated Builders',
+        organizationId: orgId,
+        appCreate: true,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Conflict Vendor',
+          email: 'conflict@example.com',
+          workspaces: [{ id: orgId, role: 'end-user', groups: [{ name: elevatedGroup.name }] }],
+        })
+        .expect(400);
+
+      expect(res.body.message.title).toBe('Conflicting permissions');
     });
   });
 

--- a/server/test/modules/external-apis/e2e/users.spec.ts
+++ b/server/test/modules/external-apis/e2e/users.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * @group platform
+ */
+
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createUser, initTestApp, closeTestApp } from 'test-helper';
+
+jest.setTimeout(120_000);
+
+const getExtAuth = () => `Basic ${process.env.EXTERNAL_API_ACCESS_TOKEN}`;
+
+describe('ExternalApisUsersController (EE enterprise)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    ({ app } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  }, 60000);
+
+  describe('POST /api/ext/users — inviteUrl', () => {
+    it('should include a non-null inviteUrl per workspace in the response', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Vendor One',
+          email: 'vendor1@example.com',
+          workspaces: [{ id: orgId }],
+        })
+        .expect(201);
+
+      expect(res.body.workspaces).toHaveLength(1);
+      expect(res.body.workspaces[0].inviteUrl).toBeTruthy();
+    });
+
+    it('inviteUrl should contain the correct oid query param matching the workspace id', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin2@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Vendor Two',
+          email: 'vendor2@example.com',
+          workspaces: [{ id: orgId }],
+        })
+        .expect(201);
+
+      const inviteUrl: string = res.body.workspaces[0].inviteUrl;
+      expect(inviteUrl).toContain(`oid=${orgId}`);
+    });
+  });
+
+  describe('GET /api/ext/user/:id — backward compat', () => {
+    it('should return inviteUrl as null for users without invitation tokens', async () => {
+      // Users created via test helper (internal path) never get invitationToken set,
+      // so getAllUsers should safely return inviteUrl: null for each of their workspaces.
+      const { user: adminUser } = await createUser(app, { email: 'admin3@tooljet.io' });
+
+      const res = await request(app.getHttpServer())
+        .get(`/api/ext/user/${adminUser.id}`)
+        .set('Authorization', getExtAuth())
+        .expect(200);
+
+      res.body.workspaces.forEach((ws: { inviteUrl: string | null }) => {
+        expect(ws.inviteUrl).toBeNull();
+      });
+    });
+  });
+});

--- a/server/test/modules/external-apis/e2e/users.spec.ts
+++ b/server/test/modules/external-apis/e2e/users.spec.ts
@@ -234,6 +234,8 @@ describe('ExternalApisUsersController (EE enterprise)', () => {
         })
         .expect(400);
 
+      // This error is thrown as BadRequestException({ message: { error, title } }),
+      // so message is an object here — unlike the other failure tests where it's a string.
       expect(res.body.message.title).toBe('Conflicting permissions');
     });
   });

--- a/server/test/modules/external-apis/e2e/users.spec.ts
+++ b/server/test/modules/external-apis/e2e/users.spec.ts
@@ -4,7 +4,12 @@
 
 import * as request from 'supertest';
 import { INestApplication } from '@nestjs/common';
+import { DataSource as TypeOrmDataSource } from 'typeorm';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { createUser, initTestApp, closeTestApp, createGroupPermission } from 'test-helper';
+import { User } from 'src/entities/user.entity';
+import { OrganizationUser } from 'src/entities/organization_user.entity';
 
 jest.setTimeout(120_000);
 
@@ -121,6 +126,25 @@ describe('ExternalApisUsersController (EE enterprise)', () => {
       const groupNames = res.body.userGroups.map((g: { name: string }) => g.name);
       expect(groupNames).toContain('builder');
       expect(groupNames).toContain('end-user');
+    });
+
+    it('should return a non-null inviteUrl even when user and workspace status are archived', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin-archived@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Archived Vendor',
+          email: 'archived-vendor@example.com',
+          status: 'archived',
+          workspaces: [{ id: orgId, status: 'archived' }],
+        })
+        .expect(201);
+
+      // Tokens are generated unconditionally at creation time — status does not gate URL generation.
+      expect(res.body.workspaces[0].inviteUrl).toBeTruthy();
     });
 
     it('should add user to multiple custom groups in a workspace', async () => {
@@ -254,6 +278,77 @@ describe('ExternalApisUsersController (EE enterprise)', () => {
       res.body.workspaces.forEach((ws: { inviteUrl: string | null }) => {
         expect(ws.inviteUrl).toBeNull();
       });
+    });
+
+    it('should return inviteUrl as null after invitation tokens are cleared (post-acceptance)', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin-post-accept@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({ name: 'Acceptance Vendor', email: 'acceptance-vendor@example.com', workspaces: [{ id: orgId }] })
+        .expect(201);
+
+      const userId = createRes.body.id;
+
+      // Simulate invite acceptance: both tokens are nulled by the onboarding flow.
+      const ds = app.get<TypeOrmDataSource>(getDataSourceToken('default'));
+      await ds.manager.update(User, { id: userId }, { invitationToken: null });
+      await ds.manager.update(OrganizationUser, { userId }, { invitationToken: null });
+
+      const getRes = await request(app.getHttpServer())
+        .get(`/api/ext/user/${userId}`)
+        .set('Authorization', getExtAuth())
+        .expect(200);
+
+      getRes.body.workspaces.forEach((ws: { inviteUrl: string | null }) => {
+        expect(ws.inviteUrl).toBeNull();
+      });
+    });
+  });
+
+  describe('POST /api/ext/users — no email dispatch', () => {
+    it('should never emit an emailEvent when creating a user', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin-noemail@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const emitter = app.get(EventEmitter2);
+      const spy = jest.spyOn(emitter, 'emit');
+
+      await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({ name: 'No Email Vendor', email: 'no-email-vendor@example.com', workspaces: [{ id: orgId }] })
+        .expect(201);
+
+      const emailEmits = spy.mock.calls.filter(([event]) => event === 'emailEvent');
+      expect(emailEmits).toHaveLength(0);
+    });
+  });
+
+  describe('GET /api/ext/users — list endpoint', () => {
+    it('should return inviteUrl for each workspace entry across all users in the list', async () => {
+      const { user: adminUser } = await createUser(app, { email: 'admin-list@tooljet.io' });
+      const orgId = adminUser.defaultOrganizationId;
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({ name: 'List Vendor', email: 'list-vendor@example.com', workspaces: [{ id: orgId }] })
+        .expect(201);
+
+      const createdUserId = createRes.body.id;
+
+      const listRes = await request(app.getHttpServer())
+        .get('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .expect(200);
+
+      const found = listRes.body.find((u: { id: string }) => u.id === createdUserId);
+      expect(found).toBeDefined();
+      expect(found.workspaces).toHaveLength(1);
+      expect(found.workspaces[0].inviteUrl).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## 📝 What this does                                            
Adds Cypress E2E coverage for the `inviteUrl` field introduced in `POST /ext/users`. Covers the happy path (invite URL onboarding flow, active user direct login), all error conditions, role/group assignment, and backward compatibility.  
   
## 🔀 Changes                                                   
- Added `inviteUrlApi.cy.js` with 9 `it()` blocks covering inviteUrl presence, multi-workspace oid correctness, role/group assignment, error conditions, onboarding via invite URL, direct login for active users, and null backward compat
- Each test creates its own workspace in `beforeEach` and restores admin session after UI flows

## 🧪 How to test
- [ ] Run `cypress/e2e/happyPath/platform/eeTestcases/externalApi/users/inviteUrlApi.cy.js` against an EE instance with `externalApiEnabled` license