### PR TITLE
Add Bilig WorkPaper marketplace plugin

### DIFF
--- a/marketplace/package-lock.json
+++ b/marketplace/package-lock.json
@@ -6822,6 +6822,10 @@
       "resolved": "plugins/azurerepos",
       "link": true
     },
+    "node_modules/@tooljet-marketplace/bilig-workpaper": {
+      "resolved": "plugins/bilig_workpaper",
+      "link": true
+    },
     "node_modules/@tooljet-marketplace/clickup": {
       "resolved": "plugins/clickup",
       "link": true
@@ -19593,6 +19597,17 @@
       "dependencies": {
         "@tooljet-marketplace/common": "^1.0.0",
         "azure-devops-node-api": "^14.1.0"
+      },
+      "devDependencies": {
+        "@vercel/ncc": "^0.34.0",
+        "typescript": "^4.7.4"
+      }
+    },
+    "plugins/bilig_workpaper": {
+      "name": "@tooljet-marketplace/bilig-workpaper",
+      "version": "1.0.0",
+      "dependencies": {
+        "@tooljet-marketplace/common": "^1.0.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.34.0",

--- a/marketplace/plugins/bilig_workpaper/.gitignore
+++ b/marketplace/plugins/bilig_workpaper/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/marketplace/plugins/bilig_workpaper/README.md
+++ b/marketplace/plugins/bilig_workpaper/README.md
@@ -7,7 +7,7 @@ Bilig WorkPaper lets ToolJet apps call a workbook formula service from datasourc
 Start a Bilig WorkPaper formula server before testing the datasource:
 
 ```bash
-npm exec --package @bilig/workpaper@0.90.8 -- bilig-n8n-formula-server --port 4321
+npm exec --package @bilig/workpaper@latest -- bilig-n8n-formula-server --port 4321
 ```
 
 Use `http://localhost:4321` as the datasource base URL. The default formula-readback path is `/api/workpaper/n8n/forecast`.

--- a/marketplace/plugins/bilig_workpaper/README.md
+++ b/marketplace/plugins/bilig_workpaper/README.md
@@ -1,0 +1,25 @@
+# Bilig WorkPaper
+
+Bilig WorkPaper lets ToolJet apps call a workbook formula service from datasource queries. Use it when a workflow needs to write an input cell, recalculate spreadsheet formulas, verify the readback, and return the computed JSON result without opening Excel.
+
+## Local formula-readback service
+
+Start a Bilig WorkPaper formula server before testing the datasource:
+
+```bash
+npm exec --package @bilig/workpaper@0.86.1 -- bilig-n8n-formula-server --port 4321
+```
+
+Use `http://localhost:4321` as the datasource base URL. The default formula-readback path is `/api/workpaper/n8n/forecast`.
+
+## Operation
+
+### Verify formula readback
+
+Posts a cell write to the Bilig service and returns the verified formula output.
+
+Inputs:
+
+- `Sheet name`: sheet that contains the input cell, for example `Inputs`.
+- `Cell address`: A1-style input cell address, for example `B3`.
+- `Value`: JSON value to write before recalculation, for example `0.4`.

--- a/marketplace/plugins/bilig_workpaper/README.md
+++ b/marketplace/plugins/bilig_workpaper/README.md
@@ -7,7 +7,7 @@ Bilig WorkPaper lets ToolJet apps call a workbook formula service from datasourc
 Start a Bilig WorkPaper formula server before testing the datasource:
 
 ```bash
-npm exec --package @bilig/workpaper@0.86.1 -- bilig-n8n-formula-server --port 4321
+npm exec --package @bilig/workpaper@0.90.0 -- bilig-n8n-formula-server --port 4321
 ```
 
 Use `http://localhost:4321` as the datasource base URL. The default formula-readback path is `/api/workpaper/n8n/forecast`.

--- a/marketplace/plugins/bilig_workpaper/README.md
+++ b/marketplace/plugins/bilig_workpaper/README.md
@@ -7,7 +7,7 @@ Bilig WorkPaper lets ToolJet apps call a workbook formula service from datasourc
 Start a Bilig WorkPaper formula server before testing the datasource:
 
 ```bash
-npm exec --package @bilig/workpaper@0.90.0 -- bilig-n8n-formula-server --port 4321
+npm exec --package @bilig/workpaper@0.90.8 -- bilig-n8n-formula-server --port 4321
 ```
 
 Use `http://localhost:4321` as the datasource base URL. The default formula-readback path is `/api/workpaper/n8n/forecast`.

--- a/marketplace/plugins/bilig_workpaper/__tests__/index.js
+++ b/marketplace/plugins/bilig_workpaper/__tests__/index.js
@@ -1,0 +1,5 @@
+describe('Bilig WorkPaper', () => {
+  it('runs marketplace validation from the package build', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/marketplace/plugins/bilig_workpaper/lib/icon.svg
+++ b/marketplace/plugins/bilig_workpaper/lib/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#111827"/>
+  <rect x="14" y="14" width="36" height="36" rx="4" fill="#ffffff"/>
+  <path d="M14 26h36M14 38h36M26 14v36M38 14v36" stroke="#d1d5db" stroke-width="2"/>
+  <path d="M20 44c5-13 9-19 13-19 3 0 4 3 6 7 1 3 2 5 5 5" fill="none" stroke="#16a34a" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/marketplace/plugins/bilig_workpaper/lib/index.ts
+++ b/marketplace/plugins/bilig_workpaper/lib/index.ts
@@ -1,0 +1,188 @@
+import {
+  QueryError,
+  QueryResult,
+  QueryService,
+  ConnectionTestResult,
+} from '@tooljet-marketplace/common';
+import {
+  FormulaReadbackPayload,
+  Operation,
+  QueryOptions,
+  SourceOptions,
+} from './types';
+
+const DEFAULT_FORMULA_READBACK_PATH = '/api/workpaper/n8n/forecast';
+
+export default class BiligWorkpaper implements QueryService {
+  async run(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions
+  ): Promise<QueryResult> {
+    let result = {};
+
+    try {
+      switch (queryOptions.operation) {
+        case Operation.VerifyFormulaReadback:
+          result = await this.verifyFormulaReadback(
+            sourceOptions,
+            queryOptions
+          );
+          break;
+        default:
+          throw new QueryError(
+            'Unsupported Operation',
+            `${queryOptions.operation} is not supported.`,
+            {}
+          );
+      }
+    } catch (error) {
+      if (error instanceof QueryError) {
+        throw error;
+      }
+
+      throw new QueryError(
+        'Query could not be completed',
+        this.errorMessage(error),
+        {}
+      );
+    }
+
+    return {
+      status: 'ok',
+      data: result,
+    };
+  }
+
+  async testConnection(
+    sourceOptions: SourceOptions
+  ): Promise<ConnectionTestResult> {
+    try {
+      const response = await fetch(this.buildEndpoint(sourceOptions), {
+        method: 'OPTIONS',
+      });
+
+      if (!response.ok) {
+        throw new QueryError(
+          'Connection could not be established',
+          `HTTP ${response.status} ${response.statusText}`,
+          await this.parseResponse(response)
+        );
+      }
+
+      return { status: 'ok' };
+    } catch (error) {
+      if (error instanceof QueryError) {
+        throw error;
+      }
+
+      throw new QueryError(
+        'Connection could not be established',
+        this.errorMessage(error),
+        {}
+      );
+    }
+  }
+
+  private async verifyFormulaReadback(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions
+  ): Promise<unknown> {
+    return this.postFormulaReadback(sourceOptions, {
+      sheetName: queryOptions.sheetName || 'Inputs',
+      address: queryOptions.address || 'B3',
+      value: this.parseValue(queryOptions.value),
+    });
+  }
+
+  private async postFormulaReadback(
+    sourceOptions: SourceOptions,
+    payload: FormulaReadbackPayload
+  ): Promise<Record<string, unknown>> {
+    const response = await fetch(this.buildEndpoint(sourceOptions), {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await this.parseResponse(response);
+
+    if (!response.ok) {
+      throw new QueryError(
+        'Bilig WorkPaper request failed',
+        `HTTP ${response.status} ${response.statusText}`,
+        data
+      );
+    }
+
+    return data;
+  }
+
+  private buildEndpoint(sourceOptions: SourceOptions): string {
+    const baseUrl = String(sourceOptions.baseUrl || '').trim();
+
+    if (!baseUrl) {
+      throw new QueryError(
+        'Bilig WorkPaper URL missing',
+        'Enter a Bilig WorkPaper formula server base URL.',
+        {}
+      );
+    }
+
+    const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    const normalizedPath = String(
+      sourceOptions.formulaReadbackPath || DEFAULT_FORMULA_READBACK_PATH
+    ).replace(/^\/+/, '');
+
+    return new URL(normalizedPath, normalizedBase).toString();
+  }
+
+  private async parseResponse(
+    response: Response
+  ): Promise<Record<string, unknown>> {
+    const text = await response.text();
+
+    if (!text) {
+      return {};
+    }
+
+    try {
+      const data = JSON.parse(text);
+
+      if (data && typeof data === 'object' && !Array.isArray(data)) {
+        return data;
+      }
+
+      return { body: data };
+    } catch (_error) {
+      return { body: text };
+    }
+  }
+
+  private parseValue(value: QueryOptions['value']): unknown {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return '';
+    }
+
+    try {
+      return JSON.parse(trimmed);
+    } catch (_error) {
+      return value;
+    }
+  }
+
+  private errorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return 'An unknown error occurred';
+  }
+}

--- a/marketplace/plugins/bilig_workpaper/lib/manifest.json
+++ b/marketplace/plugins/bilig_workpaper/lib/manifest.json
@@ -34,7 +34,7 @@
       "key": "baseUrl",
       "type": "text",
       "description": "Enter your Bilig WorkPaper formula server URL.",
-      "helpText": "For local testing, start a sidecar with <code>npm exec --package @bilig/workpaper@0.90.0 -- bilig-n8n-formula-server --port 4321</code>."
+      "helpText": "For local testing, start a sidecar with <code>npm exec --package @bilig/workpaper@0.90.8 -- bilig-n8n-formula-server --port 4321</code>."
     },
     "formulaReadbackPath": {
       "label": "Formula readback path",

--- a/marketplace/plugins/bilig_workpaper/lib/manifest.json
+++ b/marketplace/plugins/bilig_workpaper/lib/manifest.json
@@ -34,7 +34,7 @@
       "key": "baseUrl",
       "type": "text",
       "description": "Enter your Bilig WorkPaper formula server URL.",
-      "helpText": "For local testing, start a sidecar with <code>npm exec --package @bilig/workpaper@0.86.1 -- bilig-n8n-formula-server --port 4321</code>."
+      "helpText": "For local testing, start a sidecar with <code>npm exec --package @bilig/workpaper@0.90.0 -- bilig-n8n-formula-server --port 4321</code>."
     },
     "formulaReadbackPath": {
       "label": "Formula readback path",

--- a/marketplace/plugins/bilig_workpaper/lib/manifest.json
+++ b/marketplace/plugins/bilig_workpaper/lib/manifest.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/manifest.schema.json",
+  "title": "Bilig WorkPaper datasource",
+  "description": "A schema defining Bilig WorkPaper datasource",
+  "type": "api",
+  "source": {
+    "name": "Bilig WorkPaper",
+    "kind": "bilig_workpaper",
+    "exposedVariables": {
+      "isLoading": false,
+      "data": {},
+      "rawData": {}
+    },
+    "options": {
+      "baseUrl": {
+        "type": "string"
+      },
+      "formulaReadbackPath": {
+        "type": "string"
+      }
+    }
+  },
+  "defaults": {
+    "baseUrl": {
+      "value": "http://localhost:4321"
+    },
+    "formulaReadbackPath": {
+      "value": "/api/workpaper/n8n/forecast"
+    }
+  },
+  "properties": {
+    "baseUrl": {
+      "label": "Base URL",
+      "key": "baseUrl",
+      "type": "text",
+      "description": "Enter your Bilig WorkPaper formula server URL.",
+      "helpText": "For local testing, start a sidecar with <code>npm exec --package @bilig/workpaper@0.86.1 -- bilig-n8n-formula-server --port 4321</code>."
+    },
+    "formulaReadbackPath": {
+      "label": "Formula readback path",
+      "key": "formulaReadbackPath",
+      "type": "text",
+      "description": "POST endpoint for formula readback.",
+      "helpText": "Default: /api/workpaper/n8n/forecast"
+    }
+  },
+  "required": ["baseUrl"]
+}

--- a/marketplace/plugins/bilig_workpaper/lib/manifest.json
+++ b/marketplace/plugins/bilig_workpaper/lib/manifest.json
@@ -34,7 +34,7 @@
       "key": "baseUrl",
       "type": "text",
       "description": "Enter your Bilig WorkPaper formula server URL.",
-      "helpText": "For local testing, start a sidecar with <code>npm exec --package @bilig/workpaper@0.90.8 -- bilig-n8n-formula-server --port 4321</code>."
+      "helpText": "For local testing, start a sidecar with <code>npm exec --package @bilig/workpaper@latest -- bilig-n8n-formula-server --port 4321</code>."
     },
     "formulaReadbackPath": {
       "label": "Formula readback path",

--- a/marketplace/plugins/bilig_workpaper/lib/operations.json
+++ b/marketplace/plugins/bilig_workpaper/lib/operations.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/operations.schema.json",
+  "title": "Bilig WorkPaper datasource",
+  "description": "A schema defining Bilig WorkPaper datasource",
+  "type": "api",
+  "defaults": {
+    "operation": "verify_formula_readback",
+    "sheetName": "Inputs",
+    "address": "B3",
+    "value": "0.4"
+  },
+  "properties": {
+    "operation": {
+      "label": "Operation",
+      "key": "operation",
+      "type": "dropdown-component-flip",
+      "description": "Select a Bilig WorkPaper operation",
+      "list": [
+        {
+          "value": "verify_formula_readback",
+          "name": "Verify formula readback"
+        }
+      ]
+    },
+    "verify_formula_readback": {
+      "sheetName": {
+        "label": "Sheet name",
+        "key": "sheetName",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "placeholder": "Inputs",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins"
+      },
+      "address": {
+        "label": "Cell address",
+        "key": "address",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "placeholder": "B3",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins"
+      },
+      "value": {
+        "label": "Value",
+        "key": "value",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "placeholder": "0.4",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins",
+        "tooltip": "JSON value to write before recalculation. Strings that are not valid JSON are sent as strings."
+      }
+    }
+  }
+}

--- a/marketplace/plugins/bilig_workpaper/lib/types.ts
+++ b/marketplace/plugins/bilig_workpaper/lib/types.ts
@@ -1,0 +1,21 @@
+export enum Operation {
+  VerifyFormulaReadback = 'verify_formula_readback',
+}
+
+export type SourceOptions = {
+  baseUrl: string;
+  formulaReadbackPath?: string;
+};
+
+export type QueryOptions = {
+  operation: Operation;
+  sheetName?: string;
+  address?: string;
+  value?: string | number | boolean | null;
+};
+
+export type FormulaReadbackPayload = {
+  sheetName: string;
+  address: string;
+  value: unknown;
+};

--- a/marketplace/plugins/bilig_workpaper/package.json
+++ b/marketplace/plugins/bilig_workpaper/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tooljet-marketplace/bilig-workpaper",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "build": "ncc build lib/index.ts -o dist",
+    "watch": "ncc build lib/index.ts -o dist --watch"
+  },
+  "homepage": "https://github.com/tooljet/tooljet#readme",
+  "dependencies": {
+    "@tooljet-marketplace/common": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.7.4",
+    "@vercel/ncc": "^0.34.0"
+  }
+}

--- a/marketplace/plugins/bilig_workpaper/tsconfig.json
+++ b/marketplace/plugins/bilig_workpaper/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "lib"
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/server/src/assets/marketplace/plugins.json
+++ b/server/src/assets/marketplace/plugins.json
@@ -363,5 +363,17 @@
     "id": "intercom",
     "author": "Tooljet",
     "timestamp": "Wed, 16 Apr 2026 10:00:00 GMT"
+  },
+  {
+    "name": "Bilig WorkPaper",
+    "description": "Verify spreadsheet formula readback from a Bilig WorkPaper sidecar",
+    "version": "1.0.0",
+    "id": "bilig_workpaper",
+    "author": "Tooljet",
+    "timestamp": "Sun, 24 May 2026 00:00:00 GMT",
+    "tags": [
+      "AI",
+      "Productivity"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Adds a Bilig WorkPaper marketplace datasource plugin for calling a formula-readback sidecar from ToolJet queries.

The plugin lets a ToolJet app write an input cell, trigger Bilig formula recalculation, verify the readback, and return the computed JSON result without Excel UI automation.

## Changes

- Add `marketplace/plugins/bilig_workpaper`
- Register `bilig_workpaper` in `server/src/assets/marketplace/plugins.json`
- Add the workspace lockfile entries for `@tooljet-marketplace/bilig-workpaper`
- Keep the local sidecar command on `@bilig/workpaper@latest` so the docs do not drift behind the published runtime

## Validation

- `npm install --ignore-scripts` from `marketplace/`
- `npm run build --workspace=@tooljet-marketplace/common` from `marketplace/`
- `npm run build --workspace=@tooljet-marketplace/bilig-workpaper` from `marketplace/`
- `python3 -m json.tool` on the manifest, operations schema, marketplace registry, and lockfile
- `git diff --check`
- `npm view @bilig/workpaper version --json` -> `0.157.0`
- `npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json` -> `verified: true`

The current public evaluator verified 8 MCP tools, `Inputs!B3` editing, expected ARR changing from `60000` to `96000`, JSON persistence, restart readback at `96000`, and package versions `@bilig/workpaper@0.157.0` / `xlsx-formula-recalc@0.157.0`.

Original local smoke against the PR sidecar path returned `status: ok`; `verify_formula_readback` returned `verified: true`, `editedCell: Inputs!B3`, and `expectedArr: 120000`.


