### PR TITLE
fix: enhance SSRF protection by adding hostname blocklist and improving validation logic

### DIFF
--- a/plugins/packages/common/lib/ssrf-protection.ts
+++ b/plugins/packages/common/lib/ssrf-protection.ts
@@ -29,9 +29,26 @@ const CLOUD_METADATA_ENDPOINTS = [
   /^169\.254\.169\.254$/,
 ];
 
-// Note: Dangerous URL schemes (file, ftp, dict, gopher, jar, data, javascript, etc.)
-// are configured via SSRF_BLOCKED_SCHEMES environment variable for flexibility.
-// Users should configure blocked schemes based on their security requirements.
+const DEFAULT_BLOCKED_SCHEMES = ['file', 'gopher', 'dict', 'ftp', 'jar', 'data', 'javascript'];
+
+// Well-known hostnames that always resolve to loopback/private addresses.
+// Checked statically before DNS resolution as defense-in-depth.
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  '0.0.0.0',
+]);
+
+// DNS-rebinding-as-a-service domains — their sole purpose is embedding an IP
+// in a hostname, so they have no legitimate use in outbound requests.
+const BLOCKED_HOSTNAME_PATTERNS = [
+  /\.nip\.io$/i,
+  /\.xip\.io$/i,
+  /\.sslip\.io$/i,
+  /\.localtest\.me$/i,
+  /\.traefik\.me$/i,
+];
 
 interface SSRFProtectionOptions {
   enabled?: boolean;
@@ -49,7 +66,7 @@ export function getSSRFConfig(): SSRFProtectionOptions {
   const blockedSchemesEnv = process.env.SSRF_BLOCKED_SCHEMES;
   const blockedSchemes = blockedSchemesEnv
     ? blockedSchemesEnv.split(',').map(s => s.trim().toLowerCase()).filter(s => s.length > 0)
-    : [];
+    : DEFAULT_BLOCKED_SCHEMES;
 
   return {
     enabled,
@@ -73,6 +90,12 @@ export function isSchemeBlocked(scheme: string, blockedSchemes: string[]): boole
   const normalizedScheme = scheme.replace(/:$/, '').toLowerCase();
 
   return blockedSchemes.includes(normalizedScheme);
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().trim();
+  if (BLOCKED_HOSTNAMES.has(normalized)) return true;
+  return BLOCKED_HOSTNAME_PATTERNS.some(pattern => pattern.test(normalized));
 }
 
 export function isCloudMetadataEndpoint(ipOrHostname: string): boolean {
@@ -262,12 +285,22 @@ function isPrivateIPv6(ip: string): boolean {
 
   // IPv4-mapped IPv6: ::ffff:0:0/96
   if (normalized.includes('::ffff:')) {
-    // Extract the IPv4 part and check it
     const ipv4Part = normalized.split('::ffff:')[1];
     if (ipv4Part) {
-      // Handle both ::ffff:192.168.1.1 and ::ffff:c0a8:101 formats
       if (ipv4Part.includes('.')) {
+        // Dotted notation: ::ffff:192.168.1.1
         return isPrivateIP(ipv4Part);
+      } else {
+        // Hex notation: ::ffff:c0a8:101 (two 16-bit groups encoding the IPv4 address)
+        const hexParts = ipv4Part.split(':');
+        if (hexParts.length === 2) {
+          const high = parseInt(hexParts[0], 16);
+          const low = parseInt(hexParts[1], 16);
+          if (!isNaN(high) && !isNaN(low)) {
+            const dotted = `${(high >> 8) & 0xFF}.${high & 0xFF}.${(low >> 8) & 0xFF}.${low & 0xFF}`;
+            return isPrivateIP(dotted);
+          }
+        }
       }
     }
   }
@@ -298,10 +331,11 @@ export async function resolvesToPrivateIP(hostname: string): Promise<boolean> {
       // IPv6 resolution failed, continue
     }
 
-    // If no addresses resolved, fail open for self-hosted compatibility
+    // Fail-closed: if DNS returns no addresses we cannot verify the destination
+    // is safe, so block it rather than allowing the request through.
     if (addresses.length === 0) {
-      console.warn(`DNS resolution failed for ${hostname}`);
-      return false;
+      console.warn(`DNS resolution returned no addresses for ${hostname}, blocking as precaution`);
+      return true;
     }
 
     // Check if any resolved address is a private IP
@@ -373,9 +407,16 @@ export async function validateUrlForSSRF(
     }
   }
 
-  // 1. Check for blocked schemes
-  // By default, all schemes are allowed for self-hosted flexibility
-  // Users can configure blocked schemes via SSRF_BLOCKED_SCHEMES env variable
+  // 1. Static hostname blocklist — defense-in-depth before any DNS resolution
+  if (isBlockedHostname(hostname)) {
+    throw new QueryError(
+      'Hostname blocked',
+      'This hostname is not allowed for security reasons',
+      { hostname }
+    );
+  }
+
+  // 2. Check for blocked schemes
   if (config.blockedSchemes && config.blockedSchemes.length > 0) {
     if (isSchemeBlocked(scheme, config.blockedSchemes)) {
       throw new QueryError(
@@ -386,8 +427,7 @@ export async function validateUrlForSSRF(
     }
   }
 
-  // 2. Check if hostname is a private IP address
-  // When SSRF protection is enabled, block direct access to private IPs
+  // 3. Check if hostname is a private IP address
   if (isPrivateIP(hostname)) {
     throw new QueryError(
       'Private IP address blocked',
@@ -396,8 +436,7 @@ export async function validateUrlForSSRF(
     );
   }
 
-  // 3. DNS resolution check (if enabled)
-  // This protects against DNS rebinding attacks like 169.254.169.254.nip.io
+  // 4. DNS resolution check — catches rebinding services not caught by static list
   if (config.dnsResolutionCheck) {
     const resolves = await resolvesToPrivateIP(hostname);
     if (resolves) {
@@ -611,6 +650,14 @@ export function validateUrlForSSRFSync(urlString: string, options?: SSRFProtecti
 
   const hostname = url.hostname.toLowerCase();
   const scheme = url.protocol;
+
+  if (isBlockedHostname(hostname)) {
+    throw new QueryError(
+      'Hostname blocked',
+      'This hostname is not allowed for security reasons',
+      { hostname }
+    );
+  }
 
   // Check for blocked schemes
   if (config.blockedSchemes && config.blockedSchemes.length > 0) {


### PR DESCRIPTION
  ## Summary

  Addresses remaining gaps in SSRF protection identified via security advisory
  GHSA-h49f-mhmm-jx4w. The original DNS-rebinding bypass (e.g. `169.254.169.254.nip.io`)
  was already partially mitigated, but four issues remained.

  ## Changes

  **`plugins/packages/common/lib/ssrf-protection.ts`**

  - **Static hostname blocklist** — `localhost`, `ip6-localhost`, `0.0.0.0`, and all
    DNS-rebinding-as-a-service domains (`*.nip.io`, `*.xip.io`, `*.sslip.io`,
    `*.localtest.me`, `*.traefik.me`) are now blocked statically before DNS resolution,
    providing defense-in-depth independent of resolver availability

  - **DNS fail-closed** — `resolvesToPrivateIP()` previously returned `false` (allow)
    when DNS returned zero addresses; now returns `true` (block) since an unresolvable
    hostname cannot be verified as safe

  - **Dangerous schemes blocked by default** — `file`, `gopher`, `dict`, `ftp`, `jar`,
    `data`, `javascript` are now blocked unless `SSRF_BLOCKED_SCHEMES` is explicitly
    overridden; previously required opt-in via env var

  - **IPv6-mapped IPv4 hex format** — `isPrivateIPv6()` now handles `::ffff:c0a8:101`
    notation in addition to the previously supported `::ffff:192.168.1.1` dotted form

  ## Security Impact

  | Bypass vector | Before | After |
  |---|---|---|
  | `localhost` | Caught by DNS resolution only | Statically blocked |
  | `*.nip.io` / `*.sslip.io` | Caught by DNS resolution only | Statically blocked + DNS |
  | DNS resolution failure | Fail-open (allowed) | Fail-closed (blocked) |
  | `file://`, `gopher://` etc. | Allowed unless env var set | Blocked by default |
  | `::ffff:c0a8:101` (IPv6 hex) | Not detected | Blocked |