### PR TITLE
Fix: Add missing comma after oracledb in WhitelistPluginGuard allowedKinds

### DIFF
--- a/server/src/modules/data-sources/guards/whitelist-plugin.guard.ts
+++ b/server/src/modules/data-sources/guards/whitelist-plugin.guard.ts
@@ -13,7 +13,7 @@ export class WhitelistPluginGuard implements CanActivate {
     'mongodb',
     'bigquery',
     'snowflake',
-    'oracledb'
+    'oracledb',
     'databricks',
   ]); // Start with grpcv2, easily expandable
 


### PR DESCRIPTION
## 📝 What this does
Fixes a missing trailing comma after `'oracledb'` in the `allowedKinds` set in `WhitelistPluginGuard`. Without the comma, `'oracledb'` and `'databricks'` were being treated as adjacent string literals — meaning `databricks` was never actually added to the whitelist.

## 🔀 Changes
- Added missing comma after `'oracledb'` in `WhitelistPluginGuard` allowedKinds array

## 🧪 How to test
- [ ] Confirm Databricks data source operations pass through `WhitelistPluginGuard` without being blocked
- [ ] Confirm OracleDB data source operations continue to work as before