### PR TITLE
Enhance widget restriction logic for header and footer slots.

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/Grid/Grid.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/Grid/Grid.jsx
@@ -54,7 +54,11 @@ import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
 import { useElementGuidelines } from './hooks/useElementGuidelines';
 import { RIGHT_SIDE_BAR_TAB } from '../../RightSideBar/rightSidebarConstants';
 import ConfigHandleButton from '@/_components/ConfigHandleButton';
-import { RESTRICTED_WIDGETS_CONFIG } from '@/AppBuilder/WidgetManager/configs/restrictedWidgetsConfig';
+import { getDropTargetLabel } from '../appCanvasUtils';
+import {
+  RESTRICTED_WIDGETS_CONFIG,
+  RESTRICTED_WIDGET_SLOTS_CONFIG,
+} from '@/AppBuilder/WidgetManager/configs/restrictedWidgetsConfig';
 
 // Lazy load editor-only component to reduce viewer bundle size
 const MentionComponentInChat = lazy(() => import('../ConfigHandle/MentionComponentInChat'));
@@ -547,11 +551,13 @@ export default function Grid({ gridWidth, currentLayout, mainCanvasWidth }) {
 
       const parentId = targetSlotId?.length > 36 ? targetSlotId.slice(0, 36) : targetSlotId;
       const parentWidgetType = getComponentTypeFromId(parentId);
+      const parentSlotType = targetSlotId ? targetSlotId.split('-').pop() : undefined;
 
       let restrictedWidgetsTobeDropped =
-        RESTRICTED_WIDGETS_CONFIG?.[parentWidgetType]?.filter((widgetType) =>
-          widgetsTypeToBeDropped.includes(widgetType)
-        ) || [];
+        [
+          ...(RESTRICTED_WIDGETS_CONFIG?.[parentWidgetType] || []),
+          ...(['header', 'footer'].includes(parentSlotType) ? RESTRICTED_WIDGET_SLOTS_CONFIG : []),
+        ].filter((widgetType) => widgetsTypeToBeDropped.includes(widgetType)) || [];
 
       // Check nesting depth restrictions for all widget types in NESTING_LEVEL_LIMITS
       let nestingDepthExceeded = false;
@@ -602,7 +608,12 @@ export default function Grid({ gridWidth, currentLayout, mainCanvasWidth }) {
         } else if (isParentModuleContainer) {
           toast.error('Modules cannot be edited inside an app');
         } else if (!isParentChangeAllowed) {
-          toast.error(`${restrictedWidgetsTobeDropped} is not compatible as a child component of ${parentWidgetType}`);
+          toast.error(
+            `${restrictedWidgetsTobeDropped} is not compatible as a child component of ${getDropTargetLabel(
+              parentWidgetType,
+              parentSlotType
+            )}`
+          );
         }
       }
 
@@ -1069,7 +1080,12 @@ export default function Grid({ gridWidth, currentLayout, mainCanvasWidth }) {
               if (isParentModuleContainer) {
                 toast.error('Modules cannot be edited inside an app');
               } else if (!isModalToCanvas) {
-                toast.error(`${dragged.widgetType} is not compatible as a child component of ${target.widgetType}`);
+                toast.error(
+                  `${dragged.widgetType} is not compatible as a child component of ${getDropTargetLabel(
+                    target.widgetType,
+                    target.slotType
+                  )}`
+                );
               }
             }
 

