### PR TITLE
Fix QuickBooks datasource duplicate documentation links

### DIFF
--- a/frontend/src/modules/dataSources/components/DataSourceManager/DataSourceManager.jsx
+++ b/frontend/src/modules/dataSources/components/DataSourceManager/DataSourceManager.jsx
@@ -430,6 +430,9 @@ class DataSourceManagerComponent extends React.Component {
       case 'databricks': {
         return datasourceOptions?.authentication_type?.value === 'personal_access_token' ? true : false;
       }
+      case 'quickbooks': {
+        return false;
+      }
       default:
         return true;
     }


### PR DESCRIPTION
## Issue: https://github.com/ToolJet/ToolJet/issues/16590

QuickBooks datasource configuration page displayed duplicate UI elements.

### Current Behavior

* "Read documentation" link was displayed twice.
* OAuth connection controls were duplicated.
* Test Connection footer was rendered for an OAuth datasource.

### Root Cause

QuickBooks was falling through the default branch of `checkShouldRenderFooterComponent`, causing the DataSourceManager footer to render in addition to the OAuthWrapper footer.

## Fix

* Added QuickBooks handling in `checkShouldRenderFooterComponent`.
* Prevented the DataSourceManager footer from rendering for QuickBooks.
* QuickBooks now relies on the OAuthWrapper footer, consistent with other OAuth datasources such as BigQuery and GoogleSheetsV2.

<img width="1086" height="814" alt="WhatsApp Image 2026-05-29 at 12 25 10 PM" src="https://github.com/user-attachments/assets/763c742a-d267-48ec-bb5c-dca56180aac9" />

