### PR TITLE
fix: use property label as code-hinter popup header title

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
@@ -280,6 +280,7 @@ const MultiLineCodeEditor = (props) => {
           isOpen={isOpen}
           callback={setIsOpen}
           componentName={componentName}
+          portalTitle={paramLabel || componentName}
           key={componentName}
           forceUpdate={forceUpdate}
           optionalProps={{ styles: { height: 300 }, cls: '' }}

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -203,6 +203,7 @@ const SingleLineCodeEditor = ({ componentName, fieldMeta = {}, componentId, modu
         setIsFocused={setIsFocused}
         setCursorInsidePreview={setCursorInsidePreview}
         componentName={componentName}
+        portalTitle={paramLabel || componentName}
         validationSchema={validation}
         setErrorStateActive={setErrorStateActive}
         ignoreValidation={restProps?.ignoreValidation || isEmpty(validation)}
@@ -234,6 +235,7 @@ const SingleLineCodeEditor = ({ componentName, fieldMeta = {}, componentId, modu
               cyLabel={restProps.cyLabel}
               portalProps={portalProps}
               componentName={componentName}
+              portalTitle={paramLabel || componentName}
               setShowPreview={setShowPreview}
               showPreview={showPreview}
               wrapperRef={wrapperRef}
@@ -522,6 +524,7 @@ const EditorInput = ({
         isOpen={isOpen}
         callback={setIsOpen}
         componentName={componentName}
+        portalTitle={paramLabel || componentName}
         key={componentName}
         customComponent={renderPreview}
         forceUpdate={forceUpdate}

--- a/frontend/src/AppBuilder/CodeEditor/TJDBHinter.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/TJDBHinter.jsx
@@ -165,6 +165,7 @@ const TJDBCodeEditor = (props) => {
           isOpen={isOpen}
           callback={setIsOpen}
           componentName={componentName}
+          portalTitle={paramLabel || componentName}
           key={componentName}
           forceUpdate={forceUpdate}
           optionalProps={{ styles: { height: 300 }, cls: 'tjdb-hinter-portal' }}

--- a/frontend/src/_components/Portal/Portal.jsx
+++ b/frontend/src/_components/Portal/Portal.jsx
@@ -23,15 +23,15 @@ const Portal = ({ children, ...restProps }) => {
     canRefresh = false,
   } = restProps;
 
-  const [name, setName] = React.useState(componentName);
+  const [name, setName] = React.useState(portalTitle ?? componentName);
   const handleClose = (e) => {
     e.stopPropagation();
     trigger(false);
   };
 
   React.useEffect(() => {
-    setName(componentName);
-  }, [componentName]);
+    setName(portalTitle ?? componentName);
+  }, [componentName, portalTitle]);
 
   React.useEffect(() => {
     if (isOpen) {
@@ -60,6 +60,7 @@ const Portal = ({ children, ...restProps }) => {
           darkMode={darkMode}
           styles={styles}
           componentName={name}
+          portalTitle={name}
           dragResizePortal={dragResizePortal}
           callgpt={callgpt}
           isCopilotEnabled={isCopilotEnabled}
@@ -120,7 +121,7 @@ const Modal = ({
             className="codehinder-popup-badge"
             data-cy="codehinder-popup-badge"
           >
-            {componentName ?? 'Editor'}
+            {portalTitle ?? componentName ?? 'Editor'}
           </span>
         </div>
 

--- a/frontend/src/_hooks/use-portal.jsx
+++ b/frontend/src/_hooks/use-portal.jsx
@@ -40,6 +40,7 @@ const usePortal = ({ children, ...restProps }) => {
           isOpen={isOpen}
           trigger={callback}
           componentName={componentName}
+          portalTitle={portalTitle}
           dragResizePortal={dragResizePortal}
           callgpt={callgpt}
           isCopilotEnabled={isCopilotEnabled}


### PR DESCRIPTION
Use the field label as the portal title for code hinter popups, falling back to the component name. This avoids the generic 'Editor' header when the popup is opened from a specific property field.

Fixes #6655