### PR TITLE
fix: resolve truthiness bug in MySQL dynamic connection parameters

### DIFF
--- a/plugins/packages/mysql/lib/index.ts
+++ b/plugins/packages/mysql/lib/index.ts
@@ -99,12 +99,16 @@ export default class MysqlQueryService implements QueryService {
     dataSourceUpdatedAt: string
   ): Promise<QueryResult> {
     let checkCache, knexInstance;
+    
+    //Cloning the source optionn to prevent mutating of global refernce
+    sourceOptions = {...sourceOptions }
+    
     if (sourceOptions['allow_dynamic_connection_parameters']) {
       if (sourceOptions.connection_type === 'hostname') {
-        sourceOptions['host'] = queryOptions['host'] ? queryOptions['host'] : sourceOptions['host'];
-        sourceOptions['database'] = queryOptions['database'] ? queryOptions['database'] : sourceOptions['database'];
+        sourceOptions['host'] = queryOptions['host'] !== undefined ? queryOptions['host'] : sourceOptions['host'];
+        sourceOptions['database'] = queryOptions['database'] !== undefined ? queryOptions['database'] : sourceOptions['database'];
       } else if (sourceOptions.connection_type === 'socket_path') {
-        sourceOptions['database'] = queryOptions['database'] ? queryOptions['database'] : sourceOptions['database'];
+        sourceOptions['database'] = queryOptions['database'] !== undefined ? queryOptions['database'] : sourceOptions['database'];
       }
     }
 


### PR DESCRIPTION
**Fixes #16764**

**What this PR does:**
Resolves an issue where dynamic database fields for MySQL were failing to execute properly due to ternary truthiness checks.

**Changes:**
* Replaced truthiness checks (`? :`) with strict `!== undefined` checks. Previously, if a dynamic parameter evaluated to a valid falsy value (like an empty string used to query globally across schemas), it was incorrectly discarded and fell back to the default configuration.
* Maintained the shallow clone of the `sourceOptions` object (`{ ...sourceOptions }`). This ensures that the dynamic parameters are applied strictly to a localized execution context, preventing mutations to the globally cached configuration reference and avoiding side effects on subsequent queries.