### PR TITLE
fix: correct typo in NoConditionUI

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/NoConditionUI.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/NoConditionUI.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Information from '@/_ui/Icon/solidIcons/Information';
 import { generateCypressDataCy } from '../../../../modules/common/helpers/cypressHelpers.js';
-export const NoCondition = ({ text = 'There are no condition' }) => {
+export const NoCondition = ({ text = 'There are no conditions' }) => {
   return (
     <div className="border-dashed d-flex justify-content-center align-items-center h-32 border-radius-6">
       <Information width="14" />


### PR DESCRIPTION
Fix typo in NoConditionUI default text by changing "There are no condition" to "There are no conditions"
<img width="1457" height="693" alt="image" src="https://github.com/user-attachments/assets/38c27d42-593c-4f93-af57-9ff1ec55d8a8" />
