### PR TITLE
feat(query): Run a query periodically

### DIFF
--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/queries/runQueryPeriodically.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/queries/runQueryPeriodically.cy.js
@@ -1,0 +1,119 @@
+import { fake } from "Fixtures/fake";
+import { commonWidgetSelector } from "Selectors/common";
+import {
+  addInputOnQueryField,
+  changeQueryToggles,
+  query,
+  selectQueryFromLandingPage,
+} from "Support/utils/queries";
+import { resizeQueryPanel } from "Support/utils/dataSource";
+import { openNode } from "Support/utils/inspector";
+
+// Selectors for the "Run this query periodically" query setting.
+// Toggle dataCy is `run-query-periodically`; CustomToggleSwitch/FxButton/CodeHinter
+// derive the suffixes below. The interval + fx-expression fields live in PeriodicRunInputs.
+const sel = {
+  settingsTab: '[data-cy="query-tab-settings"]',
+  toggleSwitch: '[data-cy="run-query-periodically-toggle-switch"]',
+  toggleLabel: '[data-cy="run-query-periodically-toggle-label"]',
+  fxButton: '[data-cy="run-query-periodically-fx-button"]',
+  intervalLabel: '[data-cy="label-time-interval-input"]',
+  intervalField: '[data-cy="time-interval-input-field"]',
+  fxExpression: '[data-cy="run-periodically-fx-expression-input-field"]',
+  queryDataValue: '[data-cy="inspector-data-value"]',
+};
+
+const createRunjs = (code) => {
+  selectQueryFromLandingPage("runjs", "JavaScript");
+  addInputOnQueryField("runjs", code);
+};
+
+describe("Query - Run this query periodically", () => {
+  beforeEach(() => {
+    cy.apiLogin();
+    cy.apiCreateApp(`${fake.companyName}-periodic-App`);
+    cy.openApp();
+    cy.viewport(1800, 1800);
+    cy.dragAndDropWidget("Button");
+    resizeQueryPanel("80");
+  });
+
+  it("reveals the time interval only when enabled, and persists across reload", () => {
+    createRunjs("return 1");
+    cy.get(sel.settingsTab).click();
+
+    // Toggle is present; the interval field stays hidden until the toggle is on.
+    cy.get(sel.toggleLabel).verifyVisibleElement(
+      "have.text",
+      "Run this query periodically"
+    );
+    cy.get(sel.intervalField).should("not.exist");
+
+    // Enabling the toggle reveals the interval field.
+    changeQueryToggles("run-query-periodically");
+    cy.get(sel.intervalLabel).should("be.visible");
+    cy.get(sel.intervalField)
+      .should("be.visible")
+      .clearAndTypeOnCodeMirror("2000");
+    cy.waitForAutoSave();
+
+    // Round-trip: the options are stored on query.options (opaque JSON blob), so they
+    // survive a reload with no server change.
+    cy.reload();
+    cy.get('[data-cy="list-query-runjs1"]').click();
+    cy.get(sel.settingsTab).click();
+    cy.get(sel.toggleSwitch).should("be.checked");
+    cy.get(sel.intervalField).should("be.visible").and("contain", "2000");
+
+    cy.apiDeleteApp();
+  });
+
+  it("reveals the fx expression editor when fx is toggled on the periodic flag", () => {
+    createRunjs("return 1");
+    cy.get(sel.settingsTab).click();
+
+    cy.get(sel.fxExpression).should("not.exist");
+    cy.get(sel.fxButton).click();
+    // fx mode swaps the switch for an expression editor; the interval field stays.
+    cy.get(sel.fxExpression).should("be.visible");
+    cy.get(sel.intervalField).should("be.visible");
+
+    cy.apiDeleteApp();
+  });
+
+  it("re-runs on the interval after the first run, with the clock anchored to the last run", () => {
+    // Date.now() changes every execution, so a changed value proves the timer fired.
+    createRunjs("return Date.now()");
+    cy.get(sel.settingsTab).click();
+    changeQueryToggles("run-query-periodically");
+    cy.get(sel.intervalField).clearAndTypeOnCodeMirror("2000");
+    cy.waitForAutoSave();
+
+    // The first manual run is what starts the periodic timer.
+    query("run");
+
+    // Watch the exposed query data advance on the next tick via the inspector.
+    cy.get(commonWidgetSelector.sidebarinspector).click();
+    cy.get(".tooltip-inner").invoke("hide");
+    openNode("queries");
+    openNode("runjs1");
+
+    let firstValue;
+    cy.get(sel.queryDataValue)
+      .eq(0)
+      .invoke("text")
+      .then((text) => {
+        firstValue = text;
+      });
+    // Wait past one interval (2000ms) plus a buffer, then assert the value changed.
+    cy.wait(3000);
+    cy.get(sel.queryDataValue)
+      .eq(0)
+      .invoke("text")
+      .should((text) => {
+        expect(text).to.not.equal(firstValue);
+      });
+
+    cy.apiDeleteApp();
+  });
+});

--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -195,6 +195,8 @@
             "confirmBeforeQueryRun": "Request confirmation before running query",
             "notificationOnSuccess": "Show notification on success",
             "runOnDependencyChange": "Run this query on dependency change",
+            "runQueryPeriodically": "Run this query periodically",
+            "timeInterval": "Time interval ( ms )",
             "successMessage": "Success Message",
             "queryRanSuccessfully": "Query ran successfully",
             "notificationDuration": "Notification duration (s)",

