### PR TITLE
Chore: Add Copilot instruction to enforce TypeScript for new frontend files

### DIFF
--- a/.github/instructions/frontend-typescript.instructions.md
+++ b/.github/instructions/frontend-typescript.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: "frontend/src/**/*"
+---
+
+# Frontend TypeScript — File Creation Rules
+
+## File Extension Rules
+
+- All new files created under `frontend/src/` MUST use `.tsx` or `.ts` extensions.
+- `.jsx` and `.js` files are legacy and must NOT be added.
+- If a file contains JSX, use `.tsx`. If it is logic-only with no JSX, use `.ts`.
+
+## Enforcement
+
+Flag any newly created file under `frontend/src/` that uses a `.js` or `.jsx` extension. The file must be:
+
+- Rewritten in TypeScript with proper types — not just renamed.
+- All props, function parameters, return types, and state variables must be explicitly typed.
+- Avoid using `any` — use specific types, interfaces, or generics instead.
+- Define interfaces or types for component props, API responses, and shared data shapes.
+
+A file that has been renamed to `.ts`/`.tsx` but still lacks type annotations is not compliant.


### PR DESCRIPTION
## 📝 What this does
Adds a GitHub Copilot instruction file that flags any new file created under `frontend/src/` that is not TypeScript. New files must be implemented in `.ts` or `.tsx` with proper type annotations — not just renamed.

## 🔀 Changes
- Added `.github/instructions/frontend-typescript.instructions.md` with rules requiring new frontend files to use `.ts`/`.tsx` and be fully typed (props, parameters, return types, state, no `any`)

## 🧪 How to test
- [ ] Create a new `.js` or `.jsx` file under `frontend/src/` and confirm Copilot flags it as non-compliant
- [ ] Verify the instruction requires TypeScript implementation, not just a file extension rename