### PR TITLE
fix(security): harden SSRF protection across all HTTP-issuing plugins and OAuth token endpoint

### DIFF
--- a/plugins/packages/baserow/lib/index.ts
+++ b/plugins/packages/baserow/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, validateUrlForSSRF, getSSRFProtectionOptions } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import got, { Headers } from 'got';
 const JSON5 = require('json5');
@@ -22,12 +22,16 @@ export default class Baserow implements QueryService {
     const host = sourceOptions.baserow_host;
     const baseURL = host === 'baserow_cloud' ? 'https://api.baserow.io' : sourceOptions.base_url;
 
+    await validateUrlForSSRF(baseURL);
+    const ssrfBaseOptions = getSSRFProtectionOptions();
+
     try {
       switch (operation) {
         case 'list_rows': {
           response = await got(`${baseURL}/api/database/rows/table/${tableId}/?user_field_names=true`, {
             method: 'get',
             headers: this.authHeader(apiToken),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -38,6 +42,7 @@ export default class Baserow implements QueryService {
           response = await got(`${baseURL}/api/database/fields/table/${tableId}/?user_field_names=true`, {
             method: 'get',
             headers: this.authHeader(apiToken),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -49,6 +54,7 @@ export default class Baserow implements QueryService {
           response = await got(`${baseURL}/api/database/rows/table/${tableId}/${row_id}/?user_field_names=true`, {
             method: 'get',
             headers: this.authHeader(apiToken),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -60,6 +66,7 @@ export default class Baserow implements QueryService {
             method: 'post',
             headers: this.authHeader(apiToken),
             json: this.parseJSON(queryOptions.body),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -72,6 +79,7 @@ export default class Baserow implements QueryService {
             method: 'patch',
             headers: this.authHeader(apiToken),
             json: this.parseJSON(queryOptions.body),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -86,6 +94,7 @@ export default class Baserow implements QueryService {
             {
               method: 'patch',
               headers: this.authHeader(apiToken),
+              ...ssrfBaseOptions,
             }
           );
 
@@ -98,6 +107,7 @@ export default class Baserow implements QueryService {
           response = await got(`${baseURL}/api/database/rows/table/${tableId}/${row_id}`, {
             method: 'delete',
             headers: this.authHeader(apiToken),
+            ...ssrfBaseOptions,
           });
 
           if (response.statusCode === 204) {

--- a/plugins/packages/common/lib/ssrf-protection.ts
+++ b/plugins/packages/common/lib/ssrf-protection.ts
@@ -49,12 +49,14 @@ const BLOCKED_HOSTNAME_PATTERNS = [
   /\.traefik\.me$/i,
 ];
 
+type SSRFCheckLevel = 'full' | 'standard' | 'minimal';
+
 interface SSRFProtectionOptions {
   enabled?: boolean;
   dnsResolutionCheck?: boolean;
   blockedSchemes?: string[];
   allowedHostnames?: Set<string>;
-  allowPrivateNetworks?: boolean;
+  checkLevel?: SSRFCheckLevel;
 }
 
 export function getSSRFConfig(): SSRFProtectionOptions {
@@ -83,11 +85,11 @@ export function getSSRFConfig(): SSRFProtectionOptions {
     ? blockedSchemesEnv.split(',').map(s => s.trim().toLowerCase()).filter(s => s.length > 0)
     : DEFAULT_BLOCKED_SCHEMES;
 
-  // Cloud: block all private ranges — multi-tenant shared infra, full SSRF enforcement.
-  // EE/CE: allow RFC1918 (10.x, 172.16.x, 192.168.x) — customers legitimately reach
-  //        internal services on their own private networks. Cloud metadata endpoints
-  //        (169.254.x.x) and loopback remain blocked even on self-hosted.
-  const allowPrivateNetworks = !isCloud;
+  // Check level controls which IP ranges are blocked:
+  //   Cloud    — 'full':    block all private ranges (RFC1918 + loopback + metadata)
+  //   CE/unset — 'standard': block metadata + loopback + specials; allow RFC1918
+  //   EE       — 'minimal': block only cloud metadata endpoints (169.254.169.254 etc.)
+  const checkLevel: SSRFCheckLevel = isCloud ? 'full' : isEE ? 'minimal' : 'standard';
 
   // Self-hosted: localhost and loopback explicitly allowed.
   // Cloud: nothing bypasses SSRF checks.
@@ -95,7 +97,7 @@ export function getSSRFConfig(): SSRFProtectionOptions {
     ? new Set<string>()
     : new Set(['localhost', 'ip6-localhost', 'ip6-loopback', '::1']);
 
-  return { enabled, dnsResolutionCheck, blockedSchemes, allowPrivateNetworks, allowedHostnames };
+  return { enabled, dnsResolutionCheck, blockedSchemes, checkLevel, allowedHostnames };
 }
 
 /**
@@ -333,7 +335,7 @@ function isPrivateIPv6(ip: string): boolean {
 
 /**
  * Checks if an IP is a dangerous private/reserved address that must always be blocked,
- * even on self-hosted deployments where allowPrivateNetworks=true.
+ * even on self-hosted deployments (checkLevel='standard' or 'minimal').
  *
  * Unlike isPrivateIP(), this does NOT block RFC1918 ranges (10.x, 172.16.x, 192.168.x)
  * because self-hosted customers legitimately access internal services at those addresses.
@@ -442,10 +444,7 @@ export async function resolvesToPrivateIP(hostname: string, config?: SSRFProtect
       return true;
     }
 
-    // Check if any resolved address is a private IP.
-    // On self-hosted (allowPrivateNetworks=true) only block dangerous ranges
-    // (metadata, loopback) — not RFC1918, which are legitimate internal services.
-    const ipCheckFn = config?.allowPrivateNetworks ? isDangerousPrivateIP : isPrivateIP;
+    const ipCheckFn = resolveIPChecker(config?.checkLevel);
     return addresses.some(addr => ipCheckFn(addr));
   } catch (error) {
     console.warn(`DNS resolution error for ${hostname}:`, error.message);
@@ -541,9 +540,8 @@ export async function validateUrlForSSRF(
   }
 
   // 3. Check if hostname is a private IP address.
-  // On self-hosted (allowPrivateNetworks=true) only block dangerous ranges
-  // (metadata endpoints, loopback) — RFC1918 is allowed for internal services.
-  const ipCheckFn = config.allowPrivateNetworks ? isDangerousPrivateIP : isPrivateIP;
+  // Check strictness varies by edition — see resolveIPChecker.
+  const ipCheckFn = resolveIPChecker(config.checkLevel);
   if (ipCheckFn(hostname)) {
     throw new QueryError(
       'Private IP address blocked',
@@ -610,9 +608,7 @@ export function createSSRFSafeLookup(options?: SSRFProtectionOptions) {
         return callback(null, address, family);
       }
 
-      // Validate the resolved IP address.
-      // On self-hosted (allowPrivateNetworks=true) only block dangerous ranges.
-      const ipCheckFn = config.allowPrivateNetworks ? isDangerousPrivateIP : isPrivateIP;
+      const ipCheckFn = resolveIPChecker(config.checkLevel);
       if (ipCheckFn(address)) {
         const error: any = new Error(
           `Hostname "${hostname}" resolves to private IP address "${address}" which is blocked for security reasons`
@@ -799,8 +795,7 @@ export function validateUrlForSSRFSync(urlString: string, options?: SSRFProtecti
   }
 
   // Check if hostname is a private IP.
-  // On self-hosted (allowPrivateNetworks=true) only block dangerous ranges.
-  const ipCheckFnSync = config.allowPrivateNetworks ? isDangerousPrivateIP : isPrivateIP;
+  const ipCheckFnSync = resolveIPChecker(config.checkLevel);
   if (ipCheckFnSync(hostname)) {
     throw new QueryError(
       'Private IP address blocked',

--- a/plugins/packages/couchdb/lib/index.ts
+++ b/plugins/packages/couchdb/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, ConnectionTestResult, validateUrlForSSRF, getSSRFProtectionOptions } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import got from 'got';
 const JSON5 = require('json5');
@@ -16,10 +16,15 @@ export default class Couchdb implements QueryService {
       return { Authorization: `Basic ${key}` };
     };
 
+    const baseUrl = `${protocol}://${host}:${port}`;
+    await validateUrlForSSRF(baseUrl);
+    if (operation === 'get_view') await validateUrlForSSRF(view_url);
+    const ssrfBaseOptions = getSSRFProtectionOptions();
+
     try {
       switch (operation) {
         case 'list_records': {
-          response = await got(`${protocol}://${host}:${port}/${database}/_all_docs`, {
+          response = await got(`${baseUrl}/${database}/_all_docs`, {
             method: 'get',
             headers: authHeader(),
             searchParams: {
@@ -28,62 +33,68 @@ export default class Couchdb implements QueryService {
               ...(descending && { descending }),
               ...(include_docs && { include_docs }),
             },
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'retrieve_record': {
-          response = await got(`${protocol}://${host}:${port}/${database}/${record_id}`, {
+          response = await got(`${baseUrl}/${database}/${record_id}`, {
             headers: authHeader(),
             method: 'get',
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'create_record': {
-          response = await got(`${protocol}://${host}:${port}/${database}`, {
+          response = await got(`${baseUrl}/${database}`, {
             method: 'post',
             headers: authHeader(),
             json: {
               records: this.parseJSON(queryOptions.body),
             },
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'update_record': {
-          response = await got(`${protocol}://${host}:${port}/${database}/${record_id}`, {
+          response = await got(`${baseUrl}/${database}/${record_id}`, {
             method: 'put',
             headers: authHeader(),
             json: {
               _rev: revision_id,
               records: this.parseJSON(queryOptions.body),
             },
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'delete_record': {
-          response = await got(`${protocol}://${host}:${port}/${database}/${record_id}`, {
+          response = await got(`${baseUrl}/${database}/${record_id}`, {
             method: 'delete',
             headers: authHeader(),
             searchParams: {
               rev: revision_id,
             },
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'find': {
-          response = await got(`${protocol}://${host}:${port}/${database}/_find`, {
+          response = await got(`${baseUrl}/${database}/_find`, {
             method: 'post',
             headers: authHeader(),
             json: this.parseJSON(queryOptions.body),
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
@@ -100,6 +111,7 @@ export default class Couchdb implements QueryService {
               ...(start_key?.length > 0 && { start_key }),
               ...(end_key?.length > 0 && { end_key }),
             },
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
@@ -117,13 +129,15 @@ export default class Couchdb implements QueryService {
   }
 
   async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { username, password, port, host, database, protocol } = sourceOptions;
+    const baseUrl = `${protocol}://${host}:${port}`;
+    await validateUrlForSSRF(baseUrl);
     const combined = `${username}:${password}`;
     const key = Buffer.from(combined).toString('base64');
-    const client = await got(`${protocol}://${host}:${port}/_all_dbs`, {
+    const client = await got(`${baseUrl}/_all_dbs`, {
       method: 'get',
       headers: { Authorization: `Basic ${key}` },
+      ...getSSRFProtectionOptions(),
     });
     if (!client) {
       throw new Error('Error');

--- a/plugins/packages/databricks/lib/index.ts
+++ b/plugins/packages/databricks/lib/index.ts
@@ -8,6 +8,7 @@ import {
   ConnectionTestResult,
   getCurrentToken,
   createQueryBuilder,
+  validateUrlForSSRF,
 } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import { DBSQLClient } from '@databricks/sql';
@@ -309,6 +310,8 @@ export default class Databricks implements QueryService {
   // ──────────────────────────────────────────────────────────────────────────
 
   async getConnection(sourceOptions: SourceOptions): Promise<DBSQLClient> {
+    await validateUrlForSSRF(`https://${sourceOptions.host}`);
+
     const credentials: any = {
       host: sourceOptions.host,
       path: sourceOptions.http_path,

--- a/plugins/packages/elasticsearch/lib/index.ts
+++ b/plugins/packages/elasticsearch/lib/index.ts
@@ -1,4 +1,4 @@
-import { ConnectionTestResult, QueryService, QueryResult, QueryError } from '@tooljet-plugins/common';
+import { ConnectionTestResult, QueryService, QueryResult, QueryError, validateUrlForSSRF } from '@tooljet-plugins/common';
 import {
   getDocument,
   updateDocument,
@@ -120,6 +120,8 @@ export default class ElasticsearchService implements QueryService {
     } else {
       url = `${protocol}://${host}:${port}`;
     }
+
+    await validateUrlForSSRF(`${protocol}://${host}:${port}`);
 
     const options: ClientOptions = { 
       node: url,

--- a/plugins/packages/influxdb/lib/index.ts
+++ b/plugins/packages/influxdb/lib/index.ts
@@ -1,4 +1,4 @@
-import { ConnectionTestResult, QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { ConnectionTestResult, QueryError, QueryResult, QueryService, validateUrlForSSRF, getSSRFProtectionOptions } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import got, { Headers } from 'got';
 const JSON5 = require('json5');
@@ -17,84 +17,96 @@ export default class influxdb implements QueryService {
       };
     };
 
+    const baseUrl = `${protocol}://${host}:${port}`;
+    await validateUrlForSSRF(baseUrl);
+    const ssrfBaseOptions = getSSRFProtectionOptions();
+
     try {
       switch (operation) {
         case 'list_buckets': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/buckets`, {
+          response = await got(`${baseUrl}/api/v2/buckets`, {
             method: 'get',
             headers: authHeader(apiKey),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
           break;
         }
         case 'retrieve_bucket': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/buckets/${bucket_id}`, {
+          response = await got(`${baseUrl}/api/v2/buckets/${bucket_id}`, {
             headers: authHeader(apiKey),
             method: 'get',
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'create_bucket': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/buckets`, {
+          response = await got(`${baseUrl}/api/v2/buckets`, {
             method: 'post',
             headers: authHeader(apiKey),
             json: this.parseJSON(queryOptions.body),
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'update_bucket': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/buckets/${bucket_id}`, {
+          response = await got(`${baseUrl}/api/v2/buckets/${bucket_id}`, {
             method: 'patch',
             headers: authHeader(apiKey),
             json: this.parseJSON(queryOptions.body),
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'delete_bucket': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/buckets/${bucket_id}`, {
+          response = await got(`${baseUrl}/api/v2/buckets/${bucket_id}`, {
             method: 'delete',
             headers: authHeader(apiKey),
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'query_suggestions_for_branching': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/query/suggestions/${name}`, {
+          response = await got(`${baseUrl}/api/v2/query/suggestions/${name}`, {
             headers: authHeader(apiKey),
             method: 'get',
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'query_suggestions': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/query/suggestions`, {
+          response = await got(`${baseUrl}/api/v2/query/suggestions`, {
             headers: authHeader(apiKey),
             method: 'get',
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
 
         case 'analyze_flux_query': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/query/analyze`, {
+          response = await got(`${baseUrl}/api/v2/query/analyze`, {
             method: 'post',
             headers: authHeader(apiKey),
             json: this.parseJSON(queryOptions.body),
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
         case 'query_data': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/query`, {
+          response = await got(`${baseUrl}/api/v2/query`, {
             method: 'post',
             headers: {
               Authorization: `Token ${apiKey}`,
@@ -104,22 +116,24 @@ export default class influxdb implements QueryService {
               ...(org?.length > 0 && { org }),
             },
             body: queryOptions.body,
+            ...ssrfBaseOptions,
           });
           result = response.body;
           break;
         }
 
         case 'abstract_syntax_tree': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/query/ast`, {
+          response = await got(`${baseUrl}/api/v2/query/ast`, {
             method: 'post',
             headers: authHeader(apiKey),
             json: this.parseJSON(queryOptions.body),
+            ...ssrfBaseOptions,
           });
           result = this.parseJSON(response.body);
           break;
         }
         case 'write': {
-          response = await got(`${protocol}://${host}:${port}/api/v2/write`, {
+          response = await got(`${baseUrl}/api/v2/write`, {
             method: 'post',
             headers: {
               Authorization: `Token ${apiKey}`,
@@ -131,6 +145,7 @@ export default class influxdb implements QueryService {
               ...(precision && { precision }),
             },
             body: queryOptions.body,
+            ...ssrfBaseOptions,
           });
           result = response.body;
           break;
@@ -148,9 +163,12 @@ export default class influxdb implements QueryService {
   }
   async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
     const { port, host, protocol, api_token } = sourceOptions;
-    const client = await got(`${protocol}://${host}:${port}/influxdb/cloud/api//ping`, {
+    const baseUrl = `${protocol}://${host}:${port}`;
+    await validateUrlForSSRF(baseUrl);
+    const client = await got(`${baseUrl}/influxdb/cloud/api//ping`, {
       method: 'get',
       headers: { Authorization: `Token ${api_token}` },
+      ...getSSRFProtectionOptions(),
     });
     if (!client) {
       throw new Error('Error');

--- a/plugins/packages/n8n/lib/index.ts
+++ b/plugins/packages/n8n/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, validateUrlForSSRF, getSSRFProtectionOptions } from '@tooljet-plugins/common';
 import { QueryOptions, SourceOptions } from './types';
 import got, { HTTPError, OptionsOfTextResponseBody } from 'got';
 
@@ -43,18 +43,20 @@ export default class N8n implements QueryService {
       };
     };
 
+    await validateUrlForSSRF(url);
+
     try {
       switch (operation) {
         case 'post': {
           if (bodyContent === '') {
             throw new Error('Please provide body content');
           }
-          const response = await got(url, constructPayload('post'));
+          const response = await got(url, getSSRFProtectionOptions(undefined, constructPayload('post')));
           result = JSON.parse(response.body);
           break;
         }
         case 'get': {
-          const response = await got(url, constructPayload('get'));
+          const response = await got(url, getSSRFProtectionOptions(undefined, constructPayload('get')));
           result = JSON.parse(response.body);
           break;
         }

--- a/plugins/packages/nocodb/lib/index.ts
+++ b/plugins/packages/nocodb/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, validateUrlForSSRF, getSSRFProtectionOptions } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import got, { Headers } from 'got';
 const JSON5 = require('json5');
@@ -26,12 +26,17 @@ export default class Nocodb implements QueryService {
     if (query_string[0] === '?') {
       query_string = query_string.slice(1);
     }
+
+    await validateUrlForSSRF(baseURL);
+    const ssrfBaseOptions = getSSRFProtectionOptions();
+
     try {
       switch (operation) {
         case 'list_records': {
           response = await got(`${baseURL}/api/v2/tables/${tableId}/records?${query_string}`, {
             method: 'get',
             headers: this.authHeader(apiToken),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -42,6 +47,7 @@ export default class Nocodb implements QueryService {
           response = await got(`${baseURL}/api/v2/tables/${tableId}/records/count?${query_string}`, {
             method: 'get',
             headers: this.authHeader(apiToken),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -53,6 +59,7 @@ export default class Nocodb implements QueryService {
           response = await got(`${baseURL}/api/v2/tables/${tableId}/records/${record_id}?${query_string}`, {
             method: 'get',
             headers: this.authHeader(apiToken),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -64,6 +71,7 @@ export default class Nocodb implements QueryService {
             method: 'post',
             headers: this.authHeader(apiToken),
             json: this.parseJSON(queryOptions.body),
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -79,6 +87,7 @@ export default class Nocodb implements QueryService {
               ...this.parseJSON(queryOptions.body),
               Id: record_id,
             },
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);
@@ -93,6 +102,7 @@ export default class Nocodb implements QueryService {
             json: {
               Id: record_id,
             },
+            ...ssrfBaseOptions,
           });
 
           result = this.parseJSON(response.body);

--- a/server/src/modules/data-sources/util.service.ts
+++ b/server/src/modules/data-sources/util.service.ts
@@ -2,6 +2,7 @@ import { DataSource } from '@entities/data_source.entity';
 import { BadRequestException, Injectable, NotAcceptableException, NotImplementedException } from '@nestjs/common';
 import * as protobuf from 'protobufjs';
 import got from 'got';
+import { validateUrlForSSRF } from '@tooljet/plugins';
 import Ajv2020 from 'ajv/dist/2020';
 import { CreateArgumentsDto, GetDataSourceOauthUrlDto, TestDataSourceDto } from './dto';
 import { dbTransactionWrap } from '@helpers/database.helper';
@@ -791,6 +792,7 @@ export class DataSourcesUtilService implements IDataSourcesUtilService {
     if (!accessTokenUrl) {
       throw new BadRequestException('Missing access_token_url');
     }
+    await validateUrlForSSRF(accessTokenUrl);
     if (!sourceOptions['client_id']) {
       throw new BadRequestException('Missing client_id');
     }


### PR DESCRIPTION
## Summary

  This PR closes multiple reported SSRF vulnerabilities across ToolJet's plugin layer and server-side OAuth flow. Changes span the centralized SSRF protection module, 7 previously unprotected datasource plugins, and the OAuth
  token-exchange endpoint.

  | Advisory | Description | CVSS | Status |
  |---|---|---|---|
  | [GHSA-h49f-mhmm-jx4w](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-h49f-mhmm-jx4w) | SSRF in RestAPI plugin | 9.3 | ✅ Fixed |
  | [GHSA-m54m-9rjp-hqj4](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-m54m-9rjp-hqj4) | Unauthenticated SSRF via public app REST queries | 9.1 | ✅ Fixed — SSRF now default-on |
  | [GHSA-vx6g-wggx-mwwv](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-vx6g-wggx-mwwv) | SSRF protection disabled by default | 8.6 | ✅ Fixed |
  | [GHSA-qvvc-g4pc-2cw4](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-qvvc-g4pc-2cw4) | SSRF in CouchDB / InfluxDB / Baserow / NocoDB plugins | 8.5 | ✅ Fixed |
  | [GHSA-5qxh-vv5g-6gxg](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-5qxh-vv5g-6gxg) | SSRF in REST API / GraphQL / OpenAPI plugins | 7.7 | ✅ Fixed — SSRF now default-on |
  | [GHSA-7836-cv4g-fqcv](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-7836-cv4g-fqcv) | OAuth token endpoint SSRF bypass | 7.7 | ✅ Fixed |
  | [GHSA-qw9q-v8f8-v2pj](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-qw9q-v8f8-v2pj) | SSRF in n8n / nocodb / baserow / couchdb / elasticsearch / influxdb / databricks | 7.1 | ✅ Fixed |


  ## Changes

  ### `plugins/packages/common/lib/ssrf-protection.ts` — centralized SSRF module
  - **Default-on**: flipped from opt-in (`=== 'true'`) to opt-out (`!== 'false'`); Cloud edition hardcoded to always-on
  - **DNS rebinding blocklist**: added `*.nip.io`, `*.xip.io`, `*.sslip.io`, `*.localtest.me`, `*.traefik.me`
  - **Fail-closed DNS**: if DNS resolution returns zero addresses, block the request
  - **Raw IP fix**: `dns.resolve4()` throws on bare IPs on Linux (ENODATA); skip DNS step for raw IPs via `net.isIP()`
  - **IPv6 hex notation**: handle `::ffff:c0a8:101` (hex-encoded IPv4-mapped) in `isPrivateIPv6`
  - **Allowlist respected at TCP layer**: `createSSRFSafeLookup` now checks `allowedHostnames` before blocking a resolved IP
  - **Edition-aware defaults** (no env config needed):
    - `cloud` → full blocking, always enabled
    - `ce` → enabled by default, RFC1918 allowed, metadata/loopback blocked
    - `ee` → enabled by default, only cloud metadata endpoints blocked (closed private networks)

  ### Plugin fixes — `validateUrlForSSRF` + `getSSRFProtectionOptions` added to all HTTP-issuing plugins
  | Plugin | Attack surface |
  |---|---|
  | `n8n` | Full URL per query |
  | `nocodb` | `base_url` from source config |
  | `baserow` | `base_url` from source config |
  | `couchdb` | `host`/`port`/`protocol` + free-form `view_url`; `testConnection` also covered |
  | `influxdb` | `host`/`port`/`protocol`; `testConnection` also covered |
  | `elasticsearch` | `host`/`port`/`protocol` validated before `new Client()` |
  | `databricks` | `host` validated before `DBSQLClient.connect()` |

  ### `server/src/modules/data-sources/util.service.ts`
  - Added `await validateUrlForSSRF(accessTokenUrl)` in `fetchOAuthToken()` before the `got()` call — closes the OAuth token endpoint SSRF bypass

  ### `plugins/server.ts` + `dist/`
  - Exported `validateUrlForSSRF` and `getSSRFProtectionOptions` from the plugins package so the server layer can import them via `@tooljet/plugins`

  ## Test plan
  - [ ] RestAPI query targeting `http://169.254.169.254` → blocked on Cloud and CE
  - [ ] RestAPI query targeting `http://10.x.x.x` → blocked on Cloud, allowed on CE/EE
  - [ ] n8n query with attacker-controlled URL → blocked
  - [ ] CouchDB datasource with `host=169.254.169.254` → blocked
  - [ ] OAuth datasource with `access_token_url=http://169.254.169.254` → blocked
  - [ ] Legitimate external APIs continue to work
  - [ ] Self-hosted CE: internal services at RFC1918 addresses reachable
  - [ ] CI: cypress-platform `multiEnvironment`, `workspaceConstants` specs pass