--- a/frontend/src/AppBuilder/QueryManager/Components/PeriodicRunInputs.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/PeriodicRunInputs.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import CodeHinter from '@/AppBuilder/CodeEditor';
+import './PeriodicRunInputs.scss';
+
+// Revealed directly under the "Run this query periodically" toggle.
+// When fx is active, shows the expression editor for the toggle value itself
+// (stored as a string in options.runPeriodically). The time interval is in
+// milliseconds and supports fx (resolved + clamped to a safe minimum at runtime).
+export default function PeriodicRunInputs({ options, optionchanged }) {
+  const { t } = useTranslation();
+  const fxMode = !!options?.runPeriodicallyFx;
+  const toggleOn = !fxMode && !!options?.runPeriodically;
+
+  if (!fxMode && !toggleOn) return null;
+
+  const fxValue = typeof options?.runPeriodically === 'string' ? options.runPeriodically : '';
+
+  return (
+    <div className="periodic-run-inputs">
+      {fxMode && (
+        <div className="periodic-run-fx-input">
+          <CodeHinter
+            type="basic"
+            initialValue={fxValue}
+            onChange={(value) => optionchanged('runPeriodically', value)}
+            placeholder="{{}}"
+            cyLabel="run-periodically-fx-expression"
+          />
+        </div>
+      )}
+      <div className="periodic-run-interval-row">
+        <label className="form-label align-items-center" data-cy="label-time-interval-input" style={{ width: 132 }}>
+          {t('editor.queryManager.timeInterval', 'Time interval ( ms )')}
+        </label>
+        <div className="flex-grow-1" style={{ maxWidth: '530px' }}>
+          <CodeHinter
+            type="basic"
+            initialValue={options?.queryRunInterval ?? ''}
+            onChange={(value) => optionchanged('queryRunInterval', value)}
+            placeholder="60000"
+            cyLabel="time-interval"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/AppBuilder/QueryManager/Components/PeriodicRunInputs.scss
+++ b/frontend/src/AppBuilder/QueryManager/Components/PeriodicRunInputs.scss
@@ -1,0 +1,20 @@
+.periodic-run-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 8px 0 16px;
+
+  .periodic-run-fx-input {
+    padding-left: 32px;
+    width: 100%;
+    max-width: 715px;
+    box-sizing: border-box;
+  }
+
+  .periodic-run-interval-row {
+    display: flex;
+    align-items: center;
+    padding-left: 34px;
+    gap: 5px;
+  }
+}

--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -14,6 +14,7 @@ import { customToggles, mockDataQueryAsComponent, RestAPIToggles } from '../cons
 import { DataSourceTypes } from '@/modules/common/components/DataSourceComponents';
 import SuccessNotificationInputs from './SuccessNotificationInputs';
 import ConfirmationInputs from './ConfirmationInputs';
+import PeriodicRunInputs from './PeriodicRunInputs';
 import FxButton from '@/AppBuilder/CodeBuilder/Elements/FxButton';
 import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
 import ParameterList from './ParameterList';
@@ -399,6 +400,9 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
                       optionchanged={optionchanged}
                       queryName={queryName}
                     />
+                  )}
+                  {config.action === 'runPeriodically' && (
+                    <PeriodicRunInputs options={options} darkMode={darkMode} optionchanged={optionchanged} />
                   )}
                 </React.Fragment>
               );

--- a/frontend/src/AppBuilder/QueryManager/constants.js
+++ b/frontend/src/AppBuilder/QueryManager/constants.js
@@ -50,6 +50,14 @@ export const customToggles = {
     label: 'Run this query on dependency change',
     translatedLabel: 'editor.queryManager.runOnDependencyChange',
   },
+  runPeriodically: {
+    dataCy: 'run-query-periodically',
+    action: 'runPeriodically',
+    label: 'Run this query periodically',
+    translatedLabel: 'editor.queryManager.runQueryPeriodically',
+    fx: true,
+    fxKey: 'runPeriodicallyFx',
+  },
   requestConfirmation: {
     dataCy: 'confirmation-before-run',
     action: 'requestConfirmation',

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -50,6 +50,9 @@ const QUERY_OPTION_KEYS_TO_NORMALIZE = [
   'notificationDuration',
   'disableQuery',
   'disabledMessage',
+  'runPeriodically',
+  'runPeriodicallyFx',
+  'queryRunInterval',
 ];
 
 const snakeCase = (camel) => camel.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);

--- a/frontend/src/AppBuilder/_stores/slices/appSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/appSlice.js
@@ -6,6 +6,7 @@ import { getWorkspaceId } from '@/_helpers/utils';
 import { navigate } from '@/AppBuilder/_utils/misc';
 import queryString from 'query-string';
 import { replaceEntityReferencesWithIds, baseTheme } from '../utils';
+import { clearAllPeriodicTimers } from '@/AppBuilder/_stores/slices/componentsSlice';
 import _, { isEmpty, has } from 'lodash';
 import { getSubpath } from '@/_helpers/routes';
 import { v4 as uuidv4 } from 'uuid';
