### PR TITLE
Load region-specific locales before base locales

### DIFF
--- a/frontend/src/__tests__/i18nConfig.test.js
+++ b/frontend/src/__tests__/i18nConfig.test.js
@@ -1,0 +1,40 @@
+import { createInstance } from 'i18next';
+import { getI18nConfig } from '../i18nConfig';
+
+describe('getI18nConfig', () => {
+  it('keeps region-specific locale codes for translation loading', () => {
+    const config = getI18nConfig({ language: 'zh-TW', path: '/' });
+
+    expect(config).toMatchObject({
+      load: 'all',
+      fallbackLng: 'en',
+      lng: 'zh-TW',
+      backend: {
+        loadPath: '/assets/translations/{{lng}}.json',
+      },
+    });
+  });
+
+  it('resolves zh-TW before the base and fallback locales', () => {
+    const i18n = createInstance();
+
+    i18n.init({
+      ...getI18nConfig({ language: 'zh-TW', path: '/' }),
+      initImmediate: false,
+    });
+
+    expect(i18n.languages).toEqual(['zh-TW', 'zh', 'en']);
+  });
+
+  it('keeps the configured sub-path in the translation load path', () => {
+    const config = getI18nConfig({ language: 'fr', path: '/app/' });
+
+    expect(config.backend.loadPath).toBe('/app/assets/translations/{{lng}}.json');
+  });
+
+  it('normalizes sub-paths without a trailing slash', () => {
+    const config = getI18nConfig({ language: 'fr', path: '/app' });
+
+    expect(config.backend.loadPath).toBe('/app/assets/translations/{{lng}}.json');
+  });
+});

--- a/frontend/src/i18nConfig.js
+++ b/frontend/src/i18nConfig.js
@@ -1,0 +1,10 @@
+const withTrailingSlash = (path) => (path.endsWith('/') ? path : path + '/');
+
+export const getI18nConfig = ({ language = 'en', path = '/' } = {}) => ({
+  load: 'all',
+  fallbackLng: 'en',
+  lng: language,
+  backend: {
+    loadPath: withTrailingSlash(path) + 'assets/translations/{{lng}}.json',
+  },
+});

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -11,6 +11,7 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import Backend from 'i18next-http-backend';
 import config from 'config';
+import { getI18nConfig } from './i18nConfig';
 
 // When on a custom domain, use relative API path so requests go through the
 // Cloudflare Worker proxy, making cookies first-party (fixes incognito sign-in).
@@ -34,17 +35,7 @@ appService
     window.public_config = config;
     const language = config.LANGUAGE || 'en';
     const path = config?.SUB_PATH || '/';
-    i18n
-      .use(Backend)
-      .use(initReactI18next)
-      .init({
-        load: 'languageOnly',
-        fallbackLng: 'en',
-        lng: language,
-        backend: {
-          loadPath: `${path}assets/translations/{{lng}}.json`,
-        },
-      });
+    i18n.use(Backend).use(initReactI18next).init(getI18nConfig({ language, path }));
 
     if (window.public_config.APM_VENDOR === 'sentry') {
       const tooljetServerUrl = window.public_config.TOOLJET_SERVER_URL;


### PR DESCRIPTION
## Summary

- load i18next with the full language resolution chain so region-specific locale files are requested before base locales
- move the frontend i18n initialization options into a focused helper
- normalize translation asset paths when SUB_PATH is configured without a trailing slash

## Verification

- npm test -- i18nConfig.test.js --runInBand --env=node
- ./node_modules/.bin/eslint src/index.jsx src/i18nConfig.js src/__tests__/i18nConfig.test.js
- git diff --check
- coderabbit --agent
- claude -p code review prompt
- Codex sub-agent code review

Note: eslint exits successfully with the existing import/no-named-as-default-member warning on src/index.jsx.
