### PR TITLE
Fix: add waits between REST API requests to avoid httpbin 503s

### DIFF
--- a/cypress-tests/cypress/e2e/happyPath/marketplace/commonTestcases/datasources/restAPIHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/marketplace/commonTestcases/datasources/restAPIHappyPath.cy.js
@@ -528,10 +528,12 @@ describe("Data source Rest API", () => {
         { key: "tokenData", encrypted: false },
       ]
     );
+    cy.wait(1000);
     cy.reload();
     cy.intercept("GET", "/api/library_apps").as("appLibrary");
     data.basicAppName = `${fake.companyName}-restAPI-Basic-App`;
     cy.apiCreateApp(data.basicAppName);
+    cy.wait(1000);
     createAndRunRestAPIQuery({
       queryName: "get_basic_auth_valid",
       dsName: `cypress-${data.dataSourceName}-restapi`,
@@ -539,13 +541,16 @@ describe("Data source Rest API", () => {
       urlSuffix: "/basic-auth/user/pass",
       expectedResponseShape: { authenticated: true, user: "user" },
     });
+    cy.wait(1000);
     createAndRunRestAPIQuery({
       queryName: "get_basic_auth_invalid",
       dsName: `cypress-${data.dataSourceName}-restapi`,
       method: "GET",
       urlSuffix: "/basic-auth/invaliduser/invalidpass",
     });
+    cy.wait(1000);
     cy.apiDeleteApp();
+    cy.wait(1000);
     cy.apiDeleteDataSource(`cypress-${data.dataSourceName}-restapi`);
   });
   it("Should verify response for bearer authentication type connection", () => {
@@ -592,11 +597,14 @@ describe("Data source Rest API", () => {
         { key: "tokenData", encrypted: false },
       ]
     );
+    cy.wait(1000);
     cy.reload();
     cy.intercept("GET", "/api/library_apps").as("appLibrary");
     data.bearerAppName = `${fake.companyName}-restAPI-Bearer-App`;
     cy.apiCreateApp(data.bearerAppName);
+    cy.wait(1000);
     cy.openApp();
+    cy.wait(1000);
     createAndRunRestAPIQuery({
       queryName: "get_bearer_auth_valid",
       dsName: `cypress-${data.dataSourceName}-restapi`,
@@ -604,7 +612,9 @@ describe("Data source Rest API", () => {
       urlSuffix: "/bearer",
       expectedResponseShape: { authenticated: true, token: "my-token-123" },
     });
+    cy.wait(1000);
     cy.apiDeleteApp();
+    cy.wait(1000);
     cy.intercept("GET", "api/data_sources?**").as("datasource");
     cy.apiCreateDataSource(
       `${Cypress.env("server_host")}/api/data-sources`,
@@ -649,16 +659,21 @@ describe("Data source Rest API", () => {
         { key: "tokenData", encrypted: false },
       ]
     );
+    cy.wait(1000);
     data.bearerInvalidAppName = `${fake.companyName}-restAPI-Bearer-invalid`;
     cy.apiCreateApp(data.bearerInvalidAppName);
+    cy.wait(1000);
     cy.openApp();
+    cy.wait(1000);
     createAndRunRestAPIQuery({
       queryName: "get_bearer_auth_invalid",
       dsName: `cypress-${data.dataSourceName}-restapi-invalid`,
       method: "GET",
       urlSuffix: "/bearer",
     });
+    cy.wait(1000);
     cy.apiDeleteApp();
+    cy.wait(1000);
     cy.apiDeleteDataSource(`cypress-${data.dataSourceName}-restapi`);
   });
   //might be failing due to rate limit error from auth0, need to investigate and fix
@@ -723,6 +738,7 @@ describe("Data source Rest API", () => {
   });
   it("Should verify response for content-type", () => {
     cy.apiCreateApp(`${fake.companyName}-restAPI-Content-App`);
+    cy.wait(1000);
     createAndRunRestAPIQuery({
       queryName: "post_json",
       dsName: "restapidefault",
@@ -734,6 +750,7 @@ describe("Data source Rest API", () => {
       urlSuffix: "",
       expectedResponseShape: { id: true, title: "foo", body: "bar", userId: 1 },
     });
+    cy.wait(1000);
     createAndRunRestAPIQuery({
       queryName: "post_raw_text",
       dsName: "restapidefault",
@@ -745,6 +762,7 @@ describe("Data source Rest API", () => {
       run: true,
       expectedResponseShape: { data: "This is plain text content" },
     });
+    cy.wait(1000);
     createAndRunRestAPIQuery({
       queryName: "post_form_urlencoded",
       dsName: "restapidefault",
@@ -760,6 +778,7 @@ describe("Data source Rest API", () => {
         "form.age": "30",
       },
     });
+    cy.wait(1000);
     createAndRunRestAPIQuery({
       queryName: "post_xml_soap",
       dsName: "restapidefault",


### PR DESCRIPTION
## 📝 What this does
The REST API cypress spec was failing non-deterministically because httpbin.org rate-limits rapid back-to-back requests with 503 responses. Adding small delays between API calls keeps requests under the rate limit so the test runs cleanly.

## 🔀 Changes
- Added `cy.wait(1000)` between API calls in the basic-auth, bearer-auth, and content-type tests of `restAPIHappyPath.cy.js`.

## 🧪 How to test
- [ ] Run `restAPIHappyPath.cy.js` end-to-end against an `lts-3.16` setup.
- [ ] Confirm `Should verify response for basic authentication type connection` and `Should verify response for bearer authentication type connection` pass on first attempt.
- [ ] Re-run the spec 3 times; results should be stable (no 503 from httpbin in run logs).