--- a/frontend/src/AppBuilder/AppCanvas/Grid/gridUtils.js
+++ b/frontend/src/AppBuilder/AppCanvas/Grid/gridUtils.js
@@ -728,7 +728,9 @@ export const updateDashedBordersOnDragResize = (targetId, moveableControlBoxClas
 
 export const isDroppingRestrictedWidget = (target, dragged) => {
   const restrictedWidgetsOnTarget = RESTRICTED_WIDGETS_CONFIG?.[target.widgetType] || [];
-  const restrictedWidgetsOnTargetSlot = RESTRICTED_WIDGET_SLOTS_CONFIG?.[target.slotType] || [];
+  const restrictedWidgetsOnTargetSlot = ['header', 'footer'].includes(target.slotType)
+    ? RESTRICTED_WIDGET_SLOTS_CONFIG
+    : [];
 
   const restrictedWidgets = [...restrictedWidgetsOnTarget, ...restrictedWidgetsOnTargetSlot];
   return restrictedWidgets.includes(dragged.widgetType);

--- a/frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js
+++ b/frontend/src/AppBuilder/AppCanvas/appCanvasUtils.js
@@ -340,6 +340,9 @@ export const getParentWidgetFromId = (parentType, parentId) => {
   return parentType;
 };
 
+export const getDropTargetLabel = (widgetType, slotType) =>
+  slotType === 'header' || slotType === 'footer' ? slotType : widgetType;
+
 export const getTabId = (parentId) => {
   return parentId.split('-').slice(0, -1).join('-');
 };

--- a/frontend/src/AppBuilder/WidgetManager/configs/restrictedWidgetsConfig.js
+++ b/frontend/src/AppBuilder/WidgetManager/configs/restrictedWidgetsConfig.js
@@ -12,7 +12,31 @@ export const RESTRICTED_WIDGETS_CONFIG = {
   Table: ['Kanban'],
 };
 
-export const RESTRICTED_WIDGET_SLOTS_CONFIG = {
-  header: ['Calendar', 'Kanban', 'Table', 'Listview', 'Container', 'Accordion'],
-  footer: ['Calendar', 'Kanban', 'Table', 'Listview', 'Container', 'Accordion'],
-};
+export const RESTRICTED_WIDGET_SLOTS_CONFIG = [
+  'Form',
+  'Container',
+  'Listview',
+  'Tabs',
+  'Kanban',
+  'Calendar',
+  'Chart',
+  'Accordion',
+  'Map',
+  'IFrame',
+  'KeyValuePair',
+  'RichTextEditor',
+  'Timeline',
+  'JSONExplorer',
+  'JSONEditor',
+  'Html',
+  'CodeEditor',
+  'Chat',
+  'TreeSelect',
+  'PDF',
+  'Camera',
+  'QrScanner',
+  'Text',
+  'TextArea',
+  'AudioRecorder',
+  'CustomComponent',
+];

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -11,6 +11,7 @@ import { deepClone } from '@/_helpers/utilities/utils.helpers';
 import { cloneDeep, merge, set as lodashSet, isEmpty } from 'lodash';
 import {
   computeComponentName,
+  getDropTargetLabel,
   getAllChildComponents,
   getParentWidgetFromId,
 } from '@/AppBuilder/AppCanvas/appCanvasUtils';
@@ -19,7 +20,10 @@ import { RIGHT_SIDE_BAR_TAB } from '@/AppBuilder/RightSideBar/rightSidebarConsta
 import { DEFAULT_COMPONENT_STRUCTURE } from './resolvedSlice';
 import { savePageChanges } from './pageMenuSlice';
 import { toast } from 'react-hot-toast';
-import { RESTRICTED_WIDGETS_CONFIG } from '@/AppBuilder/WidgetManager/configs/restrictedWidgetsConfig';
+import {
+  RESTRICTED_WIDGETS_CONFIG,
+  RESTRICTED_WIDGET_SLOTS_CONFIG,
+} from '@/AppBuilder/WidgetManager/configs/restrictedWidgetsConfig';
 import moment from 'moment';
 import { getDateTimeFormat } from '@/_helpers/appUtils';
 import { findHighestLevelofSelection } from '@/AppBuilder/AppCanvas/Grid/gridUtils';
@@ -1225,10 +1229,16 @@ export const createComponentsSlice = (set, get) => ({
     const transformedParentId = parentId?.length > 36 ? parentId.slice(0, 36) : parentId;
     let parentType = getComponentTypeFromId(transformedParentId, moduleId);
     const parentWidget = getParentWidgetFromId(parentType, parentId);
-    const restrictedWidgets = RESTRICTED_WIDGETS_CONFIG?.[parentWidget] || [];
+    const parentSlotType = parentId ? parentId.split('-').pop() : undefined;
+    const restrictedWidgets = [
+      ...(RESTRICTED_WIDGETS_CONFIG?.[parentWidget] || []),
+      ...(['header', 'footer'].includes(parentSlotType) ? RESTRICTED_WIDGET_SLOTS_CONFIG : []),
+    ];
     const isParentChangeAllowed = !restrictedWidgets.includes(currentWidget);
     if (!isParentChangeAllowed) {
-      toast.error(`${currentWidget} is not compatible as a child component of ${parentWidget}`);
+      toast.error(
+        `${currentWidget} is not compatible as a child component of ${getDropTargetLabel(parentWidget, parentSlotType)}`
+      );
       return false;
     }
 
@@ -1280,7 +1290,8 @@ export const createComponentsSlice = (set, get) => ({
           moduleId
         ) === false
       ) {
-        return false;
+        resolve(false);
+        return;
       }
       const newComponents = buildComponentDefinition(componentDefinitions, moduleId);
 


### PR DESCRIPTION
Closes https://github.com/ToolJet/tj-ee/issues/5068

This pull request updates how restricted widgets are handled when dragging and dropping components in the App Builder, with a focus on improving slot-based restrictions (such as for `header` and `footer`), error messaging, and configuration structure. The changes ensure that widget drop restrictions are consistently enforced and that error messages are more descriptive for users.

**Improvements to restricted widget configuration and enforcement:**

* Refactored `RESTRICTED_WIDGET_SLOTS_CONFIG` from an object mapping slot names to arrays, to a single array of restricted widget types, and updated all logic to treat slot-based restrictions as a flat list applied to `header` and `footer` slots. [[1]](diffhunk://#diff-e2311018a93530c3011071708fcffedc2c0d78821a4326308106249a7220c306L15-R42) [[2]](diffhunk://#diff-d7c705dd712f721b76e812ef7ec5a4d06b69312c6b30b2af776aaa476c3cc612R554-R560) [[3]](diffhunk://#diff-d890f51227a32736d8db21c8535893f4fb85bb7d88bc6372d0d625fbd62018e6L731-R733) [[4]](diffhunk://#diff-abc6bb316d1fa4f606c614ea7977b97911af8cf27305746e2b63da0ec30dffffL22-R26)

* Updated the logic in `Grid.jsx`, `gridUtils.js`, and `componentsSlice.js` to check for slot-based restrictions by detecting if the target slot is a `header` or `footer`, and merging the slot restrictions accordingly. [[1]](diffhunk://#diff-d7c705dd712f721b76e812ef7ec5a4d06b69312c6b30b2af776aaa476c3cc612R554-R560) [[2]](diffhunk://#diff-d890f51227a32736d8db21c8535893f4fb85bb7d88bc6372d0d625fbd62018e6L731-R733) [[3]](diffhunk://#diff-abc6bb316d1fa4f606c614ea7977b97911af8cf27305746e2b63da0ec30dffffL1228-R1241)

**Enhancements to error messages and user feedback:**

* Introduced the `getDropTargetLabel` utility to generate more descriptive error messages in toasts, indicating whether the restriction is due to the slot type or the widget type. Updated all relevant error messages to use this utility. [[1]](diffhunk://#diff-4d9b8f71297881929b23b0057fede491a7349c002e2ca29317c7d9f226385fe8R343-R345) [[2]](diffhunk://#diff-d7c705dd712f721b76e812ef7ec5a4d06b69312c6b30b2af776aaa476c3cc612L605-R616) [[3]](diffhunk://#diff-d7c705dd712f721b76e812ef7ec5a4d06b69312c6b30b2af776aaa476c3cc612L1072-R1088) [[4]](diffhunk://#diff-abc6bb316d1fa4f606c614ea7977b97911af8cf27305746e2b63da0ec30dffffL1228-R1241)

**Codebase consistency and maintainability:**

* Updated imports and usages to reflect the new configuration and utility function, ensuring all files use the correct sources for restricted widget logic and error messaging. [[1]](diffhunk://#diff-d7c705dd712f721b76e812ef7ec5a4d06b69312c6b30b2af776aaa476c3cc612L57-R61) [[2]](diffhunk://#diff-abc6bb316d1fa4f606c614ea7977b97911af8cf27305746e2b63da0ec30dffffR14)

* Fixed a minor bug in the async widget drop handler by resolving the promise and returning early, instead of returning `false` directly.