@@ -317,6 +318,9 @@ export const createAppSlice = (set, get) => ({
 
   cleanUpStore: (isPageSwitch = false, moduleId) => {
     const { resetUndoRedoStack, initModules, clearSelectedComponents } = get();
+    // Tear down periodic query timers on full app teardown only — they intentionally
+    // survive page switches (e.g. a health-check query keeps polling across pages).
+    if (!isPageSwitch) clearAllPeriodicTimers();
     resetUndoRedoStack();
     clearSelectedComponents();
     set((state) => {

--- a/frontend/src/AppBuilder/_stores/slices/codeHinterSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/codeHinterSlice.js
@@ -94,8 +94,9 @@ function buildQueryHints(storeState, moduleId) {
     hints.push({ hint: `queries.${name}`, type: 'Object' });
     hints.push({ hint: `queries.${name}.run()`, type: 'Function' });
     hints.push({ hint: `queries.${name}.reset()`, type: 'Function' });
-    hints.push({ hint: `queries.${name}.pausePeriodicRun()`, type: 'Function' });
-    hints.push({ hint: `queries.${name}.resumePeriodicRun()`, type: 'Function' });
+    // Parked: pause/resume periodic-run CSAs are not exposed in v1 (engine kept for future).
+    // hints.push({ hint: `queries.${name}.pausePeriodicRun()`, type: 'Function' });
+    // hints.push({ hint: `queries.${name}.resumePeriodicRun()`, type: 'Function' });
     hints.push({ hint: `queries.${name}.getData()`, type: 'Function' });
     hints.push({ hint: `queries.${name}.getRawData()`, type: 'Function' });
     hints.push({ hint: `queries.${name}.getloadingState()`, type: 'Function' });

--- a/frontend/src/AppBuilder/_stores/slices/codeHinterSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/codeHinterSlice.js
@@ -94,6 +94,8 @@ function buildQueryHints(storeState, moduleId) {
     hints.push({ hint: `queries.${name}`, type: 'Object' });
     hints.push({ hint: `queries.${name}.run()`, type: 'Function' });
     hints.push({ hint: `queries.${name}.reset()`, type: 'Function' });
+    hints.push({ hint: `queries.${name}.pausePeriodicRun()`, type: 'Function' });
+    hints.push({ hint: `queries.${name}.resumePeriodicRun()`, type: 'Function' });
     hints.push({ hint: `queries.${name}.getData()`, type: 'Function' });
     hints.push({ hint: `queries.${name}.getRawData()`, type: 'Function' });
     hints.push({ hint: `queries.${name}.getloadingState()`, type: 'Function' });

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -114,18 +114,27 @@ function startPeriodicTimer(queryId, moduleId, intervalMs, getStore) {
     }
     // Skip this tick if a previous run is still in flight (no overlap / pile-up).
     if (store.getAllExposedValues(moduleId)?.queries?.[queryId]?.isLoading) return;
+    // Run in the module's current mode so released/public apps don't toast errors on
+    // every failing tick (runQuery only toasts when mode !== 'view').
+    const mode = store.modeStore?.modules?.[moduleId]?.currentMode || 'edit';
     // confirmed=true so periodic ticks bypass the "request confirmation" modal.
-    store.queryPanel.runQuery(queryId, query.name, true, undefined, {}, undefined, undefined, false, false, moduleId);
+    store.queryPanel.runQuery(queryId, query.name, true, mode, {}, undefined, undefined, false, false, moduleId);
   }, intervalMs);
   queryPeriodicTimers.set(queryId, { intervalId, intervalMs, moduleId });
 }
 
-/** Stop and forget a single periodic timer (e.g., on delete / toggle-off). */
-export function clearPeriodicTimer(queryId) {
+/**
+ * Stop and forget a single periodic timer (e.g., on delete / toggle-off).
+ * `forgetPaused` also drops the query from the paused-set — pass it only from the
+ * delete path. Reconcile/toggle-off must NOT forget the pause (pause survives edits),
+ * and pauseQueryPeriodicRun relies on the default (it adds to the set then clears).
+ */
+export function clearPeriodicTimer(queryId, { forgetPaused = false } = {}) {
   if (queryPeriodicTimers.has(queryId)) {
     clearInterval(queryPeriodicTimers.get(queryId).intervalId);
     queryPeriodicTimers.delete(queryId);
   }
+  if (forgetPaused) pausedPeriodicQueries.delete(queryId);
 }
 
 /** Stop ALL periodic timers (full app teardown only — NOT page switch). */

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -67,6 +67,126 @@ function clearAllQueryRerunTimers() {
   queryRerunTimers.clear();
 }
 
+// ---------------------------------------------------------------------------
+// Periodic query re-runs ("Run this query periodically" query setting).
+// Unlike the dependency-change debounce above, these are long-lived setInterval
+// timers that survive page navigation (a health-check query keeps polling) and
+// are only torn down on full app teardown, query delete, toggle-off, or pause.
+// Keyed by queryId (queries are app-global); moduleId is stored in the value so
+// each tick targets the right module.
+// ---------------------------------------------------------------------------
+const queryPeriodicTimers = new Map(); // queryId -> { intervalId, intervalMs, moduleId }
+// Queries explicitly paused via the pausePeriodicRun CSA. Reconcile must not
+// auto-restart these (a manual run / option edit shouldn't override a pause).
+const pausedPeriodicQueries = new Set();
+// Floor for the interval to protect the backend from runaway polling.
+const MIN_PERIODIC_INTERVAL_MS = 1000;
+
+// Resolve the current desired state from a query's options. `runPeriodically`
+// may be a boolean (fx off) or a `{{…}}` expression (fx on); `queryRunInterval`
+// may be a number, a numeric string, or an expression. Returns the run decision
+// plus the clamped interval (null when it shouldn't run / is invalid).
+function resolvePeriodicConfig(query, moduleId, store) {
+  const options = query?.options || {};
+  const shouldRun = !!store.getResolvedValue(options.runPeriodically, {}, moduleId);
+  if (!shouldRun) return { shouldRun: false, intervalMs: null };
+  const rawInterval = store.getResolvedValue(options.queryRunInterval, {}, moduleId);
+  const num = Number(rawInterval);
+  // shouldRun stays true so the caller can tell "misconfigured interval" apart from
+  // "toggle off" and warn once on a real start attempt (not on every reconcile).
+  if (!Number.isFinite(num) || num <= 0) {
+    return { shouldRun: true, intervalMs: null, invalid: true, rawInterval };
+  }
+  return { shouldRun: true, intervalMs: Math.max(num, MIN_PERIODIC_INTERVAL_MS) };
+}
+
+function startPeriodicTimer(queryId, moduleId, intervalMs, getStore) {
+  // Idempotent: clear any existing timer before scheduling (avoids HMR/re-run dupes).
+  if (queryPeriodicTimers.has(queryId)) {
+    clearInterval(queryPeriodicTimers.get(queryId).intervalId);
+  }
+  const intervalId = setInterval(() => {
+    const store = getStore();
+    const query = store.dataQuery?.queries?.modules?.[moduleId]?.find((q) => q.id === queryId);
+    if (!query) {
+      clearPeriodicTimer(queryId);
+      return;
+    }
+    // Skip this tick if a previous run is still in flight (no overlap / pile-up).
+    if (store.getAllExposedValues(moduleId)?.queries?.[queryId]?.isLoading) return;
+    // confirmed=true so periodic ticks bypass the "request confirmation" modal.
+    store.queryPanel.runQuery(queryId, query.name, true, undefined, {}, undefined, undefined, false, false, moduleId);
+  }, intervalMs);
+  queryPeriodicTimers.set(queryId, { intervalId, intervalMs, moduleId });
+}
+
+/** Stop and forget a single periodic timer (e.g., on delete / toggle-off). */
+export function clearPeriodicTimer(queryId) {
+  if (queryPeriodicTimers.has(queryId)) {
+    clearInterval(queryPeriodicTimers.get(queryId).intervalId);
+    queryPeriodicTimers.delete(queryId);
+  }
+}
+
+/** Stop ALL periodic timers (full app teardown only — NOT page switch). */
+export function clearAllPeriodicTimers() {
+  queryPeriodicTimers.forEach(({ intervalId }) => clearInterval(intervalId));
+  queryPeriodicTimers.clear();
+  pausedPeriodicQueries.clear();
+}
+
+/**
+ * Bring a query's periodic timer in line with its current options.
+ * - Called from runQuery (allowStart=true): the first/any run is what starts the timer.
+ * - Called from updateDataQuery (allowStart=false): only adjusts/stops an EXISTING
+ *   timer, so editing options never starts a timer for a query that hasn't run yet.
+ * Re-resolves the interval each call, so an fx interval that changed restarts cleanly.
+ */
+export function reconcileQueryPeriodicRun(queryId, moduleId, getStore, { allowStart = true } = {}) {
+  const store = getStore();
+  const query = store.dataQuery?.queries?.modules?.[moduleId]?.find((q) => q.id === queryId);
+  if (!query || pausedPeriodicQueries.has(queryId)) {
+    clearPeriodicTimer(queryId);
+    return;
+  }
+  const { shouldRun, intervalMs, invalid, rawInterval } = resolvePeriodicConfig(query, moduleId, store);
+  const existing = queryPeriodicTimers.get(queryId);
+  if (!shouldRun || invalid) {
+    // Toggle off, or the interval is invalid → ensure no timer runs. Warn once, only
+    // on a genuine start attempt (a real run with no timer yet) — never on edits/ticks.
+    if (invalid && allowStart && !existing) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[runPeriodically] Query "${
+          query?.name ?? query?.id
+        }" has an invalid time interval (${rawInterval}); periodic run not started.`
+      );
+    }
+    clearPeriodicTimer(queryId);
+    return;
+  }
+  if (!existing) {
+    if (allowStart) startPeriodicTimer(queryId, moduleId, intervalMs, getStore);
+    return;
+  }
+  // Already running — restart only if the resolved interval changed.
+  if (existing.intervalMs !== intervalMs) {
+    startPeriodicTimer(queryId, moduleId, intervalMs, getStore);
+  }
+}
+
+/** Pause a query's periodic re-run (pausePeriodicRun CSA). */
+export function pauseQueryPeriodicRun(queryId) {
+  pausedPeriodicQueries.add(queryId);
+  clearPeriodicTimer(queryId);
+}
+
+/** Resume a previously-paused periodic re-run (resumePeriodicRun CSA). */
+export function resumeQueryPeriodicRun(queryId, moduleId, getStore) {
+  pausedPeriodicQueries.delete(queryId);
+  reconcileQueryPeriodicRun(queryId, moduleId, getStore, { allowStart: true });
+}
+
 // Build the per-row components overlay used when resolving expressions inside
 // a ListView. Without this overlay, `components.<sibling>` is the per-row array
 // and `.value` access fails. Spreading `{ ...state, components: scopeCtx.scoped }`

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -69,13 +69,17 @@ function clearAllQueryRerunTimers() {
 
 // ---------------------------------------------------------------------------
 // Periodic query re-runs ("Run this query periodically" query setting).
-// Unlike the dependency-change debounce above, these are long-lived setInterval
-// timers that survive page navigation (a health-check query keeps polling) and
-// are only torn down on full app teardown, query delete, toggle-off, or pause.
+// Unlike the dependency-change debounce above, these are long-lived timers that
+// survive page navigation (a health-check query keeps polling) and are only torn
+// down on full app teardown, query delete, toggle-off, or pause.
+// Per product: "time to the next run is always calculated from the last run." So
+// these are self-re-arming one-shot setTimeouts (NOT a fixed-rate setInterval):
+// every run of the query — manual, event, page/app load, or a periodic tick —
+// re-anchors the next run to now + interval (see reconcileQueryPeriodicRun).
 // Keyed by queryId (queries are app-global); moduleId is stored in the value so
 // each tick targets the right module.
 // ---------------------------------------------------------------------------
-const queryPeriodicTimers = new Map(); // queryId -> { intervalId, intervalMs, moduleId }
+const queryPeriodicTimers = new Map(); // queryId -> { timeoutId, intervalMs, moduleId }
 // Queries explicitly paused via the pausePeriodicRun CSA. Reconcile must not
 // auto-restart these (a manual run / option edit shouldn't override a pause).
 const pausedPeriodicQueries = new Set();
@@ -100,19 +104,32 @@ function resolvePeriodicConfig(query, moduleId, store) {
   return { shouldRun: true, intervalMs: Math.max(num, MIN_PERIODIC_INTERVAL_MS) };
 }
 
-function startPeriodicTimer(queryId, moduleId, intervalMs, getStore) {
-  // Idempotent: clear any existing timer before scheduling (avoids HMR/re-run dupes).
+// Arm (or re-arm) the one-shot timer that runs the query once, `intervalMs` from now.
+// The tick re-arms itself, so the chain continues; re-resolving config each tick lets a
+// changed fx interval / toggle-off take effect without an explicit reconcile.
+function armPeriodicTimer(queryId, moduleId, intervalMs, getStore) {
+  // Idempotent: clear any pending timer before scheduling (avoids HMR/re-run dupes and
+  // resets the clock when a fresh run re-anchors the next tick).
   if (queryPeriodicTimers.has(queryId)) {
-    clearInterval(queryPeriodicTimers.get(queryId).intervalId);
+    clearTimeout(queryPeriodicTimers.get(queryId).timeoutId);
   }
-  const intervalId = setInterval(() => {
+  const timeoutId = setTimeout(() => {
     const store = getStore();
     const query = store.dataQuery?.queries?.modules?.[moduleId]?.find((q) => q.id === queryId);
-    if (!query) {
+    if (!query || pausedPeriodicQueries.has(queryId)) {
       clearPeriodicTimer(queryId);
       return;
     }
-    // Skip this tick if a previous run is still in flight (no overlap / pile-up).
+    const { shouldRun, intervalMs: nextMs, invalid } = resolvePeriodicConfig(query, moduleId, store);
+    if (!shouldRun || invalid) {
+      clearPeriodicTimer(queryId);
+      return;
+    }
+    // Re-arm BEFORE running so the chain survives even when this tick skips the run.
+    // (A run that completes will itself re-arm via reconcileQueryPeriodicRun; arming
+    // here too is idempotent and keeps the loop alive across skipped/in-flight ticks.)
+    armPeriodicTimer(queryId, moduleId, nextMs, getStore);
+    // Skip the actual run if a previous run is still in flight (no overlap / pile-up).
     if (store.getAllExposedValues(moduleId)?.queries?.[queryId]?.isLoading) return;
     // Run in the module's current mode so released/public apps don't toast errors on
     // every failing tick (runQuery only toasts when mode !== 'view').
@@ -120,7 +137,7 @@ function startPeriodicTimer(queryId, moduleId, intervalMs, getStore) {
     // confirmed=true so periodic ticks bypass the "request confirmation" modal.
     store.queryPanel.runQuery(queryId, query.name, true, mode, {}, undefined, undefined, false, false, moduleId);
   }, intervalMs);
-  queryPeriodicTimers.set(queryId, { intervalId, intervalMs, moduleId });
+  queryPeriodicTimers.set(queryId, { timeoutId, intervalMs, moduleId });
 }
 
 /**
@@ -131,7 +148,7 @@ function startPeriodicTimer(queryId, moduleId, intervalMs, getStore) {
  */
 export function clearPeriodicTimer(queryId, { forgetPaused = false } = {}) {
   if (queryPeriodicTimers.has(queryId)) {
-    clearInterval(queryPeriodicTimers.get(queryId).intervalId);
+    clearTimeout(queryPeriodicTimers.get(queryId).timeoutId);
     queryPeriodicTimers.delete(queryId);
   }
   if (forgetPaused) pausedPeriodicQueries.delete(queryId);
@@ -139,17 +156,20 @@ export function clearPeriodicTimer(queryId, { forgetPaused = false } = {}) {
 
 /** Stop ALL periodic timers (full app teardown only — NOT page switch). */
 export function clearAllPeriodicTimers() {
-  queryPeriodicTimers.forEach(({ intervalId }) => clearInterval(intervalId));
+  queryPeriodicTimers.forEach(({ timeoutId }) => clearTimeout(timeoutId));
   queryPeriodicTimers.clear();
   pausedPeriodicQueries.clear();
 }
 
 /**
  * Bring a query's periodic timer in line with its current options.
- * - Called from runQuery (allowStart=true): the first/any run is what starts the timer.
- * - Called from updateDataQuery (allowStart=false): only adjusts/stops an EXISTING
- *   timer, so editing options never starts a timer for a query that hasn't run yet.
- * Re-resolves the interval each call, so an fx interval that changed restarts cleanly.
+ * - Called from runQuery (allowStart=true): every run (re)anchors the next run to now +
+ *   interval, so "time to the next run is always calculated from the last run" — a manual
+ *   or event-triggered run mid-cycle resets the clock, not just the first run.
+ * - Called from updateDataQuery (allowStart=false): only adjusts an EXISTING timer when
+ *   the resolved interval changed, so editing options never starts a timer for a query
+ *   that hasn't run yet, and an unrelated edit doesn't reset a running query's clock.
+ * Re-resolves the interval each call, so a changed fx interval re-anchors cleanly.
  */
 export function reconcileQueryPeriodicRun(queryId, moduleId, getStore, { allowStart = true } = {}) {
   const store = getStore();
@@ -174,13 +194,16 @@ export function reconcileQueryPeriodicRun(queryId, moduleId, getStore, { allowSt
     clearPeriodicTimer(queryId);
     return;
   }
-  if (!existing) {
-    if (allowStart) startPeriodicTimer(queryId, moduleId, intervalMs, getStore);
+  if (allowStart) {
+    // A run just happened (manual / event / page-load / periodic tick): (re)arm so the
+    // next run is measured from this run. Resets the clock even if the interval is unchanged.
+    armPeriodicTimer(queryId, moduleId, intervalMs, getStore);
     return;
   }
-  // Already running — restart only if the resolved interval changed.
-  if (existing.intervalMs !== intervalMs) {
-    startPeriodicTimer(queryId, moduleId, intervalMs, getStore);
+  // Editor option edit: never start a timer for an unrun query; only re-anchor an
+  // already-running one when the resolved interval actually changed.
+  if (existing && existing.intervalMs !== intervalMs) {
+    armPeriodicTimer(queryId, moduleId, intervalMs, getStore);
   }
 }
 

--- a/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
@@ -280,7 +280,7 @@ export const createDataQuerySlice = (set, get) => ({
         .finally(() => setIsAppSaving(false));
 
       clearQueryRerunTimer(queryId);
-      clearPeriodicTimer(queryId);
+      clearPeriodicTimer(queryId, { forgetPaused: true });
       get().removeNode(`queries.${queryId}`, moduleId);
       get().updateDependencyValues(`queries.${queryId}`, moduleId);
     },

--- a/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
@@ -6,7 +6,11 @@ import { toast } from 'react-hot-toast';
 import { isQueryRunnable } from '@/_helpers/utils';
 import { replaceQueryOptionsEntityReferencesWithIds } from '@/AppBuilder/_stores/utils';
 import { normalizeQueryTransformationOptions } from '@/AppBuilder/_hooks/useAppData';
-import { clearQueryRerunTimer } from '@/AppBuilder/_stores/slices/componentsSlice';
+import {
+  clearQueryRerunTimer,
+  clearPeriodicTimer,
+  reconcileQueryPeriodicRun,
+} from '@/AppBuilder/_stores/slices/componentsSlice';
 
 const initialState = {
   sortBy: 'custom',
@@ -276,6 +280,7 @@ export const createDataQuerySlice = (set, get) => ({
         .finally(() => setIsAppSaving(false));
 
       clearQueryRerunTimer(queryId);
+      clearPeriodicTimer(queryId);
       get().removeNode(`queries.${queryId}`, moduleId);
       get().updateDependencyValues(`queries.${queryId}`, moduleId);
     },
@@ -466,6 +471,11 @@ export const createDataQuerySlice = (set, get) => ({
           return query;
         });
       });
+
+      // Reconcile an already-running periodic timer with the edited options
+      // (interval change → restart, toggle off → stop). allowStart:false so editing
+      // options never starts a timer for a query that hasn't been run yet.
+      reconcileQueryPeriodicRun(selectedQuery.id, moduleId, get, { allowStart: false });
 
       // Update query dependency registrations when options change.
       // Pass `options` (with entity names), not `newOptions` (with IDs), because

--- a/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
@@ -644,14 +644,15 @@ export const createEventsSlice = (set, get) => ({
             const { queryId } = event;
             return get().queryPanel.resetQuery(queryId, moduleId);
           }
-          case 'pause-periodic-run': {
-            const { queryId } = event;
-            return get().queryPanel.pausePeriodicRun(queryId, moduleId);
-          }
-          case 'resume-periodic-run': {
-            const { queryId } = event;
-            return get().queryPanel.resumePeriodicRun(queryId, moduleId);
-          }
+          // Parked: pause/resume periodic-run CSAs not exposed in v1 (engine kept for future).
+          // case 'pause-periodic-run': {
+          //   const { queryId } = event;
+          //   return get().queryPanel.pausePeriodicRun(queryId, moduleId);
+          // }
+          // case 'resume-periodic-run': {
+          //   const { queryId } = event;
+          //   return get().queryPanel.resumePeriodicRun(queryId, moduleId);
+          // }
           case 'logout': {
             return logoutAction();
           }
@@ -1103,19 +1104,20 @@ export const createEventsSlice = (set, get) => ({
         }
       };
 
-      const pausePeriodicRun = (queryName = '') => {
-        const query = dataQuery.queries.modules[moduleId].find((query) => query.name === queryName);
-        if (query) {
-          return executeAction({ actionId: 'pause-periodic-run', queryId: query.id }, mode, {}, moduleId);
-        }
-      };
+      // Parked: pause/resume periodic-run CSAs not exposed in v1 (engine kept for future).
+      // const pausePeriodicRun = (queryName = '') => {
+      //   const query = dataQuery.queries.modules[moduleId].find((query) => query.name === queryName);
+      //   if (query) {
+      //     return executeAction({ actionId: 'pause-periodic-run', queryId: query.id }, mode, {}, moduleId);
+      //   }
+      // };
 
-      const resumePeriodicRun = (queryName = '') => {
-        const query = dataQuery.queries.modules[moduleId].find((query) => query.name === queryName);
-        if (query) {
-          return executeAction({ actionId: 'resume-periodic-run', queryId: query.id }, mode, {}, moduleId);
-        }
-      };
+      // const resumePeriodicRun = (queryName = '') => {
+      //   const query = dataQuery.queries.modules[moduleId].find((query) => query.name === queryName);
+      //   if (query) {
+      //     return executeAction({ actionId: 'resume-periodic-run', queryId: query.id }, mode, {}, moduleId);
+      //   }
+      // };
 
       const setVariable = (key = '', value = '') => {
         if (key) {
@@ -1407,8 +1409,9 @@ export const createEventsSlice = (set, get) => ({
         logError,
         toggleAppMode,
         resetQuery,
-        pausePeriodicRun,
-        resumePeriodicRun,
+        // Parked: pause/resume periodic-run CSAs not exposed in v1 (engine kept for future).
+        // pausePeriodicRun,
+        // resumePeriodicRun,
         scrollComponentInToView,
       };
     },

--- a/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
@@ -644,6 +644,14 @@ export const createEventsSlice = (set, get) => ({
             const { queryId } = event;
             return get().queryPanel.resetQuery(queryId, moduleId);
           }
+          case 'pause-periodic-run': {
+            const { queryId } = event;
+            return get().queryPanel.pausePeriodicRun(queryId, moduleId);
+          }
+          case 'resume-periodic-run': {
+            const { queryId } = event;
+            return get().queryPanel.resumePeriodicRun(queryId, moduleId);
+          }
           case 'logout': {
             return logoutAction();
           }
@@ -1095,6 +1103,20 @@ export const createEventsSlice = (set, get) => ({
         }
       };
 
+      const pausePeriodicRun = (queryName = '') => {
+        const query = dataQuery.queries.modules[moduleId].find((query) => query.name === queryName);
+        if (query) {
+          return executeAction({ actionId: 'pause-periodic-run', queryId: query.id }, mode, {}, moduleId);
+        }
+      };
+
+      const resumePeriodicRun = (queryName = '') => {
+        const query = dataQuery.queries.modules[moduleId].find((query) => query.name === queryName);
+        if (query) {
+          return executeAction({ actionId: 'resume-periodic-run', queryId: query.id }, mode, {}, moduleId);
+        }
+      };
+
       const setVariable = (key = '', value = '') => {
         if (key) {
           const event = {
@@ -1385,6 +1407,8 @@ export const createEventsSlice = (set, get) => ({
         logError,
         toggleAppMode,
         resetQuery,
+        pausePeriodicRun,
+        resumePeriodicRun,
         scrollComponentInToView,
       };
     },

--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -9,6 +9,11 @@ import axios from 'axios';
 import { validateMultilineCode } from '@/_helpers/utility';
 import { convertMapSet, getQueryVariables } from '@/AppBuilder/_utils/queryPanel';
 import { deepClone } from '@/_helpers/utilities/utils.helpers';
+import {
+  reconcileQueryPeriodicRun,
+  pauseQueryPeriodicRun,
+  resumeQueryPeriodicRun,
+} from '@/AppBuilder/_stores/slices/componentsSlice';
 
 const queryManagerPreferences = JSON.parse(localStorage.getItem('queryManagerPreferences')) ?? {};
 
@@ -305,6 +310,15 @@ export const createQueryPanelSlice = (set, get) => ({
 
       return asyncHandler;
     },
+    // Stop a query's periodic re-run at runtime (pausePeriodicRun CSA). The pause is
+    // sticky: reconcile won't auto-restart it on the next manual run / option edit.
+    pausePeriodicRun: (queryId) => {
+      pauseQueryPeriodicRun(queryId);
+    },
+    // Resume a paused periodic re-run (resumePeriodicRun CSA).
+    resumePeriodicRun: (queryId, moduleId = 'canvas') => {
+      resumeQueryPeriodicRun(queryId, moduleId, get);
+    },
     resetQuery: (queryId, moduleId = 'canvas') => {
       const { setResolvedQuery } = get();
       setResolvedQuery(
@@ -482,6 +496,11 @@ export const createQueryPanelSlice = (set, get) => ({
           return;
         }
       }
+
+      // Query is committed to executing now — start/refresh its periodic timer if
+      // "Run this query periodically" is on. Idempotent: a tick re-running the query
+      // re-enters here and no-ops when the resolved interval is unchanged.
+      reconcileQueryPeriodicRun(queryId, moduleId, get);
 
       // Handler for transformation and completion of query results
       const processQueryResults = async (data, rawData = null) => {
@@ -1159,6 +1178,14 @@ export const createQueryPanelSlice = (set, get) => ({
                 const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
                 return actions.resetQuery(query.name);
               },
+              pausePeriodicRun: () => {
+                const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
+                return actions.pausePeriodicRun(query.name);
+              },
+              resumePeriodicRun: () => {
+                const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
+                return actions.resumePeriodicRun(query.name);
+              },
               getData: () => {
                 const resolvedState = get().getResolvedState(moduleId);
                 return resolvedState.queries[key].data;
@@ -1548,6 +1575,14 @@ export const createQueryPanelSlice = (set, get) => ({
           reset: () => {
             const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
             return actions.resetQuery(query.name);
+          },
+          pausePeriodicRun: () => {
+            const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
+            return actions.pausePeriodicRun(query.name);
+          },
+          resumePeriodicRun: () => {
+            const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
+            return actions.resumePeriodicRun(query.name);
           },
           getData: () => {
             const resolvedState = get().getResolvedState(moduleId);

--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -1178,14 +1178,15 @@ export const createQueryPanelSlice = (set, get) => ({
                 const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
                 return actions.resetQuery(query.name);
               },
-              pausePeriodicRun: () => {
-                const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
-                return actions.pausePeriodicRun(query.name);
-              },
-              resumePeriodicRun: () => {
-                const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
-                return actions.resumePeriodicRun(query.name);
-              },
+              // Parked: pause/resume periodic-run CSAs not exposed in v1 (engine kept for future).
+              // pausePeriodicRun: () => {
+              //   const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
+              //   return actions.pausePeriodicRun(query.name);
+              // },
+              // resumePeriodicRun: () => {
+              //   const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
+              //   return actions.resumePeriodicRun(query.name);
+              // },
               getData: () => {
                 const resolvedState = get().getResolvedState(moduleId);
                 return resolvedState.queries[key].data;
@@ -1576,14 +1577,15 @@ export const createQueryPanelSlice = (set, get) => ({
             const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
             return actions.resetQuery(query.name);
           },
-          pausePeriodicRun: () => {
-            const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
-            return actions.pausePeriodicRun(query.name);
-          },
-          resumePeriodicRun: () => {
-            const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
-            return actions.resumePeriodicRun(query.name);
-          },
+          // Parked: pause/resume periodic-run CSAs not exposed in v1 (engine kept for future).
+          // pausePeriodicRun: () => {
+          //   const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
+          //   return actions.pausePeriodicRun(query.name);
+          // },
+          // resumePeriodicRun: () => {
+          //   const query = dataQuery.queries.modules?.[moduleId].find((q) => q.name === key);
+          //   return actions.resumePeriodicRun(query.name);
+          // },
           getData: () => {
             const resolvedState = get().getResolvedState(moduleId);
             return resolvedState.queries[key].data;


### PR DESCRIPTION
## What & why

Adds a **"Run this query periodically"** query setting that re-runs a query on a timer after its first execution — for system health checks, dashboard auto-refresh, cache updates, and scheduled reports.

Ref: **ToolJet/tj-ee#3776**

## Release notes

> **Run a query periodically** — Queries now have a **Run this query periodically** option under **Settings**. Enable it and set a **Time interval (ms)** to automatically re-run the query on a recurring basis after its first run. Both fields support `fx` expressions. Control it at runtime with the new `queries.<name>.pausePeriodicRun()` and `queries.<name>.resumePeriodicRun()` actions.

## Changes

**UI** (`695e4aa…`)
- `Run this query periodically` toggle (with `fx`) in the Settings → Triggers section, mirroring the evolved `requestConfirmation` pattern.
- Reveals a `Time interval ( ms )` field (with `fx`) directly underneath when enabled/expression-set (`PeriodicRunInputs`).

**Runtime engine** (`5e4ba9f…`, `componentsSlice`)
- `setInterval` timer per query, mirroring the existing `runOnDependencyChange` debounce infra. Start / stop / reconcile / clear-all helpers.
- **Lifecycle:** starts after a query's first real run; reconciles on option edits (never starts an un-run query); cleared on delete; **survives page navigation**; torn down on full app teardown only.
- **Guards:** interval clamped to **≥ 1000 ms**; invalid/empty → no timer + one console warning; ticks **skip when a run is in flight** (no pile-up); ticks **bypass the confirmation modal**.

**Runtime actions** (`eventsSlice` / `queryPanelSlice` / `codeHinterSlice`)
- `queries.<name>.pausePeriodicRun()` / `resumePeriodicRun()` callable from events + runjs/runpy, with autocomplete hints. Pause is sticky until resume.

## Behavior decisions
- **Starts after the first execution** (page-load / manual / CSA). A query with the toggle on but never run won't tick — pair with *Run on app load* to auto-start.
- **Confirmation + periodic** → ticks auto-confirm (no modal spam); the first/manual run still prompts.
- **Runs in all modes including the editor canvas** (clamp + skip-in-flight keep it safe). Easy to scope to preview/released-only if desired.

## Scope
Frontend-only. Query `options` is an opaque JSON blob, so the new keys (`runPeriodically`, `runPeriodicallyFx`, `queryRunInterval`) persist and round-trip through import/export with **no server/DTO/migration changes**.

## Testing
- Lint-clean (0 errors).
- Verified live: toggle/`fx`/reveal render; 2 s interval ticks; toggle-off stops; min-interval clamp; confirmation bypass; survives page navigation.
- Cypress E2E: follow-up.

