### PR TITLE
Chore: migrate to React 18 createRoot and createPortal APIs

### DIFF
--- a/frontend/src/_components/LegalReasonsErrorModal.jsx
+++ b/frontend/src/_components/LegalReasonsErrorModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import * as ReactDOM from 'react-dom';
+import { createPortal } from 'react-dom';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 import SolidIcon from '../_ui/Icon/SolidIcons';
@@ -103,7 +103,7 @@ const LegalReasonsErrorModal = ({
       </Modal>
     </>
   );
-  return ReactDOM.createPortal(modalContent, document.body);
+  return createPortal(modalContent, document.body);
 };
 
 export default LegalReasonsErrorModal;

--- a/frontend/src/_components/Portal/ReactPortal.js
+++ b/frontend/src/_components/Portal/ReactPortal.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createPortal } from 'react-dom';
 
 export function ReactPortal({ children, parent, className, componentName }) {
   const el = React.useMemo(() => document.createElement('div'), []);
@@ -17,5 +17,5 @@ export function ReactPortal({ children, parent, className, componentName }) {
     };
   }, [el, parent, className, componentName]);
 
-  return ReactDOM.createPortal(children, el);
+  return createPortal(children, el);
 }

--- a/frontend/src/_helpers/handle-response.js
+++ b/frontend/src/_helpers/handle-response.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import LegalReasonsErrorModal from '../_components/LegalReasonsErrorModal';
 import SolidIcon from '../_ui/Icon/SolidIcons';
 import { copyToClipboard } from '@/_helpers/appUtils';
@@ -115,7 +115,10 @@ export function handleResponse(
 
         const modalContainer = document.getElementById('modal-div');
         if (!message?.includes('expired') && !avoidUpgradeModal && modalContainer) {
-          ReactDOM.render(modalEl, modalContainer);
+          if (!modalContainer._reactRoot) {
+            modalContainer._reactRoot = createRoot(modalContainer);
+          }
+          modalContainer._reactRoot.render(modalEl);
         }
       } else if ([400].indexOf(response.status) !== -1) {
         redirectToSwitchOrArchivedAppPage(data);

--- a/frontend/src/_ui/WorkspaceBranchDropdown/WorkspacePullConflictModal.jsx
+++ b/frontend/src/_ui/WorkspaceBranchDropdown/WorkspacePullConflictModal.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createPortal } from 'react-dom';
 import { ButtonSolid } from '@/_ui/AppButton/AppButton';
 import SolidIcon from '@/_ui/Icon/SolidIcons';
 import '@/_styles/workspace-pull-conflict-modal.scss';
@@ -44,7 +44,7 @@ export function PullConflictModal({ show, onClose, conflictGroups = [] }) {
 
   const darkMode = localStorage.getItem('darkMode') === 'true';
 
-  return ReactDOM.createPortal(
+  return createPortal(
     <div className="pull-conflict-modal-overlay" onClick={handleOverlayClick}>
       <div className={`pull-conflict-modal${darkMode ? ' theme-dark' : ''}`}>
         {/* HEADER */}

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import * as Sentry from '@sentry/react';
 import { useLocation, useNavigationType, createRoutesFromChildren, matchRoutes } from 'react-router-dom';
@@ -77,8 +77,7 @@ appService
     }
   })
   .then(() => {
-    render(<AppWithProfiler />, document.getElementById('app'));
-    // .then(() => createRoot(document.getElementById('app')).render(<AppWithProfiler />));
+    createRoot(document.getElementById('app')).render(<AppWithProfiler />);
 
     // App booted successfully — clear reload flags from both recovery mechanisms
     // (ChunkErrorBoundary in RootRouter.jsx and the .catch() below) so that


### PR DESCRIPTION
## 📝 What this does
Switches the app from React 17's legacy `ReactDOM.render()` to React 18's `createRoot` API, and updates all `createPortal` calls to use the named import. This unblocks full React 18 concurrent mode support.
- [ee-server](no changes)
- [ee-frontend](https://github.com/ToolJet/ee-frontend/pull/484)

## 🔀 Changes
- Migrated app entry point in `index.jsx` from `ReactDOM.render()` to `createRoot().render()`
- Updated `handle-response.js` to use `createRoot` for imperative error modal rendering, caching the root to avoid remounting on repeat calls
- Replaced `ReactDOM.createPortal` with named `createPortal` import in portal and modal components

## 🧪 How to test
- [ ] Load the app and verify normal navigation and rendering works
- [ ] Trigger a 451 legal error response and verify the modal renders correctly
- [ ] Open a git workspace with a pull conflict and verify the conflict modal renders