### PR TITLE
Fix UPS OpenAPI spec rendering, GraphQL SSL handling, and false Snowflake table access warning

### DIFF
--- a/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/userManagment/UserInviteFlow.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/userManagment/UserInviteFlow.cy.js
@@ -37,6 +37,7 @@ describe("user invite flow cases", () => {
       enableInstanceSignup();
     });
     cy.apiConfigureSmtp(smtpConfig);
+    cy.mhDeleteAll();
   });
 
   it("Should verify the user archive functionality", () => {
@@ -167,9 +168,9 @@ describe("user invite flow cases", () => {
     navigateToManageUsers();
     fillUserInviteForm(data.firstName, data.email);
     cy.get(usersSelector.buttonInviteUsers).click();
-    cy.wait(7000);
+    cy.wait(5000);
     cy.apiLogout();
-    cy.wait(7000);
+    cy.wait(5000);
 
     fetchAndVisitInviteLinkViaMH(data.email);
     confirmInviteElements(data.email);

--- a/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/userManagment/bulkUsersUpload.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/userManagment/bulkUsersUpload.cy.js
@@ -160,7 +160,6 @@ describe("Bulk User Upload", () => {
 
   it("Should successfully upload valid users", () => {
     const file = getFile(TEST_FILES.VALID_USERS);
-    cy.mhDeleteAll();
     cy.get(usersSelector.buttonAddUsers).click();
     cy.get(usersSelector.buttonUploadCsvFile).click();
 

--- a/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/workspace/workspaceUiTestcases/dashboard.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/platform/commonTestcases/workspace/workspaceUiTestcases/dashboard.cy.js
@@ -310,7 +310,6 @@ describe("dashboard", () => {
       .and("have.text", dashboardText.appClonedToast);
     cy.wait(3000);
 
-    cy.get(commonSelectors.editorAppNameInput).click();
     cy.renameApp(data.cloneAppName);
     cy.apiAddComponentToApp(data.cloneAppName, "button", 25, 25);
 

--- a/frontend/src/_components/ApiEndpointInput.jsx
+++ b/frontend/src/_components/ApiEndpointInput.jsx
@@ -83,7 +83,7 @@ const ApiEndpointInput = (props) => {
       .then((response) => response.text())
       .then((text) => {
         const format = url.endsWith('.json') ? 'json' : 'yaml';
-        openapiService.parseOpenapiSpec(text, format).then((data) => {
+        return openapiService.parseOpenapiSpec(text, format).then((data) => {
           setSpecJson(data);
 
           if (isMultiSpec) {
@@ -123,6 +123,10 @@ const ApiEndpointInput = (props) => {
 
           setLoadingSpec(false);
         });
+      })
+      .catch((err) => {
+        console.error('Failed to load OpenAPI spec:', err);
+        setLoadingSpec(false);
       });
   };
 

--- a/marketplace/plugins/ups/openapi-specs/shipping.yaml
+++ b/marketplace/plugins/ups/openapi-specs/shipping.yaml
@@ -13979,9 +13979,10 @@ components:
       maximum: 1
       properties:
         AgentRole:
-          description: 'When the value passed to the AgentRole parameter is 30, 
-          the value passed to the IDNumberTypeCode parameter must be 1002, 1005 or 0005.
-          (SHIP_FROM=20, CONSIGNEE=30)'
+          description: >-
+            When the value passed to the AgentRole parameter is 30,
+            the value passed to the IDNumberTypeCode parameter must be 1002, 1005 or 0005.
+            (SHIP_FROM=20, CONSIGNEE=30)
           type: string
         TaxIdentificationNumber:
           items:

--- a/plugins/packages/graphql/lib/index.ts
+++ b/plugins/packages/graphql/lib/index.ts
@@ -185,7 +185,7 @@ export default class GraphqlQueryService implements QueryService {
     if (process.env.NODE_EXTRA_CA_CERTS) {
       'https' in httpsParams
         ? (httpsParams.https.certificateAuthority =
-            httpsParams.https?.certificateAuthority.concat([
+            (httpsParams.https?.certificateAuthority || []).concat([
               ...tls.rootCertificates,
               readFileSync(process.env.NODE_EXTRA_CA_CERTS),
             ]))


### PR DESCRIPTION
Issue: https://github.com/ToolJet/ToolJet/issues/15974
Fix UPS OpenAPI Shipping spec rendering issue.

## Root Cause
- Malformed YAML in `shipping.yaml` caused OpenAPI spec parsing to fail
- Missing frontend error handling caused infinite loading spinner

## Changes
- Fixed malformed YAML in `shipping.yaml`
- Added proper error handling in `ApiEndpointInput.jsx`
- Prevented infinite loading spinner when OpenAPI spec parsing fails

<img width="1919" height="978" alt="image" src="https://github.com/user-attachments/assets/e3792e7b-4cbe-4ccc-a334-3815fa7c703a" />

<br/>
<br/>
<br/>

Issue: https://github.com/ToolJet/ToolJet/issues/15431
Fix GraphQL SSL handling with NODE_EXTRA_CA_CERTS.

## Note
- Verified the REST API plugin already contains the fix in the current codebase  
- While investigating the issue, the same unsafe pattern was identified and fixed in the GraphQL plugin.

## Root Cause
- GraphQL plugin assumed `certificateAuthority` always existed when `NODE_EXTRA_CA_CERTS` was set
- `ssl_certificate = 'none'` created `httpsParams.https` without initializing `certificateAuthority`
- Calling `.concat()` on `undefined` caused the datasource to crash

## Changes
- Added null-safe handling for `certificateAuthority` in GraphQL plugin
- Prevented crashes when `ssl_certificate = 'none'` and `NODE_EXTRA_CA_CERTS` is configured
- Preserved existing SSL behavior for other certificate modes

<br/>


Issue: https://github.com/ToolJet/ToolJet/issues/16294
Snowflake GUI mode showed a false "You do not have access to the selected Table" warning after datasource switching when the table name was manually entered instead of fetched from the dropdown.

## Root Cause
- DynamicSelector validation treated absence of cached table metadata (`undefined`) the same as an empty fetched table list
- Manually entered table names do not create `table_cache` until "Fetch Tables" is used
- After datasource switching, validation incorrectly assumed missing cache meant the selected table was inaccessible
- Backend query execution was unaffected because Snowflake queries use the raw table name directly

## Changes
- Updated DynamicSelector validation to distinguish between:
  - missing cache (manual entry without fetch)
  - fetched cache with unavailable tables
- Skipped table-access validation when no cache exists for manually entered tables
- Preserved existing warning behavior for genuinely inaccessible or unavailable tables
- Prevented false-positive access warnings after datasource switching in Snowflake GUI mode


