### PR TITLE
Fix/OpenAI image models

### DIFF
--- a/marketplace/package-lock.json
+++ b/marketplace/package-lock.json
@@ -20749,7 +20749,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tooljet-marketplace/common": "^1.0.0",
-        "openai": "6.39.0"
+        "openai": "^6.15.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.34.0",
@@ -20757,9 +20757,7 @@
       }
     },
     "plugins/openai/node_modules/openai": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-      "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
+      "version": "6.25.0",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/marketplace/package-lock.json
+++ b/marketplace/package-lock.json
@@ -20749,7 +20749,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tooljet-marketplace/common": "^1.0.0",
-        "openai": "^6.15.0"
+        "openai": "6.39.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.34.0",
@@ -20757,7 +20757,9 @@
       }
     },
     "plugins/openai/node_modules/openai": {
-      "version": "6.25.0",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
+      "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/marketplace/plugins/openai/lib/operations.json
+++ b/marketplace/plugins/openai/lib/operations.json
@@ -1177,12 +1177,31 @@
     			"type": "dropdown-component-flip",
     			"description": "Select OpenAI Model",
     			"list": [
-      				{ "value": "gpt-image-1", "name": "GPT Image 1" },
-					{ "value": "dall-e-3", "name": "DALL-E 3" },
-					{ "value": "dall-e-2", "name": "DALL-E 2" }
+      				{ "value": "gpt-image-1.5",   "name": "GPT Image 1.5" },
+      				{ "value": "gpt-image-1",      "name": "GPT Image 1" },
+      				{ "value": "gpt-image-1-mini", "name": "GPT Image 1 Mini" },
+					{ "value": "dall-e-3",         "name": "DALL-E 3 (Deprecated)" },
+					{ "value": "dall-e-2",         "name": "DALL-E 2 (Deprecated)" }
     			],
-    			"disabled": true,
-    			"default": "dall-e-3"
+    			"default": "gpt-image-1.5"
+  			},
+			"gpt-image-1.5": {
+   				"prompt": {
+      				"label": "Prompt",
+      				"key": "prompt",
+      				"type": "codehinter",
+      				"description": "Enter prompt for image generation",
+      				"height": "150px"
+    			},
+    			"size": {
+					"label": "Size (in pixels)",
+					"key": "size",
+					"type": "codehinter",
+					"description": "Enter image size in pixels (e.g., 1024x1024)",
+					"placeholder": "1024x1024, 1536x1024, 1024x1536 or auto. By default 1024x1024 sized image is generated",
+					"width": "320px",
+					"height": "36px"
+    			}
   			},
 			"gpt-image-1": {
    				"prompt": {
@@ -1197,7 +1216,25 @@
 					"key": "size",
 					"type": "codehinter",
 					"description": "Enter image size in pixels (e.g., 1024x1024)",
-                    "placeholder": "1024x1024, 1792x1024 or 1024x1792. By default 1024x1024 sized image is generated",
+					"placeholder": "1024x1024, 1536x1024, 1024x1536 or auto. By default 1024x1024 sized image is generated",
+					"width": "320px",
+					"height": "36px"
+    			}
+  			},
+			"gpt-image-1-mini": {
+   				"prompt": {
+      				"label": "Prompt",
+      				"key": "prompt",
+      				"type": "codehinter",
+      				"description": "Enter prompt for image generation",
+      				"height": "150px"
+    			},
+    			"size": {
+					"label": "Size (in pixels)",
+					"key": "size",
+					"type": "codehinter",
+					"description": "Enter image size in pixels (e.g., 1024x1024)",
+					"placeholder": "1024x1024, 1536x1024, 1024x1536 or auto. By default 1024x1024 sized image is generated",
 					"width": "320px",
 					"height": "36px"
     			}

--- a/marketplace/plugins/openai/lib/operations.json
+++ b/marketplace/plugins/openai/lib/operations.json
@@ -1177,13 +1177,32 @@
     			"type": "dropdown-component-flip",
     			"description": "Select OpenAI Model",
     			"list": [
-      				{ "value": "gpt-image-1.5",   "name": "GPT Image 1.5" },
+      				{ "value": "gpt-image-2",      "name": "GPT Image 2" },
+      				{ "value": "gpt-image-1.5",    "name": "GPT Image 1.5" },
       				{ "value": "gpt-image-1",      "name": "GPT Image 1" },
       				{ "value": "gpt-image-1-mini", "name": "GPT Image 1 Mini" },
 					{ "value": "dall-e-3",         "name": "DALL-E 3 (Deprecated)" },
 					{ "value": "dall-e-2",         "name": "DALL-E 2 (Deprecated)" }
     			],
     			"default": "gpt-image-1.5"
+  			},
+			"gpt-image-2": {
+   				"prompt": {
+      				"label": "Prompt",
+      				"key": "prompt",
+      				"type": "codehinter",
+      				"description": "Enter prompt for image generation",
+      				"height": "150px"
+    			},
+    			"size": {
+					"label": "Size (in pixels)",
+					"key": "size",
+					"type": "codehinter",
+					"description": "Enter image size in pixels (e.g., 1024x1024)",
+					"placeholder": "Any WIDTHxHEIGHT up to 3840x2160 (e.g. 1920x1080), or 1024x1024 / 1536x1024 / 1024x1536 / auto. By default 1024x1024 is used",
+					"width": "320px",
+					"height": "36px"
+    			}
   			},
 			"gpt-image-1.5": {
    				"prompt": {

--- a/marketplace/plugins/openai/lib/query_operations.ts
+++ b/marketplace/plugins/openai/lib/query_operations.ts
@@ -1,50 +1,55 @@
 import OpenAI from 'openai'; // Updated SDK version
 import { QueryOptions } from './types';
 
-const GPT_IMAGE_MODELS = new Set(['gpt-image-1', 'gpt-image-1-mini', 'gpt-image-1.5']);
+// All GPT image family models — always return b64_json, never a URL
+const GPT_IMAGE_MODELS = new Set([
+  'gpt-image-1',
+  'gpt-image-1-mini',
+  'gpt-image-1.5',
+  'gpt-image-2',
+  'gpt-image-2-2026-04-21',
+]);
 
-const getSizeEnum = (
-  model: string | undefined,
-  size: string | undefined
-): '256x256' | '512x512' | '1024x1024' | '1792x1024' | '1024x1792' | '1536x1024' | '1024x1536' | 'auto' => {
+// gpt-image-2 supports arbitrary WIDTHxHEIGHT strings up to 3840x2160;
+// the standard fixed-size switch used by the other GPT image models does not apply
+const GPT_IMAGE_2_MODELS = new Set(['gpt-image-2', 'gpt-image-2-2026-04-21']);
+
+const GPT_IMAGE_2_SIZE_RE = /^\d+x\d+$/;
+
+const getSizeEnum = (model: string | undefined, size: string | undefined): string => {
+  // gpt-image-2: pass through any valid WIDTHxHEIGHT string or 'auto'; default 1024x1024
+  if (GPT_IMAGE_2_MODELS.has(model ?? '')) {
+    const s = size?.trim() ?? '';
+    if (s === 'auto' || GPT_IMAGE_2_SIZE_RE.test(s)) return s;
+    return '1024x1024';
+  }
+
+  // Standard GPT image models: fixed size set + auto
   if (GPT_IMAGE_MODELS.has(model ?? '')) {
     switch (size) {
-      case '1024x1024':
-        return '1024x1024';
-      case '1536x1024':
-        return '1536x1024';
-      case '1024x1536':
-        return '1024x1536';
-      case 'auto':
-        return 'auto';
-      default:
-        return '1024x1024';
+      case '1024x1024': return '1024x1024';
+      case '1536x1024': return '1536x1024';
+      case '1024x1536': return '1024x1536';
+      case 'auto':      return 'auto';
+      default:          return '1024x1024';
     }
   }
 
   if (model === 'dall-e-3') {
     switch (size) {
-      case '1024x1024':
-        return '1024x1024';
-      case '1792x1024':
-        return '1792x1024';
-      case '1024x1792':
-        return '1024x1792';
-      default:
-        return '1024x1024';
+      case '1024x1024': return '1024x1024';
+      case '1792x1024': return '1792x1024';
+      case '1024x1792': return '1024x1792';
+      default:          return '1024x1024';
     }
   }
 
   if (model === 'dall-e-2') {
     switch (size) {
-      case '1024x1024':
-        return '1024x1024';
-      case '512x512':
-        return '512x512';
-      case '256x256':
-        return '256x256';
-      default:
-        return '1024x1024';
+      case '1024x1024': return '1024x1024';
+      case '512x512':   return '512x512';
+      case '256x256':   return '256x256';
+      default:          return '1024x1024';
     }
   }
 

--- a/marketplace/plugins/openai/lib/query_operations.ts
+++ b/marketplace/plugins/openai/lib/query_operations.ts
@@ -1,12 +1,27 @@
 import OpenAI from 'openai'; // Updated SDK version
 import { QueryOptions } from './types';
 
-// Updated utility function to handle size validation based on model
+const GPT_IMAGE_MODELS = new Set(['gpt-image-1', 'gpt-image-1-mini', 'gpt-image-1.5']);
+
 const getSizeEnum = (
   model: string | undefined,
   size: string | undefined
-): '256x256' | '512x512' | '1024x1024' | '1792x1024' | '1024x1792' => {
-  // If the model is DALL-E 3, only allow 1024x1024, 1792x1024, or 1024x1792
+): '256x256' | '512x512' | '1024x1024' | '1792x1024' | '1024x1792' | '1536x1024' | '1024x1536' | 'auto' => {
+  if (GPT_IMAGE_MODELS.has(model ?? '')) {
+    switch (size) {
+      case '1024x1024':
+        return '1024x1024';
+      case '1536x1024':
+        return '1536x1024';
+      case '1024x1536':
+        return '1024x1536';
+      case 'auto':
+        return 'auto';
+      default:
+        return '1024x1024';
+    }
+  }
+
   if (model === 'dall-e-3') {
     switch (size) {
       case '1024x1024':
@@ -16,11 +31,10 @@ const getSizeEnum = (
       case '1024x1792':
         return '1024x1792';
       default:
-        return '1024x1024'; // Default size for DALL-E 3
+        return '1024x1024';
     }
   }
 
-  // If the model is DALL-E 2, only allow 1024x1024, 512x512, or 256x256
   if (model === 'dall-e-2') {
     switch (size) {
       case '1024x1024':
@@ -30,11 +44,10 @@ const getSizeEnum = (
       case '256x256':
         return '256x256';
       default:
-        return '1024x1024'; // Default size for DALL-E 2
+        return '1024x1024';
     }
   }
 
-  // Default size if model is not recognized
   return '1024x1024';
 };
 
@@ -125,8 +138,8 @@ export async function generateImage(
     size: getSizeEnum(finalModel, size),
   });
 
-  // gpt-image-1 → base64
-  if (finalModel === 'gpt-image-1') {
+  // GPT image models always return b64_json — URLs are not supported
+  if (GPT_IMAGE_MODELS.has(finalModel)) {
     return {
       status: 'success',
       message: 'Image generated successfully',
@@ -136,7 +149,7 @@ export async function generateImage(
     };
   }
 
-  //  DALL·E → URL
+  // DALL-E models return a URL by default
   return {
     status: 'success',
     message: 'Image generated successfully',

--- a/marketplace/plugins/openai/package.json
+++ b/marketplace/plugins/openai/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/tooljet/tooljet#readme",
   "dependencies": {
     "@tooljet-marketplace/common": "^1.0.0",
-    "openai": "^6.15.0"
+    "openai": "6.39.0"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.34.0",


### PR DESCRIPTION
## Issue

* DALL-E 2 and DALL-E 3 image models were deprecated and newer GPT image models were not fully supported in the OpenAI plugin.
* The model dropdown was disabled, preventing users from selecting newer image models.

## Changes

* Added support for:

  * `gpt-image-2`
  * `gpt-image-1.5`
  * `gpt-image-1`
  * `gpt-image-1-mini`
* Marked `dall-e-2` and `dall-e-3` as deprecated while preserving backward compatibility.
* Enabled the model selection dropdown.
* Updated GPT image response handling to support the full GPT image model family.
* Added arbitrary resolution handling for `gpt-image-2`.
* Upgraded OpenAI SDK to `6.39.0`.
<img width="1454" height="845" alt="WhatsApp Image 2026-05-28 at 5 17 45 PM" src="https://github.com/user-attachments/assets/9cbf71f8-d084-40fa-b457-6ceac15663cd" />
