### PR TITLE
Custom Domain App Redirect Fix

### DIFF
--- a/frontend/src/_helpers/authorizeWorkspace.js
+++ b/frontend/src/_helpers/authorizeWorkspace.js
@@ -267,11 +267,17 @@ export const authorizeUserAndHandleErrors = (workspace_id, workspace_slug, callb
       if (data.custom_domain && !isCustomDomain() && !isLocalhost && !hasRecentRedirectAttempt()) {
         const slug = data.current_organization_slug || data.current_organization_id;
         const pathWithoutSlug = excludeWorkspaceIdFromURL(window.location.pathname);
+        // App viewer paths (/applications/, /embed-apps/) use no workspace slug prefix on
+        // custom domains — the custom domain identifies the workspace, so the URL format is
+        // /applications/:slug, not /:workspaceSlug/applications/:slug.
+        const isViewerPath = pathWithoutSlug.startsWith('/applications/') || pathWithoutSlug.startsWith('/embed-apps/');
         setRedirectAttempt();
         try {
           const { token } = await sessionTransferService.createTransferToken();
           const redirect = encodeURIComponent(
-            `/${slug}${pathWithoutSlug}${window.location.search}${window.location.hash}`
+            isViewerPath
+              ? `${pathWithoutSlug}${window.location.search}${window.location.hash}`
+              : `/${slug}${pathWithoutSlug}${window.location.search}${window.location.hash}`
           );
           window.location.href = `https://${data.custom_domain}/api/session/transfer?token=${token}&redirect=${redirect}`;
           return;


### PR DESCRIPTION
fix: redirect to app viewer (not workspace) after login on custom domain

When a workspace has a custom domain configured, logging into a released app on the base domain (tooljet.com/applications/:slug) would redirect the user to the workspace homepage instead of back to the app.

Root cause: The session transfer redirect always prepended the workspace slug to the path, producing /{workspace-slug}/applications/:slug on the custom domain. That path doesn't match the /applications/* route in RootRouter, so it fell through to MainApp's catch-all.

Fix: Skip the workspace slug prefix when the redirect target is an app viewer path (/applications/ or /embed-apps/). On a custom domain the workspace is identified by the domain itself, so viewer URLs use /applications/:slug with no slug prefix — matching the RootRouter route correctly.