### PR TITLE
Fix: strip client_secret from public SSO endpoint response

### DIFF
--- a/server/src/modules/login-configs/util.service.ts
+++ b/server/src/modules/login-configs/util.service.ts
@@ -141,12 +141,12 @@ export class LoginConfigsUtilService implements ILoginConfigsUtilService {
 
   public buildConfigs(config: any, configId: string) {
     if (!config) return config;
+    const safeConfigs = Object.fromEntries(
+      Object.entries(config?.configs || {}).filter(([key]) => !key.toLowerCase().includes('secret'))
+    );
     return {
       ...config,
-      configs: {
-        ...(config?.configs || {}),
-        ...(config?.configs ? { clientSecret: '' } : {}),
-      },
+      configs: safeConfigs,
       configId,
     };
   }

--- a/server/test/modules/login-configs/unit/util.service.spec.ts
+++ b/server/test/modules/login-configs/unit/util.service.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { LoginConfigsUtilService } from '../../../../src/modules/login-configs/util.service';
+import { EncryptionService } from '../../../../src/modules/encryption/service';
+import { OrganizationRepository } from '../../../../src/modules/organizations/repository';
+import { SSOConfigsRepository } from '../../../../src/modules/login-configs/repository';
+
+describe('LoginConfigsUtilService', () => {
+  let service: LoginConfigsUtilService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LoginConfigsUtilService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: EncryptionService, useValue: { encryptColumnValue: jest.fn(), decryptColumnValue: jest.fn() } },
+        { provide: OrganizationRepository, useValue: {} },
+        { provide: SSOConfigsRepository, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<LoginConfigsUtilService>(LoginConfigsUtilService);
+  });
+
+  describe('buildConfigs', () => {
+    it('strips clientSecret (camelCase) from configs', () => {
+      const config = {
+        sso: 'git',
+        enabled: true,
+        configs: { clientId: 'my-client-id', clientSecret: 'super-secret', hostName: 'github.com' },
+      };
+
+      const result = service.buildConfigs(config, 'config-id-1');
+
+      expect(result.configs.clientId).toBe('my-client-id');
+      expect(result.configs.hostName).toBe('github.com');
+      expect(result.configs.clientSecret).toBeUndefined();
+    });
+
+    it('strips client_secret (snake_case) from configs', () => {
+      const config = {
+        sso: 'openid',
+        enabled: true,
+        configs: { client_id: 'my-client-id', client_secret: 'super-secret', well_known_url: 'https://provider/.well-known/openid-configuration' },
+      };
+
+      const result = service.buildConfigs(config, 'config-id-2');
+
+      expect(result.configs.client_id).toBe('my-client-id');
+      expect(result.configs.well_known_url).toBeDefined();
+      expect(result.configs.client_secret).toBeUndefined();
+    });
+
+    it('strips any key containing "secret" regardless of casing', () => {
+      const config = {
+        sso: 'openid',
+        enabled: true,
+        configs: {
+          clientId: 'id',
+          clientSecret: 'secret1',
+          CLIENT_SECRET: 'secret2',
+          someSecretKey: 'secret3',
+          name: 'My OIDC',
+        },
+      };
+
+      const result = service.buildConfigs(config, 'config-id-3');
+
+      expect(result.configs.clientId).toBe('id');
+      expect(result.configs.name).toBe('My OIDC');
+      expect(result.configs.clientSecret).toBeUndefined();
+      expect(result.configs.CLIENT_SECRET).toBeUndefined();
+      expect(result.configs.someSecretKey).toBeUndefined();
+    });
+
+    it('preserves non-secret fields and the configId', () => {
+      const config = {
+        sso: 'openid',
+        enabled: true,
+        configs: { clientId: 'id', wellKnownUrl: 'https://example.com/.well-known', name: 'Corp SSO' },
+      };
+
+      const result = service.buildConfigs(config, 'cfg-abc');
+
+      expect(result.configId).toBe('cfg-abc');
+      expect(result.sso).toBe('openid');
+      expect(result.enabled).toBe(true);
+      expect(result.configs).toEqual({ clientId: 'id', wellKnownUrl: 'https://example.com/.well-known', name: 'Corp SSO' });
+    });
+
+    it('handles empty configs object without throwing', () => {
+      const config = { sso: 'google', enabled: true, configs: {} };
+      const result = service.buildConfigs(config, 'cfg-empty');
+      expect(result.configs).toEqual({});
+    });
+
+    it('returns config unchanged when config is null or undefined', () => {
+      expect(service.buildConfigs(null, 'x')).toBeNull();
+      expect(service.buildConfigs(undefined, 'x')).toBeUndefined();
+    });
+
+    it('handles missing configs key on the config object', () => {
+      const config = { sso: 'form', enabled: true };
+      const result = service.buildConfigs(config, 'cfg-form');
+      expect(result.configs).toEqual({});
+    });
+  });
+});

