### PR TITLE
Fix: Missing server URL toast shows up on switching to a GRPC 2.0 query inside Query Builder

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/GRPCv2.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/GRPCv2.jsx
@@ -336,7 +336,7 @@ const GRPCv2Component = ({ darkMode, selectedDataSource, ...restProps }) => {
   }, [options?.metadata, queryName]);
 
   const loadServices = React.useCallback(async () => {
-    if (!selectedDataSource?.id) return;
+    if (!selectedDataSource?.id || selectedDataSource?.kind !== 'grpcv2') return;
 
     if (!selectedDataSource?.options?.url?.value) {
       toast.error('Please configure the server URL in your data source settings');


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/5126

This pull request makes a small but important update to the `GRPCv2Component` in the query editor. The change ensures that the `loadServices` function only runs when the selected data source is of the correct kind (`grpcv2`), adding an extra check to prevent unintended behavior.

- Added a check in `GRPCv2Component` to ensure `loadServices` only executes if the selected data source is of kind `'grpcv2'`, preventing errors when other data source types are selected.