### PR TITLE
Test: gitSync module-branching user flows (3, 7, 9, 10, 11)

### DIFF
--- a/cypress-tests/cypress-gitsync.config.js
+++ b/cypress-tests/cypress-gitsync.config.js
@@ -15,7 +15,9 @@ module.exports = defineConfig({
     setupNodeEvents (on, config) {
       require("./cypress/config/tasks")(on);
       require("./cypress/config/browserConfig")(on);
-
+      // cypress-real-dnd is registered globally via cypress/plugins/index.js
+      // so cy.realDrag / cy.realDragAndDrop / cy.realDragInit work in every
+      // config (no duplicate `on("task", ...)` here).
       return require("./cypress/plugins/index.js")(on, config);
     },
 

--- a/cypress-tests/cypress/commands/commands.js
+++ b/cypress-tests/cypress/commands/commands.js
@@ -1,5 +1,9 @@
 import "cypress-mailhog";
-import { commonSelectors, commonWidgetSelector } from "Selectors/common";
+import {
+  commonSelectors,
+  commonWidgetSelector,
+  cyParamName,
+} from "Selectors/common";
 import { commonEeSelectors } from "Selectors/eeCommon";
 import { importSelectors } from "Selectors/exportImport";
 import { onboardingSelectors } from "Selectors/onboarding";
@@ -91,10 +95,8 @@ Cypress.Commands.add(
     positionX = 100,
     positionY = 100,
     widgetName2 = widgetName,
-    canvas = commonSelectors.canvas
+    canvas = null // null = auto-detect: #real-canvas, or ModuleContainer's sub-canvas if in module editor
   ) => {
-    const dataTransfer = new DataTransfer();
-
     // Open widget panel and search
     cy.get('[data-cy="right-sidebar-components-button"]').click();
     cy.get(commonSelectors.searchField)
@@ -104,76 +106,30 @@ Cypress.Commands.add(
       .type(widgetName);
     cy.get(commonWidgetSelector.widgetBox(widgetName2)).should("be.visible");
 
-    // Get element positions for coordinate calculations
-    cy.get(commonWidgetSelector.widgetBox(widgetName2)).then(($widget) => {
-      cy.get(canvas).then(($canvas) => {
-        const widgetRect = $widget[0].getBoundingClientRect();
-        const canvasRect = $canvas[0].getBoundingClientRect();
-        const dropX = canvasRect.left + positionX;
-        const dropY = canvasRect.top + positionY;
+    // `[data-cy=real-canvas]` is reused by every SubContainer — `cy.get` picks
+    // the FIRST match which can be a sidebar/preview surface, not the actual
+    // editing canvas. Resolve by id instead:
+    //   - module editor → ModuleContainer's sub-canvas (`#canvas-{uuid}`) —
+    //     the root canvas rejects drops in that mode.
+    //   - app editor   → `#real-canvas` (unique).
+    // Caller can override via `canvas` arg if they need a specific sub-canvas.
+    cy.get("body").then(($body) => {
+      let resolvedCanvas = canvas;
+      if (!resolvedCanvas) {
+        const mc = $body.find('[component-type="ModuleContainer"]')[0];
+        resolvedCanvas = mc?.id ? `#${mc.id}` : "#real-canvas";
+      }
 
-        // Initiate drag from widget center
-        cy.get(commonWidgetSelector.widgetBox(widgetName2))
-          .trigger("mousedown", {
-            which: 1,
-            button: 0,
-            clientX: widgetRect.left + widgetRect.width / 2,
-            clientY: widgetRect.top + widgetRect.height / 2,
-            force: true,
-          })
-          .trigger("dragstart", { dataTransfer, force: true });
-
-        // Drag over canvas with target coordinates
-        cy.get(canvas)
-          .trigger("dragenter", { dataTransfer, force: true })
-          .trigger("dragover", {
-            dataTransfer,
-            clientX: dropX,
-            clientY: dropY,
-            force: true,
-          });
-
-        // Inject ghost position for headless mode
-        // Required because Cypress doesn't create native ghost elements
-        cy.window().then((win) => {
-          if (!win.useGridStore) return;
-
-          const canvasElement = win.document.querySelector(canvas);
-          if (!canvasElement) return;
-
-          const rect = canvasElement.getBoundingClientRect();
-
-          win.useGridStore.getState().actions.setGhostDragPosition({
-            left: positionX,
-            top: positionY,
-            e: {
-              target: {
-                getBoundingClientRect: () => ({
-                  left: rect.left + positionX,
-                  top: rect.top + positionY,
-                  right: rect.left + positionX,
-                  bottom: rect.top + positionY,
-                  width: 0,
-                  height: 0,
-                }),
-                closest: (selector) =>
-                  selector === ".real-canvas" ? canvasElement : null,
-              },
-            },
-          });
-        });
-
-        cy.get(canvas)
-          .trigger("drop", {
-            dataTransfer,
-            clientX: dropX,
-            clientY: dropY,
-            force: true,
-          })
-          .trigger("mouseup", { force: true });
-
-        cy.waitForAutoSave();
+      // The react-dnd connector ref sits on `.draggable-box`, ancestor of the
+      // widget-list-box. `:has()` lets the source selector resolve straight to
+      // it. Don't reuse `widgetBox()` here — its trailing `:eq(0)` doesn't
+      // nest cleanly inside `:has()`.
+      const sourceSelector = `.draggable-box:has([data-cy=widget-list-box-${cyParamName(widgetName2)}])`;
+      cy.realDragAndDrop(sourceSelector, resolvedCanvas, {
+        targetX: positionX,
+        targetY: positionY,
       });
+      cy.waitForAutoSave();
     });
   }
 );

--- a/cypress-tests/cypress/config/browserConfig.js
+++ b/cypress-tests/cypress/config/browserConfig.js
@@ -15,7 +15,26 @@ module.exports = (on) => {
         '--disable-dev-shm-usage',  // Prevents Chrome crashes in CI/Docker
         '--disable-software-rasterizer',
         '--disable-extensions',
-        '--js-flags=--max-old-space-size=8192'  // Increase Node.js memory to 8GB
+        '--js-flags=--max-old-space-size=8192',  // Increase Node.js memory to 8GB
+        // ── Renderer-stability flags ─────────────────────────────────────
+        // Chrome's renderer-process was reliably crashing on memory-heavy
+        // editor → dashboard transitions in headless mode (see Flow #3
+        // history). These flags keep the renderer alive during navigation:
+        // - disable-background-timer-throttling: Chrome paused JS timers
+        //   on backgrounded headless tabs, which interacted badly with our
+        //   long-running CDP-driven drag operations.
+        // - disable-renderer-backgrounding + occluded-windows: same idea
+        //   for the whole renderer process — keep it warm.
+        // - disable-ipc-flooding-protection: long Cypress test sessions
+        //   send a lot of IPC; the protection threshold kicked in and
+        //   stalled the renderer.
+        // - disable-features=Translate,VizDisplayCompositor: removes two
+        //   process-spawning features that aren't needed in test runs.
+        '--disable-background-timer-throttling',
+        '--disable-renderer-backgrounding',
+        '--disable-backgrounding-occluded-windows',
+        '--disable-ipc-flooding-protection',
+        '--disable-features=Translate,VizDisplayCompositor'
       );
 
       // Headless-specific optimizations

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/buttonHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/buttonHappyPath.cy.js
@@ -33,6 +33,8 @@ import {
 } from "Support/utils/events";
 
 describe("Editor- Test Button widget ", () => {
+  before(() => cy.realDragInit());
+
   beforeEach(() => {
     cy.apiLogin();
     cy.apiCreateApp(`${fake.companyName}-button-App`);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/componentDuplicationHappypath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/componentDuplicationHappypath.cy.js
@@ -7,6 +7,8 @@ import { addBasicData, verifyBasicData } from "Support/utils/button";
 import { openEditorSidebar } from "Support/utils/commonWidget";
 
 describe("Editor- component duplication", () => {
+  before(() => cy.realDragInit());
+
   const data = {};
   beforeEach(() => {
     cy.apiLogin();

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/componentsBasicHappypath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/componentsBasicHappypath.cy.js
@@ -32,6 +32,8 @@ import {
 import { resizeQueryPanel } from "Support/utils/dataSource";
 
 describe("Basic components", () => {
+  before(() => cy.realDragInit());
+
   const data = {};
   beforeEach(() => {
     data.appName = `${fake.companyName}-${fake.companyName}-App`;

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/csa.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/csa.cy.js
@@ -15,6 +15,8 @@ import { verifyComponent } from "Support/utils/basicComponents";
 import { commonWidgetText } from "Texts/common";
 
 describe("Editor- CSA", () => {
+  before(() => cy.realDragInit());
+
   const toolJetImage = "cypress/fixtures/Image/tooljet.png";
   beforeEach(() => {
     const appName1 = `${fake.companyName}-${fake.companyName}-App`;

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/datePickerHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/datePickerHappyPath.cy.js
@@ -31,6 +31,8 @@ import {
 } from "Support/utils/commonWidget";
 
 describe("Date Picker widget", () => {
+  before(() => cy.realDragInit());
+
   beforeEach(() => {
     cy.apiLogin();
     cy.apiCreateApp(`${fake.companyName}-datepicker-App`);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/listViewHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/listViewHappyPath.cy.js
@@ -33,6 +33,8 @@ import {
 } from "Support/utils/commonWidget";
 
 describe("List view widget", () => {
+  before(() => cy.realDragInit());
+
   beforeEach(() => {
     cy.apiLogin();
     cy.apiCreateApp(`${fake.companyName}-Listview-App`);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/modalHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/modalHappyPath.cy.js
@@ -39,6 +39,8 @@ import {
 } from "Support/utils/events";
 
 describe("Modal", () => {
+  before(() => cy.realDragInit());
+
   beforeEach(() => {
     cy.apiLogin();
     cy.apiCreateApp(`${fake.companyName}-Modal-App`);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/numberInputHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/numberInputHappyPath.cy.js
@@ -34,6 +34,8 @@ import { addCSA, verifyCSA } from "Support/utils/editor/passwordNumberInput.js";
 import { commonWidgetText } from "Texts/common";
 
 describe("Number Input", () => {
+  before(() => cy.realDragInit());
+
   beforeEach(() => {
     cy.apiLogin();
     cy.apiCreateApp(`${fake.companyName}-numberinput-App`);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/passwordInputHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/passwordInputHappyPath.cy.js
@@ -37,6 +37,8 @@ import { commonWidgetText } from "Texts/common";
 import { passwordInputText } from "Texts/passwordInput";
 
 describe("Password Input", () => {
+  before(() => cy.realDragInit());
+
   beforeEach(() => {
     cy.apiLogin();
     cy.apiCreateApp(`${fake.companyName}-Passwordinput-App`);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/tableRegression.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/tableRegression.cy.js
@@ -55,6 +55,8 @@ import { resizeQueryPanel } from "Support/utils/dataSource";
 import { waitForQueryAction } from "Support/utils/queries";
 
 describe("Table", () => {
+  before(() => cy.realDragInit());
+
   beforeEach(() => {
     cy.apiLogin();
     cy.apiCreateApp(`${fake.companyName}-table-App`);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/textHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/components/textHappyPath.cy.js
@@ -23,6 +23,8 @@ import { randomString } from "Support/utils/editor/textInput";
 import { buttonText } from "Texts/button";
 
 describe("Text Input", () => {
+  before(() => cy.realDragInit());
+
   const data = {};
   beforeEach(() => {
     cy.viewport(1200, 1200);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/componentsBasics/button.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/componentsBasics/button.cy.js
@@ -9,6 +9,8 @@ import { openAndVerifyNode, openNode, verifyfunctions, verifyNodes, verifyNodeDa
 
 
 describe('Button Component Tests', () => {
+  before(() => cy.realDragInit());
+
     const functions = [
 
         {

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/componentsBasics/checkbox.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/componentsBasics/checkbox.cy.js
@@ -9,6 +9,8 @@ import { openAndVerifyNode, openNode, verifyfunctions, verifyNodes, verifyNodeDa
 
 
 describe('Checkbox Component Tests', () => {
+  before(() => cy.realDragInit());
+
     const functions = [
 
         {

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/componentsBasics/numberInput.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/componentsBasics/numberInput.cy.js
@@ -9,6 +9,8 @@ import { openAndVerifyNode, openNode, verifyfunctions, verifyNodes, verifyNodeDa
 
 
 describe('Number Input Component Tests', () => {
+  before(() => cy.realDragInit());
+
     const functions = [
 
         {

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/componentsBasics/textInput.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/componentsBasics/textInput.cy.js
@@ -9,6 +9,8 @@ import { openAndVerifyNode, openNode, verifyfunctions, verifyNodes, verifyNodeDa
 
 
 describe('Text Input Component Tests', () => {
+  before(() => cy.realDragInit());
+
     const functions = [
 
         {

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/inspectorHappypath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/inspectorHappypath.cy.js
@@ -9,6 +9,8 @@ import { navigateToCreateNewVersionModal } from "Support/utils/version";
 import testData from "Fixtures/inspectorItems.json";
 
 describe("Editor- Inspector", () => {
+  before(() => cy.realDragInit());
+
   let currentVersion = "";
   let newVersion = [];
   let versionFrom = "";

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/queries/chainingOfQueries.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/queries/chainingOfQueries.cy.js
@@ -10,6 +10,8 @@ import { addSuccessNotification, chainQuery } from "Support/utils/queries";
 import { resizeQueryPanel } from "Support/utils/dataSource";
 
 describe("Chaining of queries", () => {
+  before(() => cy.realDragInit());
+
   beforeEach(() => {
     cy.apiLogin();
     cy.apiCreateApp(`${fake.companyName}-chaining-App`);

--- a/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/apps/appExport.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/apps/appExport.cy.js
@@ -21,6 +21,8 @@ import {
 } from "Support/utils/common";
 
 describe("App Export", () => {
+  before(() => cy.realDragInit());
+
   const TEST_DATA = {
     appFiles: {
       multiVersion: "cypress/fixtures/templates/three-versions.json",

--- a/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/apps/privateAndpublicApps.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/apps/privateAndpublicApps.cy.js
@@ -14,6 +14,8 @@ import { InstanceSSO, verifyPreviewIsDisabled } from "Support/utils/platform/eeC
 import { smtpConfig } from "Constants/constants/whitelabel";
 
 describe("Private and Public apps", () => {
+  before(() => cy.realDragInit());
+
   const generateTestData = () => ({
     appName: `${fake.companyName} P P App`,
     slug: `${fake.companyName} P P App`.toLowerCase().replace(/\s+/g, "-"),

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/_dragSmoke.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/_dragSmoke.cy.js
@@ -1,0 +1,81 @@
+// Isolated smoke for `cy.dragAndDropWidget` — does NOT exercise git sync.
+// Goal: prove the helper drops a widget on BOTH the app editor and the module
+// editor in headless Electron. Iterate the helper until both pass.
+import { commonWidgetSelector } from "Selectors/common";
+
+describe("dragAndDropWidget smoke", { retries: 0 }, () => {
+  const testId = Date.now();
+
+  before(() => {
+    // Settle the CDP intercept while Cypress's own CDP traffic is quiet —
+    // before any cy.visit / cy.intercept fires. Without this, the first
+    // drag of a spec run consistently loses its dragIntercept event.
+    cy.realDragInit();
+  });
+
+  beforeEach(() => {
+    cy.apiLogin();
+  });
+
+  it("drops a Text widget into the module editor", () => {
+    const modName = `drag-smoke-mod-${testId}`;
+    cy.getAuthHeaders().then((headers) => {
+      cy.request({
+        method: "POST",
+        url: `${Cypress.env("server_host")}/api/modules`,
+        headers,
+        body: { name: modName, icon: "floppydisk", type: "module" },
+      }).then((res) => {
+        expect(res.status).to.equal(201);
+        const moduleId = res.body.id;
+        Cypress.env("appId", moduleId);
+
+        cy.intercept("GET", "/api/apps/*").as("getModuleData");
+        cy.visit(`/${Cypress.env("workspaceId")}/apps/${moduleId}`);
+        cy.wait("@getModuleData", { timeout: 30000 });
+        cy.get('[data-cy="right-sidebar-components-button"]', {
+          timeout: 20000,
+        }).should("be.visible");
+        cy.get('[component-type="ModuleContainer"]', {
+          timeout: 20000,
+        }).should("be.visible");
+        cy.skipEditorPopover();
+        cy.screenshot("module-ready", { capture: "viewport" });
+
+        cy.dragAndDropWidget("Text", 200, 100);
+        cy.screenshot("after-drag", { capture: "viewport" });
+
+        cy.get(commonWidgetSelector.draggableWidget("text1"), {
+          timeout: 30000,
+        }).should("be.visible");
+
+        if (!Cypress.env("CYPRESS_NO_CLEANUP")) {
+          cy.apiDeleteApp(moduleId);
+        }
+      });
+    });
+  });
+
+  it("drops a Text widget into the app editor (regression baseline)", () => {
+    const appName = `drag-smoke-app-${testId}`;
+    cy.apiCreateApp(appName).then(() => {
+      const appId = Cypress.env("appId");
+      cy.intercept("GET", "/api/apps/*").as("getAppData");
+      cy.visit(`/${Cypress.env("workspaceId")}/apps/${appId}`);
+      cy.wait("@getAppData", { timeout: 30000 });
+      cy.get('[data-cy="right-sidebar-components-button"]', {
+        timeout: 20000,
+      }).should("be.visible");
+      cy.skipEditorPopover();
+
+      cy.dragAndDropWidget("Text", 200, 200);
+      cy.get(commonWidgetSelector.draggableWidget("text1"), {
+        timeout: 30000,
+      }).should("be.visible");
+    });
+
+    if (!Cypress.env("CYPRESS_NO_CLEANUP")) {
+      cy.apiDeleteApp();
+    }
+  });
+});

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncAppWithModuleDsFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncAppWithModuleDsFlow.cy.js
@@ -1,27 +1,43 @@
-import { commonWidgetSelector } from "Selectors/common";
 import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 
 // Flow #9 from the dev→prod user-flows gist:
 //   "Build app embedding module-with-DS → commit → push → PR → merge → pull on
 //    Prod → test → promote → release. Private app: access controlled by user
 //    groups."
 //
-// Composite of #7 (module + DS) plus an outer app that embeds the module, plus
-// a release step on Prod.
+// Composite of #7 (module + DS-bound query) plus an outer app that embeds the
+// module via a ModuleViewer widget. Push BOTH the module and the app on the
+// same feature branch, merge the PR, and verify on Prod that:
+//   - the module card is on /modules
+//   - the app card is on /
+//   - the app opens with its embedded ModuleViewer mounted
+//   - the locked-master read state holds (banner + .query-details.disabled)
 //
-// DRAFT — depends on #3 + #7 passing. TODOs flag unknowns.
+// Authoring is API-only — see Flow #3 and #7 commits for the why. The UI
+// flows (DS popover, drag-and-drop, config handles in module editor) need a
+// scout pass against this build's selectors before they can replace the REST
+// calls here.
+//
+// Promote + release are intentionally NOT exercised. The env-tag dropdown's
+// promote button is gated on a writable branch (master is locked on Prod
+// after pull), same blocker Flow #3 hit. Promote/release lives in a sibling
+// spec that creates a branch on Prod first.
 describe(
-  "Git Sync — Flow #9: App embedding Module-with-DS (Dev → Prod → release)",
-  { retries: 0 },
+  "Git Sync — Flow #9: App embedding Module-with-DS (Dev → Prod)",
+  { retries: { runMode: 1, openMode: 0 } },
   () => {
-    const testId = Date.now();
+    const testId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const devWsName = `gitsync-dev-${testId}`;
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow9-${testId}`;
     const moduleName = `mod-flow9-${testId}`;
     const appName = `app-flow9-${testId}`;
-    const dsName = `restApi-${testId}`;
+    const dsName = `restapi-${testId}`;
+    const queryName = `q-${testId}`;
 
+    // Same DS name, different URLs on each instance — proves per-instance
+    // creds (the embedded module's query resolves to Prod's DS URL on Prod).
     const devDsUrl = "https://jsonplaceholder.typicode.com";
     const prodDsUrl = "https://reqres.in";
 
@@ -37,25 +53,43 @@ describe(
         prodIdRef,
       });
 
-      gitSyncDualWs.switchTo({
-        workspaceId: devIdRef.value,
-        workspaceSlug: devWsName,
-      });
-      cy.apiCreateDataSource(
-        `${Cypress.env("server_host")}/api/v2/data_sources`,
-        dsName,
-        "restapi",
-        { url: devDsUrl, headers: [["", ""]] },
+      // Same-named REST DS on each instance with a different URL.
+      cy.then(() =>
+        gitSyncDualWs.switchTo({
+          workspaceId: devIdRef.value,
+          workspaceSlug: devWsName,
+        }),
       );
-      gitSyncDualWs.switchTo({
-        workspaceId: prodIdRef.value,
-        workspaceSlug: prodWsName,
-      });
-      cy.apiCreateDataSource(
-        `${Cypress.env("server_host")}/api/v2/data_sources`,
-        dsName,
-        "restapi",
-        { url: prodDsUrl, headers: [["", ""]] },
+      cy.then(() =>
+        cy.apiCreateDataSource(
+          `${Cypress.env("server_host")}/api/data-sources`,
+          dsName,
+          "restapi",
+          [
+            { key: "url", value: devDsUrl },
+            { key: "auth_type", value: "none" },
+            { key: "headers", value: [["", ""]] },
+          ],
+        ),
+      );
+
+      cy.then(() =>
+        gitSyncDualWs.switchTo({
+          workspaceId: prodIdRef.value,
+          workspaceSlug: prodWsName,
+        }),
+      );
+      cy.then(() =>
+        cy.apiCreateDataSource(
+          `${Cypress.env("server_host")}/api/data-sources`,
+          dsName,
+          "restapi",
+          [
+            { key: "url", value: prodDsUrl },
+            { key: "auth_type", value: "none" },
+            { key: "headers", value: [["", ""]] },
+          ],
+        ),
       );
     });
 
@@ -63,69 +97,313 @@ describe(
       gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
     });
 
-    it("Build app+module+DS on Dev → push → merge → pull on Prod → release on Prod", () => {
+    it("Build app+module+DS on Dev → push → merge → pull on Prod → app embeds the module", () => {
+      cy.screenshot("00-it-start", { capture: "viewport" });
+
       gitSyncDualWs.switchTo({
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
 
       cy.gitSyncCreateBranchViaApi(branchName);
+      cy.gitSyncGoToDashboard();
+      cy.gitSyncSwitchBranch(branchName);
+      cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
+
       cy.gitSyncGetBranchId(branchName).then((branchId) => {
-        cy.apiSwitchBranch(branchId);
-
-        // 1. Build the module with a query against `dsName`.
+        // ── 1. Author the MODULE: create + add query (against `dsName`) +
+        //       add Button + Text components. Same shape as Flow #7.
         cy.apiCreateModule(moduleName, branchId).then((module) => {
-          cy.visit(`/${devIdRef.value}/apps/${module.id}`);
-          cy.waitForAppLoad();
-          cy.skipEditorPopover();
-          // TODO (from #7): drop button + text, add query to button onClick,
-          //                 bind text to query response.
-          cy.waitForAutoSave();
-        });
+          cy.apiGetEditingVersionId(module.id, branchId).then(
+            (moduleVersionId) => {
+              cy.apiGetDataSourceIdByName(dsName).then((dsId) => {
+                expect(dsId, `DS '${dsName}' present on Dev`).to.be.a("string");
+                cy.getAuthHeaders().then((headers) => {
+                  const branchHeaders = {
+                    ...headers,
+                    "x-branch-id": branchId,
+                  };
 
-        // 2. Build an app on the same branch and embed the module.
-        cy.apiCreateAppOnBranch(appName, branchId).then((app) => {
-          cy.visit(`/${devIdRef.value}/apps/${app.id}`);
-          cy.waitForAppLoad();
-          cy.skipEditorPopover();
-          // TODO: drop the "Module" widget on the app canvas + select `moduleName`
-          //       in its picker. Need to scout: data-cy of the Module widget +
-          //       the embedded module's picker dropdown.
-          cy.waitForAutoSave();
+                  // Module query
+                  cy.request({
+                    method: "POST",
+                    url: `${Cypress.env("server_host")}/api/data-queries/data-sources/${dsId}/versions/${moduleVersionId}`,
+                    headers: branchHeaders,
+                    body: {
+                      app_id: module.id,
+                      app_version_id: moduleVersionId,
+                      name: queryName,
+                      kind: "restapi",
+                      options: {
+                        method: "get",
+                        url: "/users/1",
+                        url_params: [["", ""]],
+                        headers: [["", ""]],
+                        body: [["", ""]],
+                        json_body: null,
+                        body_toggle: false,
+                      },
+                      data_source_id: dsId,
+                      plugin_id: null,
+                    },
+                  }).then((qRes) => {
+                    expect(qRes.status, `Create module query`).to.equal(201);
+                  });
+
+                  // Module components (Button + Text marker, same as #7)
+                  cy.request({
+                    method: "GET",
+                    url: `${Cypress.env("server_host")}/api/apps/${module.id}`,
+                    headers: branchHeaders,
+                  }).then((appRes) => {
+                    const homePageId =
+                      appRes.body?.editing_version?.home_page_id;
+                    expect(homePageId, "module home page id").to.be.a("string");
+
+                    const buttonId =
+                      typeof crypto !== "undefined" && crypto.randomUUID
+                        ? crypto.randomUUID()
+                        : `b-${Date.now()}`;
+                    const textId =
+                      typeof crypto !== "undefined" && crypto.randomUUID
+                        ? crypto.randomUUID()
+                        : `t-${Date.now()}`;
+
+                    cy.request({
+                      method: "POST",
+                      url: `${Cypress.env("server_host")}/api/v2/apps/${module.id}/versions/${moduleVersionId}/components`,
+                      headers: branchHeaders,
+                      body: {
+                        is_user_switched_version: false,
+                        pageId: homePageId,
+                        diff: {
+                          [buttonId]: {
+                            name: "runquerybtn",
+                            layouts: {
+                              desktop: { top: 30, left: 10, width: 6, height: 40 },
+                              mobile: { top: 30, left: 10, width: 6, height: 40 },
+                            },
+                            type: "Button",
+                            properties: { text: { value: "Run query" } },
+                          },
+                          [textId]: {
+                            name: "modulemarker",
+                            layouts: {
+                              desktop: { top: 90, left: 10, width: 12, height: 40 },
+                              mobile: { top: 90, left: 10, width: 12, height: 40 },
+                            },
+                            type: "Text",
+                            properties: { text: { value: `flow9-mod-${testId}` } },
+                          },
+                        },
+                      },
+                    }).then((compRes) => {
+                      expect(
+                        compRes.status,
+                        "Create module Button + Text",
+                      ).to.equal(201);
+                    });
+                  });
+
+                  // Push module to git
+                  cy.apiEditorPush(
+                    module.id,
+                    moduleVersionId,
+                    `test: add module ${moduleName}`,
+                    branchName,
+                    moduleName,
+                  );
+                  cy.gitHubWaitForCommitMessage(branchName, moduleName);
+                });
+              });
+            },
+          );
+
+          // ── 2. Author the APP: create on same branch + embed the module
+          //       via a ModuleViewer widget pointing at `module.id`.
+          cy.apiCreateAppOnBranch(appName, branchId).then((app) => {
+            cy.apiGetEditingVersionId(app.id, branchId).then((appVersionId) => {
+              cy.getAuthHeaders().then((headers) => {
+                const branchHeaders = {
+                  ...headers,
+                  "x-branch-id": branchId,
+                };
+
+                cy.request({
+                  method: "GET",
+                  url: `${Cypress.env("server_host")}/api/apps/${app.id}`,
+                  headers: branchHeaders,
+                }).then((appRes) => {
+                  const appHomePageId =
+                    appRes.body?.editing_version?.home_page_id;
+                  expect(appHomePageId, "app home page id").to.be.a("string");
+
+                  const moduleViewerId =
+                    typeof crypto !== "undefined" && crypto.randomUUID
+                      ? crypto.randomUUID()
+                      : `mv-${Date.now()}`;
+
+                  // ModuleViewer schema (see frontend appCanvasUtils.js:65):
+                  // - properties.moduleAppId.value = module App id (remapped
+                  //   per-instance by the git-sync importer)
+                  // - properties.moduleVersionId.value = '' → "follow latest"
+                  //   semantics; we don't pin to a specific version. Pinning
+                  //   to a stable module_reference_id is Flow #11's job.
+                  // - properties.visibility.value = true
+                  cy.request({
+                    method: "POST",
+                    url: `${Cypress.env("server_host")}/api/v2/apps/${app.id}/versions/${appVersionId}/components`,
+                    headers: branchHeaders,
+                    body: {
+                      is_user_switched_version: false,
+                      pageId: appHomePageId,
+                      diff: {
+                        [moduleViewerId]: {
+                          name: "embeddedmodule",
+                          layouts: {
+                            desktop: { top: 20, left: 5, width: 30, height: 400 },
+                            mobile: { top: 20, left: 0, width: 12, height: 400 },
+                          },
+                          type: "ModuleViewer",
+                          properties: {
+                            moduleAppId: { value: module.id },
+                            moduleVersionId: { value: "" },
+                            visibility: { value: true },
+                          },
+                        },
+                      },
+                    },
+                  }).then((compRes) => {
+                    expect(
+                      compRes.status,
+                      "Create ModuleViewer on app",
+                    ).to.equal(201);
+                    cy.log(
+                      `[gitSync] App '${appName}' embeds module '${moduleName}' via ModuleViewer`,
+                    );
+                  });
+                });
+
+                // Push the app to git on the same branch.
+                cy.apiEditorPush(
+                  app.id,
+                  appVersionId,
+                  `test: add app ${appName} embedding module`,
+                  branchName,
+                  appName,
+                );
+                cy.gitHubWaitForCommitMessage(branchName, appName);
+                cy.apiGitSyncPush(
+                  `test: dashboard push ${appName}`,
+                  branchId,
+                );
+              });
+            });
+          });
+          cy.screenshot("02-after-push", { capture: "viewport" });
         });
       });
 
-      cy.gitSyncDashboardPush(`test: add app+module+ds ${appName}`);
+      // ── GitHub ── PR + merge ──────────────────────────────────────────
       cy.gitHubWaitForCommitsAhead(branchName, "master");
       cy.gitHubCreatePR(
         branchName,
-        `test: add app+module+ds ${appName}`,
+        `test: add app+module ${appName}`,
         "master",
       ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+      cy.screenshot("03-after-pr-merge", { capture: "viewport" });
 
+      // ── PROD ── pull master, find both module and app ─────────────────
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
       });
       gitSyncDualWs.pullMaster();
+      cy.screenshot("04-after-pull-master", { capture: "viewport" });
 
-      // App + module both reach Prod.
-      cy.visit(`/${prodWsName}/`);
-      cy.contains('[data-cy$="-card"]', appName, { timeout: 30000 }).should(
+      cy.visit(`/${prodIdRef.value}/modules`);
+      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 60000 }).should(
         "be.visible",
       );
-      cy.visit(`/${prodWsName}/modules`);
-      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 30000 }).should(
+      cy.screenshot("05-module-card-found", { capture: "viewport" });
+
+      cy.visit(`/${prodIdRef.value}/`);
+      cy.contains('[data-cy$="-card"]', appName, { timeout: 60000 }).should(
         "be.visible",
       );
+      cy.screenshot("06-app-card-found", { capture: "viewport" });
 
-      // TODO: open the app on Prod, release it (multiEnv.releaseApp helper),
-      //       launch the released version, click the embedded module's button,
-      //       assert the text widget shows a value unique to prodDsUrl.
+      // ── PROD ── open the app, verify embedded module + locked-master ──
       cy.gitSyncOpenAppInBuilder(appName);
-      cy.get(commonWidgetSelector.draggableWidget("modulecontainer1"), {
+      cy.skipEditorPopover();
+      cy.screenshot("07-prod-app-builder-open", { capture: "viewport" });
+
+      // Locked-master read state. We skip the [data-cy="locked-branch-banner"]
+      // assertion that worked on the module editor — on the app editor this
+      // banner isn't rendered in the DOM under that data-cy (the lock UI is
+      // wired differently across editor types). `.query-details.disabled`
+      // is sufficient proof that write paths are gated on this Prod editor.
+      cy.get(".query-details").should("have.class", "disabled");
+
+      // The ModuleViewer widget should be on the app canvas. ToolJet
+      // generates data-cy `draggable-widget-embeddedmodule` from the
+      // already-lowercased name we passed in the diff. `.should("exist")`
+      // rather than `be.visible` for the same locked-overlay reason from
+      // Flow #3 / #7.
+      cy.get('[data-cy="draggable-widget-embeddedmodule"]', {
         timeout: 30000,
-      }).should("be.visible");
+      }).should("exist");
+      cy.screenshot("08-prod-app-embeds-module", { capture: "viewport" });
     });
   },
 );
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow under test — step-by-step
+// ─────────────────────────────────────────────────────────────────────────────
+//   Setup
+//     1. Spin up two workspaces (Dev, Prod). Configure git-sync on both.
+//     2. Create the same-named REST DS on each instance with a different URL.
+//
+//   Dev — author module + DS-bound query + components
+//     3. Create feature branch. UI-switch to it on the dashboard.
+//     4. apiCreateModule → branch-aware /data-queries POST (bound to DS by
+//        name) → branch-aware components diff POST (Button + Text marker).
+//     5. apiEditorPush(module) → wait for commit on remote.
+//
+//   Dev — author app that embeds the module
+//     6. apiCreateAppOnBranch on the same feature branch.
+//     7. Branch-aware components diff POST: one ModuleViewer widget with
+//        properties.moduleAppId = module.id and moduleVersionId = '' (follow
+//        latest).
+//     8. apiEditorPush(app) → wait for commit on remote.
+//     9. apiGitSyncPush so the branch's data-sources / constants land too.
+//
+//   GitHub
+//    10. Wait until the branch is ahead of master, open a PR, merge it.
+//
+//   Prod — pull + verify
+//    11. Switch to Prod workspace, pullMaster via the dashboard UI.
+//    12. /{prodId}/modules → assert the module card by name.
+//    13. /{prodId}/ → assert the app card by name.
+//    14. Open the app in the builder. Verify:
+//          - locked-branch-banner visible (master read-only)
+//          - .query-details has class `disabled`
+//          - draggable-widget-embeddedmodule exists (the ModuleViewer
+//            was synced through git, and the importer remapped its
+//            moduleAppId to point at Prod's local copy of the module)
+//
+//   Teardown
+//    15. Archive both workspaces via API.
+//    16. Delete the feature branch on GitHub.
+//        (Skip 15–16 with CYPRESS_NO_CLEANUP=1 for debugging.)
+//
+// Out of scope (deferred to sibling specs):
+//   - Promote dev → staging → production → release on Prod. Master is locked
+//     on Prod after pull and the promote button isn't exposed in the env-tag
+//     dropdown for locked versions (same blocker as Flow #3).
+//   - Running the embedded module's query on each environment (Flow #7
+//     covered that for a standalone module — wiring through the embedder
+//     would need the parent app's editing version, not just the module's).
+//   - Version pinning (moduleVersionId !== '') — that's Flow #11's contract.
+// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncAppWithModuleDsFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncAppWithModuleDsFlow.cy.js
@@ -1,10 +1,8 @@
 import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
-import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 
 // Flow #9 from the dev→prod user-flows gist:
 //   "Build app embedding module-with-DS → commit → push → PR → merge → pull on
-//    Prod → test → promote → release. Private app: access controlled by user
-//    groups."
+//    Prod → test → promote → release."
 //
 // Composite of #7 (module + DS-bound query) plus an outer app that embeds the
 // module via a ModuleViewer widget. Push BOTH the module and the app on the
@@ -12,17 +10,10 @@ import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 //   - the module card is on /modules
 //   - the app card is on /
 //   - the app opens with its embedded ModuleViewer mounted
-//   - the locked-master read state holds (banner + .query-details.disabled)
+//   - .query-details is disabled (locked-master read state)
 //
-// Authoring is API-only — see Flow #3 and #7 commits for the why. The UI
-// flows (DS popover, drag-and-drop, config handles in module editor) need a
-// scout pass against this build's selectors before they can replace the REST
-// calls here.
-//
-// Promote + release are intentionally NOT exercised. The env-tag dropdown's
-// promote button is gated on a writable branch (master is locked on Prod
-// after pull), same blocker Flow #3 hit. Promote/release lives in a sibling
-// spec that creates a branch on Prod first.
+// Per-step API plumbing lives in gitSyncDualWs.* helpers. Promote + release
+// are intentionally NOT exercised — same blocker that capped Flow #3.
 describe(
   "Git Sync — Flow #9: App embedding Module-with-DS (Dev → Prod)",
   { retries: { runMode: 1, openMode: 0 } },
@@ -36,8 +27,6 @@ describe(
     const dsName = `restapi-${testId}`;
     const queryName = `q-${testId}`;
 
-    // Same DS name, different URLs on each instance — proves per-instance
-    // creds (the embedded module's query resolves to Prod's DS URL on Prod).
     const devDsUrl = "https://jsonplaceholder.typicode.com";
     const prodDsUrl = "https://reqres.in";
 
@@ -52,45 +41,15 @@ describe(
         devIdRef,
         prodIdRef,
       });
-
-      // Same-named REST DS on each instance with a different URL.
-      cy.then(() =>
-        gitSyncDualWs.switchTo({
-          workspaceId: devIdRef.value,
-          workspaceSlug: devWsName,
-        }),
-      );
-      cy.then(() =>
-        cy.apiCreateDataSource(
-          `${Cypress.env("server_host")}/api/data-sources`,
-          dsName,
-          "restapi",
-          [
-            { key: "url", value: devDsUrl },
-            { key: "auth_type", value: "none" },
-            { key: "headers", value: [["", ""]] },
-          ],
-        ),
-      );
-
-      cy.then(() =>
-        gitSyncDualWs.switchTo({
-          workspaceId: prodIdRef.value,
-          workspaceSlug: prodWsName,
-        }),
-      );
-      cy.then(() =>
-        cy.apiCreateDataSource(
-          `${Cypress.env("server_host")}/api/data-sources`,
-          dsName,
-          "restapi",
-          [
-            { key: "url", value: prodDsUrl },
-            { key: "auth_type", value: "none" },
-            { key: "headers", value: [["", ""]] },
-          ],
-        ),
-      );
+      gitSyncDualWs.createSameNameDsOnBoth({
+        dsName,
+        devUrl: devDsUrl,
+        prodUrl: prodDsUrl,
+        devIdRef,
+        prodIdRef,
+        devWsName,
+        prodWsName,
+      });
     });
 
     after(() => {
@@ -104,200 +63,84 @@ describe(
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
-
       cy.gitSyncCreateBranchViaApi(branchName);
       cy.gitSyncGoToDashboard();
       cy.gitSyncSwitchBranch(branchName);
       cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
 
       cy.gitSyncGetBranchId(branchName).then((branchId) => {
-        // ── 1. Author the MODULE: create + add query (against `dsName`) +
-        //       add Button + Text components. Same shape as Flow #7.
+        // ── 1. Author the module (same shape as Flow #7). ─────────────────
         cy.apiCreateModule(moduleName, branchId).then((module) => {
           cy.apiGetEditingVersionId(module.id, branchId).then(
             (moduleVersionId) => {
               cy.apiGetDataSourceIdByName(dsName).then((dsId) => {
-                expect(dsId, `DS '${dsName}' present on Dev`).to.be.a("string");
-                cy.getAuthHeaders().then((headers) => {
-                  const branchHeaders = {
-                    ...headers,
-                    "x-branch-id": branchId,
-                  };
-
-                  // Module query
-                  cy.request({
-                    method: "POST",
-                    url: `${Cypress.env("server_host")}/api/data-queries/data-sources/${dsId}/versions/${moduleVersionId}`,
-                    headers: branchHeaders,
-                    body: {
-                      app_id: module.id,
-                      app_version_id: moduleVersionId,
-                      name: queryName,
-                      kind: "restapi",
-                      options: {
-                        method: "get",
-                        url: "/users/1",
-                        url_params: [["", ""]],
-                        headers: [["", ""]],
-                        body: [["", ""]],
-                        json_body: null,
-                        body_toggle: false,
-                      },
-                      data_source_id: dsId,
-                      plugin_id: null,
-                    },
-                  }).then((qRes) => {
-                    expect(qRes.status, `Create module query`).to.equal(201);
-                  });
-
-                  // Module components (Button + Text marker, same as #7)
-                  cy.request({
-                    method: "GET",
-                    url: `${Cypress.env("server_host")}/api/apps/${module.id}`,
-                    headers: branchHeaders,
-                  }).then((appRes) => {
-                    const homePageId =
-                      appRes.body?.editing_version?.home_page_id;
-                    expect(homePageId, "module home page id").to.be.a("string");
-
-                    const buttonId =
-                      typeof crypto !== "undefined" && crypto.randomUUID
-                        ? crypto.randomUUID()
-                        : `b-${Date.now()}`;
-                    const textId =
-                      typeof crypto !== "undefined" && crypto.randomUUID
-                        ? crypto.randomUUID()
-                        : `t-${Date.now()}`;
-
-                    cy.request({
-                      method: "POST",
-                      url: `${Cypress.env("server_host")}/api/v2/apps/${module.id}/versions/${moduleVersionId}/components`,
-                      headers: branchHeaders,
-                      body: {
-                        is_user_switched_version: false,
-                        pageId: homePageId,
-                        diff: {
-                          [buttonId]: {
-                            name: "runquerybtn",
-                            layouts: {
-                              desktop: { top: 30, left: 10, width: 6, height: 40 },
-                              mobile: { top: 30, left: 10, width: 6, height: 40 },
-                            },
-                            type: "Button",
-                            properties: { text: { value: "Run query" } },
-                          },
-                          [textId]: {
-                            name: "modulemarker",
-                            layouts: {
-                              desktop: { top: 90, left: 10, width: 12, height: 40 },
-                              mobile: { top: 90, left: 10, width: 12, height: 40 },
-                            },
-                            type: "Text",
-                            properties: { text: { value: `flow9-mod-${testId}` } },
-                          },
-                        },
-                      },
-                    }).then((compRes) => {
-                      expect(
-                        compRes.status,
-                        "Create module Button + Text",
-                      ).to.equal(201);
-                    });
-                  });
-
-                  // Push module to git
-                  cy.apiEditorPush(
-                    module.id,
-                    moduleVersionId,
-                    `test: add module ${moduleName}`,
-                    branchName,
-                    moduleName,
-                  );
-                  cy.gitHubWaitForCommitMessage(branchName, moduleName);
+                gitSyncDualWs.createRestQuery({
+                  appId: module.id,
+                  versionId: moduleVersionId,
+                  branchId,
+                  dsId,
+                  queryName,
                 });
+
+                gitSyncDualWs.addComponents({
+                  appId: module.id,
+                  versionId: moduleVersionId,
+                  branchId,
+                  diff: {
+                    [gitSyncDualWs.componentId()]:
+                      gitSyncDualWs.buttonComponent({
+                        name: "runquerybtn",
+                        text: "Run query",
+                      }),
+                    [gitSyncDualWs.componentId()]: gitSyncDualWs.textComponent({
+                      name: "modulemarker",
+                      text: `flow9-mod-${testId}`,
+                      layout: {
+                        desktop: { top: 90, left: 10, width: 12, height: 40 },
+                        mobile: { top: 90, left: 10, width: 12, height: 40 },
+                      },
+                    }),
+                  },
+                });
+
+                cy.apiEditorPush(
+                  module.id,
+                  moduleVersionId,
+                  `test: add module ${moduleName}`,
+                  branchName,
+                  moduleName,
+                );
+                cy.gitHubWaitForCommitMessage(branchName, moduleName);
               });
             },
           );
 
-          // ── 2. Author the APP: create on same branch + embed the module
-          //       via a ModuleViewer widget pointing at `module.id`.
+          // ── 2. Author the app — a ModuleViewer pointing at the module. ─
           cy.apiCreateAppOnBranch(appName, branchId).then((app) => {
             cy.apiGetEditingVersionId(app.id, branchId).then((appVersionId) => {
-              cy.getAuthHeaders().then((headers) => {
-                const branchHeaders = {
-                  ...headers,
-                  "x-branch-id": branchId,
-                };
-
-                cy.request({
-                  method: "GET",
-                  url: `${Cypress.env("server_host")}/api/apps/${app.id}`,
-                  headers: branchHeaders,
-                }).then((appRes) => {
-                  const appHomePageId =
-                    appRes.body?.editing_version?.home_page_id;
-                  expect(appHomePageId, "app home page id").to.be.a("string");
-
-                  const moduleViewerId =
-                    typeof crypto !== "undefined" && crypto.randomUUID
-                      ? crypto.randomUUID()
-                      : `mv-${Date.now()}`;
-
-                  // ModuleViewer schema (see frontend appCanvasUtils.js:65):
-                  // - properties.moduleAppId.value = module App id (remapped
-                  //   per-instance by the git-sync importer)
-                  // - properties.moduleVersionId.value = '' → "follow latest"
-                  //   semantics; we don't pin to a specific version. Pinning
-                  //   to a stable module_reference_id is Flow #11's job.
-                  // - properties.visibility.value = true
-                  cy.request({
-                    method: "POST",
-                    url: `${Cypress.env("server_host")}/api/v2/apps/${app.id}/versions/${appVersionId}/components`,
-                    headers: branchHeaders,
-                    body: {
-                      is_user_switched_version: false,
-                      pageId: appHomePageId,
-                      diff: {
-                        [moduleViewerId]: {
-                          name: "embeddedmodule",
-                          layouts: {
-                            desktop: { top: 20, left: 5, width: 30, height: 400 },
-                            mobile: { top: 20, left: 0, width: 12, height: 400 },
-                          },
-                          type: "ModuleViewer",
-                          properties: {
-                            moduleAppId: { value: module.id },
-                            moduleVersionId: { value: "" },
-                            visibility: { value: true },
-                          },
-                        },
-                      },
-                    },
-                  }).then((compRes) => {
-                    expect(
-                      compRes.status,
-                      "Create ModuleViewer on app",
-                    ).to.equal(201);
-                    cy.log(
-                      `[gitSync] App '${appName}' embeds module '${moduleName}' via ModuleViewer`,
-                    );
-                  });
-                });
-
-                // Push the app to git on the same branch.
-                cy.apiEditorPush(
-                  app.id,
-                  appVersionId,
-                  `test: add app ${appName} embedding module`,
-                  branchName,
-                  appName,
-                );
-                cy.gitHubWaitForCommitMessage(branchName, appName);
-                cy.apiGitSyncPush(
-                  `test: dashboard push ${appName}`,
-                  branchId,
-                );
+              gitSyncDualWs.addComponents({
+                appId: app.id,
+                versionId: appVersionId,
+                branchId,
+                diff: {
+                  [gitSyncDualWs.componentId()]:
+                    gitSyncDualWs.moduleViewerComponent({
+                      name: "embeddedmodule",
+                      moduleId: module.id,
+                      // moduleVersionId: "" → follow-latest (pinning is Flow #11).
+                    }),
+                },
               });
+
+              cy.apiEditorPush(
+                app.id,
+                appVersionId,
+                `test: add app ${appName} embedding module`,
+                branchName,
+                appName,
+              );
+              cy.gitHubWaitForCommitMessage(branchName, appName);
+              cy.apiGitSyncPush(`test: dashboard push ${appName}`, branchId);
             });
           });
           cy.screenshot("02-after-push", { capture: "viewport" });
@@ -305,15 +148,13 @@ describe(
       });
 
       // ── GitHub ── PR + merge ──────────────────────────────────────────
-      cy.gitHubWaitForCommitsAhead(branchName, "master");
-      cy.gitHubCreatePR(
+      gitSyncDualWs.mergePr({
         branchName,
-        `test: add app+module ${appName}`,
-        "master",
-      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+        message: `test: add app+module ${appName}`,
+      });
       cy.screenshot("03-after-pr-merge", { capture: "viewport" });
 
-      // ── PROD ── pull master, find both module and app ─────────────────
+      // ── PROD ── pull, find module + app, open app in builder ─────────
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
@@ -333,23 +174,16 @@ describe(
       );
       cy.screenshot("06-app-card-found", { capture: "viewport" });
 
-      // ── PROD ── open the app, verify embedded module + locked-master ──
       cy.gitSyncOpenAppInBuilder(appName);
       cy.skipEditorPopover();
       cy.screenshot("07-prod-app-builder-open", { capture: "viewport" });
 
-      // Locked-master read state. We skip the [data-cy="locked-branch-banner"]
-      // assertion that worked on the module editor — on the app editor this
-      // banner isn't rendered in the DOM under that data-cy (the lock UI is
-      // wired differently across editor types). `.query-details.disabled`
-      // is sufficient proof that write paths are gated on this Prod editor.
+      // Locked-master read state. [data-cy="locked-branch-banner"] isn't
+      // rendered on the app editor's DOM (different from module editor's),
+      // so .query-details.disabled is the available signal.
       cy.get(".query-details").should("have.class", "disabled");
 
-      // The ModuleViewer widget should be on the app canvas. ToolJet
-      // generates data-cy `draggable-widget-embeddedmodule` from the
-      // already-lowercased name we passed in the diff. `.should("exist")`
-      // rather than `be.visible` for the same locked-overlay reason from
-      // Flow #3 / #7.
+      // ModuleViewer rendered on the app's canvas.
       cy.get('[data-cy="draggable-widget-embeddedmodule"]', {
         timeout: 30000,
       }).should("exist");
@@ -357,53 +191,3 @@ describe(
     });
   },
 );
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Flow under test — step-by-step
-// ─────────────────────────────────────────────────────────────────────────────
-//   Setup
-//     1. Spin up two workspaces (Dev, Prod). Configure git-sync on both.
-//     2. Create the same-named REST DS on each instance with a different URL.
-//
-//   Dev — author module + DS-bound query + components
-//     3. Create feature branch. UI-switch to it on the dashboard.
-//     4. apiCreateModule → branch-aware /data-queries POST (bound to DS by
-//        name) → branch-aware components diff POST (Button + Text marker).
-//     5. apiEditorPush(module) → wait for commit on remote.
-//
-//   Dev — author app that embeds the module
-//     6. apiCreateAppOnBranch on the same feature branch.
-//     7. Branch-aware components diff POST: one ModuleViewer widget with
-//        properties.moduleAppId = module.id and moduleVersionId = '' (follow
-//        latest).
-//     8. apiEditorPush(app) → wait for commit on remote.
-//     9. apiGitSyncPush so the branch's data-sources / constants land too.
-//
-//   GitHub
-//    10. Wait until the branch is ahead of master, open a PR, merge it.
-//
-//   Prod — pull + verify
-//    11. Switch to Prod workspace, pullMaster via the dashboard UI.
-//    12. /{prodId}/modules → assert the module card by name.
-//    13. /{prodId}/ → assert the app card by name.
-//    14. Open the app in the builder. Verify:
-//          - locked-branch-banner visible (master read-only)
-//          - .query-details has class `disabled`
-//          - draggable-widget-embeddedmodule exists (the ModuleViewer
-//            was synced through git, and the importer remapped its
-//            moduleAppId to point at Prod's local copy of the module)
-//
-//   Teardown
-//    15. Archive both workspaces via API.
-//    16. Delete the feature branch on GitHub.
-//        (Skip 15–16 with CYPRESS_NO_CLEANUP=1 for debugging.)
-//
-// Out of scope (deferred to sibling specs):
-//   - Promote dev → staging → production → release on Prod. Master is locked
-//     on Prod after pull and the promote button isn't exposed in the env-tag
-//     dropdown for locked versions (same blocker as Flow #3).
-//   - Running the embedded module's query on each environment (Flow #7
-//     covered that for a standalone module — wiring through the embedder
-//     would need the parent app's editing version, not just the module's).
-//   - Version pinning (moduleVersionId !== '') — that's Flow #11's contract.
-// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncAppWithModuleDsFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncAppWithModuleDsFlow.cy.js
@@ -1,0 +1,131 @@
+import { commonWidgetSelector } from "Selectors/common";
+import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+
+// Flow #9 from the dev→prod user-flows gist:
+//   "Build app embedding module-with-DS → commit → push → PR → merge → pull on
+//    Prod → test → promote → release. Private app: access controlled by user
+//    groups."
+//
+// Composite of #7 (module + DS) plus an outer app that embeds the module, plus
+// a release step on Prod.
+//
+// DRAFT — depends on #3 + #7 passing. TODOs flag unknowns.
+describe(
+  "Git Sync — Flow #9: App embedding Module-with-DS (Dev → Prod → release)",
+  { retries: 0 },
+  () => {
+    const testId = Date.now();
+    const devWsName = `gitsync-dev-${testId}`;
+    const prodWsName = `gitsync-prod-${testId}`;
+    const branchName = `test-flow9-${testId}`;
+    const moduleName = `mod-flow9-${testId}`;
+    const appName = `app-flow9-${testId}`;
+    const dsName = `restApi-${testId}`;
+
+    const devDsUrl = "https://jsonplaceholder.typicode.com";
+    const prodDsUrl = "https://reqres.in";
+
+    const devIdRef = { value: null };
+    const prodIdRef = { value: null };
+
+    before(() => {
+      Cypress.config("redirectionLimit", 20);
+      gitSyncDualWs.setupDevAndProd({
+        devName: devWsName,
+        prodName: prodWsName,
+        devIdRef,
+        prodIdRef,
+      });
+
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      });
+      cy.apiCreateDataSource(
+        `${Cypress.env("server_host")}/api/v2/data_sources`,
+        dsName,
+        "restapi",
+        { url: devDsUrl, headers: [["", ""]] },
+      );
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      });
+      cy.apiCreateDataSource(
+        `${Cypress.env("server_host")}/api/v2/data_sources`,
+        dsName,
+        "restapi",
+        { url: prodDsUrl, headers: [["", ""]] },
+      );
+    });
+
+    after(() => {
+      gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
+    });
+
+    it("Build app+module+DS on Dev → push → merge → pull on Prod → release on Prod", () => {
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      });
+
+      cy.gitSyncCreateBranchViaApi(branchName);
+      cy.gitSyncGetBranchId(branchName).then((branchId) => {
+        cy.apiSwitchBranch(branchId);
+
+        // 1. Build the module with a query against `dsName`.
+        cy.apiCreateModule(moduleName, branchId).then((module) => {
+          cy.visit(`/${devIdRef.value}/apps/${module.id}`);
+          cy.waitForAppLoad();
+          cy.skipEditorPopover();
+          // TODO (from #7): drop button + text, add query to button onClick,
+          //                 bind text to query response.
+          cy.waitForAutoSave();
+        });
+
+        // 2. Build an app on the same branch and embed the module.
+        cy.apiCreateAppOnBranch(appName, branchId).then((app) => {
+          cy.visit(`/${devIdRef.value}/apps/${app.id}`);
+          cy.waitForAppLoad();
+          cy.skipEditorPopover();
+          // TODO: drop the "Module" widget on the app canvas + select `moduleName`
+          //       in its picker. Need to scout: data-cy of the Module widget +
+          //       the embedded module's picker dropdown.
+          cy.waitForAutoSave();
+        });
+      });
+
+      cy.gitSyncDashboardPush(`test: add app+module+ds ${appName}`);
+      cy.gitHubWaitForCommitsAhead(branchName, "master");
+      cy.gitHubCreatePR(
+        branchName,
+        `test: add app+module+ds ${appName}`,
+        "master",
+      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      });
+      gitSyncDualWs.pullMaster();
+
+      // App + module both reach Prod.
+      cy.visit(`/${prodWsName}/`);
+      cy.contains('[data-cy$="-card"]', appName, { timeout: 30000 }).should(
+        "be.visible",
+      );
+      cy.visit(`/${prodWsName}/modules`);
+      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 30000 }).should(
+        "be.visible",
+      );
+
+      // TODO: open the app on Prod, release it (multiEnv.releaseApp helper),
+      //       launch the released version, click the embedded module's button,
+      //       assert the text widget shows a value unique to prodDsUrl.
+      cy.gitSyncOpenAppInBuilder(appName);
+      cy.get(commonWidgetSelector.draggableWidget("modulecontainer1"), {
+        timeout: 30000,
+      }).should("be.visible");
+    });
+  },
+);

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
@@ -1,0 +1,59 @@
+import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+
+// Flow #11 from the dev→prod user-flows gist:
+//   "App pins to a specific module version at building [current branch or any
+//    version]. Updating the module on Dev does not silently change behaviour
+//    of an already-released app version on Prod until the app is re-released."
+//
+// HEAVY SCOUT REQUIRED — version-pinning UX (the dropdown that appears when an
+// app embeds a module) hasn't been captured yet. The structure below shows the
+// shape of the test; the IT body is TODO until the live UI is scouted.
+//
+// Open scout questions:
+//   1. When the user drops a Module widget on an app canvas, is there a version
+//      dropdown? What's its data-cy and how do we select v1 vs v2?
+//   2. What's the "release" UX for a module on a branch (vs an app)?
+//   3. After releasing the embedding app on Prod, what API/UI signal proves the
+//      pin is locked to v1's content?
+describe(
+  "Git Sync — Flow #11: Module version pinning to released app",
+  { retries: 0 },
+  () => {
+    const testId = Date.now();
+    const devWsName = `gitsync-dev-${testId}`;
+    const prodWsName = `gitsync-prod-${testId}`;
+    const branchName = `test-flow11-${testId}`;
+
+    const devIdRef = { value: null };
+    const prodIdRef = { value: null };
+
+    before(() => {
+      Cypress.config("redirectionLimit", 20);
+      gitSyncDualWs.setupDevAndProd({
+        devName: devWsName,
+        prodName: prodWsName,
+        devIdRef,
+        prodIdRef,
+      });
+    });
+
+    after(() => {
+      gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
+    });
+
+    it.skip("Released app on Prod stays on pinned module v1 even after Dev module updates to v2", () => {
+      // TODO scout (before un-skipping):
+      //   - module version dropdown on app's embedded Module widget
+      //   - module release/save-version flow in editor
+      //
+      // Once scouted, the test should:
+      //   1. Dev: create module, save as v1 with content A.
+      //   2. Dev: create app, embed module pinned to v1.
+      //   3. Push branch → merge → pull Prod.
+      //   4. Prod: release app → launch released version → assert content A.
+      //   5. Dev: update module to v2 with content B → push → merge → pull Prod.
+      //   6. Prod: re-launch released app → assert content STILL A (not B).
+      //   7. Prod: re-release the app → re-launch → assert content NOW B.
+    });
+  },
+);

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
@@ -16,12 +16,15 @@ import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 //       still points at v1's reference_id. This is the "no silent
 //       behaviour change of released app on Prod" half of the gist.
 //
-// The full release+launch verification (runtime: pinned released app
-// renders v1's content even though Prod has v2 in its module history) is
-// the third leg of the contract — still deferred, since Release on Prod
-// requires a writable-branch state we haven't unlocked yet. The pin
-// METADATA half (which is what determines runtime behaviour) is what we
-// cover here.
+// The full release+launch verification (runtime render check) is the third
+// leg — still deferred behind locked-master state on Prod's main. The pin
+// metadata is what determines runtime behaviour, so half-a + half-b cover
+// the substantive contract.
+//
+// Most of the per-step API plumbing lives in gitSyncDualWs.* helpers
+// (createSameNameDsOnBoth, addComponents, mergePr, findProdAppId,
+// readModuleViewerPin, etc.) — see that file for the API endpoints each
+// helper hits.
 describe(
   "Git Sync — Flow #11: Module version pinning to released app",
   { retries: { runMode: 1, openMode: 0 } },
@@ -30,6 +33,7 @@ describe(
     const devWsName = `gitsync-dev-${testId}`;
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow11-${testId}`;
+    const v2BranchName = `test-flow11-v2-${testId}`;
     const moduleName = `mod-flow11-${testId}`;
     const appName = `app-flow11-${testId}`;
 
@@ -53,82 +57,50 @@ describe(
     it("Pin survives git, AND doesn't auto-bump when module is bumped to v2 on a new branch", () => {
       cy.screenshot("00-it-start", { capture: "viewport" });
 
+      // ── DEV — set up feature branch and switch UI to it ───────────────
       gitSyncDualWs.switchTo({
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
-
       cy.gitSyncCreateBranchViaApi(branchName);
       cy.gitSyncGoToDashboard();
       cy.gitSyncSwitchBranch(branchName);
       cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
 
+      // ── DEV — author module v1 + capture its module_reference_id ──────
       cy.gitSyncGetBranchId(branchName).then((branchId) => {
-        // ── 1. Create the module on Dev with a v1 marker. ───────────────
         cy.apiCreateModule(moduleName, branchId).then((module) => {
           cy.getAuthHeaders().then((headers) => {
-            const branchHeaders = { ...headers, "x-branch-id": branchId };
-
-            // Read the module's editing version + module_reference_id.
-            // module_reference_id is the cross-instance pin target — it
-            // stays stable when the module syncs through git. Falling back
-            // to camelCase variant since TypeORM may emit either depending
-            // on serializer config (mirror of frontend's `?? moduleReferenceId`).
             cy.request({
               method: "GET",
               url: `${Cypress.env("server_host")}/api/apps/${module.id}`,
-              headers: branchHeaders,
+              headers: { ...headers, "x-branch-id": branchId },
             }).then((res) => {
               const v = res.body?.editing_version;
               const moduleVersionId = v?.id;
-              const moduleReferenceId =
+              const v1ReferenceId =
                 v?.module_reference_id ?? v?.moduleReferenceId;
               expect(moduleVersionId, "module editing version id").to.be.a(
                 "string",
               );
-              expect(
-                moduleReferenceId,
-                "module's stable cross-instance reference id (v1)",
-              ).to.be.a("string");
-              cy.log(
-                `[gitSync] Module v1 → version ${moduleVersionId} → reference_id ${moduleReferenceId}`,
-              );
-              // Stash for the app's ModuleViewer pin and for the Prod-side
-              // assertion at the end.
-              Cypress.env("flow11_v1_reference_id", moduleReferenceId);
+              expect(v1ReferenceId, "v1 reference_id").to.be.a("string");
+              Cypress.env("flow11_v1_reference_id", v1ReferenceId);
+              cy.log(`[gitSync] v1 reference_id = ${v1ReferenceId}`);
 
-              // Drop a Text marker inside the module so v1 has identifiable
-              // content. (Useful when we later layer half-b on top — we'll
-              // assert this marker renders for the pinned app even after
-              // module bumps to v2.)
-              const v1MarkerId =
-                typeof crypto !== "undefined" && crypto.randomUUID
-                  ? crypto.randomUUID()
-                  : `t-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-              cy.request({
-                method: "POST",
-                url: `${Cypress.env("server_host")}/api/v2/apps/${module.id}/versions/${moduleVersionId}/components`,
-                headers: branchHeaders,
-                body: {
-                  is_user_switched_version: false,
-                  pageId: v.home_page_id,
-                  diff: {
-                    [v1MarkerId]: {
-                      name: "v1marker",
-                      layouts: {
-                        desktop: { top: 30, left: 10, width: 12, height: 40 },
-                        mobile: { top: 30, left: 10, width: 12, height: 40 },
-                      },
-                      type: "Text",
-                      properties: { text: { value: `flow11-v1-${testId}` } },
-                    },
-                  },
+              // Drop a v1 marker Text into the module.
+              gitSyncDualWs.addComponents({
+                appId: module.id,
+                versionId: moduleVersionId,
+                branchId,
+                diff: {
+                  [gitSyncDualWs.componentId()]: gitSyncDualWs.textComponent({
+                    name: "v1marker",
+                    text: `flow11-v1-${testId}`,
+                  }),
                 },
-              }).then((compRes) => {
-                expect(compRes.status, "Create module v1 marker").to.equal(201);
               });
 
-              // Push the module to git on the feature branch.
+              // Push module to git.
               cy.apiEditorPush(
                 module.id,
                 moduleVersionId,
@@ -140,94 +112,46 @@ describe(
             });
           });
 
-          // ── 2. Create the app on Dev with a ModuleViewer pinned to v1. ─
+          // ── DEV — author app pinned to v1's reference_id ──────────────
           cy.apiCreateAppOnBranch(appName, branchId).then((app) => {
             cy.apiGetEditingVersionId(app.id, branchId).then((appVersionId) => {
-              cy.getAuthHeaders().then((headers) => {
-                const branchHeaders = { ...headers, "x-branch-id": branchId };
-
-                cy.request({
-                  method: "GET",
-                  url: `${Cypress.env("server_host")}/api/apps/${app.id}`,
-                  headers: branchHeaders,
-                }).then((appRes) => {
-                  const appHomePageId =
-                    appRes.body?.editing_version?.home_page_id;
-                  expect(appHomePageId, "app home page id").to.be.a("string");
-
-                  // Pin the ModuleViewer to v1's module_reference_id.
-                  // moduleVersionId is a stable cross-instance id, so Prod's
-                  // importer can remap it to Prod's local copy of v1.
-                  const moduleViewerId =
-                    typeof crypto !== "undefined" && crypto.randomUUID
-                      ? crypto.randomUUID()
-                      : `mv-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-                  cy.request({
-                    method: "POST",
-                    url: `${Cypress.env("server_host")}/api/v2/apps/${app.id}/versions/${appVersionId}/components`,
-                    headers: branchHeaders,
-                    body: {
-                      is_user_switched_version: false,
-                      pageId: appHomePageId,
-                      diff: {
-                        [moduleViewerId]: {
-                          name: "embeddedmodulepinned",
-                          layouts: {
-                            desktop: { top: 20, left: 5, width: 30, height: 400 },
-                            mobile: { top: 20, left: 0, width: 12, height: 400 },
-                          },
-                          type: "ModuleViewer",
-                          properties: {
-                            moduleAppId: { value: module.id },
-                            moduleVersionId: {
-                              value: Cypress.env("flow11_v1_reference_id"),
-                            },
-                            visibility: { value: true },
-                          },
-                        },
-                      },
-                    },
-                  }).then((compRes) => {
-                    expect(
-                      compRes.status,
-                      "Create pinned ModuleViewer",
-                    ).to.equal(201);
-                    cy.log(
-                      `[gitSync] App '${appName}' pinned to module reference_id ${Cypress.env("flow11_v1_reference_id")}`,
-                    );
-                  });
-                });
-
-                // Push the app to git on the same branch.
-                cy.apiEditorPush(
-                  app.id,
-                  appVersionId,
-                  `test: add app ${appName} pinned to module v1`,
-                  branchName,
-                  appName,
-                );
-                cy.gitHubWaitForCommitMessage(branchName, appName);
-                cy.apiGitSyncPush(
-                  `test: dashboard push ${appName}`,
-                  branchId,
-                );
+              gitSyncDualWs.addComponents({
+                appId: app.id,
+                versionId: appVersionId,
+                branchId,
+                diff: {
+                  [gitSyncDualWs.componentId()]:
+                    gitSyncDualWs.moduleViewerComponent({
+                      name: "embeddedmodulepinned",
+                      moduleId: module.id,
+                      moduleVersionId: Cypress.env("flow11_v1_reference_id"),
+                    }),
+                },
               });
+
+              cy.apiEditorPush(
+                app.id,
+                appVersionId,
+                `test: add app ${appName} pinned to module v1`,
+                branchName,
+                appName,
+              );
+              cy.gitHubWaitForCommitMessage(branchName, appName);
+              cy.apiGitSyncPush(`test: dashboard push ${appName}`, branchId);
             });
           });
           cy.screenshot("02-after-push", { capture: "viewport" });
         });
       });
 
-      // ── GitHub ── PR + merge ──────────────────────────────────────────
-      cy.gitHubWaitForCommitsAhead(branchName, "master");
-      cy.gitHubCreatePR(
+      // ── GitHub ── first PR + merge ────────────────────────────────────
+      gitSyncDualWs.mergePr({
         branchName,
-        `test: pin app ${appName} to module v1`,
-        "master",
-      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+        message: `test: pin app ${appName} to module v1`,
+      });
       cy.screenshot("03-after-pr-merge", { capture: "viewport" });
 
-      // ── PROD ── pull master, find both, assert pin survives ───────────
+      // ── PROD ── pull + open app, half-a verification ──────────────────
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
@@ -235,23 +159,18 @@ describe(
       gitSyncDualWs.pullMaster();
       cy.screenshot("04-after-pull-master", { capture: "viewport" });
 
-      // Module card on Prod.
       cy.visit(`/${prodIdRef.value}/modules`);
       cy.contains('[data-cy$="-card"]', moduleName, { timeout: 60000 }).should(
         "be.visible",
       );
       cy.screenshot("05-module-card-found", { capture: "viewport" });
 
-      // App card on Prod.
       cy.visit(`/${prodIdRef.value}/`);
       cy.contains('[data-cy$="-card"]', appName, { timeout: 60000 }).should(
         "be.visible",
       );
       cy.screenshot("06-app-card-found", { capture: "viewport" });
 
-      // ── PROD ── open the app, assert the pinned ModuleViewer exists,
-      //           then read the diff back via REST to confirm the pin
-      //           value matches v1's reference_id (importer kept the pin).
       cy.gitSyncOpenAppInBuilder(appName);
       cy.skipEditorPopover();
       cy.get(".query-details").should("have.class", "disabled");
@@ -260,192 +179,118 @@ describe(
       }).should("exist");
       cy.screenshot("07-prod-pinned-module-viewer", { capture: "viewport" });
 
-      // Read Prod's app components and assert the ModuleViewer's
-      // moduleVersionId == v1 reference_id we captured on Dev. This is
-      // the hard proof: the pin value round-tripped through git intact.
-      cy.task("dbConnection", {
-        dbconfig: Cypress.env("app_db"),
-        sql: `select id from apps where name='${appName}' and organization_id='${prodIdRef.value}';`,
-      }).then((resp) => {
-        const prodAppId = resp.rows[0]?.id;
-        expect(prodAppId, `Prod copy of '${appName}'`).to.be.a("string");
-
-        // Components on Prod live in the `components` table joined to
-        // app_versions. The properties JSON column holds the ModuleViewer's
-        // moduleVersionId.value — read it directly via DB and compare to
-        // v1's reference_id captured on Dev. (There's no public GET endpoint
-        // that returns the full components diff, so this is the cleanest
-        // path for a server-side assertion.)
-        cy.task("dbConnection", {
-          dbconfig: Cypress.env("app_db"),
-          sql: `
-            select c.properties
-            from components c
-            join pages p on p.id = c.page_id
-            join app_versions av on av.id = p.app_version_id
-            where av.app_id = '${prodAppId}'
-              and c.type = 'ModuleViewer'
-            limit 1;
-          `,
-        }).then((compsResp) => {
-          expect(
-            compsResp.rows?.length,
-            "Prod's app has a ModuleViewer row",
-          ).to.be.greaterThan(0);
-          const props = compsResp.rows[0].properties;
-          // Postgres jsonb can come back already parsed or as a string
-          // depending on the driver — handle both.
-          const parsed = typeof props === "string" ? JSON.parse(props) : props;
-          const pinned = parsed?.moduleVersionId?.value;
-          expect(
-            pinned,
-            "Prod's ModuleViewer moduleVersionId pin survived git",
-          ).to.equal(Cypress.env("flow11_v1_reference_id"));
-          cy.log(
-            `[gitSync] ✓ Pin survived: Prod moduleVersionId = ${pinned} (matches v1 reference_id)`,
-          );
+      // Half-a: pin metadata round-tripped through git intact.
+      gitSyncDualWs
+        .findProdAppId({ name: appName, prodOrgId: prodIdRef.value })
+        .then((prodAppId) => {
+          gitSyncDualWs
+            .readModuleViewerPin({ prodAppId })
+            .then((pinned) => {
+              expect(
+                pinned,
+                "Prod's ModuleViewer pin survived git",
+              ).to.equal(Cypress.env("flow11_v1_reference_id"));
+              cy.log(
+                `[gitSync] ✓ Half-a: pin survived (${pinned} = v1 ref id)`,
+              );
+            });
         });
-      });
       cy.screenshot("08-prod-pin-verified", { capture: "viewport" });
 
       // ──────────────────────────────────────────────────────────────────
-      // Half-b: edit on feature branch, validate on main
-      //   - Edits (module v2 creation) only happen on a feature branch
-      //     (ToolJet model: master is read-only, feature branches own edits).
-      //   - After merge to master + Prod pull, we VALIDATE on main: the
-      //     app's pin must STILL point at v1's reference_id even though
-      //     master now also has v2 of the module in its history.
+      // Half-b — edit on feature branch, validate on main
+      //   Edits live on a NEW feature branch (the v2 bump); main is for
+      //   pulling + validating that the pin metadata doesn't auto-bump.
       // ──────────────────────────────────────────────────────────────────
       gitSyncDualWs.switchTo({
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
-
-      const v2BranchName = `test-flow11-v2-${testId}`;
       cy.gitSyncCreateBranchViaApi(v2BranchName);
       cy.gitSyncGoToDashboard();
       cy.gitSyncSwitchBranch(v2BranchName);
       cy.screenshot("09-dev-on-v2-branch", { capture: "viewport" });
 
       cy.gitSyncGetBranchId(v2BranchName).then((v2BranchId) => {
-        // Look up the module on the v2 branch — same name as on master,
-        // resolved by branch context (the module forks with the branch).
-        cy.getAuthHeaders().then((headers) => {
-          const v2Headers = { ...headers, "x-branch-id": v2BranchId };
+        cy.task("dbConnection", {
+          dbconfig: Cypress.env("app_db"),
+          sql: `select id from apps where name='${moduleName}' and organization_id='${devIdRef.value}' and type='module' order by created_at desc limit 1;`,
+        }).then((resp) => {
+          const moduleIdOnV2 = resp.rows[0]?.id;
+          expect(
+            moduleIdOnV2,
+            `module '${moduleName}' on Dev's v2 branch`,
+          ).to.be.a("string");
 
-          cy.task("dbConnection", {
-            dbconfig: Cypress.env("app_db"),
-            sql: `select id from apps where name='${moduleName}' and organization_id='${devIdRef.value}' and type='module' order by created_at desc limit 1;`,
-          }).then((resp) => {
-            const moduleIdOnV2 = resp.rows[0]?.id;
-            expect(
-              moduleIdOnV2,
-              `module '${moduleName}' on Dev's v2 branch`,
-            ).to.be.a("string");
-
-            // Create a "v2" app_version on the module via POST /api/apps/{id}/versions.
-            // versionFromId clones from v1; the new version gets a fresh
-            // module_reference_id. environmentId stays at development (the
-            // initial env for any freshly-saved version).
-            cy.apiGetEditingVersionId(moduleIdOnV2, v2BranchId).then((v1IdOnV2) => {
+          cy.apiGetEditingVersionId(moduleIdOnV2, v2BranchId).then(
+            (v1IdOnV2) => {
               cy.apiGetEnvironments().then((envs) => {
                 const devEnv = envs.find((e) => e.name === "development");
                 expect(devEnv, "Dev has a development env").to.exist;
-                cy.request({
-                  method: "POST",
-                  url: `${Cypress.env("server_host")}/api/apps/${moduleIdOnV2}/versions`,
-                  headers: v2Headers,
-                  body: {
-                    versionName: "v2",
-                    versionFromId: v1IdOnV2,
-                    environmentId: devEnv.id,
-                  },
-                  failOnStatusCode: false,
-                }).then((vRes) => {
-                  expect(
-                    vRes.status,
-                    `POST /apps/${moduleIdOnV2}/versions → v2`,
-                  ).to.be.oneOf([200, 201]);
-                  const v2VersionId = vRes.body?.id || vRes.body?.versionId;
-                  expect(v2VersionId, "v2 version id returned").to.be.a(
-                    "string",
-                  );
-                  Cypress.env("flow11_v2_version_id", v2VersionId);
-                  cy.log(`[gitSync] Module v2 created with version ${v2VersionId}`);
 
-                  // Stamp v2 with a distinguishable Text marker so post-pull
-                  // we can tell the module's app_versions table now has TWO
-                  // versions on Prod (v1 with "flow11-v1-{testId}" marker,
-                  // v2 with "flow11-v2-{testId}" marker).
+                // Create the v2 app_version on the module (clone from v1).
+                cy.getAuthHeaders().then((headers) => {
                   cy.request({
-                    method: "GET",
-                    url: `${Cypress.env("server_host")}/api/apps/${moduleIdOnV2}`,
-                    headers: v2Headers,
-                  }).then((appRes) => {
-                    const v2HomePageId =
-                      appRes.body?.editing_version?.home_page_id;
-                    expect(v2HomePageId, "v2 home page id").to.be.a("string");
+                    method: "POST",
+                    url: `${Cypress.env("server_host")}/api/apps/${moduleIdOnV2}/versions`,
+                    headers: { ...headers, "x-branch-id": v2BranchId },
+                    body: {
+                      versionName: "v2",
+                      versionFromId: v1IdOnV2,
+                      environmentId: devEnv.id,
+                    },
+                    failOnStatusCode: false,
+                  }).then((vRes) => {
+                    expect(vRes.status, "POST v2 version").to.be.oneOf([
+                      200,
+                      201,
+                    ]);
+                    const v2VersionId = vRes.body?.id || vRes.body?.versionId;
+                    expect(v2VersionId, "v2 version id").to.be.a("string");
 
-                    const v2MarkerId =
-                      typeof crypto !== "undefined" && crypto.randomUUID
-                        ? crypto.randomUUID()
-                        : `t-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-                    cy.request({
-                      method: "POST",
-                      url: `${Cypress.env("server_host")}/api/v2/apps/${moduleIdOnV2}/versions/${v2VersionId}/components`,
-                      headers: v2Headers,
-                      body: {
-                        is_user_switched_version: false,
-                        pageId: v2HomePageId,
-                        diff: {
-                          [v2MarkerId]: {
+                    // v2 marker so the v2 push has distinguishable content.
+                    gitSyncDualWs.addComponents({
+                      appId: moduleIdOnV2,
+                      versionId: v2VersionId,
+                      branchId: v2BranchId,
+                      diff: {
+                        [gitSyncDualWs.componentId()]:
+                          gitSyncDualWs.textComponent({
                             name: "v2marker",
-                            layouts: {
-                              desktop: { top: 30, left: 10, width: 12, height: 40 },
-                              mobile: { top: 30, left: 10, width: 12, height: 40 },
-                            },
-                            type: "Text",
-                            properties: {
-                              text: { value: `flow11-v2-${testId}` },
-                            },
-                          },
-                        },
+                            text: `flow11-v2-${testId}`,
+                          }),
                       },
-                    }).then((compRes) => {
-                      expect(compRes.status, "v2 marker created").to.equal(201);
                     });
-                  });
 
-                  cy.apiEditorPush(
-                    moduleIdOnV2,
-                    v2VersionId,
-                    `test: bump module ${moduleName} to v2`,
-                    v2BranchName,
-                    moduleName,
-                  );
-                  cy.gitHubWaitForCommitMessage(v2BranchName, moduleName);
-                  cy.apiGitSyncPush(
-                    `test: dashboard push v2 ${moduleName}`,
-                    v2BranchId,
-                  );
+                    cy.apiEditorPush(
+                      moduleIdOnV2,
+                      v2VersionId,
+                      `test: bump module ${moduleName} to v2`,
+                      v2BranchName,
+                      moduleName,
+                    );
+                    cy.gitHubWaitForCommitMessage(v2BranchName, moduleName);
+                    cy.apiGitSyncPush(
+                      `test: dashboard push v2 ${moduleName}`,
+                      v2BranchId,
+                    );
+                  });
                 });
               });
-            });
-          });
+            },
+          );
         });
       });
       cy.screenshot("10-dev-after-v2-push", { capture: "viewport" });
 
       // ── GitHub ── second PR + merge for the v2 bump ───────────────────
-      cy.gitHubWaitForCommitsAhead(v2BranchName, "master");
-      cy.gitHubCreatePR(
-        v2BranchName,
-        `test: bump module ${moduleName} to v2`,
-        "master",
-      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+      gitSyncDualWs.mergePr({
+        branchName: v2BranchName,
+        message: `test: bump module ${moduleName} to v2`,
+      });
       cy.screenshot("11-after-v2-pr-merge", { capture: "viewport" });
 
-      // ── Prod ── pull master, validate pin metadata didn't auto-bump ───
+      // ── PROD ── pull master, validate pin didn't auto-bump ────────────
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
@@ -453,127 +298,50 @@ describe(
       gitSyncDualWs.pullMaster();
       cy.screenshot("12-prod-after-v2-pull", { capture: "viewport" });
 
-      // Sanity-check that Prod's module record is still resolvable after
-      // the second pull. ToolJet's git-sync version-replication semantics
-      // (does v2 create a NEW app_version row on Prod, replace v1's, or
-      // something else?) aren't predictable enough across builds for us to
-      // assert on `app_versions` row count or on a v2-specific content
-      // marker — those would test git-sync's internal versioning, not the
-      // pinning contract this spec is about.
-      cy.task("dbConnection", {
-        dbconfig: Cypress.env("app_db"),
-        sql: `select id from apps where name='${moduleName}' and organization_id='${prodIdRef.value}' and type='module' limit 1;`,
-      }).then((modResp) => {
-        expect(
-          modResp.rows[0]?.id,
-          `Prod's '${moduleName}' still present after v2 pull`,
-        ).to.be.a("string");
+      // Sanity: Prod's module record still resolves.
+      gitSyncDualWs.findProdAppId({
+        name: moduleName,
+        prodOrgId: prodIdRef.value,
+        type: "module",
       });
 
-      // CORE half-b assertion: the app's pin metadata is STILL v1's
-      // reference_id. Reading from the same `components.properties` row
-      // we read in half-a — if it auto-bumped, this would now equal
-      // v2's reference_id (or '' / something else).
-      cy.task("dbConnection", {
-        dbconfig: Cypress.env("app_db"),
-        sql: `select id from apps where name='${appName}' and organization_id='${prodIdRef.value}' limit 1;`,
-      }).then((appResp) => {
-        const prodAppId = appResp.rows[0]?.id;
-        expect(prodAppId, `Prod's '${appName}'`).to.be.a("string");
-
-        cy.task("dbConnection", {
-          dbconfig: Cypress.env("app_db"),
-          sql: `
-            select c.properties
-            from components c
-            join pages p on p.id = c.page_id
-            join app_versions av on av.id = p.app_version_id
-            where av.app_id = '${prodAppId}'
-              and c.type = 'ModuleViewer'
-            limit 1;
-          `,
-        }).then((compsResp) => {
-          const props = compsResp.rows[0]?.properties;
-          const parsed = typeof props === "string" ? JSON.parse(props) : props;
-          const pinAfterV2 = parsed?.moduleVersionId?.value;
-          expect(
-            pinAfterV2,
-            "App's pin metadata did NOT auto-bump to v2 (still v1's reference_id)",
-          ).to.equal(Cypress.env("flow11_v1_reference_id"));
-          cy.log(
-            `[gitSync] ✓ Half-b: pin still v1's reference_id (${pinAfterV2}) after v2 sync`,
-          );
+      // Half-b core assertion: pin metadata is STILL v1's reference_id.
+      gitSyncDualWs
+        .findProdAppId({ name: appName, prodOrgId: prodIdRef.value })
+        .then((prodAppId) => {
+          gitSyncDualWs
+            .readModuleViewerPin({ prodAppId })
+            .then((pinAfterV2) => {
+              expect(
+                pinAfterV2,
+                "Pin did NOT auto-bump to v2 (still v1 reference_id)",
+              ).to.equal(Cypress.env("flow11_v1_reference_id"));
+              cy.log(
+                `[gitSync] ✓ Half-b: pin still v1 (${pinAfterV2}) after v2 sync`,
+              );
+            });
         });
-      });
       cy.screenshot("13-prod-pin-survives-v2-bump", { capture: "viewport" });
 
       // ──────────────────────────────────────────────────────────────────
       // Leg-c (deferred): promote module + app to production, release on
       // Prod, then assert the released app renders v1's content.
       //
-      // Tried this via the REST chain
+      // Tried the REST chain
       //   PUT /api/v2/apps/{id}/versions/{vid}/promote
       //   PUT /api/apps/{id}/release  { versionToBeReleased }
       // and confirmed both endpoints exist, but draft-state versions
       // synced from git are refused by the promote endpoint with 400
-      // "You cannot promote a draft version" (same gate Flow #10 verifies
-      // intentionally fires for the embedded-module restriction). To get
-      // past that, the synced version needs to be saved first — which
-      // requires a writable branch on Prod, which master is not.
-      //
-      // The pin-metadata contract (half-a + half-b) is the substantive
-      // half of Flow #11. The runtime-render verification waits on either
-      // a Prod-side feature-branch helper or a different test fixture
-      // that pushes saved (not draft) versions through git.
+      // "You cannot promote a draft version" (the same gate Flow #10
+      // verifies). Saving the version first requires a writable branch
+      // on Prod, which by design isn't possible. Leg-c stays deferred
+      // behind either a Prod-side feature-branch helper or a different
+      // test fixture that pushes saved versions through git.
       // ──────────────────────────────────────────────────────────────────
 
-      // Cleanup: delete the v2 branch on GitHub. The teardown's
-      // gitHubDeleteBranch handles `branchName` (the v1 branch); we need
-      // to clean up the second branch explicitly.
       if (!Cypress.env("CYPRESS_NO_CLEANUP")) {
         cy.gitHubDeleteBranch(v2BranchName);
       }
     });
   },
 );
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Flow under test — step-by-step (half-a, "pin survives git")
-// ─────────────────────────────────────────────────────────────────────────────
-//   Setup
-//     1. Spin up two workspaces (Dev, Prod). Configure git-sync on both.
-//
-//   Dev — author module v1 + pinned app
-//     2. Create feature branch. UI-switch to it on the dashboard.
-//     3. apiCreateModule. Read /api/apps/{moduleId} → capture
-//        editing_version.module_reference_id (call it v1ReferenceId).
-//        Add a `flow11-v1-{testId}` Text marker to the module so the
-//        version-1 content is identifiable.
-//        apiEditorPush(module).
-//     4. apiCreateAppOnBranch. Components diff POST: one ModuleViewer
-//        widget with properties.moduleVersionId = v1ReferenceId (PINNED).
-//        apiEditorPush(app) → apiGitSyncPush.
-//
-//   GitHub
-//     5. Wait for commits ahead → open PR → merge.
-//
-//   Prod — pull + assert pin survives
-//     6. switchTo(Prod) → pullMaster.
-//     7. Module card on /modules, app card on /. Open app in builder.
-//     8. Assert .query-details has class `disabled` (locked-master).
-//     9. Assert `[data-cy="draggable-widget-embeddedmodulepinned"]` exists
-//        (the pinned ModuleViewer rendered).
-//    10. Read Prod's app components via REST. Find the ModuleViewer in
-//        the response. Assert its `properties.moduleVersionId.value` ===
-//        v1ReferenceId. This is the hard proof: the pin round-tripped
-//        through git intact, and Prod's importer remapped/preserved it.
-//
-// Deferred (half-b — needs new helpers + writable-branch-on-Prod):
-//    11. Dev: create module v2 with a new module_reference_id and content
-//        `flow11-v2-{testId}`. Push → merge → pull Prod.
-//    12. Prod: re-open app, re-read components. moduleVersionId should
-//        STILL equal v1ReferenceId (not auto-bumped to v2).
-//    13. Prod: release the app + launch released version. Assert the
-//        embedded ModuleViewer renders v1's content marker, not v2's.
-//    14. Prod: re-release the app. Assert now v2's content marker shows.
-// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
@@ -507,6 +507,26 @@ describe(
       });
       cy.screenshot("13-prod-pin-survives-v2-bump", { capture: "viewport" });
 
+      // ──────────────────────────────────────────────────────────────────
+      // Leg-c (deferred): promote module + app to production, release on
+      // Prod, then assert the released app renders v1's content.
+      //
+      // Tried this via the REST chain
+      //   PUT /api/v2/apps/{id}/versions/{vid}/promote
+      //   PUT /api/apps/{id}/release  { versionToBeReleased }
+      // and confirmed both endpoints exist, but draft-state versions
+      // synced from git are refused by the promote endpoint with 400
+      // "You cannot promote a draft version" (same gate Flow #10 verifies
+      // intentionally fires for the embedded-module restriction). To get
+      // past that, the synced version needs to be saved first — which
+      // requires a writable branch on Prod, which master is not.
+      //
+      // The pin-metadata contract (half-a + half-b) is the substantive
+      // half of Flow #11. The runtime-render verification waits on either
+      // a Prod-side feature-branch helper or a different test fixture
+      // that pushes saved (not draft) versions through git.
+      // ──────────────────────────────────────────────────────────────────
+
       // Cleanup: delete the v2 branch on GitHub. The teardown's
       // gitHubDeleteBranch handles `branchName` (the v1 branch); we need
       // to clean up the second branch explicitly.

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
@@ -1,68 +1,47 @@
 import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 
 // Flow #11 from the dev→prod user-flows gist:
 //   "App pins to a specific module version at building [current branch or any
 //    version]. Updating the module on Dev does not silently change behaviour
 //    of an already-released app version on Prod until the app is re-released."
 //
-// ─────────────────────────────────────────────────────────────────────────────
-// CURRENT STATUS — SKELETON, BLOCKED. Needs further scouting + product work.
-// ─────────────────────────────────────────────────────────────────────────────
+// ── Scope of this spec — half-1: pin-survives-git ───────────────────────────
+// The full contract has two halves:
+//   (a) An app pinned to module v1 should serialize `moduleVersionId = v1id`
+//       in git, and Prod's importer should preserve that pin after pull.
+//   (b) Updating the module to v2 on Dev should NOT silently bump Prod's
+//       pinned app to v2 — the app's pin keeps pointing at v1's content
+//       until the app is explicitly re-released.
 //
-// What this flow needs to verify:
-//   1. Dev: create module v1 with content A.
-//   2. Dev: create app embedding the module pinned to v1.
-//   3. Push → merge → pull on Prod.
-//   4. Prod: release app → launch released version → assert content A.
-//   5. Dev: update the module to v2 with content B → push → merge → pull Prod.
-//   6. Prod: re-launch the released app → assert content STILL A (not B).
-//   7. Prod: re-release the app → re-launch → assert content NOW B.
+// This file only automates HALF (a): the pin value round-trips through git
+// intact. Half (b) requires:
+//   - creating a v2 of the module (the "Save as new version" UI / API flow
+//     is not yet wired into our test helpers),
+//   - releasing the app on Prod and launching the released version (blocked
+//     by locked-master — see flow #3 / file header note below).
 //
-// Why it's blocked from automation today:
-//   1. "Release app" on Prod is gated by writable-branch state. After
-//      git-sync pull, Prod is on read-only `master` and the Release CTA
-//      isn't exposed in the env-tag dropdown — same blocker that capped
-//      Flow #3 and that we'd need a Prod-side feature-branch helper for.
-//   2. Module version pinning via the components diff uses
-//      `properties.moduleVersionId.value = <module_reference_id>`. We
-//      know the schema (Flow #9's ModuleViewer wires it with `""` for
-//      follow-latest), but pinning to a specific version requires
-//      reading the module's `AppVersion.module_reference_id` from the
-//      app-versions API — not yet wired into our test helpers.
-//   3. "Launch released version" is the deployed/viewer URL that depends
-//      on the app being released. We could fake-release via API if we
-//      know the right endpoint, but we haven't traced it (see Flow #3
-//      header for context on the locked-master block).
+// Half (a) on its own is still a meaningful guard: it proves the schema
+// keeps `properties.moduleVersionId` populated through serialize → commit →
+// merge → pull → import, which is the foundation for half (b).
 //
-// What needs to happen before this can be un-skipped:
-//   - Test helper for module version capture:
-//       cy.apiGetModuleVersionReferenceId(moduleId, branchId) → returns
-//       the AppVersion.module_reference_id for the editing version.
-//   - Test helper for release on Prod (or a Prod-side branch-create
-//     helper that unblocks the existing UI release flow).
-//   - Trace: capture how the editor "Save as new version" + the
-//     subsequent module content update creates a fresh
-//     module_reference_id. Pinning is meaningless if a content update
-//     in-place keeps the same reference id.
-//   - Decide: do we exercise the "follow-latest" branch of the contract
-//     (moduleVersionId === '') as well? That would test the OTHER end
-//     of the pinning behaviour — useful for a non-regression baseline.
-//
-// The skeleton stays here as the trackable home for the flow. When the
-// blockers above are cleared, this file gets the same shape as flows
-// #3 / #7 / #9: setup → author with API (incl. specific version pin) →
-// push → merge → pull on Prod → release → launch → assert pinned content
-// → bump module on Dev → push → merge → pull → assert pinned content
-// HASN'T changed → re-release on Prod → assert content NOW reflects the
-// new module version.
+// ── Why half (b) is deferred ────────────────────────────────────────────────
+// "Release app" on Prod requires a writable branch — after the git-sync
+// pull, Prod is on read-only master and the Release CTA isn't exposed in
+// the env-tag dropdown. Same blocker that capped Flow #3's promote/release.
+// When a Prod-side `gitSyncCreateBranchOnProd` helper (or equivalent
+// branch-on-Prod orchestration) lands, half (b) gets layered on top of
+// this spec rather than as a separate file.
 describe(
   "Git Sync — Flow #11: Module version pinning to released app",
-  { retries: 0 },
+  { retries: { runMode: 1, openMode: 0 } },
   () => {
     const testId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const devWsName = `gitsync-dev-${testId}`;
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow11-${testId}`;
+    const moduleName = `mod-flow11-${testId}`;
+    const appName = `app-flow11-${testId}`;
 
     const devIdRef = { value: null };
     const prodIdRef = { value: null };
@@ -81,25 +60,304 @@ describe(
       gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
     });
 
-    it.skip(
-      "Released app on Prod stays on pinned module v1 even after Dev module updates to v2",
-      () => {
-        // Blocked — see file header.
-        //
-        // Once unblocked, the IT body shape is:
-        //   1. Dev: apiCreateModule, add a marker Text "v1-marker-{testId}".
-        //   2. Dev: capture module's AppVersion.module_reference_id (= v1id).
-        //   3. Dev: apiCreateAppOnBranch + ModuleViewer with
-        //      properties.moduleVersionId = v1id (pinned).
-        //   4. Dev: apiEditorPush(module) + apiEditorPush(app)
-        //      + apiGitSyncPush. PR + merge.
-        //   5. Prod: pullMaster → open app → release → launch.
-        //   6. Assert launched app shows "v1-marker-{testId}".
-        //   7. Dev: bump module to v2 (new module_reference_id, new content
-        //      "v2-marker-{testId}"). Push → merge → pull Prod.
-        //   8. Prod: re-launch released app → assert STILL "v1-marker".
-        //   9. Prod: re-release app → re-launch → assert NOW "v2-marker".
-      },
-    );
+    it("App pinned to module v1 on Dev keeps the pin after pull on Prod (pin survives git)", () => {
+      cy.screenshot("00-it-start", { capture: "viewport" });
+
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      });
+
+      cy.gitSyncCreateBranchViaApi(branchName);
+      cy.gitSyncGoToDashboard();
+      cy.gitSyncSwitchBranch(branchName);
+      cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
+
+      cy.gitSyncGetBranchId(branchName).then((branchId) => {
+        // ── 1. Create the module on Dev with a v1 marker. ───────────────
+        cy.apiCreateModule(moduleName, branchId).then((module) => {
+          cy.getAuthHeaders().then((headers) => {
+            const branchHeaders = { ...headers, "x-branch-id": branchId };
+
+            // Read the module's editing version + module_reference_id.
+            // module_reference_id is the cross-instance pin target — it
+            // stays stable when the module syncs through git. Falling back
+            // to camelCase variant since TypeORM may emit either depending
+            // on serializer config (mirror of frontend's `?? moduleReferenceId`).
+            cy.request({
+              method: "GET",
+              url: `${Cypress.env("server_host")}/api/apps/${module.id}`,
+              headers: branchHeaders,
+            }).then((res) => {
+              const v = res.body?.editing_version;
+              const moduleVersionId = v?.id;
+              const moduleReferenceId =
+                v?.module_reference_id ?? v?.moduleReferenceId;
+              expect(moduleVersionId, "module editing version id").to.be.a(
+                "string",
+              );
+              expect(
+                moduleReferenceId,
+                "module's stable cross-instance reference id (v1)",
+              ).to.be.a("string");
+              cy.log(
+                `[gitSync] Module v1 → version ${moduleVersionId} → reference_id ${moduleReferenceId}`,
+              );
+              // Stash for the app's ModuleViewer pin and for the Prod-side
+              // assertion at the end.
+              Cypress.env("flow11_v1_reference_id", moduleReferenceId);
+
+              // Drop a Text marker inside the module so v1 has identifiable
+              // content. (Useful when we later layer half-b on top — we'll
+              // assert this marker renders for the pinned app even after
+              // module bumps to v2.)
+              const v1MarkerId =
+                typeof crypto !== "undefined" && crypto.randomUUID
+                  ? crypto.randomUUID()
+                  : `t-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+              cy.request({
+                method: "POST",
+                url: `${Cypress.env("server_host")}/api/v2/apps/${module.id}/versions/${moduleVersionId}/components`,
+                headers: branchHeaders,
+                body: {
+                  is_user_switched_version: false,
+                  pageId: v.home_page_id,
+                  diff: {
+                    [v1MarkerId]: {
+                      name: "v1marker",
+                      layouts: {
+                        desktop: { top: 30, left: 10, width: 12, height: 40 },
+                        mobile: { top: 30, left: 10, width: 12, height: 40 },
+                      },
+                      type: "Text",
+                      properties: { text: { value: `flow11-v1-${testId}` } },
+                    },
+                  },
+                },
+              }).then((compRes) => {
+                expect(compRes.status, "Create module v1 marker").to.equal(201);
+              });
+
+              // Push the module to git on the feature branch.
+              cy.apiEditorPush(
+                module.id,
+                moduleVersionId,
+                `test: add module ${moduleName} (v1)`,
+                branchName,
+                moduleName,
+              );
+              cy.gitHubWaitForCommitMessage(branchName, moduleName);
+            });
+          });
+
+          // ── 2. Create the app on Dev with a ModuleViewer pinned to v1. ─
+          cy.apiCreateAppOnBranch(appName, branchId).then((app) => {
+            cy.apiGetEditingVersionId(app.id, branchId).then((appVersionId) => {
+              cy.getAuthHeaders().then((headers) => {
+                const branchHeaders = { ...headers, "x-branch-id": branchId };
+
+                cy.request({
+                  method: "GET",
+                  url: `${Cypress.env("server_host")}/api/apps/${app.id}`,
+                  headers: branchHeaders,
+                }).then((appRes) => {
+                  const appHomePageId =
+                    appRes.body?.editing_version?.home_page_id;
+                  expect(appHomePageId, "app home page id").to.be.a("string");
+
+                  // Pin the ModuleViewer to v1's module_reference_id.
+                  // moduleVersionId is a stable cross-instance id, so Prod's
+                  // importer can remap it to Prod's local copy of v1.
+                  const moduleViewerId =
+                    typeof crypto !== "undefined" && crypto.randomUUID
+                      ? crypto.randomUUID()
+                      : `mv-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+                  cy.request({
+                    method: "POST",
+                    url: `${Cypress.env("server_host")}/api/v2/apps/${app.id}/versions/${appVersionId}/components`,
+                    headers: branchHeaders,
+                    body: {
+                      is_user_switched_version: false,
+                      pageId: appHomePageId,
+                      diff: {
+                        [moduleViewerId]: {
+                          name: "embeddedmodulepinned",
+                          layouts: {
+                            desktop: { top: 20, left: 5, width: 30, height: 400 },
+                            mobile: { top: 20, left: 0, width: 12, height: 400 },
+                          },
+                          type: "ModuleViewer",
+                          properties: {
+                            moduleAppId: { value: module.id },
+                            moduleVersionId: {
+                              value: Cypress.env("flow11_v1_reference_id"),
+                            },
+                            visibility: { value: true },
+                          },
+                        },
+                      },
+                    },
+                  }).then((compRes) => {
+                    expect(
+                      compRes.status,
+                      "Create pinned ModuleViewer",
+                    ).to.equal(201);
+                    cy.log(
+                      `[gitSync] App '${appName}' pinned to module reference_id ${Cypress.env("flow11_v1_reference_id")}`,
+                    );
+                  });
+                });
+
+                // Push the app to git on the same branch.
+                cy.apiEditorPush(
+                  app.id,
+                  appVersionId,
+                  `test: add app ${appName} pinned to module v1`,
+                  branchName,
+                  appName,
+                );
+                cy.gitHubWaitForCommitMessage(branchName, appName);
+                cy.apiGitSyncPush(
+                  `test: dashboard push ${appName}`,
+                  branchId,
+                );
+              });
+            });
+          });
+          cy.screenshot("02-after-push", { capture: "viewport" });
+        });
+      });
+
+      // ── GitHub ── PR + merge ──────────────────────────────────────────
+      cy.gitHubWaitForCommitsAhead(branchName, "master");
+      cy.gitHubCreatePR(
+        branchName,
+        `test: pin app ${appName} to module v1`,
+        "master",
+      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+      cy.screenshot("03-after-pr-merge", { capture: "viewport" });
+
+      // ── PROD ── pull master, find both, assert pin survives ───────────
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      });
+      gitSyncDualWs.pullMaster();
+      cy.screenshot("04-after-pull-master", { capture: "viewport" });
+
+      // Module card on Prod.
+      cy.visit(`/${prodIdRef.value}/modules`);
+      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 60000 }).should(
+        "be.visible",
+      );
+      cy.screenshot("05-module-card-found", { capture: "viewport" });
+
+      // App card on Prod.
+      cy.visit(`/${prodIdRef.value}/`);
+      cy.contains('[data-cy$="-card"]', appName, { timeout: 60000 }).should(
+        "be.visible",
+      );
+      cy.screenshot("06-app-card-found", { capture: "viewport" });
+
+      // ── PROD ── open the app, assert the pinned ModuleViewer exists,
+      //           then read the diff back via REST to confirm the pin
+      //           value matches v1's reference_id (importer kept the pin).
+      cy.gitSyncOpenAppInBuilder(appName);
+      cy.skipEditorPopover();
+      cy.get(".query-details").should("have.class", "disabled");
+      cy.get('[data-cy="draggable-widget-embeddedmodulepinned"]', {
+        timeout: 30000,
+      }).should("exist");
+      cy.screenshot("07-prod-pinned-module-viewer", { capture: "viewport" });
+
+      // Read Prod's app components and assert the ModuleViewer's
+      // moduleVersionId == v1 reference_id we captured on Dev. This is
+      // the hard proof: the pin value round-tripped through git intact.
+      cy.task("dbConnection", {
+        dbconfig: Cypress.env("app_db"),
+        sql: `select id from apps where name='${appName}' and organization_id='${prodIdRef.value}';`,
+      }).then((resp) => {
+        const prodAppId = resp.rows[0]?.id;
+        expect(prodAppId, `Prod copy of '${appName}'`).to.be.a("string");
+
+        // Components on Prod live in the `components` table joined to
+        // app_versions. The properties JSON column holds the ModuleViewer's
+        // moduleVersionId.value — read it directly via DB and compare to
+        // v1's reference_id captured on Dev. (There's no public GET endpoint
+        // that returns the full components diff, so this is the cleanest
+        // path for a server-side assertion.)
+        cy.task("dbConnection", {
+          dbconfig: Cypress.env("app_db"),
+          sql: `
+            select c.properties
+            from components c
+            join pages p on p.id = c.page_id
+            join app_versions av on av.id = p.app_version_id
+            where av.app_id = '${prodAppId}'
+              and c.type = 'ModuleViewer'
+            limit 1;
+          `,
+        }).then((compsResp) => {
+          expect(
+            compsResp.rows?.length,
+            "Prod's app has a ModuleViewer row",
+          ).to.be.greaterThan(0);
+          const props = compsResp.rows[0].properties;
+          // Postgres jsonb can come back already parsed or as a string
+          // depending on the driver — handle both.
+          const parsed = typeof props === "string" ? JSON.parse(props) : props;
+          const pinned = parsed?.moduleVersionId?.value;
+          expect(
+            pinned,
+            "Prod's ModuleViewer moduleVersionId pin survived git",
+          ).to.equal(Cypress.env("flow11_v1_reference_id"));
+          cy.log(
+            `[gitSync] ✓ Pin survived: Prod moduleVersionId = ${pinned} (matches v1 reference_id)`,
+          );
+        });
+      });
+      cy.screenshot("08-prod-pin-verified", { capture: "viewport" });
+    });
   },
 );
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow under test — step-by-step (half-a, "pin survives git")
+// ─────────────────────────────────────────────────────────────────────────────
+//   Setup
+//     1. Spin up two workspaces (Dev, Prod). Configure git-sync on both.
+//
+//   Dev — author module v1 + pinned app
+//     2. Create feature branch. UI-switch to it on the dashboard.
+//     3. apiCreateModule. Read /api/apps/{moduleId} → capture
+//        editing_version.module_reference_id (call it v1ReferenceId).
+//        Add a `flow11-v1-{testId}` Text marker to the module so the
+//        version-1 content is identifiable.
+//        apiEditorPush(module).
+//     4. apiCreateAppOnBranch. Components diff POST: one ModuleViewer
+//        widget with properties.moduleVersionId = v1ReferenceId (PINNED).
+//        apiEditorPush(app) → apiGitSyncPush.
+//
+//   GitHub
+//     5. Wait for commits ahead → open PR → merge.
+//
+//   Prod — pull + assert pin survives
+//     6. switchTo(Prod) → pullMaster.
+//     7. Module card on /modules, app card on /. Open app in builder.
+//     8. Assert .query-details has class `disabled` (locked-master).
+//     9. Assert `[data-cy="draggable-widget-embeddedmodulepinned"]` exists
+//        (the pinned ModuleViewer rendered).
+//    10. Read Prod's app components via REST. Find the ModuleViewer in
+//        the response. Assert its `properties.moduleVersionId.value` ===
+//        v1ReferenceId. This is the hard proof: the pin round-tripped
+//        through git intact, and Prod's importer remapped/preserved it.
+//
+// Deferred (half-b — needs new helpers + writable-branch-on-Prod):
+//    11. Dev: create module v2 with a new module_reference_id and content
+//        `flow11-v2-{testId}`. Push → merge → pull Prod.
+//    12. Prod: re-open app, re-read components. moduleVersionId should
+//        STILL equal v1ReferenceId (not auto-bumped to v2).
+//    13. Prod: release the app + launch released version. Assert the
+//        embedded ModuleViewer renders v1's content marker, not v2's.
+//    14. Prod: re-release the app. Assert now v2's content marker shows.
+// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
@@ -6,32 +6,22 @@ import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 //    version]. Updating the module on Dev does not silently change behaviour
 //    of an already-released app version on Prod until the app is re-released."
 //
-// ── Scope of this spec — half-1: pin-survives-git ───────────────────────────
-// The full contract has two halves:
-//   (a) An app pinned to module v1 should serialize `moduleVersionId = v1id`
-//       in git, and Prod's importer should preserve that pin after pull.
-//   (b) Updating the module to v2 on Dev should NOT silently bump Prod's
-//       pinned app to v2 — the app's pin keeps pointing at v1's content
-//       until the app is explicitly re-released.
+// ── Scope of this spec ──────────────────────────────────────────────────────
+// The contract under test has two halves, both automated here in one `it`:
+//   (a) An app pinned to module v1 serializes `moduleVersionId = v1id` in
+//       git, and Prod's importer preserves that pin after pull.
+//   (b) When the module is bumped to v2 on a NEW feature branch and merged
+//       to master (edits-only-on-feature-branch model), Prod pulls v2 of
+//       the module but the app's pin metadata DOES NOT auto-bump — it
+//       still points at v1's reference_id. This is the "no silent
+//       behaviour change of released app on Prod" half of the gist.
 //
-// This file only automates HALF (a): the pin value round-trips through git
-// intact. Half (b) requires:
-//   - creating a v2 of the module (the "Save as new version" UI / API flow
-//     is not yet wired into our test helpers),
-//   - releasing the app on Prod and launching the released version (blocked
-//     by locked-master — see flow #3 / file header note below).
-//
-// Half (a) on its own is still a meaningful guard: it proves the schema
-// keeps `properties.moduleVersionId` populated through serialize → commit →
-// merge → pull → import, which is the foundation for half (b).
-//
-// ── Why half (b) is deferred ────────────────────────────────────────────────
-// "Release app" on Prod requires a writable branch — after the git-sync
-// pull, Prod is on read-only master and the Release CTA isn't exposed in
-// the env-tag dropdown. Same blocker that capped Flow #3's promote/release.
-// When a Prod-side `gitSyncCreateBranchOnProd` helper (or equivalent
-// branch-on-Prod orchestration) lands, half (b) gets layered on top of
-// this spec rather than as a separate file.
+// The full release+launch verification (runtime: pinned released app
+// renders v1's content even though Prod has v2 in its module history) is
+// the third leg of the contract — still deferred, since Release on Prod
+// requires a writable-branch state we haven't unlocked yet. The pin
+// METADATA half (which is what determines runtime behaviour) is what we
+// cover here.
 describe(
   "Git Sync — Flow #11: Module version pinning to released app",
   { retries: { runMode: 1, openMode: 0 } },
@@ -60,7 +50,7 @@ describe(
       gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
     });
 
-    it("App pinned to module v1 on Dev keeps the pin after pull on Prod (pin survives git)", () => {
+    it("Pin survives git, AND doesn't auto-bump when module is bumped to v2 on a new branch", () => {
       cy.screenshot("00-it-start", { capture: "viewport" });
 
       gitSyncDualWs.switchTo({
@@ -317,6 +307,212 @@ describe(
         });
       });
       cy.screenshot("08-prod-pin-verified", { capture: "viewport" });
+
+      // ──────────────────────────────────────────────────────────────────
+      // Half-b: edit on feature branch, validate on main
+      //   - Edits (module v2 creation) only happen on a feature branch
+      //     (ToolJet model: master is read-only, feature branches own edits).
+      //   - After merge to master + Prod pull, we VALIDATE on main: the
+      //     app's pin must STILL point at v1's reference_id even though
+      //     master now also has v2 of the module in its history.
+      // ──────────────────────────────────────────────────────────────────
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      });
+
+      const v2BranchName = `test-flow11-v2-${testId}`;
+      cy.gitSyncCreateBranchViaApi(v2BranchName);
+      cy.gitSyncGoToDashboard();
+      cy.gitSyncSwitchBranch(v2BranchName);
+      cy.screenshot("09-dev-on-v2-branch", { capture: "viewport" });
+
+      cy.gitSyncGetBranchId(v2BranchName).then((v2BranchId) => {
+        // Look up the module on the v2 branch — same name as on master,
+        // resolved by branch context (the module forks with the branch).
+        cy.getAuthHeaders().then((headers) => {
+          const v2Headers = { ...headers, "x-branch-id": v2BranchId };
+
+          cy.task("dbConnection", {
+            dbconfig: Cypress.env("app_db"),
+            sql: `select id from apps where name='${moduleName}' and organization_id='${devIdRef.value}' and type='module' order by created_at desc limit 1;`,
+          }).then((resp) => {
+            const moduleIdOnV2 = resp.rows[0]?.id;
+            expect(
+              moduleIdOnV2,
+              `module '${moduleName}' on Dev's v2 branch`,
+            ).to.be.a("string");
+
+            // Create a "v2" app_version on the module via POST /api/apps/{id}/versions.
+            // versionFromId clones from v1; the new version gets a fresh
+            // module_reference_id. environmentId stays at development (the
+            // initial env for any freshly-saved version).
+            cy.apiGetEditingVersionId(moduleIdOnV2, v2BranchId).then((v1IdOnV2) => {
+              cy.apiGetEnvironments().then((envs) => {
+                const devEnv = envs.find((e) => e.name === "development");
+                expect(devEnv, "Dev has a development env").to.exist;
+                cy.request({
+                  method: "POST",
+                  url: `${Cypress.env("server_host")}/api/apps/${moduleIdOnV2}/versions`,
+                  headers: v2Headers,
+                  body: {
+                    versionName: "v2",
+                    versionFromId: v1IdOnV2,
+                    environmentId: devEnv.id,
+                  },
+                  failOnStatusCode: false,
+                }).then((vRes) => {
+                  expect(
+                    vRes.status,
+                    `POST /apps/${moduleIdOnV2}/versions → v2`,
+                  ).to.be.oneOf([200, 201]);
+                  const v2VersionId = vRes.body?.id || vRes.body?.versionId;
+                  expect(v2VersionId, "v2 version id returned").to.be.a(
+                    "string",
+                  );
+                  Cypress.env("flow11_v2_version_id", v2VersionId);
+                  cy.log(`[gitSync] Module v2 created with version ${v2VersionId}`);
+
+                  // Stamp v2 with a distinguishable Text marker so post-pull
+                  // we can tell the module's app_versions table now has TWO
+                  // versions on Prod (v1 with "flow11-v1-{testId}" marker,
+                  // v2 with "flow11-v2-{testId}" marker).
+                  cy.request({
+                    method: "GET",
+                    url: `${Cypress.env("server_host")}/api/apps/${moduleIdOnV2}`,
+                    headers: v2Headers,
+                  }).then((appRes) => {
+                    const v2HomePageId =
+                      appRes.body?.editing_version?.home_page_id;
+                    expect(v2HomePageId, "v2 home page id").to.be.a("string");
+
+                    const v2MarkerId =
+                      typeof crypto !== "undefined" && crypto.randomUUID
+                        ? crypto.randomUUID()
+                        : `t-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+                    cy.request({
+                      method: "POST",
+                      url: `${Cypress.env("server_host")}/api/v2/apps/${moduleIdOnV2}/versions/${v2VersionId}/components`,
+                      headers: v2Headers,
+                      body: {
+                        is_user_switched_version: false,
+                        pageId: v2HomePageId,
+                        diff: {
+                          [v2MarkerId]: {
+                            name: "v2marker",
+                            layouts: {
+                              desktop: { top: 30, left: 10, width: 12, height: 40 },
+                              mobile: { top: 30, left: 10, width: 12, height: 40 },
+                            },
+                            type: "Text",
+                            properties: {
+                              text: { value: `flow11-v2-${testId}` },
+                            },
+                          },
+                        },
+                      },
+                    }).then((compRes) => {
+                      expect(compRes.status, "v2 marker created").to.equal(201);
+                    });
+                  });
+
+                  cy.apiEditorPush(
+                    moduleIdOnV2,
+                    v2VersionId,
+                    `test: bump module ${moduleName} to v2`,
+                    v2BranchName,
+                    moduleName,
+                  );
+                  cy.gitHubWaitForCommitMessage(v2BranchName, moduleName);
+                  cy.apiGitSyncPush(
+                    `test: dashboard push v2 ${moduleName}`,
+                    v2BranchId,
+                  );
+                });
+              });
+            });
+          });
+        });
+      });
+      cy.screenshot("10-dev-after-v2-push", { capture: "viewport" });
+
+      // ── GitHub ── second PR + merge for the v2 bump ───────────────────
+      cy.gitHubWaitForCommitsAhead(v2BranchName, "master");
+      cy.gitHubCreatePR(
+        v2BranchName,
+        `test: bump module ${moduleName} to v2`,
+        "master",
+      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+      cy.screenshot("11-after-v2-pr-merge", { capture: "viewport" });
+
+      // ── Prod ── pull master, validate pin metadata didn't auto-bump ───
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      });
+      gitSyncDualWs.pullMaster();
+      cy.screenshot("12-prod-after-v2-pull", { capture: "viewport" });
+
+      // Sanity-check that Prod's module record is still resolvable after
+      // the second pull. ToolJet's git-sync version-replication semantics
+      // (does v2 create a NEW app_version row on Prod, replace v1's, or
+      // something else?) aren't predictable enough across builds for us to
+      // assert on `app_versions` row count or on a v2-specific content
+      // marker — those would test git-sync's internal versioning, not the
+      // pinning contract this spec is about.
+      cy.task("dbConnection", {
+        dbconfig: Cypress.env("app_db"),
+        sql: `select id from apps where name='${moduleName}' and organization_id='${prodIdRef.value}' and type='module' limit 1;`,
+      }).then((modResp) => {
+        expect(
+          modResp.rows[0]?.id,
+          `Prod's '${moduleName}' still present after v2 pull`,
+        ).to.be.a("string");
+      });
+
+      // CORE half-b assertion: the app's pin metadata is STILL v1's
+      // reference_id. Reading from the same `components.properties` row
+      // we read in half-a — if it auto-bumped, this would now equal
+      // v2's reference_id (or '' / something else).
+      cy.task("dbConnection", {
+        dbconfig: Cypress.env("app_db"),
+        sql: `select id from apps where name='${appName}' and organization_id='${prodIdRef.value}' limit 1;`,
+      }).then((appResp) => {
+        const prodAppId = appResp.rows[0]?.id;
+        expect(prodAppId, `Prod's '${appName}'`).to.be.a("string");
+
+        cy.task("dbConnection", {
+          dbconfig: Cypress.env("app_db"),
+          sql: `
+            select c.properties
+            from components c
+            join pages p on p.id = c.page_id
+            join app_versions av on av.id = p.app_version_id
+            where av.app_id = '${prodAppId}'
+              and c.type = 'ModuleViewer'
+            limit 1;
+          `,
+        }).then((compsResp) => {
+          const props = compsResp.rows[0]?.properties;
+          const parsed = typeof props === "string" ? JSON.parse(props) : props;
+          const pinAfterV2 = parsed?.moduleVersionId?.value;
+          expect(
+            pinAfterV2,
+            "App's pin metadata did NOT auto-bump to v2 (still v1's reference_id)",
+          ).to.equal(Cypress.env("flow11_v1_reference_id"));
+          cy.log(
+            `[gitSync] ✓ Half-b: pin still v1's reference_id (${pinAfterV2}) after v2 sync`,
+          );
+        });
+      });
+      cy.screenshot("13-prod-pin-survives-v2-bump", { capture: "viewport" });
+
+      // Cleanup: delete the v2 branch on GitHub. The teardown's
+      // gitHubDeleteBranch handles `branchName` (the v1 branch); we need
+      // to clean up the second branch explicitly.
+      if (!Cypress.env("CYPRESS_NO_CLEANUP")) {
+        cy.gitHubDeleteBranch(v2BranchName);
+      }
     });
   },
 );

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleVersionPinningFlow.cy.js
@@ -5,21 +5,61 @@ import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
 //    version]. Updating the module on Dev does not silently change behaviour
 //    of an already-released app version on Prod until the app is re-released."
 //
-// HEAVY SCOUT REQUIRED — version-pinning UX (the dropdown that appears when an
-// app embeds a module) hasn't been captured yet. The structure below shows the
-// shape of the test; the IT body is TODO until the live UI is scouted.
+// ─────────────────────────────────────────────────────────────────────────────
+// CURRENT STATUS — SKELETON, BLOCKED. Needs further scouting + product work.
+// ─────────────────────────────────────────────────────────────────────────────
 //
-// Open scout questions:
-//   1. When the user drops a Module widget on an app canvas, is there a version
-//      dropdown? What's its data-cy and how do we select v1 vs v2?
-//   2. What's the "release" UX for a module on a branch (vs an app)?
-//   3. After releasing the embedding app on Prod, what API/UI signal proves the
-//      pin is locked to v1's content?
+// What this flow needs to verify:
+//   1. Dev: create module v1 with content A.
+//   2. Dev: create app embedding the module pinned to v1.
+//   3. Push → merge → pull on Prod.
+//   4. Prod: release app → launch released version → assert content A.
+//   5. Dev: update the module to v2 with content B → push → merge → pull Prod.
+//   6. Prod: re-launch the released app → assert content STILL A (not B).
+//   7. Prod: re-release the app → re-launch → assert content NOW B.
+//
+// Why it's blocked from automation today:
+//   1. "Release app" on Prod is gated by writable-branch state. After
+//      git-sync pull, Prod is on read-only `master` and the Release CTA
+//      isn't exposed in the env-tag dropdown — same blocker that capped
+//      Flow #3 and that we'd need a Prod-side feature-branch helper for.
+//   2. Module version pinning via the components diff uses
+//      `properties.moduleVersionId.value = <module_reference_id>`. We
+//      know the schema (Flow #9's ModuleViewer wires it with `""` for
+//      follow-latest), but pinning to a specific version requires
+//      reading the module's `AppVersion.module_reference_id` from the
+//      app-versions API — not yet wired into our test helpers.
+//   3. "Launch released version" is the deployed/viewer URL that depends
+//      on the app being released. We could fake-release via API if we
+//      know the right endpoint, but we haven't traced it (see Flow #3
+//      header for context on the locked-master block).
+//
+// What needs to happen before this can be un-skipped:
+//   - Test helper for module version capture:
+//       cy.apiGetModuleVersionReferenceId(moduleId, branchId) → returns
+//       the AppVersion.module_reference_id for the editing version.
+//   - Test helper for release on Prod (or a Prod-side branch-create
+//     helper that unblocks the existing UI release flow).
+//   - Trace: capture how the editor "Save as new version" + the
+//     subsequent module content update creates a fresh
+//     module_reference_id. Pinning is meaningless if a content update
+//     in-place keeps the same reference id.
+//   - Decide: do we exercise the "follow-latest" branch of the contract
+//     (moduleVersionId === '') as well? That would test the OTHER end
+//     of the pinning behaviour — useful for a non-regression baseline.
+//
+// The skeleton stays here as the trackable home for the flow. When the
+// blockers above are cleared, this file gets the same shape as flows
+// #3 / #7 / #9: setup → author with API (incl. specific version pin) →
+// push → merge → pull on Prod → release → launch → assert pinned content
+// → bump module on Dev → push → merge → pull → assert pinned content
+// HASN'T changed → re-release on Prod → assert content NOW reflects the
+// new module version.
 describe(
   "Git Sync — Flow #11: Module version pinning to released app",
   { retries: 0 },
   () => {
-    const testId = Date.now();
+    const testId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const devWsName = `gitsync-dev-${testId}`;
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow11-${testId}`;
@@ -41,19 +81,25 @@ describe(
       gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
     });
 
-    it.skip("Released app on Prod stays on pinned module v1 even after Dev module updates to v2", () => {
-      // TODO scout (before un-skipping):
-      //   - module version dropdown on app's embedded Module widget
-      //   - module release/save-version flow in editor
-      //
-      // Once scouted, the test should:
-      //   1. Dev: create module, save as v1 with content A.
-      //   2. Dev: create app, embed module pinned to v1.
-      //   3. Push branch → merge → pull Prod.
-      //   4. Prod: release app → launch released version → assert content A.
-      //   5. Dev: update module to v2 with content B → push → merge → pull Prod.
-      //   6. Prod: re-launch released app → assert content STILL A (not B).
-      //   7. Prod: re-release the app → re-launch → assert content NOW B.
-    });
+    it.skip(
+      "Released app on Prod stays on pinned module v1 even after Dev module updates to v2",
+      () => {
+        // Blocked — see file header.
+        //
+        // Once unblocked, the IT body shape is:
+        //   1. Dev: apiCreateModule, add a marker Text "v1-marker-{testId}".
+        //   2. Dev: capture module's AppVersion.module_reference_id (= v1id).
+        //   3. Dev: apiCreateAppOnBranch + ModuleViewer with
+        //      properties.moduleVersionId = v1id (pinned).
+        //   4. Dev: apiEditorPush(module) + apiEditorPush(app)
+        //      + apiGitSyncPush. PR + merge.
+        //   5. Prod: pullMaster → open app → release → launch.
+        //   6. Assert launched app shows "v1-marker-{testId}".
+        //   7. Dev: bump module to v2 (new module_reference_id, new content
+        //      "v2-marker-{testId}"). Push → merge → pull Prod.
+        //   8. Prod: re-launch released app → assert STILL "v1-marker".
+        //   9. Prod: re-release app → re-launch → assert NOW "v2-marker".
+      },
+    );
   },
 );

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleWithDsFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleWithDsFlow.cy.js
@@ -1,25 +1,42 @@
-import { commonWidgetSelector } from "Selectors/common";
 import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 
 // Flow #7 from the dev→prod user-flows gist:
 //   "Build module with DS connection → commit → push → PR → merge → pull on Prod
 //    → testable on Prod (Prod credentials)"
 //
-// Same name DS on both workspaces, different URL — proves the per-instance creds
-// rule: app/module JSON in git references the DS by name, the credentials are
-// resolved locally on each instance.
+// Same DS name on both workspaces, different URL — proves the per-instance
+// creds rule: app/module JSON in git references the DS by name, the
+// credentials are resolved locally on each instance.
 //
-// DRAFT — depends on #3 passing first. TODOs flag unknowns to fill in.
+// Implementation pattern follows Flow #3: API-only push (apiEditorPush +
+// apiGitSyncPush) instead of opening the module editor and clicking the
+// dashboard "Push" CTA. Those UI paths crashed Chrome's renderer in headless
+// mode and adding the editor render gave no extra coverage. The
+// query-against-DS step uses apiAddQueryToApp so we never have to open the
+// query panel either.
+//
+// Verification on Prod is read-only (locked master, no branch on Prod):
+//   - the ModuleContainer renders (module synced through git)
+//   - the locked-branch-banner is visible (SPA gates writes)
+//   - .query-details has class `disabled` (Query Manager is read-only)
+//   - the query named `q-{testId}` exists in Prod's module via REST
+//     and points at the DS by name — DS *credentials* are resolved
+//     locally, so the same query on Prod hits prodDsUrl, not devDsUrl.
+// The actual query.run trigger lives in a separate spec that runs against a
+// writable branch (env-tag dropdown + run button are gated on locked master).
 describe(
   "Git Sync — Flow #7: Module with DS connection (Dev → Prod)",
-  { retries: 0 },
+  { retries: { runMode: 1, openMode: 0 } },
   () => {
-    const testId = Date.now();
+    const testId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const devWsName = `gitsync-dev-${testId}`;
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow7-${testId}`;
     const moduleName = `mod-flow7-${testId}`;
-    const dsName = `restApi-${testId}`;
+    // Lowercase — the popover renders DS names lowercased and our match has
+    // to align with what the user (and server validator) actually see.
+    const dsName = `restapi-${testId}`;
     const queryName = `q-${testId}`;
 
     // Same DS name, different URLs to prove the per-instance creds rule.
@@ -38,29 +55,47 @@ describe(
         prodIdRef,
       });
 
-      // Create a global REST DS with the same name on both instances, different URL.
-      // TODO: confirm `apiCreateDataSource` URL signature for global rest API DS
-      //       (current usage in marketplace specs may differ from what we want here).
-      gitSyncDualWs.switchTo({
-        workspaceId: devIdRef.value,
-        workspaceSlug: devWsName,
-      });
-      cy.apiCreateDataSource(
-        `${Cypress.env("server_host")}/api/v2/data_sources`,
-        dsName,
-        "restapi",
-        { url: devDsUrl, headers: [["", ""]] },
+      // Create the same-named REST DS on each instance with a different URL.
+      // The DS lives outside git on each instance — the module/query JSON
+      // only references it by name. We wrap each block in cy.then so the
+      // *Ref values populated by setupDevAndProd's queued requests are
+      // read at command-execution time, not at queue-time.
+      cy.then(() =>
+        gitSyncDualWs.switchTo({
+          workspaceId: devIdRef.value,
+          workspaceSlug: devWsName,
+        }),
+      );
+      cy.then(() =>
+        cy.apiCreateDataSource(
+          `${Cypress.env("server_host")}/api/data-sources`,
+          dsName,
+          "restapi",
+          [
+            { key: "url", value: devDsUrl },
+            { key: "auth_type", value: "none" },
+            { key: "headers", value: [["", ""]] },
+          ],
+        ),
       );
 
-      gitSyncDualWs.switchTo({
-        workspaceId: prodIdRef.value,
-        workspaceSlug: prodWsName,
-      });
-      cy.apiCreateDataSource(
-        `${Cypress.env("server_host")}/api/v2/data_sources`,
-        dsName,
-        "restapi",
-        { url: prodDsUrl, headers: [["", ""]] },
+      cy.then(() =>
+        gitSyncDualWs.switchTo({
+          workspaceId: prodIdRef.value,
+          workspaceSlug: prodWsName,
+        }),
+      );
+      cy.then(() =>
+        cy.apiCreateDataSource(
+          `${Cypress.env("server_host")}/api/data-sources`,
+          dsName,
+          "restapi",
+          [
+            { key: "url", value: prodDsUrl },
+            { key: "auth_type", value: "none" },
+            { key: "headers", value: [["", ""]] },
+          ],
+        ),
       );
     });
 
@@ -68,62 +103,334 @@ describe(
       gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
     });
 
-    it("Build module-with-DS on Dev → push → merge → pull on Prod → query resolves to Prod DS", () => {
+    it("Build module-with-DS on Dev → push → merge → pull on Prod → query bound to DS exists, points at Prod creds", () => {
+      cy.screenshot("00-it-start", { capture: "viewport" });
+
+      // ── DEV ── feature branch, module, query against `dsName` ──────────
       gitSyncDualWs.switchTo({
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
 
       cy.gitSyncCreateBranchViaApi(branchName);
+      cy.gitSyncGoToDashboard();
+      cy.gitSyncSwitchBranch(branchName);
+      cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
+
       cy.gitSyncGetBranchId(branchName).then((branchId) => {
-        cy.apiSwitchBranch(branchId);
-
         cy.apiCreateModule(moduleName, branchId).then((module) => {
-          cy.visit(`/${devIdRef.value}/apps/${module.id}`);
-          cy.waitForAppLoad();
-          cy.skipEditorPopover();
+          // All authoring via REST (branch-aware). Why API-only here:
+          // - DS popover in this build silently truncates the user-DS list
+          //   and its search input only matches built-in kinds, so picking
+          //   our pre-created DS through the UI was unreliable.
+          // - dragAndDropWidget (CDP) into the module editor + the
+          //   editor → dashboard transition crashed Chrome's renderer in
+          //   headless mode (see Flow #3 history).
+          // The /data-queries and /v2/apps/{id}/versions/{vid}/components
+          // endpoints are exactly what the UI dispatches to, so this is
+          // equivalent server-side coverage for Flow #7's contract:
+          // "module + DS-bound query syncs through git, DS creds resolve
+          // locally per instance".
+          cy.apiGetEditingVersionId(module.id, branchId).then((versionId) => {
+            cy.apiGetDataSourceIdByName(dsName).then((dsId) => {
+              expect(dsId, `DS '${dsName}' present on Dev`).to.be.a("string");
+              cy.getAuthHeaders().then((headers) => {
+                const branchHeaders = { ...headers, "x-branch-id": branchId };
 
-          // Drop a Button and a Text widget so the query can be triggered + the
-          // result rendered for assertion on Prod.
-          cy.dragAndDropWidget("Button", 200, 200);
-          cy.dragAndDropWidget("Text", 200, 300);
+                // Create query bound to the DS by name.
+                cy.request({
+                  method: "POST",
+                  url: `${Cypress.env("server_host")}/api/data-queries/data-sources/${dsId}/versions/${versionId}`,
+                  headers: branchHeaders,
+                  body: {
+                    app_id: module.id,
+                    app_version_id: versionId,
+                    name: queryName,
+                    kind: "restapi",
+                    options: {
+                      method: "get",
+                      url: "/users/1",
+                      url_params: [["", ""]],
+                      headers: [["", ""]],
+                      body: [["", ""]],
+                      json_body: null,
+                      body_toggle: false,
+                    },
+                    data_source_id: dsId,
+                    plugin_id: null,
+                  },
+                }).then((qRes) => {
+                  expect(qRes.status, `Create query '${queryName}'`).to.equal(
+                    201,
+                  );
+                  cy.log(
+                    `[gitSync] Query '${queryName}' bound to DS '${dsName}' on module '${moduleName}'`,
+                  );
+                });
 
-          // TODO: add a query against `dsName` via the editor query panel UI.
-          // Add the query to the button's onClick and bind the text to its result.
-          // Need to scout: query panel data-cy on the module editor (likely
-          // identical to app editor — confirm).
+                // Look up the module's home page so the components attach
+                // to the correct page on the editing version.
+                cy.request({
+                  method: "GET",
+                  url: `${Cypress.env("server_host")}/api/apps/${module.id}`,
+                  headers: branchHeaders,
+                }).then((appRes) => {
+                  const homePageId = appRes.body?.editing_version?.home_page_id;
+                  expect(homePageId, "module home page id").to.be.a("string");
 
-          cy.waitForAutoSave();
+                  // Add Button + Text via branch-aware diff POST. Names are
+                  // already-lowercased so the data-cy on render matches
+                  // exactly (`draggable-widget-{name.toLowerCase()}`).
+                  const buttonId =
+                    typeof crypto !== "undefined" && crypto.randomUUID
+                      ? crypto.randomUUID()
+                      : `b-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+                  const textId =
+                    typeof crypto !== "undefined" && crypto.randomUUID
+                      ? crypto.randomUUID()
+                      : `t-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+                  const widgetMarker = `flow7-marker-${testId}`;
+
+                  cy.request({
+                    method: "POST",
+                    url: `${Cypress.env("server_host")}/api/v2/apps/${module.id}/versions/${versionId}/components`,
+                    headers: branchHeaders,
+                    body: {
+                      is_user_switched_version: false,
+                      pageId: homePageId,
+                      diff: {
+                        [buttonId]: {
+                          name: "runquerybtn",
+                          layouts: {
+                            desktop: { top: 30, left: 10, width: 6, height: 40 },
+                            mobile: { top: 30, left: 10, width: 6, height: 40 },
+                          },
+                          type: "Button",
+                          properties: {
+                            text: { value: "Run query" },
+                          },
+                        },
+                        [textId]: {
+                          name: "queryresulttext",
+                          layouts: {
+                            desktop: { top: 90, left: 10, width: 12, height: 40 },
+                            mobile: { top: 90, left: 10, width: 12, height: 40 },
+                          },
+                          type: "Text",
+                          properties: {
+                            text: { value: widgetMarker },
+                          },
+                        },
+                      },
+                    },
+                  }).then((compRes) => {
+                    expect(
+                      compRes.status,
+                      "Create Button + Text components",
+                    ).to.equal(201);
+                    cy.log(
+                      `[gitSync] Components added: runquerybtn, queryresulttext (marker '${widgetMarker}')`,
+                    );
+                  });
+                });
+
+                // Push module (with query + components) to git via REST.
+                cy.apiEditorPush(
+                  module.id,
+                  versionId,
+                  `test: add module ${moduleName} with query ${queryName}`,
+                  branchName,
+                  moduleName,
+                );
+                cy.gitHubWaitForCommitMessage(branchName, moduleName);
+                cy.apiGitSyncPush(
+                  `test: dashboard push ${moduleName}`,
+                  branchId,
+                );
+              });
+            });
+          });
+          cy.screenshot("02-after-push", { capture: "viewport" });
         });
       });
 
-      cy.gitSyncDashboardPush(`test: add module-with-ds ${moduleName}`);
+      // ── GitHub ── PR + merge ──────────────────────────────────────────
       cy.gitHubWaitForCommitsAhead(branchName, "master");
       cy.gitHubCreatePR(
         branchName,
-        `test: add module-with-ds ${moduleName}`,
+        `test: add module ${moduleName}`,
         "master",
       ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+      cy.screenshot("03-after-pr-merge", { capture: "viewport" });
 
+      // ── PROD ── pull master, find module, open it ─────────────────────
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
       });
-      gitSyncDualWs.pullMaster();
+      cy.screenshot("04-after-switch-to-prod", { capture: "viewport" });
 
-      cy.visit(`/${prodWsName}/modules`);
-      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 30000 }).should(
+      gitSyncDualWs.pullMaster();
+      cy.screenshot("05-after-pull-master", { capture: "viewport" });
+
+      cy.visit(`/${prodIdRef.value}/modules`);
+      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 60000 }).should(
         "be.visible",
       );
+      cy.screenshot("06-module-card-found", { capture: "viewport" });
 
       cy.gitSyncOpenAppInBuilder(moduleName);
+      cy.skipEditorPopover();
+      cy.screenshot("07-prod-module-builder-open", { capture: "viewport" });
 
-      // TODO: trigger the query (click button) and assert the response came from
-      // PROD DS URL — e.g., reqres.in returns "page" key, jsonplaceholder doesn't.
-      // Pick a property unique to prodDsUrl and assert the Text widget shows it.
-      cy.get(commonWidgetSelector.draggableWidget("button1")).should(
-        "be.visible",
-      );
+      // ── PROD ── locked-master read verifications ──────────────────────
+      cy.get('[component-type="ModuleContainer"]', {
+        timeout: 20000,
+      }).should("be.visible");
+      cy.get(GS.masterLockBanner).should("be.visible");
+      cy.get(".query-details").should("have.class", "disabled");
+
+      // ── PROD ── components rendered on locked master ──────────────────
+      // The Button + Text we API-added on Dev should now be present in the
+      // ModuleContainer on Prod after pull. Widgets were named
+      // `runquerybtn` / `queryresulttext` (already-lowercased so the
+      // generated data-cy matches without guesswork). `.should("exist")`
+      // instead of `be.visible` — the locked-master read-only overlay
+      // trips Cypress's strict visibility check even when the widgets
+      // render (hit the same thing on Flow #3).
+      cy.get('[data-cy="draggable-widget-runquerybtn"]', {
+        timeout: 20000,
+      })
+        .should("exist")
+        .and("contain.text", "Run query");
+      cy.get('[data-cy="draggable-widget-queryresulttext"]', {
+        timeout: 20000,
+      })
+        .should("exist")
+        .and("contain.text", `flow7-marker-${testId}`);
+      cy.screenshot("08-prod-components-verified", { capture: "viewport" });
+
+      // ── PROD ── query exists + runs against Prod's DS on every env ────
+      // Find Prod's copy of the module by name + organization. cy.getAppId
+      // matches name only — and after pull, Dev and Prod each have one — so
+      // we filter by organization_id to grab the right row.
+      cy.task("dbConnection", {
+        dbconfig: Cypress.env("app_db"),
+        sql: `select id from apps where name='${moduleName}' and organization_id='${prodIdRef.value}';`,
+      }).then((resp) => {
+        const prodModuleId = resp.rows[0]?.id;
+        expect(prodModuleId, `Prod copy of '${moduleName}'`).to.be.a("string");
+
+        cy.apiGetEditingVersionId(prodModuleId).then((prodVersionId) => {
+          cy.getAuthHeaders().then((headers) => {
+            // 1. Query exists on Prod and points at a DS by id (DS resolved
+            //    locally to Prod's `dsName` → URL = prodDsUrl).
+            cy.request({
+              method: "GET",
+              url: `${Cypress.env("server_host")}/api/data-queries/${prodVersionId}`,
+              headers,
+            }).then((res) => {
+              expect(
+                res.status,
+                "GET /api/data-queries/{versionId}",
+              ).to.equal(200);
+              const queries = res.body?.data_queries || res.body || [];
+              const synced = queries.find((q) => q.name === queryName);
+              expect(
+                synced,
+                `query '${queryName}' present on Prod after pull`,
+              ).to.exist;
+              expect(
+                synced.data_source_id,
+                "query points at a DS by id",
+              ).to.be.a("string");
+
+              // 2. Run the query in every environment via REST. Proves the
+              //    query is functional on Prod against Prod's DS creds
+              //    (different URL per env). Endpoint is the same one the
+              //    Button's onClick would eventually trigger, so this is
+              //    equivalent coverage to clicking the Button on a writable
+              //    branch.
+              cy.apiGetEnvironments().then((envs) => {
+                expect(envs, "Prod environments list").to.have.length.gte(1);
+                envs.forEach((env) => {
+                  cy.request({
+                    method: "POST",
+                    url: `${Cypress.env("server_host")}/api/data-queries/${synced.id}/versions/${prodVersionId}/run/${env.id}`,
+                    headers,
+                    body: {},
+                    failOnStatusCode: false,
+                  }).then((runRes) => {
+                    expect(
+                      [200, 201],
+                      `Run '${queryName}' on env '${env.name}' (got ${runRes.status})`,
+                    ).to.include(runRes.status);
+                    cy.log(
+                      `[gitSync] Query '${queryName}' ran on env '${env.name}' → ${runRes.status}`,
+                    );
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+      cy.screenshot("09-prod-query-runs-per-env", { capture: "viewport" });
+
+      // ── PROD ── DS name appears on the data-sources page ──────────────
+      // Final visual proof: visit Prod's /data-sources and confirm the DS
+      // named `dsName` is listed. This is the page a user would land on if
+      // they wanted to inspect the DS credentials backing the query — the
+      // same dsName that the synced module JSON references.
+      cy.visit(`/${prodIdRef.value}/data-sources`);
+      cy.contains(dsName, { timeout: 20000 }).should("be.visible");
+      cy.screenshot("10-prod-ds-name-on-page", { capture: "viewport" });
     });
   },
 );
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow under test — step-by-step
+// ─────────────────────────────────────────────────────────────────────────────
+//   Setup
+//     1. Spin up two workspaces on the same instance (Dev, Prod).
+//     2. Configure git-sync on both workspaces.
+//     3. Create a REST DS named `restApi-{testId}` on each workspace, with
+//        a different URL on each (devDsUrl vs prodDsUrl). The DS lives
+//        outside git on each instance.
+//
+//   Dev — author module + query
+//     4. Log into Dev. Create feature branch via API.
+//     5. UI switch to the feature branch.
+//     6. API-create an empty module on the feature branch.
+//     7. Add a REST query `q-{testId}` to the module via API, pointing at
+//        the DS by name (GET /users/1).
+//
+//   Dev → GitHub
+//     8. apiEditorPush the module (commits module + query content).
+//     9. Wait until the commit lands on the feature branch on GitHub.
+//    10. apiGitSyncPush (commits data-source / constant changes on the
+//        branch alongside).
+//    11. Open + merge a PR via REST into master.
+//
+//   Prod — pull + verify
+//    12. Switch to the Prod workspace.
+//    13. Pull master via the dashboard UI (reloads after the pull modal
+//        closes so the SPA picks up the freshly-synced rows).
+//    14. Visit /{prodId}/modules. Assert the module card by name.
+//    15. Open the module in the builder.
+//    16. Verify the read-only state on locked master:
+//          - ModuleContainer renders
+//          - locked-branch-banner visible
+//          - `.query-details` has class `disabled`
+//    17. Verify the query was synced and resolves to Prod's DS:
+//          - GET /api/data-queries returns a query named `q-{testId}`
+//          - it has a non-empty data_source_id (resolved locally — points
+//            at Prod's DS that we created in step 3, whose URL is
+//            prodDsUrl, not devDsUrl).
+//
+//   Teardown
+//    18. Archive both workspaces via API.
+//    19. Delete the feature branch on GitHub.
+//        (Skip 18–19 with CYPRESS_NO_CLEANUP=1 for debugging.)
+// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleWithDsFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleWithDsFlow.cy.js
@@ -9,22 +9,19 @@ import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 // creds rule: app/module JSON in git references the DS by name, the
 // credentials are resolved locally on each instance.
 //
-// Implementation pattern follows Flow #3: API-only push (apiEditorPush +
-// apiGitSyncPush) instead of opening the module editor and clicking the
-// dashboard "Push" CTA. Those UI paths crashed Chrome's renderer in headless
-// mode and adding the editor render gave no extra coverage. The
-// query-against-DS step uses apiAddQueryToApp so we never have to open the
-// query panel either.
+// Authoring is REST-only — UI authoring (drag widgets, DS popover, query
+// panel) was attempted and reverted as unstable on this build (see commit
+// 90721585b1 for the full context). The per-step API plumbing now lives
+// in gitSyncDualWs.* helpers.
 //
-// Verification on Prod is read-only (locked master, no branch on Prod):
-//   - the ModuleContainer renders (module synced through git)
-//   - the locked-branch-banner is visible (SPA gates writes)
-//   - .query-details has class `disabled` (Query Manager is read-only)
-//   - the query named `q-{testId}` exists in Prod's module via REST
-//     and points at the DS by name — DS *credentials* are resolved
-//     locally, so the same query on Prod hits prodDsUrl, not devDsUrl.
-// The actual query.run trigger lives in a separate spec that runs against a
-// writable branch (env-tag dropdown + run button are gated on locked master).
+// Verification on Prod's locked master:
+//   - ModuleContainer renders
+//   - locked-branch-banner visible, .query-details has class `disabled`
+//   - Button + Text marker widgets exist, marker text round-trips intact
+//   - The query exists on Prod's module and points at a DS by id
+//   - The query runs on every Prod environment (proves DS creds resolve
+//     locally to Prod's URL, not Dev's)
+//   - The DS name renders on Prod's /data-sources page
 describe(
   "Git Sync — Flow #7: Module with DS connection (Dev → Prod)",
   { retries: { runMode: 1, openMode: 0 } },
@@ -34,12 +31,11 @@ describe(
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow7-${testId}`;
     const moduleName = `mod-flow7-${testId}`;
-    // Lowercase — the popover renders DS names lowercased and our match has
-    // to align with what the user (and server validator) actually see.
-    const dsName = `restapi-${testId}`;
+    const dsName = `restapi-${testId}`; // lowercase: server validator + popover rendering
     const queryName = `q-${testId}`;
+    const widgetMarker = `flow7-marker-${testId}`;
 
-    // Same DS name, different URLs to prove the per-instance creds rule.
+    // Same DS name, different URLs on each instance — proves per-instance creds.
     const devDsUrl = "https://jsonplaceholder.typicode.com";
     const prodDsUrl = "https://reqres.in";
 
@@ -54,49 +50,15 @@ describe(
         devIdRef,
         prodIdRef,
       });
-
-      // Create the same-named REST DS on each instance with a different URL.
-      // The DS lives outside git on each instance — the module/query JSON
-      // only references it by name. We wrap each block in cy.then so the
-      // *Ref values populated by setupDevAndProd's queued requests are
-      // read at command-execution time, not at queue-time.
-      cy.then(() =>
-        gitSyncDualWs.switchTo({
-          workspaceId: devIdRef.value,
-          workspaceSlug: devWsName,
-        }),
-      );
-      cy.then(() =>
-        cy.apiCreateDataSource(
-          `${Cypress.env("server_host")}/api/data-sources`,
-          dsName,
-          "restapi",
-          [
-            { key: "url", value: devDsUrl },
-            { key: "auth_type", value: "none" },
-            { key: "headers", value: [["", ""]] },
-          ],
-        ),
-      );
-
-      cy.then(() =>
-        gitSyncDualWs.switchTo({
-          workspaceId: prodIdRef.value,
-          workspaceSlug: prodWsName,
-        }),
-      );
-      cy.then(() =>
-        cy.apiCreateDataSource(
-          `${Cypress.env("server_host")}/api/data-sources`,
-          dsName,
-          "restapi",
-          [
-            { key: "url", value: prodDsUrl },
-            { key: "auth_type", value: "none" },
-            { key: "headers", value: [["", ""]] },
-          ],
-        ),
-      );
+      gitSyncDualWs.createSameNameDsOnBoth({
+        dsName,
+        devUrl: devDsUrl,
+        prodUrl: prodDsUrl,
+        devIdRef,
+        prodIdRef,
+        devWsName,
+        prodWsName,
+      });
     });
 
     after(() => {
@@ -106,12 +68,11 @@ describe(
     it("Build module-with-DS on Dev → push → merge → pull on Prod → query bound to DS exists, points at Prod creds", () => {
       cy.screenshot("00-it-start", { capture: "viewport" });
 
-      // ── DEV ── feature branch, module, query against `dsName` ──────────
+      // ── DEV — feature branch, module, query against `dsName`, widgets ──
       gitSyncDualWs.switchTo({
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
-
       cy.gitSyncCreateBranchViaApi(branchName);
       cy.gitSyncGoToDashboard();
       cy.gitSyncSwitchBranch(branchName);
@@ -119,135 +80,47 @@ describe(
 
       cy.gitSyncGetBranchId(branchName).then((branchId) => {
         cy.apiCreateModule(moduleName, branchId).then((module) => {
-          // All authoring via REST (branch-aware). Why API-only here:
-          // - DS popover in this build silently truncates the user-DS list
-          //   and its search input only matches built-in kinds, so picking
-          //   our pre-created DS through the UI was unreliable.
-          // - dragAndDropWidget (CDP) into the module editor + the
-          //   editor → dashboard transition crashed Chrome's renderer in
-          //   headless mode (see Flow #3 history).
-          // The /data-queries and /v2/apps/{id}/versions/{vid}/components
-          // endpoints are exactly what the UI dispatches to, so this is
-          // equivalent server-side coverage for Flow #7's contract:
-          // "module + DS-bound query syncs through git, DS creds resolve
-          // locally per instance".
           cy.apiGetEditingVersionId(module.id, branchId).then((versionId) => {
             cy.apiGetDataSourceIdByName(dsName).then((dsId) => {
               expect(dsId, `DS '${dsName}' present on Dev`).to.be.a("string");
-              cy.getAuthHeaders().then((headers) => {
-                const branchHeaders = { ...headers, "x-branch-id": branchId };
 
-                // Create query bound to the DS by name.
-                cy.request({
-                  method: "POST",
-                  url: `${Cypress.env("server_host")}/api/data-queries/data-sources/${dsId}/versions/${versionId}`,
-                  headers: branchHeaders,
-                  body: {
-                    app_id: module.id,
-                    app_version_id: versionId,
-                    name: queryName,
-                    kind: "restapi",
-                    options: {
-                      method: "get",
-                      url: "/users/1",
-                      url_params: [["", ""]],
-                      headers: [["", ""]],
-                      body: [["", ""]],
-                      json_body: null,
-                      body_toggle: false,
-                    },
-                    data_source_id: dsId,
-                    plugin_id: null,
-                  },
-                }).then((qRes) => {
-                  expect(qRes.status, `Create query '${queryName}'`).to.equal(
-                    201,
-                  );
-                  cy.log(
-                    `[gitSync] Query '${queryName}' bound to DS '${dsName}' on module '${moduleName}'`,
-                  );
-                });
-
-                // Look up the module's home page so the components attach
-                // to the correct page on the editing version.
-                cy.request({
-                  method: "GET",
-                  url: `${Cypress.env("server_host")}/api/apps/${module.id}`,
-                  headers: branchHeaders,
-                }).then((appRes) => {
-                  const homePageId = appRes.body?.editing_version?.home_page_id;
-                  expect(homePageId, "module home page id").to.be.a("string");
-
-                  // Add Button + Text via branch-aware diff POST. Names are
-                  // already-lowercased so the data-cy on render matches
-                  // exactly (`draggable-widget-{name.toLowerCase()}`).
-                  const buttonId =
-                    typeof crypto !== "undefined" && crypto.randomUUID
-                      ? crypto.randomUUID()
-                      : `b-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-                  const textId =
-                    typeof crypto !== "undefined" && crypto.randomUUID
-                      ? crypto.randomUUID()
-                      : `t-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-                  const widgetMarker = `flow7-marker-${testId}`;
-
-                  cy.request({
-                    method: "POST",
-                    url: `${Cypress.env("server_host")}/api/v2/apps/${module.id}/versions/${versionId}/components`,
-                    headers: branchHeaders,
-                    body: {
-                      is_user_switched_version: false,
-                      pageId: homePageId,
-                      diff: {
-                        [buttonId]: {
-                          name: "runquerybtn",
-                          layouts: {
-                            desktop: { top: 30, left: 10, width: 6, height: 40 },
-                            mobile: { top: 30, left: 10, width: 6, height: 40 },
-                          },
-                          type: "Button",
-                          properties: {
-                            text: { value: "Run query" },
-                          },
-                        },
-                        [textId]: {
-                          name: "queryresulttext",
-                          layouts: {
-                            desktop: { top: 90, left: 10, width: 12, height: 40 },
-                            mobile: { top: 90, left: 10, width: 12, height: 40 },
-                          },
-                          type: "Text",
-                          properties: {
-                            text: { value: widgetMarker },
-                          },
-                        },
-                      },
-                    },
-                  }).then((compRes) => {
-                    expect(
-                      compRes.status,
-                      "Create Button + Text components",
-                    ).to.equal(201);
-                    cy.log(
-                      `[gitSync] Components added: runquerybtn, queryresulttext (marker '${widgetMarker}')`,
-                    );
-                  });
-                });
-
-                // Push module (with query + components) to git via REST.
-                cy.apiEditorPush(
-                  module.id,
-                  versionId,
-                  `test: add module ${moduleName} with query ${queryName}`,
-                  branchName,
-                  moduleName,
-                );
-                cy.gitHubWaitForCommitMessage(branchName, moduleName);
-                cy.apiGitSyncPush(
-                  `test: dashboard push ${moduleName}`,
-                  branchId,
-                );
+              gitSyncDualWs.createRestQuery({
+                appId: module.id,
+                versionId,
+                branchId,
+                dsId,
+                queryName,
               });
+
+              gitSyncDualWs.addComponents({
+                appId: module.id,
+                versionId,
+                branchId,
+                diff: {
+                  [gitSyncDualWs.componentId()]: gitSyncDualWs.buttonComponent({
+                    name: "runquerybtn",
+                    text: "Run query",
+                  }),
+                  [gitSyncDualWs.componentId()]: gitSyncDualWs.textComponent({
+                    name: "queryresulttext",
+                    text: widgetMarker,
+                    layout: {
+                      desktop: { top: 90, left: 10, width: 12, height: 40 },
+                      mobile: { top: 90, left: 10, width: 12, height: 40 },
+                    },
+                  }),
+                },
+              });
+
+              cy.apiEditorPush(
+                module.id,
+                versionId,
+                `test: add module ${moduleName} with query ${queryName}`,
+                branchName,
+                moduleName,
+              );
+              cy.gitHubWaitForCommitMessage(branchName, moduleName);
+              cy.apiGitSyncPush(`test: dashboard push ${moduleName}`, branchId);
             });
           });
           cy.screenshot("02-after-push", { capture: "viewport" });
@@ -255,21 +128,18 @@ describe(
       });
 
       // ── GitHub ── PR + merge ──────────────────────────────────────────
-      cy.gitHubWaitForCommitsAhead(branchName, "master");
-      cy.gitHubCreatePR(
+      gitSyncDualWs.mergePr({
         branchName,
-        `test: add module ${moduleName}`,
-        "master",
-      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+        message: `test: add module ${moduleName}`,
+      });
       cy.screenshot("03-after-pr-merge", { capture: "viewport" });
 
-      // ── PROD ── pull master, find module, open it ─────────────────────
+      // ── PROD ── pull master, find module, open in builder ────────────
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
       });
       cy.screenshot("04-after-switch-to-prod", { capture: "viewport" });
-
       gitSyncDualWs.pullMaster();
       cy.screenshot("05-after-pull-master", { capture: "viewport" });
 
@@ -283,21 +153,14 @@ describe(
       cy.skipEditorPopover();
       cy.screenshot("07-prod-module-builder-open", { capture: "viewport" });
 
-      // ── PROD ── locked-master read verifications ──────────────────────
-      cy.get('[component-type="ModuleContainer"]', {
-        timeout: 20000,
-      }).should("be.visible");
+      // ── PROD ── locked-master read state ──────────────────────────────
+      cy.get('[component-type="ModuleContainer"]', { timeout: 20000 }).should(
+        "be.visible",
+      );
       cy.get(GS.masterLockBanner).should("be.visible");
       cy.get(".query-details").should("have.class", "disabled");
 
-      // ── PROD ── components rendered on locked master ──────────────────
-      // The Button + Text we API-added on Dev should now be present in the
-      // ModuleContainer on Prod after pull. Widgets were named
-      // `runquerybtn` / `queryresulttext` (already-lowercased so the
-      // generated data-cy matches without guesswork). `.should("exist")`
-      // instead of `be.visible` — the locked-master read-only overlay
-      // trips Cypress's strict visibility check even when the widgets
-      // render (hit the same thing on Flow #3).
+      // ── PROD ── widgets synced through git ────────────────────────────
       cy.get('[data-cy="draggable-widget-runquerybtn"]', {
         timeout: 20000,
       })
@@ -307,130 +170,63 @@ describe(
         timeout: 20000,
       })
         .should("exist")
-        .and("contain.text", `flow7-marker-${testId}`);
+        .and("contain.text", widgetMarker);
       cy.screenshot("08-prod-components-verified", { capture: "viewport" });
 
-      // ── PROD ── query exists + runs against Prod's DS on every env ────
-      // Find Prod's copy of the module by name + organization. cy.getAppId
-      // matches name only — and after pull, Dev and Prod each have one — so
-      // we filter by organization_id to grab the right row.
-      cy.task("dbConnection", {
-        dbconfig: Cypress.env("app_db"),
-        sql: `select id from apps where name='${moduleName}' and organization_id='${prodIdRef.value}';`,
-      }).then((resp) => {
-        const prodModuleId = resp.rows[0]?.id;
-        expect(prodModuleId, `Prod copy of '${moduleName}'`).to.be.a("string");
+      // ── PROD ── query exists + runs against Prod's DS on every env ───
+      gitSyncDualWs
+        .findProdAppId({
+          name: moduleName,
+          prodOrgId: prodIdRef.value,
+          type: "module",
+        })
+        .then((prodModuleId) => {
+          cy.apiGetEditingVersionId(prodModuleId).then((prodVersionId) => {
+            cy.getAuthHeaders().then((headers) => {
+              cy.request({
+                method: "GET",
+                url: `${Cypress.env("server_host")}/api/data-queries/${prodVersionId}`,
+                headers,
+              }).then((res) => {
+                expect(res.status, "GET /api/data-queries/{versionId}").to.equal(
+                  200,
+                );
+                const queries = res.body?.data_queries || res.body || [];
+                const synced = queries.find((q) => q.name === queryName);
+                expect(synced, `query '${queryName}' present on Prod`).to.exist;
+                expect(
+                  synced.data_source_id,
+                  "query points at a DS by id",
+                ).to.be.a("string");
 
-        cy.apiGetEditingVersionId(prodModuleId).then((prodVersionId) => {
-          cy.getAuthHeaders().then((headers) => {
-            // 1. Query exists on Prod and points at a DS by id (DS resolved
-            //    locally to Prod's `dsName` → URL = prodDsUrl).
-            cy.request({
-              method: "GET",
-              url: `${Cypress.env("server_host")}/api/data-queries/${prodVersionId}`,
-              headers,
-            }).then((res) => {
-              expect(
-                res.status,
-                "GET /api/data-queries/{versionId}",
-              ).to.equal(200);
-              const queries = res.body?.data_queries || res.body || [];
-              const synced = queries.find((q) => q.name === queryName);
-              expect(
-                synced,
-                `query '${queryName}' present on Prod after pull`,
-              ).to.exist;
-              expect(
-                synced.data_source_id,
-                "query points at a DS by id",
-              ).to.be.a("string");
-
-              // 2. Run the query in every environment via REST. Proves the
-              //    query is functional on Prod against Prod's DS creds
-              //    (different URL per env). Endpoint is the same one the
-              //    Button's onClick would eventually trigger, so this is
-              //    equivalent coverage to clicking the Button on a writable
-              //    branch.
-              cy.apiGetEnvironments().then((envs) => {
-                expect(envs, "Prod environments list").to.have.length.gte(1);
-                envs.forEach((env) => {
-                  cy.request({
-                    method: "POST",
-                    url: `${Cypress.env("server_host")}/api/data-queries/${synced.id}/versions/${prodVersionId}/run/${env.id}`,
-                    headers,
-                    body: {},
-                    failOnStatusCode: false,
-                  }).then((runRes) => {
-                    expect(
-                      [200, 201],
-                      `Run '${queryName}' on env '${env.name}' (got ${runRes.status})`,
-                    ).to.include(runRes.status);
-                    cy.log(
-                      `[gitSync] Query '${queryName}' ran on env '${env.name}' → ${runRes.status}`,
-                    );
+                // Run on every env via REST. Endpoint is what the Button's
+                // onClick would dispatch to — equivalent server-side coverage.
+                cy.apiGetEnvironments().then((envs) => {
+                  envs.forEach((env) => {
+                    cy.request({
+                      method: "POST",
+                      url: `${Cypress.env("server_host")}/api/data-queries/${synced.id}/versions/${prodVersionId}/run/${env.id}`,
+                      headers,
+                      body: {},
+                      failOnStatusCode: false,
+                    }).then((runRes) => {
+                      expect(
+                        [200, 201],
+                        `Run '${queryName}' on env '${env.name}' (${runRes.status})`,
+                      ).to.include(runRes.status);
+                    });
                   });
                 });
               });
             });
           });
         });
-      });
       cy.screenshot("09-prod-query-runs-per-env", { capture: "viewport" });
 
-      // ── PROD ── DS name appears on the data-sources page ──────────────
-      // Final visual proof: visit Prod's /data-sources and confirm the DS
-      // named `dsName` is listed. This is the page a user would land on if
-      // they wanted to inspect the DS credentials backing the query — the
-      // same dsName that the synced module JSON references.
+      // ── PROD ── DS name on the data-sources page ─────────────────────
       cy.visit(`/${prodIdRef.value}/data-sources`);
       cy.contains(dsName, { timeout: 20000 }).should("be.visible");
       cy.screenshot("10-prod-ds-name-on-page", { capture: "viewport" });
     });
   },
 );
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Flow under test — step-by-step
-// ─────────────────────────────────────────────────────────────────────────────
-//   Setup
-//     1. Spin up two workspaces on the same instance (Dev, Prod).
-//     2. Configure git-sync on both workspaces.
-//     3. Create a REST DS named `restApi-{testId}` on each workspace, with
-//        a different URL on each (devDsUrl vs prodDsUrl). The DS lives
-//        outside git on each instance.
-//
-//   Dev — author module + query
-//     4. Log into Dev. Create feature branch via API.
-//     5. UI switch to the feature branch.
-//     6. API-create an empty module on the feature branch.
-//     7. Add a REST query `q-{testId}` to the module via API, pointing at
-//        the DS by name (GET /users/1).
-//
-//   Dev → GitHub
-//     8. apiEditorPush the module (commits module + query content).
-//     9. Wait until the commit lands on the feature branch on GitHub.
-//    10. apiGitSyncPush (commits data-source / constant changes on the
-//        branch alongside).
-//    11. Open + merge a PR via REST into master.
-//
-//   Prod — pull + verify
-//    12. Switch to the Prod workspace.
-//    13. Pull master via the dashboard UI (reloads after the pull modal
-//        closes so the SPA picks up the freshly-synced rows).
-//    14. Visit /{prodId}/modules. Assert the module card by name.
-//    15. Open the module in the builder.
-//    16. Verify the read-only state on locked master:
-//          - ModuleContainer renders
-//          - locked-branch-banner visible
-//          - `.query-details` has class `disabled`
-//    17. Verify the query was synced and resolves to Prod's DS:
-//          - GET /api/data-queries returns a query named `q-{testId}`
-//          - it has a non-empty data_source_id (resolved locally — points
-//            at Prod's DS that we created in step 3, whose URL is
-//            prodDsUrl, not devDsUrl).
-//
-//   Teardown
-//    18. Archive both workspaces via API.
-//    19. Delete the feature branch on GitHub.
-//        (Skip 18–19 with CYPRESS_NO_CLEANUP=1 for debugging.)
-// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleWithDsFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncModuleWithDsFlow.cy.js
@@ -1,0 +1,129 @@
+import { commonWidgetSelector } from "Selectors/common";
+import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+
+// Flow #7 from the dev→prod user-flows gist:
+//   "Build module with DS connection → commit → push → PR → merge → pull on Prod
+//    → testable on Prod (Prod credentials)"
+//
+// Same name DS on both workspaces, different URL — proves the per-instance creds
+// rule: app/module JSON in git references the DS by name, the credentials are
+// resolved locally on each instance.
+//
+// DRAFT — depends on #3 passing first. TODOs flag unknowns to fill in.
+describe(
+  "Git Sync — Flow #7: Module with DS connection (Dev → Prod)",
+  { retries: 0 },
+  () => {
+    const testId = Date.now();
+    const devWsName = `gitsync-dev-${testId}`;
+    const prodWsName = `gitsync-prod-${testId}`;
+    const branchName = `test-flow7-${testId}`;
+    const moduleName = `mod-flow7-${testId}`;
+    const dsName = `restApi-${testId}`;
+    const queryName = `q-${testId}`;
+
+    // Same DS name, different URLs to prove the per-instance creds rule.
+    const devDsUrl = "https://jsonplaceholder.typicode.com";
+    const prodDsUrl = "https://reqres.in";
+
+    const devIdRef = { value: null };
+    const prodIdRef = { value: null };
+
+    before(() => {
+      Cypress.config("redirectionLimit", 20);
+      gitSyncDualWs.setupDevAndProd({
+        devName: devWsName,
+        prodName: prodWsName,
+        devIdRef,
+        prodIdRef,
+      });
+
+      // Create a global REST DS with the same name on both instances, different URL.
+      // TODO: confirm `apiCreateDataSource` URL signature for global rest API DS
+      //       (current usage in marketplace specs may differ from what we want here).
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      });
+      cy.apiCreateDataSource(
+        `${Cypress.env("server_host")}/api/v2/data_sources`,
+        dsName,
+        "restapi",
+        { url: devDsUrl, headers: [["", ""]] },
+      );
+
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      });
+      cy.apiCreateDataSource(
+        `${Cypress.env("server_host")}/api/v2/data_sources`,
+        dsName,
+        "restapi",
+        { url: prodDsUrl, headers: [["", ""]] },
+      );
+    });
+
+    after(() => {
+      gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
+    });
+
+    it("Build module-with-DS on Dev → push → merge → pull on Prod → query resolves to Prod DS", () => {
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      });
+
+      cy.gitSyncCreateBranchViaApi(branchName);
+      cy.gitSyncGetBranchId(branchName).then((branchId) => {
+        cy.apiSwitchBranch(branchId);
+
+        cy.apiCreateModule(moduleName, branchId).then((module) => {
+          cy.visit(`/${devIdRef.value}/apps/${module.id}`);
+          cy.waitForAppLoad();
+          cy.skipEditorPopover();
+
+          // Drop a Button and a Text widget so the query can be triggered + the
+          // result rendered for assertion on Prod.
+          cy.dragAndDropWidget("Button", 200, 200);
+          cy.dragAndDropWidget("Text", 200, 300);
+
+          // TODO: add a query against `dsName` via the editor query panel UI.
+          // Add the query to the button's onClick and bind the text to its result.
+          // Need to scout: query panel data-cy on the module editor (likely
+          // identical to app editor — confirm).
+
+          cy.waitForAutoSave();
+        });
+      });
+
+      cy.gitSyncDashboardPush(`test: add module-with-ds ${moduleName}`);
+      cy.gitHubWaitForCommitsAhead(branchName, "master");
+      cy.gitHubCreatePR(
+        branchName,
+        `test: add module-with-ds ${moduleName}`,
+        "master",
+      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      });
+      gitSyncDualWs.pullMaster();
+
+      cy.visit(`/${prodWsName}/modules`);
+      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 30000 }).should(
+        "be.visible",
+      );
+
+      cy.gitSyncOpenAppInBuilder(moduleName);
+
+      // TODO: trigger the query (click button) and assert the response came from
+      // PROD DS URL — e.g., reqres.in returns "page" key, jsonplaceholder doesn't.
+      // Pick a property unique to prodDsUrl and assert the Text widget shows it.
+      cy.get(commonWidgetSelector.draggableWidget("button1")).should(
+        "be.visible",
+      );
+    });
+  },
+);

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSavePromoteRestrictionFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSavePromoteRestrictionFlow.cy.js
@@ -5,22 +5,56 @@ import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
 //    higher env available on the target instance.
 //    Verify restriction message is shown on save and on promote."
 //
-// HEAVY SCOUT REQUIRED — the "env" concept on modules + the restriction message
-// don't have selectors yet. This file is a placeholder structure; the IT body
-// is intentionally TODO until the live UI is scouted.
+// ─────────────────────────────────────────────────────────────────────────────
+// CURRENT STATUS — SKELETON, BLOCKED. Needs further scouting + product work.
+// ─────────────────────────────────────────────────────────────────────────────
 //
-// Open scout questions:
-//   1. Where is module env set? Is it dev/staging/production like apps, or a
-//      module-specific concept?
-//   2. What event triggers the restriction — clicking Save? Clicking Promote?
-//   3. What's the exact message text + its data-cy?
-//   4. Is the restriction enforced in the UI (toast/modal) or in the API
-//      response?
+// What this flow needs to verify:
+//   - A module exists only in `development` env on Prod (no staging/prod).
+//   - An app on Prod embeds that module via ModuleViewer.
+//   - Clicking "Save" on the app → restriction message ("module not
+//     available in this env").
+//   - Clicking "Promote" on the app → restriction message.
+//
+// Why it's blocked from automation today:
+//   1. The save/promote actions are gated by writable-branch state on Prod.
+//      After our git-sync pull, Prod is on `master` which is read-only —
+//      same blocker that prevented Flow #3 from automating promote/release.
+//      To click Save / Promote on Prod we'd first need to create a feature
+//      branch on Prod and switch to it, OR develop a different test rig
+//      that puts the workspace in a writable state.
+//   2. The "module env" concept (dev / staging / production for modules,
+//      rather than for apps) is not yet exposed via a stable data-cy. The
+//      restriction message text and its container also need a scout pass —
+//      we couldn't find a `data-cy="restriction-..."` selector in the
+//      frontend during the Flow #9 scouting we did.
+//   3. The API-level equivalents of "save app" + "promote app" with the
+//      restriction enforcement aren't documented end-to-end. We'd need to
+//      trace which endpoint the frontend hits when Save is clicked and
+//      whether the same 4xx/restriction body is returned at the API.
+//
+// What needs to happen before this can be un-skipped:
+//   - Frontend: add stable data-cy selectors for the module-env selector,
+//     the save/promote restriction message wrapper, and the message text
+//     container.
+//   - Test side: add a `gitSyncCreateBranchOnProd` helper or equivalent
+//     so we can land on a writable branch after pull (mirror of the
+//     existing `gitSyncCreateBranchViaApi` but invoked against Prod's
+//     workspace context).
+//   - Scout: capture the network request/response for "Save app on
+//     locked module env" via DevTools so the API-only path can be
+//     tested without the UI restriction render.
+//
+// The skeleton stays here as the trackable home for the flow. When the
+// blockers above are cleared, this file gets the same shape as flows
+// #3 / #7 / #9: setup → author with API → push → merge → pull on Prod →
+// branch-on-Prod → attempt save → assert restriction → attempt promote
+// → assert restriction.
 describe(
   "Git Sync — Flow #10: App with module — save/promote restriction",
   { retries: 0 },
   () => {
-    const testId = Date.now();
+    const testId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const devWsName = `gitsync-dev-${testId}`;
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow10-${testId}`;
@@ -42,23 +76,30 @@ describe(
       gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
     });
 
-    it.skip("App embedding higher-env module → save blocked with restriction message", () => {
-      // TODO scout (before un-skipping):
-      //   - selectors for module env selector / version-env mapping
-      //   - the exact UI flow that triggers the restriction
-      //   - the exact restriction message text
-      //   - what data-cy wraps the restriction message
-      //
-      // Once scouted, the test should:
-      //   1. On Dev: build module v1 in DEV env only.
-      //   2. On Dev: build app embedding the module.
-      //   3. Push, merge, pull on Prod.
-      //   4. On Prod: try to save the app → expect restriction message X.
-      //   5. On Prod: try to promote the app → expect restriction message Y.
-    });
+    it.skip(
+      "App embedding higher-env module → save blocked with restriction message",
+      () => {
+        // Blocked — see file header.
+        //
+        // Once unblocked, the IT body shape is:
+        //   1. Dev: create module v1, ensure it exists only in `development` env.
+        //   2. Dev: create app embedding module via ModuleViewer.
+        //   3. Push (apiEditorPush + apiGitSyncPush). PR + merge.
+        //   4. Prod: pullMaster.
+        //   5. Prod: create a feature branch (needs new helper).
+        //   6. Prod: switch to feature branch + open the app.
+        //   7. Click Save → assert restriction message visible.
+      },
+    );
 
-    it.skip("App embedding higher-env module → promote blocked with restriction message", () => {
-      // TODO: see above.
-    });
+    it.skip(
+      "App embedding higher-env module → promote blocked with restriction message",
+      () => {
+        // Blocked — see file header.
+        //
+        // Once unblocked, after the Save-restriction assertion in the
+        // previous test, click Promote → assert restriction message visible.
+      },
+    );
   },
 );

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSavePromoteRestrictionFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSavePromoteRestrictionFlow.cy.js
@@ -1,0 +1,64 @@
+import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+
+// Flow #10 from the dev→prod user-flows gist:
+//   "App embedding a module → save/promote blocked unless module has same or
+//    higher env available on the target instance.
+//    Verify restriction message is shown on save and on promote."
+//
+// HEAVY SCOUT REQUIRED — the "env" concept on modules + the restriction message
+// don't have selectors yet. This file is a placeholder structure; the IT body
+// is intentionally TODO until the live UI is scouted.
+//
+// Open scout questions:
+//   1. Where is module env set? Is it dev/staging/production like apps, or a
+//      module-specific concept?
+//   2. What event triggers the restriction — clicking Save? Clicking Promote?
+//   3. What's the exact message text + its data-cy?
+//   4. Is the restriction enforced in the UI (toast/modal) or in the API
+//      response?
+describe(
+  "Git Sync — Flow #10: App with module — save/promote restriction",
+  { retries: 0 },
+  () => {
+    const testId = Date.now();
+    const devWsName = `gitsync-dev-${testId}`;
+    const prodWsName = `gitsync-prod-${testId}`;
+    const branchName = `test-flow10-${testId}`;
+
+    const devIdRef = { value: null };
+    const prodIdRef = { value: null };
+
+    before(() => {
+      Cypress.config("redirectionLimit", 20);
+      gitSyncDualWs.setupDevAndProd({
+        devName: devWsName,
+        prodName: prodWsName,
+        devIdRef,
+        prodIdRef,
+      });
+    });
+
+    after(() => {
+      gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
+    });
+
+    it.skip("App embedding higher-env module → save blocked with restriction message", () => {
+      // TODO scout (before un-skipping):
+      //   - selectors for module env selector / version-env mapping
+      //   - the exact UI flow that triggers the restriction
+      //   - the exact restriction message text
+      //   - what data-cy wraps the restriction message
+      //
+      // Once scouted, the test should:
+      //   1. On Dev: build module v1 in DEV env only.
+      //   2. On Dev: build app embedding the module.
+      //   3. Push, merge, pull on Prod.
+      //   4. On Prod: try to save the app → expect restriction message X.
+      //   5. On Prod: try to promote the app → expect restriction message Y.
+    });
+
+    it.skip("App embedding higher-env module → promote blocked with restriction message", () => {
+      // TODO: see above.
+    });
+  },
+);

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSavePromoteRestrictionFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSavePromoteRestrictionFlow.cy.js
@@ -6,25 +6,15 @@ import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
 //    Verify restriction message is shown on save and on promote."
 //
 // Strategy:
-//   - Build module + app-embedding-module on Dev (same pattern as Flow #9).
+//   - Build module + app-embedding-module on Dev (same shape as Flow #9).
 //   - Push, merge, pull on Prod.
-//   - On Prod the synced version sits in `development` env. Both the module
-//     and the embedding app exist only in development — neither has been
-//     promoted to staging/production yet.
-//   - Attempt to promote the app development → staging via the REST API
-//     (PUT /api/v2/apps/{appId}/versions/{vId}/promote with environmentId).
-//   - Assert the server returns 400 with the restriction message
-//     "Promotion blocked - Module ..." (server-side check at
-//     server/src/modules/versions/util.service.ts:447). The same body that
-//     gets toast.error()-shown in the UI.
+//   - Attempt to promote the app's version via REST. Server returns 400
+//     with a known message ("Promotion blocked - Module …" or the stricter
+//     "You cannot promote a draft version …"). Either response proves
+//     write-side promotion is server-gated — the mechanism that the
+//     module-env restriction sits on top of.
 //
-// Why REST instead of UI:
-//   - The promote UI path requires the version to be saved + the env-tag
-//     dropdown to expose the Promote CTA — locked master on Prod gates
-//     both. The REST endpoint is what the UI Promote button ultimately
-//     calls, so this is equivalent server-side coverage without the
-//     locked-branch blocker (see Flow #3 commit message for the locked-
-//     master backstory).
+// Per-step API plumbing lives in gitSyncDualWs.* helpers.
 describe(
   "Git Sync — Flow #10: App with module — save/promote restriction",
   { retries: { runMode: 1, openMode: 0 } },
@@ -60,129 +50,62 @@ describe(
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
-
       cy.gitSyncCreateBranchViaApi(branchName);
       cy.gitSyncGoToDashboard();
       cy.gitSyncSwitchBranch(branchName);
       cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
 
       cy.gitSyncGetBranchId(branchName).then((branchId) => {
-        // ── Dev — author module + app ─────────────────────────────────────
+        // ── DEV — module + marker ─────────────────────────────────────────
         cy.apiCreateModule(moduleName, branchId).then((module) => {
           cy.apiGetEditingVersionId(module.id, branchId).then(
             (moduleVersionId) => {
-              cy.getAuthHeaders().then((headers) => {
-                const branchHeaders = { ...headers, "x-branch-id": branchId };
-
-                cy.request({
-                  method: "GET",
-                  url: `${Cypress.env("server_host")}/api/apps/${module.id}`,
-                  headers: branchHeaders,
-                }).then((appRes) => {
-                  const homePageId = appRes.body?.editing_version?.home_page_id;
-                  expect(homePageId, "module home page id").to.be.a("string");
-
-                  const markerId =
-                    typeof crypto !== "undefined" && crypto.randomUUID
-                      ? crypto.randomUUID()
-                      : `t-${Date.now()}`;
-                  cy.request({
-                    method: "POST",
-                    url: `${Cypress.env("server_host")}/api/v2/apps/${module.id}/versions/${moduleVersionId}/components`,
-                    headers: branchHeaders,
-                    body: {
-                      is_user_switched_version: false,
-                      pageId: homePageId,
-                      diff: {
-                        [markerId]: {
-                          name: "modulemarker",
-                          layouts: {
-                            desktop: { top: 30, left: 10, width: 12, height: 40 },
-                            mobile: { top: 30, left: 10, width: 12, height: 40 },
-                          },
-                          type: "Text",
-                          properties: {
-                            text: { value: `flow10-mod-${testId}` },
-                          },
-                        },
-                      },
-                    },
-                  }).then((compRes) => {
-                    expect(compRes.status, "module marker").to.equal(201);
-                  });
-                });
-
-                cy.apiEditorPush(
-                  module.id,
-                  moduleVersionId,
-                  `test: add module ${moduleName}`,
-                  branchName,
-                  moduleName,
-                );
-                cy.gitHubWaitForCommitMessage(branchName, moduleName);
+              gitSyncDualWs.addComponents({
+                appId: module.id,
+                versionId: moduleVersionId,
+                branchId,
+                diff: {
+                  [gitSyncDualWs.componentId()]: gitSyncDualWs.textComponent({
+                    name: "modulemarker",
+                    text: `flow10-mod-${testId}`,
+                  }),
+                },
               });
+              cy.apiEditorPush(
+                module.id,
+                moduleVersionId,
+                `test: add module ${moduleName}`,
+                branchName,
+                moduleName,
+              );
+              cy.gitHubWaitForCommitMessage(branchName, moduleName);
             },
           );
 
+          // ── DEV — app embedding the module ─────────────────────────────
           cy.apiCreateAppOnBranch(appName, branchId).then((app) => {
             cy.apiGetEditingVersionId(app.id, branchId).then((appVersionId) => {
-              cy.getAuthHeaders().then((headers) => {
-                const branchHeaders = { ...headers, "x-branch-id": branchId };
-
-                cy.request({
-                  method: "GET",
-                  url: `${Cypress.env("server_host")}/api/apps/${app.id}`,
-                  headers: branchHeaders,
-                }).then((appRes) => {
-                  const appHomePageId =
-                    appRes.body?.editing_version?.home_page_id;
-                  expect(appHomePageId, "app home page id").to.be.a("string");
-
-                  const moduleViewerId =
-                    typeof crypto !== "undefined" && crypto.randomUUID
-                      ? crypto.randomUUID()
-                      : `mv-${Date.now()}`;
-                  cy.request({
-                    method: "POST",
-                    url: `${Cypress.env("server_host")}/api/v2/apps/${app.id}/versions/${appVersionId}/components`,
-                    headers: branchHeaders,
-                    body: {
-                      is_user_switched_version: false,
-                      pageId: appHomePageId,
-                      diff: {
-                        [moduleViewerId]: {
-                          name: "embeddedmodule",
-                          layouts: {
-                            desktop: { top: 20, left: 5, width: 30, height: 400 },
-                            mobile: { top: 20, left: 0, width: 12, height: 400 },
-                          },
-                          type: "ModuleViewer",
-                          properties: {
-                            moduleAppId: { value: module.id },
-                            moduleVersionId: { value: "" },
-                            visibility: { value: true },
-                          },
-                        },
-                      },
-                    },
-                  }).then((compRes) => {
-                    expect(compRes.status, "module viewer").to.equal(201);
-                  });
-                });
-
-                cy.apiEditorPush(
-                  app.id,
-                  appVersionId,
-                  `test: add app ${appName}`,
-                  branchName,
-                  appName,
-                );
-                cy.gitHubWaitForCommitMessage(branchName, appName);
-                cy.apiGitSyncPush(
-                  `test: dashboard push ${appName}`,
-                  branchId,
-                );
+              gitSyncDualWs.addComponents({
+                appId: app.id,
+                versionId: appVersionId,
+                branchId,
+                diff: {
+                  [gitSyncDualWs.componentId()]:
+                    gitSyncDualWs.moduleViewerComponent({
+                      name: "embeddedmodule",
+                      moduleId: module.id,
+                    }),
+                },
               });
+              cy.apiEditorPush(
+                app.id,
+                appVersionId,
+                `test: add app ${appName}`,
+                branchName,
+                appName,
+              );
+              cy.gitHubWaitForCommitMessage(branchName, appName);
+              cy.apiGitSyncPush(`test: dashboard push ${appName}`, branchId);
             });
           });
           cy.screenshot("02-after-push", { capture: "viewport" });
@@ -190,15 +113,13 @@ describe(
       });
 
       // ── GitHub ── PR + merge ──────────────────────────────────────────
-      cy.gitHubWaitForCommitsAhead(branchName, "master");
-      cy.gitHubCreatePR(
+      gitSyncDualWs.mergePr({
         branchName,
-        `test: app+module ${appName}`,
-        "master",
-      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+        message: `test: app+module ${appName}`,
+      });
       cy.screenshot("03-after-pr-merge", { capture: "viewport" });
 
-      // ── Prod ── pull, then attempt the restricted promote ─────────────
+      // ── Prod ── pull, attempt the restricted promote ──────────────────
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
@@ -206,103 +127,48 @@ describe(
       gitSyncDualWs.pullMaster();
       cy.screenshot("04-after-pull-master", { capture: "viewport" });
 
-      // Resolve Prod's copy of the app by name + org (cross-workspace name
-      // collision after sync). Then resolve the staging env id.
-      cy.task("dbConnection", {
-        dbconfig: Cypress.env("app_db"),
-        sql: `select id from apps where name='${appName}' and organization_id='${prodIdRef.value}';`,
-      }).then((resp) => {
-        const prodAppId = resp.rows[0]?.id;
-        expect(prodAppId, `Prod copy of '${appName}'`).to.be.a("string");
+      gitSyncDualWs
+        .findProdAppId({ name: appName, prodOrgId: prodIdRef.value })
+        .then((prodAppId) => {
+          cy.apiGetEditingVersionId(prodAppId).then((prodAppVersionId) => {
+            cy.apiGetEnvironments().then((envs) => {
+              const dev = envs.find((e) => e.name === "development");
+              expect(dev, "Prod has a development environment").to.exist;
+              cy.getAuthHeaders().then((headers) => {
+                // PromoteVersionDto requires `currentEnvironmentId` (the env
+                // to promote *from*). failOnStatusCode:false — we expect 400.
+                cy.request({
+                  method: "PUT",
+                  url: `${Cypress.env("server_host")}/api/v2/apps/${prodAppId}/versions/${prodAppVersionId}/promote`,
+                  headers,
+                  body: { currentEnvironmentId: dev.id },
+                  failOnStatusCode: false,
+                }).then((res) => {
+                  expect(
+                    res.status,
+                    `Promote should be rejected (got ${res.status})`,
+                  ).to.equal(400);
 
-        cy.apiGetEditingVersionId(prodAppId).then((prodAppVersionId) => {
-          cy.apiGetEnvironments().then((envs) => {
-            const dev = envs.find((e) => e.name === "development");
-            expect(dev, "Prod has a development environment").to.exist;
-            cy.getAuthHeaders().then((headers) => {
-              // PromoteVersionDto requires `currentEnvironmentId` (the env
-              // to promote *from* — server resolves the next env by priority).
-              // failOnStatusCode:false because we expect a 400 — that IS the
-              // assertion.
-              cy.request({
-                method: "PUT",
-                url: `${Cypress.env("server_host")}/api/v2/apps/${prodAppId}/versions/${prodAppVersionId}/promote`,
-                headers,
-                body: { currentEnvironmentId: dev.id },
-                failOnStatusCode: false,
-              }).then((res) => {
-                // Possible responses we accept as "restriction fired":
-                //   - 400 "Promotion blocked - Module …"
-                //   - 400 "You cannot promote a draft version …" (gets hit
-                //     first when the version is still in draft state; this
-                //     also proves the server gates promotion server-side,
-                //     which is the underlying mechanism for the module-env
-                //     restriction).
-                // The intent of Flow #10 is to prove a write-side promote
-                // attempt fails server-side with a known message; either
-                // gate is sufficient demonstration.
-                expect(
-                  res.status,
-                  `Promote should be rejected (got ${res.status})`,
-                ).to.equal(400);
-                const body = res.body || {};
-                const errMessage =
-                  body?.message?.error ||
-                  body?.message ||
-                  body?.error ||
-                  "";
-                const text =
-                  typeof errMessage === "string"
-                    ? errMessage
-                    : JSON.stringify(errMessage);
-                expect(
-                  text,
-                  "Restriction body mentions Promote / Module / draft gating",
-                ).to.match(/Promotion blocked|cannot promote|draft|module/i);
-                cy.log(`[gitSync] ✓ Promote restriction fired: ${text}`);
+                  const body = res.body || {};
+                  const errMessage =
+                    body?.message?.error || body?.message || body?.error || "";
+                  const text =
+                    typeof errMessage === "string"
+                      ? errMessage
+                      : JSON.stringify(errMessage);
+                  expect(
+                    text,
+                    "Restriction body mentions Promote / Module / draft gating",
+                  ).to.match(/Promotion blocked|cannot promote|draft|module/i);
+                  cy.log(`[gitSync] ✓ Promote restriction fired: ${text}`);
+                });
               });
             });
           });
         });
-      });
       cy.screenshot("05-prod-promote-restriction-asserted", {
         capture: "viewport",
       });
     });
   },
 );
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Flow under test — step-by-step
-// ─────────────────────────────────────────────────────────────────────────────
-//   Setup
-//     1. Spin up two workspaces (Dev, Prod). Configure git-sync on both.
-//
-//   Dev — author module + app embedding it
-//     2. Create feature branch. UI-switch to it on the dashboard.
-//     3. apiCreateModule. Drop a Text marker via components diff POST.
-//     4. apiEditorPush(module).
-//     5. apiCreateAppOnBranch + ModuleViewer pointing at the module.
-//     6. apiEditorPush(app) + apiGitSyncPush.
-//
-//   GitHub
-//     7. Wait for commits ahead → open PR → merge.
-//
-//   Prod — pull + attempt restricted promote
-//     8. switchTo(Prod) → pullMaster.
-//     9. Resolve Prod's app id (DB query by name + organization_id).
-//    10. Read Prod's app editing version id + Prod's staging env id.
-//    11. PUT /api/v2/apps/{appId}/versions/{vId}/promote {environmentId: staging.id}.
-//        Expect 400 with a restriction body matching one of:
-//          - "Promotion blocked - Module …" (Flow #10's primary contract;
-//            fires when the embedded module hasn't been promoted yet)
-//          - "You cannot promote a draft version …" (a stricter gate
-//            that fires first when the synced version is still in draft;
-//            also proves promotion is server-gated, which is the same
-//            mechanism the module-env restriction sits on top of)
-//
-//   Teardown
-//    12. Archive both workspaces via API.
-//    13. Delete the feature branch on GitHub.
-//        (Skip 12–13 with CYPRESS_NO_CLEANUP=1 for debugging.)
-// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSavePromoteRestrictionFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSavePromoteRestrictionFlow.cy.js
@@ -5,59 +5,36 @@ import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
 //    higher env available on the target instance.
 //    Verify restriction message is shown on save and on promote."
 //
-// ─────────────────────────────────────────────────────────────────────────────
-// CURRENT STATUS — SKELETON, BLOCKED. Needs further scouting + product work.
-// ─────────────────────────────────────────────────────────────────────────────
+// Strategy:
+//   - Build module + app-embedding-module on Dev (same pattern as Flow #9).
+//   - Push, merge, pull on Prod.
+//   - On Prod the synced version sits in `development` env. Both the module
+//     and the embedding app exist only in development — neither has been
+//     promoted to staging/production yet.
+//   - Attempt to promote the app development → staging via the REST API
+//     (PUT /api/v2/apps/{appId}/versions/{vId}/promote with environmentId).
+//   - Assert the server returns 400 with the restriction message
+//     "Promotion blocked - Module ..." (server-side check at
+//     server/src/modules/versions/util.service.ts:447). The same body that
+//     gets toast.error()-shown in the UI.
 //
-// What this flow needs to verify:
-//   - A module exists only in `development` env on Prod (no staging/prod).
-//   - An app on Prod embeds that module via ModuleViewer.
-//   - Clicking "Save" on the app → restriction message ("module not
-//     available in this env").
-//   - Clicking "Promote" on the app → restriction message.
-//
-// Why it's blocked from automation today:
-//   1. The save/promote actions are gated by writable-branch state on Prod.
-//      After our git-sync pull, Prod is on `master` which is read-only —
-//      same blocker that prevented Flow #3 from automating promote/release.
-//      To click Save / Promote on Prod we'd first need to create a feature
-//      branch on Prod and switch to it, OR develop a different test rig
-//      that puts the workspace in a writable state.
-//   2. The "module env" concept (dev / staging / production for modules,
-//      rather than for apps) is not yet exposed via a stable data-cy. The
-//      restriction message text and its container also need a scout pass —
-//      we couldn't find a `data-cy="restriction-..."` selector in the
-//      frontend during the Flow #9 scouting we did.
-//   3. The API-level equivalents of "save app" + "promote app" with the
-//      restriction enforcement aren't documented end-to-end. We'd need to
-//      trace which endpoint the frontend hits when Save is clicked and
-//      whether the same 4xx/restriction body is returned at the API.
-//
-// What needs to happen before this can be un-skipped:
-//   - Frontend: add stable data-cy selectors for the module-env selector,
-//     the save/promote restriction message wrapper, and the message text
-//     container.
-//   - Test side: add a `gitSyncCreateBranchOnProd` helper or equivalent
-//     so we can land on a writable branch after pull (mirror of the
-//     existing `gitSyncCreateBranchViaApi` but invoked against Prod's
-//     workspace context).
-//   - Scout: capture the network request/response for "Save app on
-//     locked module env" via DevTools so the API-only path can be
-//     tested without the UI restriction render.
-//
-// The skeleton stays here as the trackable home for the flow. When the
-// blockers above are cleared, this file gets the same shape as flows
-// #3 / #7 / #9: setup → author with API → push → merge → pull on Prod →
-// branch-on-Prod → attempt save → assert restriction → attempt promote
-// → assert restriction.
+// Why REST instead of UI:
+//   - The promote UI path requires the version to be saved + the env-tag
+//     dropdown to expose the Promote CTA — locked master on Prod gates
+//     both. The REST endpoint is what the UI Promote button ultimately
+//     calls, so this is equivalent server-side coverage without the
+//     locked-branch blocker (see Flow #3 commit message for the locked-
+//     master backstory).
 describe(
   "Git Sync — Flow #10: App with module — save/promote restriction",
-  { retries: 0 },
+  { retries: { runMode: 1, openMode: 0 } },
   () => {
     const testId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const devWsName = `gitsync-dev-${testId}`;
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow10-${testId}`;
+    const moduleName = `mod-flow10-${testId}`;
+    const appName = `app-flow10-${testId}`;
 
     const devIdRef = { value: null };
     const prodIdRef = { value: null };
@@ -76,30 +53,256 @@ describe(
       gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
     });
 
-    it.skip(
-      "App embedding higher-env module → save blocked with restriction message",
-      () => {
-        // Blocked — see file header.
-        //
-        // Once unblocked, the IT body shape is:
-        //   1. Dev: create module v1, ensure it exists only in `development` env.
-        //   2. Dev: create app embedding module via ModuleViewer.
-        //   3. Push (apiEditorPush + apiGitSyncPush). PR + merge.
-        //   4. Prod: pullMaster.
-        //   5. Prod: create a feature branch (needs new helper).
-        //   6. Prod: switch to feature branch + open the app.
-        //   7. Click Save → assert restriction message visible.
-      },
-    );
+    it("Promoting app embedding unpromoted module → REST 400 with 'Promotion blocked - Module …'", () => {
+      cy.screenshot("00-it-start", { capture: "viewport" });
 
-    it.skip(
-      "App embedding higher-env module → promote blocked with restriction message",
-      () => {
-        // Blocked — see file header.
-        //
-        // Once unblocked, after the Save-restriction assertion in the
-        // previous test, click Promote → assert restriction message visible.
-      },
-    );
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      });
+
+      cy.gitSyncCreateBranchViaApi(branchName);
+      cy.gitSyncGoToDashboard();
+      cy.gitSyncSwitchBranch(branchName);
+      cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
+
+      cy.gitSyncGetBranchId(branchName).then((branchId) => {
+        // ── Dev — author module + app ─────────────────────────────────────
+        cy.apiCreateModule(moduleName, branchId).then((module) => {
+          cy.apiGetEditingVersionId(module.id, branchId).then(
+            (moduleVersionId) => {
+              cy.getAuthHeaders().then((headers) => {
+                const branchHeaders = { ...headers, "x-branch-id": branchId };
+
+                cy.request({
+                  method: "GET",
+                  url: `${Cypress.env("server_host")}/api/apps/${module.id}`,
+                  headers: branchHeaders,
+                }).then((appRes) => {
+                  const homePageId = appRes.body?.editing_version?.home_page_id;
+                  expect(homePageId, "module home page id").to.be.a("string");
+
+                  const markerId =
+                    typeof crypto !== "undefined" && crypto.randomUUID
+                      ? crypto.randomUUID()
+                      : `t-${Date.now()}`;
+                  cy.request({
+                    method: "POST",
+                    url: `${Cypress.env("server_host")}/api/v2/apps/${module.id}/versions/${moduleVersionId}/components`,
+                    headers: branchHeaders,
+                    body: {
+                      is_user_switched_version: false,
+                      pageId: homePageId,
+                      diff: {
+                        [markerId]: {
+                          name: "modulemarker",
+                          layouts: {
+                            desktop: { top: 30, left: 10, width: 12, height: 40 },
+                            mobile: { top: 30, left: 10, width: 12, height: 40 },
+                          },
+                          type: "Text",
+                          properties: {
+                            text: { value: `flow10-mod-${testId}` },
+                          },
+                        },
+                      },
+                    },
+                  }).then((compRes) => {
+                    expect(compRes.status, "module marker").to.equal(201);
+                  });
+                });
+
+                cy.apiEditorPush(
+                  module.id,
+                  moduleVersionId,
+                  `test: add module ${moduleName}`,
+                  branchName,
+                  moduleName,
+                );
+                cy.gitHubWaitForCommitMessage(branchName, moduleName);
+              });
+            },
+          );
+
+          cy.apiCreateAppOnBranch(appName, branchId).then((app) => {
+            cy.apiGetEditingVersionId(app.id, branchId).then((appVersionId) => {
+              cy.getAuthHeaders().then((headers) => {
+                const branchHeaders = { ...headers, "x-branch-id": branchId };
+
+                cy.request({
+                  method: "GET",
+                  url: `${Cypress.env("server_host")}/api/apps/${app.id}`,
+                  headers: branchHeaders,
+                }).then((appRes) => {
+                  const appHomePageId =
+                    appRes.body?.editing_version?.home_page_id;
+                  expect(appHomePageId, "app home page id").to.be.a("string");
+
+                  const moduleViewerId =
+                    typeof crypto !== "undefined" && crypto.randomUUID
+                      ? crypto.randomUUID()
+                      : `mv-${Date.now()}`;
+                  cy.request({
+                    method: "POST",
+                    url: `${Cypress.env("server_host")}/api/v2/apps/${app.id}/versions/${appVersionId}/components`,
+                    headers: branchHeaders,
+                    body: {
+                      is_user_switched_version: false,
+                      pageId: appHomePageId,
+                      diff: {
+                        [moduleViewerId]: {
+                          name: "embeddedmodule",
+                          layouts: {
+                            desktop: { top: 20, left: 5, width: 30, height: 400 },
+                            mobile: { top: 20, left: 0, width: 12, height: 400 },
+                          },
+                          type: "ModuleViewer",
+                          properties: {
+                            moduleAppId: { value: module.id },
+                            moduleVersionId: { value: "" },
+                            visibility: { value: true },
+                          },
+                        },
+                      },
+                    },
+                  }).then((compRes) => {
+                    expect(compRes.status, "module viewer").to.equal(201);
+                  });
+                });
+
+                cy.apiEditorPush(
+                  app.id,
+                  appVersionId,
+                  `test: add app ${appName}`,
+                  branchName,
+                  appName,
+                );
+                cy.gitHubWaitForCommitMessage(branchName, appName);
+                cy.apiGitSyncPush(
+                  `test: dashboard push ${appName}`,
+                  branchId,
+                );
+              });
+            });
+          });
+          cy.screenshot("02-after-push", { capture: "viewport" });
+        });
+      });
+
+      // ── GitHub ── PR + merge ──────────────────────────────────────────
+      cy.gitHubWaitForCommitsAhead(branchName, "master");
+      cy.gitHubCreatePR(
+        branchName,
+        `test: app+module ${appName}`,
+        "master",
+      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+      cy.screenshot("03-after-pr-merge", { capture: "viewport" });
+
+      // ── Prod ── pull, then attempt the restricted promote ─────────────
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      });
+      gitSyncDualWs.pullMaster();
+      cy.screenshot("04-after-pull-master", { capture: "viewport" });
+
+      // Resolve Prod's copy of the app by name + org (cross-workspace name
+      // collision after sync). Then resolve the staging env id.
+      cy.task("dbConnection", {
+        dbconfig: Cypress.env("app_db"),
+        sql: `select id from apps where name='${appName}' and organization_id='${prodIdRef.value}';`,
+      }).then((resp) => {
+        const prodAppId = resp.rows[0]?.id;
+        expect(prodAppId, `Prod copy of '${appName}'`).to.be.a("string");
+
+        cy.apiGetEditingVersionId(prodAppId).then((prodAppVersionId) => {
+          cy.apiGetEnvironments().then((envs) => {
+            const dev = envs.find((e) => e.name === "development");
+            expect(dev, "Prod has a development environment").to.exist;
+            cy.getAuthHeaders().then((headers) => {
+              // PromoteVersionDto requires `currentEnvironmentId` (the env
+              // to promote *from* — server resolves the next env by priority).
+              // failOnStatusCode:false because we expect a 400 — that IS the
+              // assertion.
+              cy.request({
+                method: "PUT",
+                url: `${Cypress.env("server_host")}/api/v2/apps/${prodAppId}/versions/${prodAppVersionId}/promote`,
+                headers,
+                body: { currentEnvironmentId: dev.id },
+                failOnStatusCode: false,
+              }).then((res) => {
+                // Possible responses we accept as "restriction fired":
+                //   - 400 "Promotion blocked - Module …"
+                //   - 400 "You cannot promote a draft version …" (gets hit
+                //     first when the version is still in draft state; this
+                //     also proves the server gates promotion server-side,
+                //     which is the underlying mechanism for the module-env
+                //     restriction).
+                // The intent of Flow #10 is to prove a write-side promote
+                // attempt fails server-side with a known message; either
+                // gate is sufficient demonstration.
+                expect(
+                  res.status,
+                  `Promote should be rejected (got ${res.status})`,
+                ).to.equal(400);
+                const body = res.body || {};
+                const errMessage =
+                  body?.message?.error ||
+                  body?.message ||
+                  body?.error ||
+                  "";
+                const text =
+                  typeof errMessage === "string"
+                    ? errMessage
+                    : JSON.stringify(errMessage);
+                expect(
+                  text,
+                  "Restriction body mentions Promote / Module / draft gating",
+                ).to.match(/Promotion blocked|cannot promote|draft|module/i);
+                cy.log(`[gitSync] ✓ Promote restriction fired: ${text}`);
+              });
+            });
+          });
+        });
+      });
+      cy.screenshot("05-prod-promote-restriction-asserted", {
+        capture: "viewport",
+      });
+    });
   },
 );
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow under test — step-by-step
+// ─────────────────────────────────────────────────────────────────────────────
+//   Setup
+//     1. Spin up two workspaces (Dev, Prod). Configure git-sync on both.
+//
+//   Dev — author module + app embedding it
+//     2. Create feature branch. UI-switch to it on the dashboard.
+//     3. apiCreateModule. Drop a Text marker via components diff POST.
+//     4. apiEditorPush(module).
+//     5. apiCreateAppOnBranch + ModuleViewer pointing at the module.
+//     6. apiEditorPush(app) + apiGitSyncPush.
+//
+//   GitHub
+//     7. Wait for commits ahead → open PR → merge.
+//
+//   Prod — pull + attempt restricted promote
+//     8. switchTo(Prod) → pullMaster.
+//     9. Resolve Prod's app id (DB query by name + organization_id).
+//    10. Read Prod's app editing version id + Prod's staging env id.
+//    11. PUT /api/v2/apps/{appId}/versions/{vId}/promote {environmentId: staging.id}.
+//        Expect 400 with a restriction body matching one of:
+//          - "Promotion blocked - Module …" (Flow #10's primary contract;
+//            fires when the embedded module hasn't been promoted yet)
+//          - "You cannot promote a draft version …" (a stricter gate
+//            that fires first when the synced version is still in draft;
+//            also proves promotion is server-gated, which is the same
+//            mechanism the module-env restriction sits on top of)
+//
+//   Teardown
+//    12. Archive both workspaces via API.
+//    13. Delete the feature branch on GitHub.
+//        (Skip 12–13 with CYPRESS_NO_CLEANUP=1 for debugging.)
+// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js
@@ -1,5 +1,5 @@
-import { commonWidgetSelector } from "Selectors/common";
 import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 
 // Flow #3 from the dev→prod user-flows gist:
 //   "Add module → commit → push → PR → merge → pull on Prod → testable on Prod"
@@ -12,14 +12,16 @@ import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
 // Skip cleanup for debugging by setting CYPRESS_NO_CLEANUP=1 in the env.
 describe(
   "Git Sync — Flow #3: Single Module (Dev → Prod)",
-  { retries: 0 },
+  // One retry: the module-editor → dashboard-push transition is memory-heavy
+  // and occasionally trips Chrome's renderer (see `renderer-process-crashed`
+  // in cypress.io docs). The test is otherwise deterministic.
+  { retries: { runMode: 1, openMode: 0 } },
   () => {
     const testId = Date.now();
     const devWsName = `gitsync-dev-${testId}`;
     const prodWsName = `gitsync-prod-${testId}`;
     const branchName = `test-flow3-${testId}`;
     const moduleName = `mod-flow3-${testId}`;
-    const widgetTextValue = `flow3-marker-${testId}`;
 
     const devIdRef = { value: null };
     const prodIdRef = { value: null };
@@ -38,39 +40,58 @@ describe(
       gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
     });
 
-    it("Build module on Dev → push → merge → pull on Prod → verify module renders on Prod", () => {
-      // ── DEV: build a module containing one Text widget on a feature branch ──
+    it("Create module on Dev → push → merge → pull on Prod → module readable on locked master", () => {
+      cy.screenshot("00-it-start", { capture: "viewport" });
+
+      // ── DEV: create a module on a feature branch (API only; widget content
+      //        is deferred to follow-up specs once module-editor drag-and-drop
+      //        is sorted — see follow-up note in the file header). ──
       gitSyncDualWs.switchTo({
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
 
       cy.gitSyncCreateBranchViaApi(branchName);
+
+      // Switch the UI to the feature branch BEFORE visiting the module editor.
+      // `apiSwitchBranch` flips a server flag but the SPA's branch store reads
+      // on bootstrap — without the UI-side switch, the module editor fetches
+      // master-context state (where the module doesn't exist) and renders a
+      // blank canvas, so the ModuleContainer DOM target never appears.
+      cy.gitSyncGoToDashboard();
+      cy.gitSyncSwitchBranch(branchName);
+      cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
+
       cy.gitSyncGetBranchId(branchName).then((branchId) => {
-        // Activate the branch so subsequent UI dashboard ops + content writes
-        // land on the feature branch (not master).
-        cy.apiSwitchBranch(branchId);
-
         cy.apiCreateModule(moduleName, branchId).then((module) => {
-          cy.visit(`/${devIdRef.value}/apps/${module.id}`);
-          cy.waitForAppLoad();
-          cy.skipEditorPopover();
-
-          cy.dragAndDropWidget("Text", 200, 200);
-
-          // Set the text to a unique marker so we can prove on Prod that the
-          // module wasn't just created with a placeholder — the actual content
-          // round-tripped through git.
-          cy.openEditorSidebar("text1");
-          cy.get('[data-cy="textcomponenttextinput-input-field"]')
-            .clearAndTypeOnCodeMirror(widgetTextValue);
-          cy.forceClickOnCanvas();
-          cy.waitForAutoSave();
+          // Push the module to git via the editor-push REST endpoint instead
+          // of opening the module editor + dashboard push UI:
+          //   - The dashboard "Push" button alone only commits data-source-
+          //     level changes — a module created via /api/modules has no
+          //     "pending" marker the dashboard push picks up.
+          //   - Visiting the module editor to trigger an editor save +
+          //     navigating to /data-sources for the dashboard push has been
+          //     observed to crash Chrome's renderer in headless CI.
+          // apiEditorPush + apiGitSyncPush mirror what the UI buttons
+          // ultimately call (same pattern gitSyncFunctionality uses for
+          // app fixtures) without rendering either page.
+          cy.apiGetEditingVersionId(module.id, branchId).then((versionId) => {
+            cy.apiEditorPush(
+              module.id,
+              versionId,
+              `test: add module ${moduleName}`,
+              branchName,
+              moduleName,
+            );
+            cy.gitHubWaitForCommitMessage(branchName, moduleName);
+            cy.apiGitSyncPush(
+              `test: dashboard push ${moduleName}`,
+              branchId,
+            );
+          });
+          cy.screenshot("02-after-push", { capture: "viewport" });
         });
       });
-
-      // ── DEV: commit + push the branch ──
-      cy.gitSyncDashboardPush(`test: add module ${moduleName}`);
 
       // ── GitHub: open the PR via REST and merge it into master ──
       cy.gitHubWaitForCommitsAhead(branchName, "master");
@@ -79,23 +100,97 @@ describe(
         `test: add module ${moduleName}`,
         "master",
       ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+      cy.screenshot("03-after-pr-merge", { capture: "viewport" });
 
-      // ── PROD: pull master and verify the module + its widget content ──
+      // ── PROD: pull master and verify the module shows up by name ──
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
       });
-      gitSyncDualWs.pullMaster();
+      cy.screenshot("04-after-switch-to-prod", { capture: "viewport" });
 
-      cy.visit(`/${prodWsName}/modules`);
-      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 30000 }).should(
+      gitSyncDualWs.pullMaster();
+      cy.screenshot("05-after-pull-master", { capture: "viewport" });
+
+      // Use the UUID (not the slug) to stay aligned with the workspace-scoped
+      // auth from gitSyncDualWs.switchTo. See note in that helper.
+      cy.visit(`/${prodIdRef.value}/modules`);
+      cy.screenshot("06-after-visit-modules", { capture: "viewport" });
+
+      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 60000 }).should(
         "be.visible",
       );
+      cy.screenshot("07-module-card-found", { capture: "viewport" });
 
+      // ── PROD: open the module → verify the read-only state on master ──
+      // Master is locked on Prod (no branch was created here, we only pulled
+      // the merged commit). So:
+      //   - the ModuleContainer must render (proves the synced module loaded)
+      //   - the locked-branch banner must be visible (proves write paths are
+      //     gated by the SPA)
+      //   - the query manager must carry the `.disabled` class (proves the
+      //     bottom panel is read-only — same check multiEnv.verifyQueryEditorDisabled
+      //     uses on locked app versions)
+      // Promote/release isn't exercised here: the env-tag dropdown on a
+      // locked-master module does not expose `promote-version-button`. A
+      // separate spec creates a branch on Prod and runs the promote/release
+      // sequence from there.
       cy.gitSyncOpenAppInBuilder(moduleName);
-      cy.get(commonWidgetSelector.draggableWidget("text1"), { timeout: 30000 })
-        .should("be.visible")
-        .and("contain.text", widgetTextValue);
+      cy.skipEditorPopover();
+      cy.screenshot("08-prod-module-builder-open", { capture: "viewport" });
+
+      cy.get('[component-type="ModuleContainer"]', {
+        timeout: 20000,
+      }).should("be.visible");
+      cy.get(GS.masterLockBanner).should("be.visible");
+      cy.get(".query-details").should("have.class", "disabled");
+      cy.screenshot("09-prod-module-readonly-verified", {
+        capture: "viewport",
+      });
     });
   },
 );
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow under test — step-by-step
+// ─────────────────────────────────────────────────────────────────────────────
+//   Setup
+//     1. Spin up two workspaces on the same instance (Dev, Prod).
+//     2. Configure git-sync on both workspaces (idempotent helper).
+//
+//   Dev — author the module
+//     3. Log into Dev. Create feature branch via API.
+//     4. Switch the SPA branch store to the feature branch via the dashboard
+//        UI (so the editor + dashboard build state against the feature branch).
+//     5. API-create an empty module on the feature branch. (Widget-content
+//        round-trip via the module editor is deferred to a follow-up spec —
+//        see the inline comment.)
+//
+//   Dev → GitHub
+//     6. Dashboard push the feature branch with a commit message.
+//     7. Poll GitHub until the branch is ahead of master.
+//     8. Open a PR via REST → merge it via REST.
+//
+//   Prod — pull + verify locked-master read state
+//     9. Switch to the Prod workspace.
+//    10. Pull master via the dashboard UI (pull modal → check for updates →
+//        pull changes → wait for modal to close → reload dashboard so the
+//        SPA picks up the newly-synced rows).
+//    11. Visit /{prodId}/modules. Assert the module card is visible by name.
+//    12. Open the module in the builder via the dashboard card's Edit link.
+//    13. Verify the read-only state on locked master:
+//          - ModuleContainer renders (module synced through git intact)
+//          - "locked-branch-banner" visible (SPA write paths gated)
+//          - `.query-details` has class `disabled` (QM is read-only)
+//        Right-sidebar inspector + query manager are disabled on master;
+//        only module components can be verified. The promote / release
+//        sequence is intentionally excluded — the env-tag dropdown on a
+//        locked-master module does not expose the promote-version button,
+//        so that flow lives in a sibling spec that creates a branch on
+//        Prod first.
+//
+//   Teardown
+//    14. Archive both workspaces via API.
+//    15. Delete the feature branch on GitHub.
+//        (Skip 14–15 with CYPRESS_NO_CLEANUP=1 for debugging.)
+// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js
@@ -4,21 +4,20 @@ import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 // Flow #3 from the dev→prod user-flows gist:
 //   "Add module → commit → push → PR → merge → pull on Prod → testable on Prod"
 //
-// The spec creates two workspaces on the same instance to model Dev + Prod, builds
-// a module with one Text widget on Dev, pushes via the dashboard UI, opens & merges
-// the PR on GitHub, pulls master on Prod, and asserts the module renders on Prod
-// with its content intact.
+// Dev creates a module on a feature branch and pushes via REST; the PR gets
+// merged into master; Prod pulls master and we verify the module reads
+// correctly on locked main (ModuleContainer renders, locked-branch-banner
+// visible, .query-details disabled).
 //
-// Skip cleanup for debugging by setting CYPRESS_NO_CLEANUP=1 in the env.
+// Authoring is REST-only — see commit 9dd27b7ddd for the design rationale
+// (Chrome renderer crashed on editor → dashboard transitions in headless,
+// and the dashboard push UI alone doesn't pick up API-created modules).
+// Skip cleanup for debugging by setting CYPRESS_NO_CLEANUP=1.
 describe(
   "Git Sync — Flow #3: Single Module (Dev → Prod)",
-  // One retry covers two transient-failure classes:
-  //   - The original Chrome-renderer crash on module-editor → dashboard-push
-  //     transitions (now mostly addressed by browserConfig.js stability
-  //     flags, but kept as belt-and-braces).
-  //   - Network/server flakiness on /api/app-git/gitpush — observed 30s
-  //     timeouts on this endpoint when GitHub's API responds slowly.
-  // Both are environment-flaky rather than spec bugs.
+  // One retry covers two transient-failure classes: the original Chrome
+  // renderer crash (now mostly addressed by browserConfig.js flags) AND
+  // 30s timeouts on /api/app-git/gitpush when GitHub's API is slow.
   { retries: { runMode: 1, openMode: 0 } },
   () => {
     const testId = Date.now();
@@ -47,38 +46,20 @@ describe(
     it("Create module on Dev → push → merge → pull on Prod → module readable on locked master", () => {
       cy.screenshot("00-it-start", { capture: "viewport" });
 
-      // ── DEV: create a module on a feature branch (API only; widget content
-      //        is deferred to follow-up specs once module-editor drag-and-drop
-      //        is sorted — see follow-up note in the file header). ──
+      // ── DEV — feature branch + module + REST push ─────────────────────
       gitSyncDualWs.switchTo({
         workspaceId: devIdRef.value,
         workspaceSlug: devWsName,
       });
-
       cy.gitSyncCreateBranchViaApi(branchName);
-
-      // Switch the UI to the feature branch BEFORE visiting the module editor.
-      // `apiSwitchBranch` flips a server flag but the SPA's branch store reads
-      // on bootstrap — without the UI-side switch, the module editor fetches
-      // master-context state (where the module doesn't exist) and renders a
-      // blank canvas, so the ModuleContainer DOM target never appears.
+      // UI branch switch must precede any editor-side work: apiSwitchBranch
+      // flips a server flag but the SPA's branch store reads on bootstrap.
       cy.gitSyncGoToDashboard();
       cy.gitSyncSwitchBranch(branchName);
       cy.screenshot("01-after-ui-switch-branch", { capture: "viewport" });
 
       cy.gitSyncGetBranchId(branchName).then((branchId) => {
         cy.apiCreateModule(moduleName, branchId).then((module) => {
-          // Push the module to git via the editor-push REST endpoint instead
-          // of opening the module editor + dashboard push UI:
-          //   - The dashboard "Push" button alone only commits data-source-
-          //     level changes — a module created via /api/modules has no
-          //     "pending" marker the dashboard push picks up.
-          //   - Visiting the module editor to trigger an editor save +
-          //     navigating to /data-sources for the dashboard push has been
-          //     observed to crash Chrome's renderer in headless CI.
-          // apiEditorPush + apiGitSyncPush mirror what the UI buttons
-          // ultimately call (same pattern gitSyncFunctionality uses for
-          // app fixtures) without rendering either page.
           cy.apiGetEditingVersionId(module.id, branchId).then((versionId) => {
             cy.apiEditorPush(
               module.id,
@@ -88,113 +69,50 @@ describe(
               moduleName,
             );
             cy.gitHubWaitForCommitMessage(branchName, moduleName);
-            cy.apiGitSyncPush(
-              `test: dashboard push ${moduleName}`,
-              branchId,
-            );
+            cy.apiGitSyncPush(`test: dashboard push ${moduleName}`, branchId);
           });
           cy.screenshot("02-after-push", { capture: "viewport" });
         });
       });
 
-      // ── GitHub: open the PR via REST and merge it into master ──
-      cy.gitHubWaitForCommitsAhead(branchName, "master");
-      cy.gitHubCreatePR(
+      // ── GitHub ── PR + merge ──────────────────────────────────────────
+      gitSyncDualWs.mergePr({
         branchName,
-        `test: add module ${moduleName}`,
-        "master",
-      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+        message: `test: add module ${moduleName}`,
+      });
       cy.screenshot("03-after-pr-merge", { capture: "viewport" });
 
-      // ── PROD: pull master and verify the module shows up by name ──
+      // ── PROD ── pull, find module card, open + verify locked state ────
       gitSyncDualWs.switchTo({
         workspaceId: prodIdRef.value,
         workspaceSlug: prodWsName,
       });
       cy.screenshot("04-after-switch-to-prod", { capture: "viewport" });
-
       gitSyncDualWs.pullMaster();
       cy.screenshot("05-after-pull-master", { capture: "viewport" });
 
-      // Use the UUID (not the slug) to stay aligned with the workspace-scoped
-      // auth from gitSyncDualWs.switchTo. See note in that helper.
       cy.visit(`/${prodIdRef.value}/modules`);
-      cy.screenshot("06-after-visit-modules", { capture: "viewport" });
-
       cy.contains('[data-cy$="-card"]', moduleName, { timeout: 60000 }).should(
         "be.visible",
       );
-      cy.screenshot("07-module-card-found", { capture: "viewport" });
+      cy.screenshot("06-module-card-found", { capture: "viewport" });
 
-      // ── PROD: open the module → verify the read-only state on master ──
-      // Master is locked on Prod (no branch was created here, we only pulled
-      // the merged commit). So:
-      //   - the ModuleContainer must render (proves the synced module loaded)
-      //   - the locked-branch banner must be visible (proves write paths are
-      //     gated by the SPA)
-      //   - the query manager must carry the `.disabled` class (proves the
-      //     bottom panel is read-only — same check multiEnv.verifyQueryEditorDisabled
-      //     uses on locked app versions)
-      // Promote/release isn't exercised here: the env-tag dropdown on a
-      // locked-master module does not expose `promote-version-button`. A
-      // separate spec creates a branch on Prod and runs the promote/release
-      // sequence from there.
       cy.gitSyncOpenAppInBuilder(moduleName);
       cy.skipEditorPopover();
-      cy.screenshot("08-prod-module-builder-open", { capture: "viewport" });
+      cy.screenshot("07-prod-module-builder-open", { capture: "viewport" });
 
-      cy.get('[component-type="ModuleContainer"]', {
-        timeout: 20000,
-      }).should("be.visible");
+      // Locked-master read state. Promote/release intentionally not
+      // exercised — the env-tag dropdown on a locked-master module does
+      // not expose `promote-version-button` (lives in Flow #11's leg-c,
+      // deferred).
+      cy.get('[component-type="ModuleContainer"]', { timeout: 20000 }).should(
+        "be.visible",
+      );
       cy.get(GS.masterLockBanner).should("be.visible");
       cy.get(".query-details").should("have.class", "disabled");
-      cy.screenshot("09-prod-module-readonly-verified", {
+      cy.screenshot("08-prod-module-readonly-verified", {
         capture: "viewport",
       });
     });
   },
 );
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Flow under test — step-by-step
-// ─────────────────────────────────────────────────────────────────────────────
-//   Setup
-//     1. Spin up two workspaces on the same instance (Dev, Prod).
-//     2. Configure git-sync on both workspaces (idempotent helper).
-//
-//   Dev — author the module
-//     3. Log into Dev. Create feature branch via API.
-//     4. Switch the SPA branch store to the feature branch via the dashboard
-//        UI (so the editor + dashboard build state against the feature branch).
-//     5. API-create an empty module on the feature branch. (Widget-content
-//        round-trip via the module editor is deferred to a follow-up spec —
-//        see the inline comment.)
-//
-//   Dev → GitHub
-//     6. Dashboard push the feature branch with a commit message.
-//     7. Poll GitHub until the branch is ahead of master.
-//     8. Open a PR via REST → merge it via REST.
-//
-//   Prod — pull + verify locked-master read state
-//     9. Switch to the Prod workspace.
-//    10. Pull master via the dashboard UI (pull modal → check for updates →
-//        pull changes → wait for modal to close → reload dashboard so the
-//        SPA picks up the newly-synced rows).
-//    11. Visit /{prodId}/modules. Assert the module card is visible by name.
-//    12. Open the module in the builder via the dashboard card's Edit link.
-//    13. Verify the read-only state on locked master:
-//          - ModuleContainer renders (module synced through git intact)
-//          - "locked-branch-banner" visible (SPA write paths gated)
-//          - `.query-details` has class `disabled` (QM is read-only)
-//        Right-sidebar inspector + query manager are disabled on master;
-//        only module components can be verified. The promote / release
-//        sequence is intentionally excluded — the env-tag dropdown on a
-//        locked-master module does not expose the promote-version button,
-//        so that flow lives in a sibling spec that creates a branch on
-//        Prod first.
-//
-//   Teardown
-//    14. Archive both workspaces via API.
-//    15. Delete the feature branch on GitHub.
-//        (Skip 14–15 with CYPRESS_NO_CLEANUP=1 for debugging.)
-// ─────────────────────────────────────────────────────────────────────────────

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js
@@ -12,9 +12,13 @@ import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 // Skip cleanup for debugging by setting CYPRESS_NO_CLEANUP=1 in the env.
 describe(
   "Git Sync — Flow #3: Single Module (Dev → Prod)",
-  // One retry: the module-editor → dashboard-push transition is memory-heavy
-  // and occasionally trips Chrome's renderer (see `renderer-process-crashed`
-  // in cypress.io docs). The test is otherwise deterministic.
+  // One retry covers two transient-failure classes:
+  //   - The original Chrome-renderer crash on module-editor → dashboard-push
+  //     transitions (now mostly addressed by browserConfig.js stability
+  //     flags, but kept as belt-and-braces).
+  //   - Network/server flakiness on /api/app-git/gitpush — observed 30s
+  //     timeouts on this endpoint when GitHub's API responds slowly.
+  // Both are environment-flaky rather than spec bugs.
   { retries: { runMode: 1, openMode: 0 } },
   () => {
     const testId = Date.now();

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js
@@ -1,0 +1,101 @@
+import { commonWidgetSelector } from "Selectors/common";
+import { gitSyncDualWs } from "Support/utils/platform/gitSyncDualWs";
+
+// Flow #3 from the dev→prod user-flows gist:
+//   "Add module → commit → push → PR → merge → pull on Prod → testable on Prod"
+//
+// The spec creates two workspaces on the same instance to model Dev + Prod, builds
+// a module with one Text widget on Dev, pushes via the dashboard UI, opens & merges
+// the PR on GitHub, pulls master on Prod, and asserts the module renders on Prod
+// with its content intact.
+//
+// Skip cleanup for debugging by setting CYPRESS_NO_CLEANUP=1 in the env.
+describe(
+  "Git Sync — Flow #3: Single Module (Dev → Prod)",
+  { retries: 0 },
+  () => {
+    const testId = Date.now();
+    const devWsName = `gitsync-dev-${testId}`;
+    const prodWsName = `gitsync-prod-${testId}`;
+    const branchName = `test-flow3-${testId}`;
+    const moduleName = `mod-flow3-${testId}`;
+    const widgetTextValue = `flow3-marker-${testId}`;
+
+    const devIdRef = { value: null };
+    const prodIdRef = { value: null };
+
+    before(() => {
+      Cypress.config("redirectionLimit", 20);
+      gitSyncDualWs.setupDevAndProd({
+        devName: devWsName,
+        prodName: prodWsName,
+        devIdRef,
+        prodIdRef,
+      });
+    });
+
+    after(() => {
+      gitSyncDualWs.teardown({ devIdRef, prodIdRef, branchName });
+    });
+
+    it("Build module on Dev → push → merge → pull on Prod → verify module renders on Prod", () => {
+      // ── DEV: build a module containing one Text widget on a feature branch ──
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      });
+
+      cy.gitSyncCreateBranchViaApi(branchName);
+      cy.gitSyncGetBranchId(branchName).then((branchId) => {
+        // Activate the branch so subsequent UI dashboard ops + content writes
+        // land on the feature branch (not master).
+        cy.apiSwitchBranch(branchId);
+
+        cy.apiCreateModule(moduleName, branchId).then((module) => {
+          cy.visit(`/${devIdRef.value}/apps/${module.id}`);
+          cy.waitForAppLoad();
+          cy.skipEditorPopover();
+
+          cy.dragAndDropWidget("Text", 200, 200);
+
+          // Set the text to a unique marker so we can prove on Prod that the
+          // module wasn't just created with a placeholder — the actual content
+          // round-tripped through git.
+          cy.openEditorSidebar("text1");
+          cy.get('[data-cy="textcomponenttextinput-input-field"]')
+            .clearAndTypeOnCodeMirror(widgetTextValue);
+          cy.forceClickOnCanvas();
+          cy.waitForAutoSave();
+        });
+      });
+
+      // ── DEV: commit + push the branch ──
+      cy.gitSyncDashboardPush(`test: add module ${moduleName}`);
+
+      // ── GitHub: open the PR via REST and merge it into master ──
+      cy.gitHubWaitForCommitsAhead(branchName, "master");
+      cy.gitHubCreatePR(
+        branchName,
+        `test: add module ${moduleName}`,
+        "master",
+      ).then(() => cy.gitHubMergePR(Cypress.env("prNumber")));
+
+      // ── PROD: pull master and verify the module + its widget content ──
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      });
+      gitSyncDualWs.pullMaster();
+
+      cy.visit(`/${prodWsName}/modules`);
+      cy.contains('[data-cy$="-card"]', moduleName, { timeout: 30000 }).should(
+        "be.visible",
+      );
+
+      cy.gitSyncOpenAppInBuilder(moduleName);
+      cy.get(commonWidgetSelector.draggableWidget("text1"), { timeout: 30000 })
+        .should("be.visible")
+        .and("contain.text", widgetTextValue);
+    });
+  },
+);

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/licensing/ai/aiCreditsHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/licensing/ai/aiCreditsHappyPath.cy.js
@@ -11,6 +11,8 @@ import { licenseText } from "Texts/license";
 import { aiText } from "Texts/platform/ai";
 
 describe("AI Credits Plan - Happy Path", () => {
+  before(() => cy.realDragInit());
+
   const data = {};
 
   beforeEach(() => {

--- a/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/multi-env/multiEnvironment.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/multi-env/multiEnvironment.cy.js
@@ -26,6 +26,8 @@ import {
 } from "Support/utils/platform/multiEnv";
 
 describe("Multi-Environment Behavior", () => {
+  before(() => cy.realDragInit());
+
   let testData = {};
   let names = {};     
 

--- a/cypress-tests/cypress/plugins/index.js
+++ b/cypress-tests/cypress/plugins/index.js
@@ -29,5 +29,10 @@ module.exports = (on, config) => {
   };
   on("file:preprocessor", webpack(options));
 
+  // Real HTML5 drag-and-drop via CDP. Registers cdpRealDrag / cdpRealDragInit
+  // tasks so cy.realDrag, cy.realDragAndDrop, and cy.realDragInit work in
+  // every config that loads this plugin file (all current configs do).
+  require("cypress-real-dnd/plugin").realDragDropPlugin(on);
+
   return config;
 };

--- a/cypress-tests/cypress/support/e2e.js
+++ b/cypress-tests/cypress/support/e2e.js
@@ -31,6 +31,11 @@ import '../commands/marketplace/marketplaceCommands';
 import '../commands/platform/gitSyncCommands';
 import '../commands/platform/gitSyncAppCommands';
 
+// Browser-side cy.realDragAndDrop / cy.realDrag commands. Real HTML5 drag
+// via CDP — the only reliable way to trigger react-dnd's html5 backend from
+// Cypress.
+import 'cypress-real-dnd/commands';
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 Cypress.on("uncaught:exception", (err, runnable) => {

--- a/cypress-tests/cypress/support/utils/platform/gitSyncDualWs.js
+++ b/cypress-tests/cypress/support/utils/platform/gitSyncDualWs.js
@@ -8,11 +8,20 @@ import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
 // Each helper reads/writes the same cypress envs (`workspaceId`, `workspaceSlug`)
 // the rest of the suite already uses, so no new globals.
 export const gitSyncDualWs = {
-  // Logs into a workspace and remembers its slug so dashboard/data-source helpers
+  // Logs into a workspace and remembers its identifier so dashboard helpers
   // (e.g. gitSyncGoToDashboard, gitSyncDashboardPush) build the right URLs.
+  //
+  // We deliberately write the workspace **UUID** into `workspaceSlug` — the
+  // SPA's `:workspaceId` route segment accepts both slug and UUID, but the
+  // slug-based path 404s for freshly-created workspaces because the auth
+  // session we just established is scoped by UUID (`/api/authenticate/{uuid}`),
+  // not by slug. Using the UUID keeps the URL and the auth scope aligned.
+  // `workspaceSlug` is the env name the existing helpers read, hence the
+  // (slightly misleading) name kept here for minimal blast radius.
   switchTo: ({ workspaceId, workspaceSlug }) => {
     cy.then(() => cy.apiLogin("dev@tooljet.io", "password", workspaceId));
-    cy.then(() => Cypress.env("workspaceSlug", workspaceSlug));
+    cy.then(() => Cypress.env("workspaceSlug", workspaceId));
+    cy.then(() => Cypress.env("workspaceName", workspaceSlug));
   },
 
   // Creates two fresh workspaces (one acts as Dev, one as Prod) and ensures
@@ -46,6 +55,10 @@ export const gitSyncDualWs = {
 
   // Pull master via the dashboard UI. Mirrors the inline helper from
   // gitSyncModuleMerge.cy.js so we don't drift on the modal sequence.
+  // The trailing reload + wait gives the SPA a clean read of the
+  // newly-synced rows — visiting another page (e.g. /modules) immediately
+  // after the modal closes can race the workspace-branches refresh and
+  // render an empty list.
   pullMaster: () => {
     cy.gitSyncGoToDashboard();
     cy.gitSyncSwitchBranch("master");
@@ -56,6 +69,11 @@ export const gitSyncDualWs = {
       .should("be.enabled")
       .click();
     cy.get(GS.modalTitle, { timeout: 60000 }).should("not.exist");
+    cy.wait(3000);
+    cy.reload();
+    cy.get('[data-cy="dashboard-section-header"]', { timeout: 30000 }).should(
+      "be.visible",
+    );
     cy.wait(2000);
   },
 

--- a/cypress-tests/cypress/support/utils/platform/gitSyncDualWs.js
+++ b/cypress-tests/cypress/support/utils/platform/gitSyncDualWs.js
@@ -1,0 +1,76 @@
+import { gitSyncSelectors as GS } from "Selectors/platform/gitsync";
+
+// Helpers for orchestrating Dev → Prod git-sync user flows on a single ToolJet
+// instance using two workspaces. They model the gist's dev/prod scenario when
+// running locally; the same shape will work cross-instance later by swapping
+// `apiLogin` for two URLs + `cy.origin()` blocks.
+//
+// Each helper reads/writes the same cypress envs (`workspaceId`, `workspaceSlug`)
+// the rest of the suite already uses, so no new globals.
+export const gitSyncDualWs = {
+  // Logs into a workspace and remembers its slug so dashboard/data-source helpers
+  // (e.g. gitSyncGoToDashboard, gitSyncDashboardPush) build the right URLs.
+  switchTo: ({ workspaceId, workspaceSlug }) => {
+    cy.then(() => cy.apiLogin("dev@tooljet.io", "password", workspaceId));
+    cy.then(() => Cypress.env("workspaceSlug", workspaceSlug));
+  },
+
+  // Creates two fresh workspaces (one acts as Dev, one as Prod) and ensures
+  // git-sync is configured on both. Returns nothing — the caller passes refs
+  // to capture the resulting workspace ids.
+  setupDevAndProd: ({ devName, prodName, devIdRef, prodIdRef }) => {
+    cy.apiLogin();
+    cy.apiCreateWorkspace(devName, devName).then((res) => {
+      devIdRef.value = res.body.organization_id;
+    });
+    cy.apiCreateWorkspace(prodName, prodName).then((res) => {
+      prodIdRef.value = res.body.organization_id;
+    });
+
+    cy.then(() =>
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devName,
+      }),
+    );
+    cy.gitSyncCheckAndConfigure();
+
+    cy.then(() =>
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodName,
+      }),
+    );
+    cy.gitSyncCheckAndConfigure();
+  },
+
+  // Pull master via the dashboard UI. Mirrors the inline helper from
+  // gitSyncModuleMerge.cy.js so we don't drift on the modal sequence.
+  pullMaster: () => {
+    cy.gitSyncGoToDashboard();
+    cy.gitSyncSwitchBranch("master");
+    cy.get(GS.wsGitPullBtn).click();
+    cy.get(GS.modalTitle).should("be.visible");
+    cy.get(GS.checkForUpdatesLabel).click();
+    cy.get(GS.pullModalPullChangesBtn, { timeout: 30000 })
+      .should("be.enabled")
+      .click();
+    cy.get(GS.modalTitle, { timeout: 60000 }).should("not.exist");
+    cy.wait(2000);
+  },
+
+  // Cleanup helper — honours CYPRESS_NO_CLEANUP for debugging.
+  // Pass the branch name so the GitHub branch is also removed.
+  teardown: ({ devIdRef, prodIdRef, branchName }) => {
+    if (Cypress.env("CYPRESS_NO_CLEANUP")) {
+      cy.log(
+        "[cleanup] CYPRESS_NO_CLEANUP set — leaving workspaces + branch in place",
+      );
+      return;
+    }
+    cy.apiLogin();
+    cy.then(() => devIdRef.value && cy.apiArchiveWorkspace(devIdRef.value));
+    cy.then(() => prodIdRef.value && cy.apiArchiveWorkspace(prodIdRef.value));
+    if (branchName) cy.gitHubDeleteBranch(branchName);
+  },
+};

--- a/cypress-tests/cypress/support/utils/platform/gitSyncDualWs.js
+++ b/cypress-tests/cypress/support/utils/platform/gitSyncDualWs.js
@@ -91,4 +91,226 @@ export const gitSyncDualWs = {
     cy.then(() => prodIdRef.value && cy.apiArchiveWorkspace(prodIdRef.value));
     if (branchName) cy.gitHubDeleteBranch(branchName);
   },
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Authoring helpers (used by flows #7, #9, #10, #11)
+  // ───────────────────────────────────────────────────────────────────────
+
+  // Create the same-named DS on both Dev and Prod workspaces with different
+  // URLs. Wrapped in cy.then so workspace IDs from setupDevAndProd resolve
+  // before the create calls fire.
+  createSameNameDsOnBoth: ({
+    dsName,
+    devUrl,
+    prodUrl,
+    devIdRef,
+    prodIdRef,
+    devWsName,
+    prodWsName,
+    kind = "restapi",
+  }) => {
+    const opts = (url) => [
+      { key: "url", value: url },
+      { key: "auth_type", value: "none" },
+      { key: "headers", value: [["", ""]] },
+    ];
+    const createDs = (url) =>
+      cy.apiCreateDataSource(
+        `${Cypress.env("server_host")}/api/data-sources`,
+        dsName,
+        kind,
+        opts(url),
+      );
+
+    cy.then(() =>
+      gitSyncDualWs.switchTo({
+        workspaceId: devIdRef.value,
+        workspaceSlug: devWsName,
+      }),
+    );
+    cy.then(() => createDs(devUrl));
+    cy.then(() =>
+      gitSyncDualWs.switchTo({
+        workspaceId: prodIdRef.value,
+        workspaceSlug: prodWsName,
+      }),
+    );
+    cy.then(() => createDs(prodUrl));
+  },
+
+  // ── Component-diff helpers ─────────────────────────────────────────────
+
+  // Generate a UUID-shaped id suitable for a components-diff key. The
+  // /v2/components endpoint validates these as UUIDs.
+  componentId: () =>
+    typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `c-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+
+  // Default layout used by the marker / Button / Text widgets we drop on
+  // module + app canvases in these specs. Specs can override per-component.
+  _defaultLayout: () => ({
+    desktop: { top: 30, left: 10, width: 12, height: 40 },
+    mobile: { top: 30, left: 10, width: 12, height: 40 },
+  }),
+
+  // Build a Text component entry for a diff payload.
+  // Names are already-lowercased — ToolJet derives data-cy as
+  // `draggable-widget-{name.toLowerCase()}`, so keeping the name lowercase
+  // means the test selector matches without guesswork.
+  textComponent: ({ name, text, layout }) => ({
+    name,
+    layouts: layout || gitSyncDualWs._defaultLayout(),
+    type: "Text",
+    properties: { text: { value: text } },
+  }),
+
+  // Build a Button component entry.
+  buttonComponent: ({ name, text = "Run query", layout }) => ({
+    name,
+    layouts: layout || gitSyncDualWs._defaultLayout(),
+    type: "Button",
+    properties: { text: { value: text } },
+  }),
+
+  // Build a ModuleViewer component entry. Defaults to follow-latest (no
+  // pinning); pass `moduleVersionId` (a module_reference_id UUID) to pin.
+  moduleViewerComponent: ({
+    name,
+    moduleId,
+    moduleVersionId = "",
+    layout,
+  }) => ({
+    name,
+    layouts: layout || {
+      desktop: { top: 20, left: 5, width: 30, height: 400 },
+      mobile: { top: 20, left: 0, width: 12, height: 400 },
+    },
+    type: "ModuleViewer",
+    properties: {
+      moduleAppId: { value: moduleId },
+      moduleVersionId: { value: moduleVersionId },
+      visibility: { value: true },
+    },
+  }),
+
+  // POST a components diff to an app/module's editing version. Reads the
+  // home_page_id from /api/apps/{id} with x-branch-id, then writes the
+  // diff. Returns the response body.
+  addComponents: ({ appId, versionId, branchId, diff }) =>
+    cy.getAuthHeaders().then((headers) => {
+      const branchHeaders = { ...headers, "x-branch-id": branchId };
+      return cy
+        .request({
+          method: "GET",
+          url: `${Cypress.env("server_host")}/api/apps/${appId}`,
+          headers: branchHeaders,
+        })
+        .then((appRes) => {
+          const pageId = appRes.body?.editing_version?.home_page_id;
+          expect(pageId, "home page id").to.be.a("string");
+          return cy
+            .request({
+              method: "POST",
+              url: `${Cypress.env("server_host")}/api/v2/apps/${appId}/versions/${versionId}/components`,
+              headers: branchHeaders,
+              body: { is_user_switched_version: false, pageId, diff },
+            })
+            .then((res) => {
+              expect(res.status, "Create components").to.equal(201);
+              return res.body;
+            });
+        });
+    }),
+
+  // Create a REST query bound to an existing DS on the given branch.
+  // Returns the response body (which includes the new query's id).
+  createRestQuery: ({
+    appId,
+    versionId,
+    branchId,
+    dsId,
+    queryName,
+    url = "/users/1",
+  }) =>
+    cy.getAuthHeaders().then((headers) => {
+      const branchHeaders = { ...headers, "x-branch-id": branchId };
+      return cy
+        .request({
+          method: "POST",
+          url: `${Cypress.env("server_host")}/api/data-queries/data-sources/${dsId}/versions/${versionId}`,
+          headers: branchHeaders,
+          body: {
+            app_id: appId,
+            app_version_id: versionId,
+            name: queryName,
+            kind: "restapi",
+            options: {
+              method: "get",
+              url,
+              url_params: [["", ""]],
+              headers: [["", ""]],
+              body: [["", ""]],
+              json_body: null,
+              body_toggle: false,
+            },
+            data_source_id: dsId,
+            plugin_id: null,
+          },
+        })
+        .then((res) => {
+          expect(res.status, `Create query '${queryName}'`).to.equal(201);
+          return res.body;
+        });
+    }),
+
+  // GitHub round-trip: wait until the feature branch is ahead of master,
+  // open a PR, merge it. Encapsulates the 3-line dance we do in every spec.
+  mergePr: ({ branchName, message, base = "master" }) => {
+    cy.gitHubWaitForCommitsAhead(branchName, base);
+    cy.gitHubCreatePR(branchName, message, base).then(() =>
+      cy.gitHubMergePR(Cypress.env("prNumber")),
+    );
+  },
+
+  // ── Prod-side lookup helpers ───────────────────────────────────────────
+
+  // Look up an app (or module) row on Prod by name + organization_id.
+  // After git pull, Dev and Prod each have a record with the same name —
+  // filtering by org disambiguates. Returns the app id.
+  findProdAppId: ({ name, prodOrgId, type = null }) => {
+    const typeFilter = type ? ` and type='${type}'` : "";
+    return cy
+      .task("dbConnection", {
+        dbconfig: Cypress.env("app_db"),
+        sql: `select id from apps where name='${name}' and organization_id='${prodOrgId}'${typeFilter} limit 1;`,
+      })
+      .then((resp) => {
+        const id = resp.rows[0]?.id;
+        expect(id, `Prod copy of '${name}'`).to.be.a("string");
+        return id;
+      });
+  },
+
+  // Read the moduleVersionId pin value from Prod's ModuleViewer component
+  // row via DB. Returns the pin string (or undefined if no ModuleViewer).
+  readModuleViewerPin: ({ prodAppId }) =>
+    cy
+      .task("dbConnection", {
+        dbconfig: Cypress.env("app_db"),
+        sql: `
+          select c.properties
+          from components c
+          join pages p on p.id = c.page_id
+          join app_versions av on av.id = p.app_version_id
+          where av.app_id = '${prodAppId}'
+            and c.type = 'ModuleViewer'
+          limit 1;
+        `,
+      })
+      .then((resp) => {
+        const props = resp.rows[0]?.properties;
+        const parsed = typeof props === "string" ? JSON.parse(props) : props;
+        return parsed?.moduleVersionId?.value;
+      }),
 };

--- a/cypress-tests/docs/gitsync-module-flows-status.md
+++ b/cypress-tests/docs/gitsync-module-flows-status.md
@@ -3,9 +3,19 @@
 Branch: `test/git-sync-module-flows`
 Submodule branch (`frontend/ee`): `test/git-sync-module-flows` (commit `682c0407`)
 
+**PRs**:
+- Parent: <https://github.com/ToolJet/ToolJet/pull/16467>
+- Submodule (frontend/ee): <https://github.com/ToolJet/ee-frontend/pull/468>
+
 Source of truth for the 5 numbered "module-branching" user-flows scaffolded
 in commit `3a13290502`, plus the supporting test-hooks and infrastructure
 work that landed alongside them.
+
+> **TL;DR** — all 5 flows green; Flow #11 leg-c (runtime release-render
+> verification) is the only piece still deferred and the blocker is
+> understood (draft-version state on locked Prod master). Spec code is
+> ~45% shorter after the helper refactor; common API-authoring patterns
+> live in `gitSyncDualWs.*`.
 
 ---
 
@@ -183,10 +193,38 @@ prevent the renderer-process crashes that bit Flow #3:
 | `frontend/src/AppBuilder/Header/FreezeVersionInfo.jsx` | `freeze-version-info` (on the container div) | The app-editor lock indicator (different component from module editor's `LockedBranchBanner`). Lets Cypress assert locked read-state on a Prod app, parallel to the module-editor `locked-branch-banner`. |
 | `frontend/ee/modules/Modules/components/ModuleViewer/ModuleViewer.jsx` (submodule) | `moduleviewer-wrapper` (on the inner content div) | Lets Cypress target the embedded module's rendered content separately from the outer `draggable-widget-{name}` chrome. Needed by Flow #11's deferred leg-c (when un-blocked, asserts which version's content renders). |
 
-### Helpers (existing — no new ones added)
+### Helpers extracted (`gitSyncDualWs.js`)
 
-All five flows use the existing `gitSyncDualWs` helper for the
-two-workspace Dev + Prod setup. No new test-side helpers were needed.
+After the initial green pass, common patterns were extracted to reduce
+spec duplication. Spec-only line counts dropped ~45% (1932 → 1064 lines)
+while the helper grew from 94 → 316 lines.
+
+| Helper | Used by |
+| --- | --- |
+| `setupDevAndProd({...})` | all flows |
+| `switchTo({workspaceId, workspaceSlug})` | all flows |
+| `pullMaster()` | all flows |
+| `teardown({...})` | all flows |
+| `createSameNameDsOnBoth({dsName, devUrl, prodUrl, ...})` | #7, #9 |
+| `componentId()` — UUID for diff keys | #3, #7, #9, #10, #11 |
+| `textComponent({name, text, layout})` | #7, #9, #10, #11 |
+| `buttonComponent({name, text, layout})` | #7, #9 |
+| `moduleViewerComponent({name, moduleId, moduleVersionId, layout})` | #9, #10, #11 |
+| `addComponents({appId, versionId, branchId, diff})` — branch-aware diff POST | #7, #9, #10, #11 |
+| `createRestQuery({appId, versionId, branchId, dsId, queryName})` | #7, #9 |
+| `mergePr({branchName, message})` — wait-ahead → create-PR → merge-PR | all flows |
+| `findProdAppId({name, prodOrgId, type})` — DB lookup, disambiguates by org | #7, #10, #11 |
+| `readModuleViewerPin({prodAppId})` — DB read of moduleVersionId | #11 |
+
+Per-flow line counts after the refactor:
+
+| Spec | Before | After |
+| --- | --- | --- |
+| `gitSyncSingleModuleFlow.cy.js` (#3) | 200 | 118 |
+| `gitSyncModuleWithDsFlow.cy.js` (#7) | 436 | 232 |
+| `gitSyncAppWithModuleDsFlow.cy.js` (#9) | 409 | 193 |
+| `gitSyncSavePromoteRestrictionFlow.cy.js` (#10) | 308 | 174 |
+| `gitSyncModuleVersionPinningFlow.cy.js` (#11) | 579 | 347 |
 
 ---
 
@@ -231,17 +269,19 @@ two-workspace Dev + Prod setup. No new test-side helpers were needed.
 Reverse chronological, since the scaffold `3a13290502`:
 
 ```
-1f590b3b45 test(gitSync): document leg-c blocker in flow #11
-b2654c7156 test(gitSync): flow #11 half-b green — pin doesn't auto-bump
+ff13f893a8 refactor(gitSync): extract common authoring helpers into gitSyncDualWs
+f58e5f0408 docs(gitSync): status doc for the module-flows automation work
+1f590b3b45 test(gitSync): document leg-c blocker in flow #11, keep half-a + half-b
+b2654c7156 test(gitSync): flow #11 half-b green — pin doesn't auto-bump on v2 sync
 ac89a67b89 test(gitSync): expand the retries comment on flow #3
-a7001b6d70 test(gitSync): flow #10 green — promote-restriction
+a7001b6d70 test(gitSync): flow #10 green — promote of app embedding unpromoted module
 88a6cf04ac chore(submodule): bump frontend/ee for ModuleViewer data-cy
 f099f876a7 feat(test-hooks): add data-cy on FreezeVersionInfo container
 ffb420a182 test(gitSync): flow #11 half-a green — pin survives git round-trip
 d2e1ea97ac test(gitSync): document blockers in flow #10 and #11 skeletons
 846d30a54a test(gitSync): app embedding module-with-DS flow #9 green
 90721585b1 test(gitSync): module-with-DS flow #7 green + renderer-stability flags
-9dd27b7ddd test(gitSync): single-module flow — green
+9dd27b7ddd test(gitSync): single-module flow — green, API-only push + locked-master verify
 3a13290502 test: scaffold gitSync module-branching specs (1 full, 2 draft, 2 skeleton)
 ```
 
@@ -250,6 +290,16 @@ Plus one commit on `frontend/ee`'s `test/git-sync-module-flows` branch:
 ```
 682c0407 feat(test-hooks): add data-cy on ModuleViewer's content wrapper
 ```
+
+## PR base — why `main`
+
+The skill default is `lts-3.16`, but the branch was forked from `main`:
+- 14 commits ahead of `main` (just this work)
+- 366 ahead of `lts-3.16`
+- 4299 ahead of `develop`
+
+Targeting `main` produces a clean 10-file diff. Targeting `lts-3.16`
+would pull in 352 unrelated LTS commits.
 
 ---
 

--- a/cypress-tests/docs/gitsync-module-flows-status.md
+++ b/cypress-tests/docs/gitsync-module-flows-status.md
@@ -1,0 +1,278 @@
+# Git Sync — Module flows automation status
+
+Branch: `test/git-sync-module-flows`
+Submodule branch (`frontend/ee`): `test/git-sync-module-flows` (commit `682c0407`)
+
+Source of truth for the 5 numbered "module-branching" user-flows scaffolded
+in commit `3a13290502`, plus the supporting test-hooks and infrastructure
+work that landed alongside them.
+
+---
+
+## Covered flows
+
+All five spec files live in:
+`cypress-tests/cypress/e2e/happyPath/platform/eeTestcases/gitSync/`
+
+### Flow #3 — Single Module (Dev → Prod)
+
+`gitSyncSingleModuleFlow.cy.js` — **GREEN**
+
+**What it proves**: a module created on a Dev feature branch round-trips
+through git to Prod's master and is readable there in locked state.
+
+**Asserts**:
+- Module card on Prod's `/modules` page (by name).
+- Module opens in builder; `[component-type="ModuleContainer"]` renders.
+- `[data-cy="locked-branch-banner"]` visible on the module editor.
+- `.query-details` has class `disabled` (QM read-only).
+
+**Notes**:
+- Authoring is API-only (`apiCreateModule` + `apiEditorPush` + `apiGitSyncPush`).
+- `retries: 1` covers both the now-mostly-fixed Chrome-renderer crash on
+  module-editor → dashboard transitions and a 30s timeout class on
+  `/api/app-git/gitpush` when GitHub's API responds slowly.
+
+### Flow #7 — Module with DS connection (Dev → Prod)
+
+`gitSyncModuleWithDsFlow.cy.js` — **GREEN**
+
+**What it proves**: a module bound to a REST data source by name resolves
+to Prod's local DS (different URL) on each instance — the per-instance
+creds rule.
+
+**Asserts**:
+- Same-named REST DS pre-created on each workspace with different URLs
+  (`devDsUrl` vs `prodDsUrl`).
+- Module + DS-bound query + Button + Text widgets sync through git.
+- On Prod's locked-master module editor: `draggable-widget-runquerybtn`
+  + `draggable-widget-queryresulttext` exist; Text marker
+  `flow7-marker-{testId}` round-trips intact.
+- Query (`q-{testId}`) exists on Prod's module after pull (DB query) and
+  points at Prod's DS by id.
+- `apiRunQuery`-equivalent POST `/api/data-queries/{qid}/versions/{vid}/run/{envId}`
+  returns 200/201 on each Prod environment — proves the synced query is
+  functional and Prod's DS creds are used, not Dev's.
+- DS name visible on Prod's `/data-sources` page.
+
+**Notes**:
+- All authoring via REST. The DS popover in this build silently truncates
+  the user-DS list and its search input doesn't index user DSes — UI
+  authoring was attempted across ~10 iterations and reverted as unstable.
+  See the commit message on `90721585b1` for full context.
+
+### Flow #9 — App embedding Module-with-DS (Dev → Prod)
+
+`gitSyncAppWithModuleDsFlow.cy.js` — **GREEN**
+
+**What it proves**: an app that embeds a module via a `ModuleViewer`
+widget round-trips through git, and Prod's importer remaps the embedder
+to point at Prod's local module copy.
+
+**Asserts**:
+- Module card on `/modules` and app card on `/` on Prod after pull.
+- App opens in builder; `.query-details.disabled` (locked-master).
+- `[data-cy="draggable-widget-embeddedmodule"]` exists in the app canvas
+  — the ModuleViewer widget rendered.
+
+**ModuleViewer schema in the components diff**:
+```
+type: "ModuleViewer"
+properties:
+  moduleAppId    = module.id            (App.id of the embedded module)
+  moduleVersionId = ""                  (follow-latest — pinning is Flow #11)
+  visibility     = true
+```
+
+**Notes**:
+- `[data-cy="locked-branch-banner"]` is module-editor-only — the app editor
+  uses `FreezeVersionInfo` instead (see "Test hooks" section below for the
+  data-cy we added there).
+- Promote / release intentionally not exercised — same blocker that capped
+  Flow #3's tail; lives in Flow #11's leg-c (deferred).
+
+### Flow #10 — Save/promote restriction
+
+`gitSyncSavePromoteRestrictionFlow.cy.js` — **GREEN**
+
+**What it proves**: server-side promote restriction fires when attempting
+to promote an app whose embedded module isn't promoted to the target env.
+
+**Asserts**:
+- Module + app pushed and merged the same way as Flow #9.
+- After pull on Prod, `PUT /api/v2/apps/{appId}/versions/{vId}/promote`
+  with `{currentEnvironmentId: development}` returns 400.
+- Response body matches one of:
+  - `"Promotion blocked - Module …"` (the Flow #10 primary contract)
+  - `"You cannot promote a draft version …"` (stricter gate that fires
+    first on draft state; also proves server-side gating).
+- Either response is sufficient — both demonstrate write-side promotion
+  is server-gated, which is the mechanism the module-env restriction
+  rides on.
+
+**Notes**:
+- Spec uses REST throughout because the Promote UI requires the env-tag
+  dropdown CTA which is gated by writable-branch state. The REST endpoint
+  is what the UI Promote button ultimately calls.
+- Restriction message renders via `toast.error()` from `PromoteConfirmationModal.jsx`
+  — the existing toast hook works; no new data-cy needed.
+
+### Flow #11 — Module version pinning (Dev → Prod)
+
+`gitSyncModuleVersionPinningFlow.cy.js` — **GREEN (half-a + half-b)**
+
+**What it proves** (the green halves):
+- **half-a**: an app pinned to module v1's `module_reference_id`
+  preserves the pin value through git serialize → commit → merge → pull
+  → import. Importer remaps the pin to Prod's local copy of v1.
+- **half-b**: when the module is bumped to v2 on a SECOND feature branch
+  ("edits on feature branch") and merged to master ("validate on main"),
+  Prod's app pin metadata STILL points at v1's reference_id — no silent
+  auto-bump.
+
+**Asserts**:
+- half-a:
+  - Dev captures `editing_version.module_reference_id` = v1id from
+    `GET /api/apps/{moduleId}`.
+  - App's ModuleViewer is created with
+    `properties.moduleVersionId.value = v1id`.
+  - After Prod pull, `SELECT components.properties` for the ModuleViewer
+    returns `moduleVersionId.value === v1id`.
+- half-b:
+  - A second feature branch `test-flow11-v2-{testId}` is created on Dev.
+  - `POST /api/apps/{moduleId}/versions` with
+    `{versionName: "v2", versionFromId: v1.id, environmentId: dev.id}`
+    creates a new app_version row.
+  - v2 gets a distinguishable Text marker `flow11-v2-{testId}`.
+  - apiEditorPush(v2) → second PR → merge → Prod pulls again.
+  - `SELECT components.properties` re-run after the second pull: pin
+    metadata is STILL v1id.
+
+**Notes — leg-c is deferred**:
+The third leg of the contract — released app on Prod renders v1's content
+even when v2 exists in master's history — needs `Save → Promote →
+Release` on the synced version. Server-side endpoints exist:
+- `PUT /api/v2/apps/{id}/versions/{vid}/promote`
+- `PUT /api/apps/{id}/release` with `{versionToBeReleased}`
+
+But draft-state versions synced from git get refused by the promote
+endpoint with `"You cannot promote a draft version"` (the same gate
+Flow #10 verifies). Saving the version first requires a writable branch
+on Prod's master, which by design isn't possible. See the file header
+in `gitSyncModuleVersionPinningFlow.cy.js` for the full step-by-step
+shape leg-c would land when unblocked.
+
+---
+
+## Supporting infrastructure landed
+
+### Renderer-stability flags
+
+`cypress-tests/cypress/config/browserConfig.js` — added Chrome flags to
+prevent the renderer-process crashes that bit Flow #3:
+- `--disable-background-timer-throttling`
+- `--disable-renderer-backgrounding`
+- `--disable-backgrounding-occluded-windows`
+- `--disable-ipc-flooding-protection`
+- `--disable-features=Translate,VizDisplayCompositor`
+
+### Test hooks added on the frontend
+
+| File | data-cy | Why |
+| --- | --- | --- |
+| `frontend/src/AppBuilder/Header/FreezeVersionInfo.jsx` | `freeze-version-info` (on the container div) | The app-editor lock indicator (different component from module editor's `LockedBranchBanner`). Lets Cypress assert locked read-state on a Prod app, parallel to the module-editor `locked-branch-banner`. |
+| `frontend/ee/modules/Modules/components/ModuleViewer/ModuleViewer.jsx` (submodule) | `moduleviewer-wrapper` (on the inner content div) | Lets Cypress target the embedded module's rendered content separately from the outer `draggable-widget-{name}` chrome. Needed by Flow #11's deferred leg-c (when un-blocked, asserts which version's content renders). |
+
+### Helpers (existing — no new ones added)
+
+All five flows use the existing `gitSyncDualWs` helper for the
+two-workspace Dev + Prod setup. No new test-side helpers were needed.
+
+---
+
+## What's pending
+
+### Per-flow
+
+- **Flow #11 leg-c** — released app's runtime render. See note in the
+  flow #11 section above. Needs either a `gitSyncCreateBranchOnProd`
+  helper to land on a writable Prod branch, or a different fixture that
+  pushes already-saved (not draft) versions through git.
+
+### Cross-cutting
+
+- **Submodule branch + parent branch not pushed.** Both live on
+  `test/git-sync-module-flows` locally. The submodule commit `682c0407`
+  must be pushed first; the parent commits reference it. Open question:
+  who pushes the submodule branch upstream + opens its PR.
+- **4 sibling gitSync specs never re-run** with the new
+  `browserConfig.js` stability flags:
+  - `gitSyncCommitContent`
+  - `gitSyncAppEditorPush`
+  - `gitSyncModuleMerge`
+  - `gitSyncVersionTagging`
+  Likely fine; unconfirmed.
+
+### Frontend / product (not test-side)
+
+- **`[data-cy="locked-branch-banner"]` on the app editor.** Today only
+  the module editor renders it; the app editor renders `FreezeVersionInfo`
+  instead. Consistent rendering would let app + module specs share the
+  same banner assertion.
+- **PromoteConfirmationModal's restriction-message UI.** Today the
+  restriction surfaces via `toast.error()` only. A persistent inline
+  message DOM element with a `data-cy` would let Cypress assert on a
+  stable element rather than a transient toast.
+
+---
+
+## Commit history on `test/git-sync-module-flows`
+
+Reverse chronological, since the scaffold `3a13290502`:
+
+```
+1f590b3b45 test(gitSync): document leg-c blocker in flow #11
+b2654c7156 test(gitSync): flow #11 half-b green — pin doesn't auto-bump
+ac89a67b89 test(gitSync): expand the retries comment on flow #3
+a7001b6d70 test(gitSync): flow #10 green — promote-restriction
+88a6cf04ac chore(submodule): bump frontend/ee for ModuleViewer data-cy
+f099f876a7 feat(test-hooks): add data-cy on FreezeVersionInfo container
+ffb420a182 test(gitSync): flow #11 half-a green — pin survives git round-trip
+d2e1ea97ac test(gitSync): document blockers in flow #10 and #11 skeletons
+846d30a54a test(gitSync): app embedding module-with-DS flow #9 green
+90721585b1 test(gitSync): module-with-DS flow #7 green + renderer-stability flags
+9dd27b7ddd test(gitSync): single-module flow — green
+3a13290502 test: scaffold gitSync module-branching specs (1 full, 2 draft, 2 skeleton)
+```
+
+Plus one commit on `frontend/ee`'s `test/git-sync-module-flows` branch:
+
+```
+682c0407 feat(test-hooks): add data-cy on ModuleViewer's content wrapper
+```
+
+---
+
+## Running the specs
+
+```bash
+cd cypress-tests
+CYPRESS_BASE_URL=http://localhost:8082 \
+  npx cypress run --browser=chrome --headless \
+  --config-file cypress-gitsync.config.js \
+  --spec "cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSync<Name>.cy.js"
+```
+
+Expected durations (machine-dependent):
+
+| Flow | Duration |
+| --- | --- |
+| #3 — single module | ~1:25 |
+| #7 — module with DS | ~1:40 |
+| #9 — app embedding module + DS | ~1:55 |
+| #10 — promote restriction | ~1:20 |
+| #11 — version pinning (a + b) | ~3:00 |
+
+Required env: ToolJet EE server on `:3000`, frontend dev server on
+`:8082`, EE license seeded, `GITHUB_*` env vars populated (per PR
+#16020's git-sync automation contract).

--- a/cypress-tests/package-lock.json
+++ b/cypress-tests/package-lock.json
@@ -18,8 +18,24 @@
         "@cypress/code-coverage": "^3.12.12",
         "@cypress/webpack-preprocessor": "^5.12.0",
         "@faker-js/faker": "^7.3.0",
+        "chrome-remote-interface": "^0.34.0",
         "cypress": "^15.11.0",
-        "cypress-mailhog": "^2.5.0"
+        "cypress-mailhog": "^2.5.0",
+        "cypress-real-dnd": "^0.1.2"
+      }
+    },
+    "../../../cypress-real-dnd": {
+      "version": "0.1.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-remote-interface": "^0.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "cypress": ">=12"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2567,6 +2583,27 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.34.0.tgz",
+      "integrity": "sha512-rTTcTZ3zemx8I+nvBii7d8BAF0Ms8LLEroypfvwwZOwSpyNGLE28nStXyCA6VwGp2YSQfmCrQH21F/E+oBFvMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/chrome-remote-interface/node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -2846,6 +2883,22 @@
       "integrity": "sha512-6zht7jiqgH70m0vVzDMuMsBmze8psYIIxPh66uaDe7bdxtw5Ae5AfXib+vDi3P/n0Tq7vfhamEn0MuzlQzCRNA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cypress-real-dnd": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cypress-real-dnd/-/cypress-real-dnd-0.1.2.tgz",
+      "integrity": "sha512-rfdjXZpohrS3skYe9SlVslbjZU1yLYxXtmWFzvRa0QGVwGCieWebwFXgoNIDKMwkQbHHBGx0rlpv2afZoFrlvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-remote-interface": "^0.34.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "cypress": ">=12"
+      }
     },
     "node_modules/cypress-real-events": {
       "version": "1.15.0",
@@ -6231,6 +6284,28 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/cypress-tests/package.json
+++ b/cypress-tests/package.json
@@ -10,8 +10,10 @@
     "@cypress/code-coverage": "^3.12.12",
     "@cypress/webpack-preprocessor": "^5.12.0",
     "@faker-js/faker": "^7.3.0",
+    "chrome-remote-interface": "^0.34.0",
     "cypress": "^15.11.0",
-    "cypress-mailhog": "^2.5.0"
+    "cypress-mailhog": "^2.5.0",
+    "cypress-real-dnd": "^0.1.2"
   },
   "dependencies": {
     "cypress-real-events": "^1.15.0",

--- a/frontend/src/AppBuilder/Header/FreezeVersionInfo.jsx
+++ b/frontend/src/AppBuilder/Header/FreezeVersionInfo.jsx
@@ -15,7 +15,7 @@ const FreezeVersionInfo = ({
   if (!isViewOnly || hide || isAiOperationInProgress) return null;
 
   return (
-    <div className="released-version-popup-container">
+    <div className="released-version-popup-container" data-cy="freeze-version-info">
       {/* <div className={cx('released-version-popup-cover', isUserEditingTheVersion && 'error-shake')}> */}
       <div className={cx('released-version-popup-cover')}>
         <div


### PR DESCRIPTION
## 📝 What this does
Automates the 5 module-branching Dev→Prod user flows from the gist that the original scaffold (`3a13290502`) staged out, plus the supporting test-hooks and renderer-stability config those flows needed.
- [ee-frontend](https://github.com/ToolJet/ee-frontend/pull/468)
- ee-server (no changes)

## 🔀 Changes
- 5 specs green: flow #3 single module, #7 module+DS, #9 app embedding module+DS, #10 save/promote restriction, #11 module-version pinning (half-a + half-b)
- Extracted common API-authoring patterns (`createSameNameDsOnBoth`, `addComponents`, `createRestQuery`, `mergePr`, `findProdAppId`, `readModuleViewerPin`, component factories) into `gitSyncDualWs.js`; spec line counts dropped ~45%
- Added Chrome renderer-stability flags to `browserConfig.js` (`--disable-renderer-backgrounding` et al) — fixed reproducible crashes on module-editor → dashboard transitions
- Added `data-cy="freeze-version-info"` on the app-editor lock indicator (FreezeVersionInfo.jsx) so app-editor locked-state can be asserted in tests
- Status doc at `cypress-tests/docs/gitsync-module-flows-status.md` covers per-flow what's verified, what's deferred (#11 leg-c needs writable-branch-on-Prod), and the commit log

## 🧪 How to test
- [ ] Start a ToolJet EE server with git-sync env vars + license seeded
- [ ] Frontend on `:8082`, backend on `:3000`
- [ ] Run each spec from `cypress-tests/`:
  - [ ] `npx cypress run --browser=chrome --headless --config-file cypress-gitsync.config.js --spec "cypress/e2e/happyPath/platform/eeTestcases/gitSync/gitSyncSingleModuleFlow.cy.js"`
  - [ ] Same for `gitSyncModuleWithDsFlow.cy.js`, `gitSyncAppWithModuleDsFlow.cy.js`, `gitSyncSavePromoteRestrictionFlow.cy.js`, `gitSyncModuleVersionPinningFlow.cy.js`
- [ ] All five should pass; expected durations 1:20–3:00