### PR TITLE
fix: show correct property name in code hinter header (#6655)

### DIFF
--- a/frontend/src/Editor/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/Editor/CodeEditor/SingleLineCodeEditor.jsx
@@ -407,7 +407,7 @@ const DynamicEditorBridge = (props) => {
         <div className={`row custom-row`} style={{ display: codeShow ? 'flex' : 'none' }}>
           <div className={`col code-hinter-col`}>
             <div className="d-flex">
-              <SingleLineCodeEditor initialValue {...props} />
+              <SingleLineCodeEditor initialValue componentName={paramLabel} {...props} />
             </div>
           </div>
         </div>
@@ -420,3 +420,4 @@ SingleLineCodeEditor.Editor = EditorInput;
 SingleLineCodeEditor.EditorBridge = DynamicEditorBridge;
 
 export default SingleLineCodeEditor;
+


### PR DESCRIPTION
## Summary

When the code hinter popup is opened, the header text displays Editor instead of the actual property name.

## Fix

Pass paramLabel as componentName to SingleLineCodeEditor.

Fixes #6655

Bounty: $45 (Opire issue 01J8898W2WES9F4FJ57GDG0BYS)