### PR TITLE
fix: show code hinter titles per field

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
@@ -280,6 +280,7 @@ const MultiLineCodeEditor = (props) => {
           isOpen={isOpen}
           callback={setIsOpen}
           componentName={componentName}
+          portalTitle={paramLabel || componentName}
           key={componentName}
           forceUpdate={forceUpdate}
           optionalProps={{ styles: { height: 300 }, cls: '' }}

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -517,13 +517,14 @@ const EditorInput = ({
           isQueryManager={isInsideQueryPane}
         />
       )}
-      <CodeHinter.Portal
-        isCopilotEnabled={false}
-        isOpen={isOpen}
-        callback={setIsOpen}
-        componentName={componentName}
-        key={componentName}
-        customComponent={renderPreview}
+        <CodeHinter.Portal
+          isCopilotEnabled={false}
+          isOpen={isOpen}
+          callback={setIsOpen}
+          componentName={componentName}
+          portalTitle={paramLabel || componentName}
+          key={componentName}
+          customComponent={renderPreview}
         forceUpdate={forceUpdate}
         optionalProps={{ styles: { height: 300 }, cls: '' }}
         darkMode={darkMode}

--- a/frontend/src/AppBuilder/CodeEditor/TJDBHinter.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/TJDBHinter.jsx
@@ -165,6 +165,7 @@ const TJDBCodeEditor = (props) => {
           isOpen={isOpen}
           callback={setIsOpen}
           componentName={componentName}
+          portalTitle={paramLabel || componentName}
           key={componentName}
           forceUpdate={forceUpdate}
           optionalProps={{ styles: { height: 300 }, cls: 'tjdb-hinter-portal' }}

--- a/frontend/src/_components/Portal/Portal.jsx
+++ b/frontend/src/_components/Portal/Portal.jsx
@@ -16,6 +16,7 @@ const Portal = ({ children, ...restProps }) => {
     styles,
     className,
     componentName,
+    portalTitle,
     dragResizePortal,
     callgpt,
     isCopilotEnabled,
@@ -23,15 +24,15 @@ const Portal = ({ children, ...restProps }) => {
     canRefresh = false,
   } = restProps;
 
-  const [name, setName] = React.useState(componentName);
+  const [name, setName] = React.useState(portalTitle ?? componentName);
   const handleClose = (e) => {
     e.stopPropagation();
     trigger(false);
   };
 
   React.useEffect(() => {
-    setName(componentName);
-  }, [componentName]);
+    setName(portalTitle ?? componentName);
+  }, [componentName, portalTitle]);
 
   React.useEffect(() => {
     if (isOpen) {
@@ -59,6 +60,7 @@ const Portal = ({ children, ...restProps }) => {
           portalStyles={portalStyles}
           darkMode={darkMode}
           styles={styles}
+          portalTitle={name}
           componentName={name}
           dragResizePortal={dragResizePortal}
           callgpt={callgpt}
@@ -82,6 +84,7 @@ const Modal = ({
   handleClose,
   portalStyles,
   styles,
+  portalTitle,
   componentName,
   darkMode,
   dragResizePortal,
@@ -120,7 +123,7 @@ const Modal = ({
             className="codehinder-popup-badge"
             data-cy="codehinder-popup-badge"
           >
-            {componentName ?? 'Editor'}
+            {portalTitle ?? componentName ?? 'Editor'}
           </span>
         </div>
 

--- a/frontend/src/_hooks/use-portal.jsx
+++ b/frontend/src/_hooks/use-portal.jsx
@@ -6,6 +6,7 @@ const usePortal = ({ children, ...restProps }) => {
     isOpen,
     callback,
     componentName,
+    portalTitle,
     key = '',
     customComponent = () => null,
     forceUpdate,
@@ -40,6 +41,7 @@ const usePortal = ({ children, ...restProps }) => {
           isOpen={isOpen}
           trigger={callback}
           componentName={componentName}
+          portalTitle={portalTitle}
           dragResizePortal={dragResizePortal}
           callgpt={callgpt}
           isCopilotEnabled={isCopilotEnabled}


### PR DESCRIPTION
Use the field label as the portal title for code hinter popups, falling back to the component name. This avoids the generic "Editor" header when the popup is opened from a specific property.