--- a/server/test/modules/organizations/e2e/organizations.spec.ts
+++ b/server/test/modules/organizations/e2e/organizations.spec.ts
@@ -416,6 +416,9 @@ describe('OrganizationsController', () => {
         expect(getResponse.body.sso_configs.form).toBeDefined();
         expect(getResponse.body.sso_configs.form.sso).toBe('form');
         expect(getResponse.body.sso_configs.form.enabled).toBe(true);
+        // client_secret must never be returned on the public (unauthenticated) endpoint
+        expect(getResponse.body.sso_configs.git?.configs?.client_secret).toBeUndefined();
+        expect(getResponse.body.sso_configs.git?.configs?.client_id).toBeDefined();
       });
 
       it('should get organization specific details with instance level sso and override it with organization sso configs for all users for multiple organization deployment', async () => {
@@ -459,6 +462,9 @@ describe('OrganizationsController', () => {
         // Git config should be present (org-level overrides instance)
         expect(getResponse.body.sso_configs.git).toBeDefined();
         expect(getResponse.body.sso_configs.git.sso).toBe('git');
+        // client_secret must never be returned on the public (unauthenticated) endpoint
+        expect(getResponse.body.sso_configs.git?.configs?.client_secret).toBeUndefined();
+        expect(getResponse.body.sso_configs.git?.configs?.client_id).toBeDefined();
       });
 
       it('should get organization specific details with instance level sso for all users for multiple organization deployment', async () => {
@@ -491,6 +497,45 @@ describe('OrganizationsController', () => {
         expect(getResponse.body.sso_configs.form).toBeDefined();
         expect(getResponse.body.sso_configs.form.sso).toBe('form');
         expect(getResponse.body.sso_configs.form.enabled).toBe(true);
+      });
+
+      it('should not expose client_secret in OIDC configs on the public endpoint', async () => {
+        const { user, organization } = await createUser(app, {
+          email: 'admin@tooljet.io',
+        });
+        const loggedUser = await login(app);
+
+        const patchResponse = await request(app.getHttpServer())
+          .patch('/api/login-configs/organization-sso')
+          .send({
+            type: 'openid',
+            configs: {
+              clientId: 'oidc-client-id',
+              clientSecret: 'oidc-super-secret',
+              wellKnownUrl: 'https://idp.example.com/.well-known/openid-configuration',
+              name: 'Test OIDC',
+            },
+            enabled: true,
+          })
+          .set('tj-workspace-id', user.defaultOrganizationId)
+          .set('Cookie', loggedUser.tokenCookie);
+
+        expect(patchResponse.statusCode).toBe(200);
+
+        const getResponse = await request(app.getHttpServer()).get(
+          `/api/login-configs/${organization.id}/public`
+        );
+
+        expect(getResponse.statusCode).toBe(200);
+        const oidcConfigs = getResponse.body.sso_configs?.openid;
+        // OIDC is returned as an array for workspace-scoped configs
+        const oidcEntry = Array.isArray(oidcConfigs) ? oidcConfigs[0] : oidcConfigs;
+        expect(oidcEntry).toBeDefined();
+        // client_secret must never appear — neither snake_case nor camelCase
+        expect(oidcEntry?.configs?.client_secret).toBeUndefined();
+        expect(oidcEntry?.configs?.clientSecret).toBeUndefined();
+        // Public fields should still be present
+        expect(oidcEntry?.configs?.client_id ?? oidcEntry?.configs?.clientId).toBeDefined();
       });
     });
   });


### PR DESCRIPTION
## 📝 What this does
The unauthenticated `GET /api/login-configs/public` endpoint was leaking the OIDC and Git OAuth `clientSecret` in plaintext. Two code paths were affected: `constructSSOConfigs()` (instance-level, no-org-ID path) returned fully decrypted secrets, and `buildConfigs()` (workspace-level path) blanked `clientSecret` with an empty string instead of removing it and missed snake_case variants.
- [ee-server](https://github.com/ToolJet/ee-server/pull/570)
- [ee-frontend](no changes)

## 🔀 Changes
- `buildConfigs()`: replaced spread-and-blank pattern with `Object.entries` filter that removes any key containing `"secret"` — covers `clientSecret`, `client_secret`, and any future variants
- `constructSSOConfigs()` (EE): added `stripSecrets()` helper applied to `git.configs` and `openid.configs` before returning on the public endpoint
- Added 7 unit tests for `buildConfigs` covering camelCase, snake_case, mixed casing, edge cases
- Added 3 e2e assertions to existing public endpoint tests asserting `client_secret` is absent from Git and OIDC configs in the response

## 🧪 How to test
- [ ] Configure an OIDC SSO provider in workspace settings with a `clientSecret`
- [ ] `curl -s http://localhost:3000/api/login-configs/<org-id>/public | jq '.sso_configs.openid'` — verify `client_secret` is absent
- [ ] `curl -s http://localhost:3000/api/login-configs/public | jq '.sso_configs.openid.configs | keys'` — verify `client_secret` absent from instance-level response
- [ ] Verify SSO login still works end-to-end after the change
- [ ] Run unit tests: `task test:unit-filter -- login-configs`
- [ ] Run e2e suite: `task test:e2e-filter -- organizations`