### PR TITLE
Added FIX for security issues

### DIFF
--- a/.github/workflows/maketplace-plugins-deploy.yml
+++ b/.github/workflows/maketplace-plugins-deploy.yml
@@ -1,4 +1,4 @@
-name: Maketplace plugin build
+name: Marketplace plugin build
 
 on:
   pull_request_target:
@@ -6,50 +6,35 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   PR_NUMBER: ${{ github.event.number }}
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  deploy-marketplace-plugin:
+  build-plugins:
     if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy-marketplace-plugin' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read          # nothing else — this job runs fork code
 
     steps:
-      - name: Sync repo
-        uses: actions/checkout@v3
-
-      - name: Check if PR is from the same repo
-        id: check_repo
-        run: echo "::set-output name=is_fork::$(if [[ '${{ github.event.pull_request.head.repo.full_name }}' != '${{ github.event.pull_request.base.repo.full_name }}' ]]; then echo true; else echo false; fi)"
-
-      - name: Fetch the remote branch if it's a forked PR
-        if: steps.check_repo.outputs.is_fork == 'true'
-        run: |
-          git fetch origin pull/${{ github.event.number }}/head:${{ env.BRANCH_NAME }}
-          git checkout ${{ env.BRANCH_NAME }}
-
-      - name: Checkout
-        if: steps.check_repo.outputs.is_fork == 'false'
-        uses: actions/checkout@v3
+      - name: Checkout PR code (fork or same-repo)
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 22.15.1
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_MAR_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_MAR_ACCESS_KEY }}
-          aws-region: us-east-2
-
       - name: Install and build dependencies in order
+        working-directory: marketplace
         run: |
-          cd marketplace
           echo "🔧 Installing all workspace dependencies"
           npm install
 
@@ -60,35 +45,122 @@ jobs:
           PLUGINS=$(ls plugins | grep -v '^common$')
           for plugin in $PLUGINS; do
             echo "🔨 Building plugin: $plugin"
-            npm run build --workspace=plugins/$plugin || exit 1
+            npm run build --workspace="plugins/$plugin" || exit 1
           done
 
-      - name: Build marketplace plugins and capture summary
+      - name: Package built artifacts (dist + manifest only)
+        working-directory: marketplace
         run: |
-          cd marketplace
-          echo "🚀 Uploading to S3"
+          # Only build outputs leave this job. No package.json, no node_modules,
+          # no scripts — those would be fork-controlled and must not cross over.
+          tar -czf /tmp/plugin-dist.tar.gz \
+            plugins/*/dist \
+            plugins/*/manifest.json 2>/dev/null || \
+          tar -czf /tmp/plugin-dist.tar.gz plugins/*/dist
+
+      - name: Upload artifact for deploy job
+        uses: actions/upload-artifact@v4
+        with:
+          name: marketplace-plugin-dist
+          path: /tmp/plugin-dist.tar.gz
+          retention-days: 1
+
+
+  deploy-plugins:
+    needs: build-plugins
+    # Independent guard (defense in depth) — do NOT rely on `needs` alone.
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy-marketplace-plugin' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write     # for the status comment
+      issues: write            # for label updates
+
+    steps:
+      - name: Checkout BASE branch (trusted scripts only)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
+
+      - name: Download built artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: marketplace-plugin-dist
+          path: /tmp/artifact
+
+      # ── Treat the artifact as hostile data ──────────────────────────────────
+      - name: Validate artifact paths (reject traversal / absolute paths)
+        run: |
+          if tar -tzf /tmp/artifact/plugin-dist.tar.gz | grep -E '(^/|(^|/)\.\.(/|$))'; then
+            echo "❌ Artifact contains unsafe paths (absolute or ../). Aborting."
+            exit 1
+          fi
+          echo "✅ Artifact paths look safe."
+
+      - name: Extract artifact into ISOLATED staging dir
+        run: |
+          rm -rf /tmp/staging
+          mkdir -p /tmp/staging
+          # Never extract over the repo tree. No ownership/perms from the tar.
+          tar -xzf /tmp/artifact/plugin-dist.tar.gz -C /tmp/staging \
+            --no-same-owner --no-same-permissions
+
+      - name: Promote ONLY dist/manifest of already-known plugins
+        working-directory: marketplace
+        run: |
+          shopt -s nullglob
+          for distdir in /tmp/staging/plugins/*/dist; do
+            plugin="$(basename "$(dirname "$distdir")")"
+            # Refuse anything that isn't a plugin dir present in the trusted tree.
+            if [ -d "plugins/$plugin" ]; then
+              echo "→ Placing dist for known plugin: $plugin"
+              rm -rf "plugins/$plugin/dist"
+              cp -r "$distdir" "plugins/$plugin/dist"
+              if [ -f "/tmp/staging/plugins/$plugin/manifest.json" ]; then
+                cp "/tmp/staging/plugins/$plugin/manifest.json" "plugins/$plugin/manifest.json"
+              fi
+            else
+              echo "⚠️  Skipping unknown plugin from artifact: $plugin"
+            fi
+          done
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_MAR_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_MAR_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Upload to S3 (trusted base-branch script)
+        working-directory: marketplace
+        run: |
+          echo "🚀 Uploading to S3 using base-branch script"
           AWS_BUCKET=tooljet-plugins-stage bash scripts/upload-to-s3.sh | tee upload_summary.log
 
       - name: Extract upload summary
         id: upload_summary
         run: |
           SUMMARY=$(awk '/UPLOAD SUMMARY/,0' marketplace/upload_summary.log)
-          echo "UPLOAD_SUMMARY<<EOF" >> $GITHUB_ENV
-          echo "$SUMMARY" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          {
+            echo "UPLOAD_SUMMARY<<EOF"
+            echo "$SUMMARY"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Comment on success
         if: success()
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const runId = process.env.GITHUB_RUN_ID;
             const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${runId}`;
-            const summary = process.env.UPLOAD_SUMMARY;
-            const body = `Marketplace Plugin added to stage bucket\n\n🔍 [View Deployment Logs & Summary](${runUrl})\n\n\`\`\`\n${summary}\n\`\`\``;
-
-            github.rest.issues.createComment({
+            const summary = process.env.UPLOAD_SUMMARY || '';
+            const body = `Marketplace Plugin added to stage bucket\n\n` +
+                         `🔍 [View Deployment Logs & Summary](${runUrl})\n\n` +
+                         `\`\`\`\n${summary}\n\`\`\``;
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -97,7 +169,7 @@ jobs:
 
       - name: Label update on success
         if: success()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             try {
@@ -106,27 +178,25 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name: 'deploy-marketplace-plugin'
-              })
+              });
             } catch (e) {
-              console.log(e)
+              console.log(e);
             }
-
             await github.rest.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: ['marketplace-plugin-deployed']
-            })
+            });
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const runId = process.env.GITHUB_RUN_ID;
             const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${runId}`;
-
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/maketplace-plugins-deploy.yml
+++ b/.github/workflows/maketplace-plugins-deploy.yml
@@ -1,48 +1,30 @@
-name: TEST - Marketplace plugin build (isolated)
+name: Marketplace plugin build
 
 on:
+  pull_request_target:
+    types: [labeled, unlabeled, closed]
+
   workflow_dispatch:
-    inputs:
-      source_repo:
-        description: "Repo to build from (simulate a fork). Default: this repo."
-        required: false
-        default: ""
-      source_ref:
-        description: "Branch/SHA to build (simulate PR head). Default: this branch."
-        required: false
-        default: ""
-      dry_run:
-        description: "If true, skip the actual S3 upload (build only)."
-        required: false
-        default: "true"
-        type: choice
-        options:
-          - "true"
-          - "false"
 
 permissions:
   contents: read
 
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
 jobs:
   build-plugins:
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy-marketplace-plugin' }}
     runs-on: ubuntu-latest
-    steps:
-      - name: Resolve source
-        id: src
-        run: |
-          REPO="${{ github.event.inputs.source_repo }}"
-          REF="${{ github.event.inputs.source_ref }}"
-          [ -z "$REPO" ] && REPO="${{ github.repository }}"
-          [ -z "$REF" ] && REF="${{ github.ref_name }}"
-          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
-          echo "ref=$REF"  >> "$GITHUB_OUTPUT"
-          echo "Building from $REPO @ $REF"
+    permissions:
+      contents: read          # nothing else — this job runs fork code
 
-      - name: Checkout source code
+    steps:
+      - name: Checkout PR code (fork or same-repo)
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.src.outputs.repo }}
-          ref: ${{ steps.src.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -55,8 +37,10 @@ jobs:
         run: |
           echo "🔧 Installing all workspace dependencies"
           npm install
+
           echo "🏗️ Building 'common' plugin first"
           npm run build --workspace=plugins/common || exit 1
+
           echo "🔁 Building all remaining plugins"
           PLUGINS=$(ls plugins | grep -v '^common$')
           for plugin in $PLUGINS; do
@@ -67,14 +51,12 @@ jobs:
       - name: Package built artifacts (dist + manifest only)
         working-directory: marketplace
         run: |
+          # Only build outputs leave this job. No package.json, no node_modules,
+          # no scripts — those would be fork-controlled and must not cross over.
           tar -czf /tmp/plugin-dist.tar.gz \
             plugins/*/dist \
             plugins/*/manifest.json 2>/dev/null || \
           tar -czf /tmp/plugin-dist.tar.gz plugins/*/dist
-          echo "Artifact size:"
-          du -h /tmp/plugin-dist.tar.gz
-          echo "Contents:"
-          tar -tzf /tmp/plugin-dist.tar.gz | head -50
 
       - name: Upload artifact for deploy job
         uses: actions/upload-artifact@v4
@@ -83,14 +65,22 @@ jobs:
           path: /tmp/plugin-dist.tar.gz
           retention-days: 1
 
+
   deploy-plugins:
     needs: build-plugins
+    # Independent guard (defense in depth) — do NOT rely on `needs` alone.
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy-marketplace-plugin' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write     # for the status comment
+      issues: write            # for label updates
+
     steps:
       - name: Checkout BASE branch (trusted scripts only)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
       - name: Download built artifact
@@ -99,6 +89,7 @@ jobs:
           name: marketplace-plugin-dist
           path: /tmp/artifact
 
+      # ── Treat the artifact as hostile data ──────────────────────────────────
       - name: Validate artifact paths (reject traversal / absolute paths)
         run: |
           if tar -tzf /tmp/artifact/plugin-dist.tar.gz | grep -E '(^/|(^|/)\.\.(/|$))'; then
@@ -111,6 +102,7 @@ jobs:
         run: |
           rm -rf /tmp/staging
           mkdir -p /tmp/staging
+          # Never extract over the repo tree. No ownership/perms from the tar.
           tar -xzf /tmp/artifact/plugin-dist.tar.gz -C /tmp/staging \
             --no-same-owner --no-same-permissions
 
@@ -120,6 +112,7 @@ jobs:
           shopt -s nullglob
           for distdir in /tmp/staging/plugins/*/dist; do
             plugin="$(basename "$(dirname "$distdir")")"
+            # Refuse anything that isn't a plugin dir present in the trusted tree.
             if [ -d "plugins/$plugin" ]; then
               echo "→ Placing dist for known plugin: $plugin"
               rm -rf "plugins/$plugin/dist"
@@ -133,7 +126,6 @@ jobs:
           done
 
       - name: Configure AWS Credentials
-        if: ${{ github.event.inputs.dry_run == 'false' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_MAR_KEY_ID }}
@@ -141,15 +133,73 @@ jobs:
           aws-region: us-east-2
 
       - name: Upload to S3 (trusted base-branch script)
-        if: ${{ github.event.inputs.dry_run == 'false' }}
         working-directory: marketplace
         run: |
           echo "🚀 Uploading to S3 using base-branch script"
           AWS_BUCKET=tooljet-plugins-stage bash scripts/upload-to-s3.sh | tee upload_summary.log
 
-      - name: Dry-run notice
-        if: ${{ github.event.inputs.dry_run != 'false' }}
+      - name: Extract upload summary
+        id: upload_summary
         run: |
-          echo "✅ DRY RUN — build succeeded and artifact unpacked & promoted."
-          echo "No AWS credentials were loaded and nothing was uploaded."
-          echo "Re-run with dry_run=false to test the real S3 upload."
+          SUMMARY=$(awk '/UPLOAD SUMMARY/,0' marketplace/upload_summary.log)
+          {
+            echo "UPLOAD_SUMMARY<<EOF"
+            echo "$SUMMARY"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Comment on success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runId = process.env.GITHUB_RUN_ID;
+            const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${runId}`;
+            const summary = process.env.UPLOAD_SUMMARY || '';
+            const body = `Marketplace Plugin added to stage bucket\n\n` +
+                         `🔍 [View Deployment Logs & Summary](${runUrl})\n\n` +
+                         `\`\`\`\n${summary}\n\`\`\``;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+
+      - name: Label update on success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'deploy-marketplace-plugin'
+              });
+            } catch (e) {
+              console.log(e);
+            }
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['marketplace-plugin-deployed']
+            });
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runId = process.env.GITHUB_RUN_ID;
+            const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ Marketplace Plugin deployment failed.\n\n🔍 [View Deployment Logs & Summary](${runUrl})`
+            });

--- a/.github/workflows/maketplace-plugins-deploy.yml
+++ b/.github/workflows/maketplace-plugins-deploy.yml
@@ -1,30 +1,48 @@
-name: Marketplace plugin build
+name: TEST - Marketplace plugin build (isolated)
 
 on:
-  pull_request_target:
-    types: [labeled, unlabeled, closed]
-
   workflow_dispatch:
+    inputs:
+      source_repo:
+        description: "Repo to build from (simulate a fork). Default: this repo."
+        required: false
+        default: ""
+      source_ref:
+        description: "Branch/SHA to build (simulate PR head). Default: this branch."
+        required: false
+        default: ""
+      dry_run:
+        description: "If true, skip the actual S3 upload (build only)."
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 permissions:
   contents: read
 
-env:
-  PR_NUMBER: ${{ github.event.number }}
-
 jobs:
   build-plugins:
-    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy-marketplace-plugin' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read          # nothing else — this job runs fork code
-
     steps:
-      - name: Checkout PR code (fork or same-repo)
+      - name: Resolve source
+        id: src
+        run: |
+          REPO="${{ github.event.inputs.source_repo }}"
+          REF="${{ github.event.inputs.source_ref }}"
+          [ -z "$REPO" ] && REPO="${{ github.repository }}"
+          [ -z "$REF" ] && REF="${{ github.ref_name }}"
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF"  >> "$GITHUB_OUTPUT"
+          echo "Building from $REPO @ $REF"
+
+      - name: Checkout source code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          repository: ${{ steps.src.outputs.repo }}
+          ref: ${{ steps.src.outputs.ref }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -37,10 +55,8 @@ jobs:
         run: |
           echo "🔧 Installing all workspace dependencies"
           npm install
-
           echo "🏗️ Building 'common' plugin first"
           npm run build --workspace=plugins/common || exit 1
-
           echo "🔁 Building all remaining plugins"
           PLUGINS=$(ls plugins | grep -v '^common$')
           for plugin in $PLUGINS; do
@@ -51,12 +67,14 @@ jobs:
       - name: Package built artifacts (dist + manifest only)
         working-directory: marketplace
         run: |
-          # Only build outputs leave this job. No package.json, no node_modules,
-          # no scripts — those would be fork-controlled and must not cross over.
           tar -czf /tmp/plugin-dist.tar.gz \
             plugins/*/dist \
             plugins/*/manifest.json 2>/dev/null || \
           tar -czf /tmp/plugin-dist.tar.gz plugins/*/dist
+          echo "Artifact size:"
+          du -h /tmp/plugin-dist.tar.gz
+          echo "Contents:"
+          tar -tzf /tmp/plugin-dist.tar.gz | head -50
 
       - name: Upload artifact for deploy job
         uses: actions/upload-artifact@v4
@@ -65,22 +83,14 @@ jobs:
           path: /tmp/plugin-dist.tar.gz
           retention-days: 1
 
-
   deploy-plugins:
     needs: build-plugins
-    # Independent guard (defense in depth) — do NOT rely on `needs` alone.
-    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy-marketplace-plugin' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write     # for the status comment
-      issues: write            # for label updates
-
     steps:
       - name: Checkout BASE branch (trusted scripts only)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.ref_name }}
           persist-credentials: false
 
       - name: Download built artifact
@@ -89,7 +99,6 @@ jobs:
           name: marketplace-plugin-dist
           path: /tmp/artifact
 
-      # ── Treat the artifact as hostile data ──────────────────────────────────
       - name: Validate artifact paths (reject traversal / absolute paths)
         run: |
           if tar -tzf /tmp/artifact/plugin-dist.tar.gz | grep -E '(^/|(^|/)\.\.(/|$))'; then
@@ -102,7 +111,6 @@ jobs:
         run: |
           rm -rf /tmp/staging
           mkdir -p /tmp/staging
-          # Never extract over the repo tree. No ownership/perms from the tar.
           tar -xzf /tmp/artifact/plugin-dist.tar.gz -C /tmp/staging \
             --no-same-owner --no-same-permissions
 
@@ -112,7 +120,6 @@ jobs:
           shopt -s nullglob
           for distdir in /tmp/staging/plugins/*/dist; do
             plugin="$(basename "$(dirname "$distdir")")"
-            # Refuse anything that isn't a plugin dir present in the trusted tree.
             if [ -d "plugins/$plugin" ]; then
               echo "→ Placing dist for known plugin: $plugin"
               rm -rf "plugins/$plugin/dist"
@@ -126,6 +133,7 @@ jobs:
           done
 
       - name: Configure AWS Credentials
+        if: ${{ github.event.inputs.dry_run == 'false' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_MAR_KEY_ID }}
@@ -133,73 +141,15 @@ jobs:
           aws-region: us-east-2
 
       - name: Upload to S3 (trusted base-branch script)
+        if: ${{ github.event.inputs.dry_run == 'false' }}
         working-directory: marketplace
         run: |
           echo "🚀 Uploading to S3 using base-branch script"
           AWS_BUCKET=tooljet-plugins-stage bash scripts/upload-to-s3.sh | tee upload_summary.log
 
-      - name: Extract upload summary
-        id: upload_summary
+      - name: Dry-run notice
+        if: ${{ github.event.inputs.dry_run != 'false' }}
         run: |
-          SUMMARY=$(awk '/UPLOAD SUMMARY/,0' marketplace/upload_summary.log)
-          {
-            echo "UPLOAD_SUMMARY<<EOF"
-            echo "$SUMMARY"
-            echo "EOF"
-          } >> "$GITHUB_ENV"
-
-      - name: Comment on success
-        if: success()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const runId = process.env.GITHUB_RUN_ID;
-            const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${runId}`;
-            const summary = process.env.UPLOAD_SUMMARY || '';
-            const body = `Marketplace Plugin added to stage bucket\n\n` +
-                         `🔍 [View Deployment Logs & Summary](${runUrl})\n\n` +
-                         `\`\`\`\n${summary}\n\`\`\``;
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            });
-
-      - name: Label update on success
-        if: success()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: 'deploy-marketplace-plugin'
-              });
-            } catch (e) {
-              console.log(e);
-            }
-            await github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['marketplace-plugin-deployed']
-            });
-
-      - name: Comment on failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const runId = process.env.GITHUB_RUN_ID;
-            const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${runId}`;
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `❌ Marketplace Plugin deployment failed.\n\n🔍 [View Deployment Logs & Summary](${runUrl})`
-            });
+          echo "✅ DRY RUN — build succeeded and artifact unpacked & promoted."
+          echo "No AWS credentials were loaded and nothing was uploaded."
+          echo "Re-run with dry_run=false to test the real S3 upload."

--- a/marketplace/scripts/upload-to-s3.sh
+++ b/marketplace/scripts/upload-to-s3.sh
@@ -5,7 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MARKETPLACE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo "📦 Installing AWS SDK v3 dependencies..."
-npm install --no-save --prefix "$MARKETPLACE_DIR" @aws-sdk/client-s3 @aws-sdk/lib-storage
+npm install --no-save --ignore-scripts --prefix "$MARKETPLACE_DIR" \
+  @aws-sdk/client-s3 @aws-sdk/lib-storage
 
 echo ""
 echo "🚀 Running upload-to-s3.js..."


### PR DESCRIPTION
## Summary

Hardens `maketplace-plugins-deploy.yml` against a credential-exfiltration vulnerability where pull-request-controlled code executed in a `pull_request_target` context with AWS deployment secrets in scope. Splits the workflow into an unprivileged build job and a privileged deploy job so untrusted code and secrets never coexist.

Addresses the externally reported `pull_request_target` finding for this workflow.

## Vulnerability Being Fixed

The previous workflow ran on `pull_request_target` (which carries repo secrets even for fork PRs), checked out the **PR head branch including from forks**, loaded AWS credentials, and then executed fork-controlled `npm install` lifecycle hooks, build scripts, and the fork's own `upload-to-s3.sh` — all in the same job.

A malicious contributor could place credential-stealing code in any of those paths; once a maintainer applied the `deploy-marketplace-plugin` label, that code would run with live AWS secrets.

**Severity:** Critical (secret exfiltration via fork PR)

## Changes

### 1. Architecture: One Job → Two Isolated Jobs

| Aspect | Before | After |
| --- | --- | --- |
| Structure | Single `deploy-marketplace-plugin` job | `build-plugins` (no secrets) + `deploy-plugins` (secrets) |
| Fork code execution | Ran alongside AWS credentials | Runs in `build-plugins` only — which has **no** credentials |
| Credential exposure | Fork code could read `AWS_*` env vars | Credentials loaded only in `deploy-plugins`, which never checks out fork code |

`build-plugins` checks out the PR head, builds, and uploads only the built `dist` / `manifest.json` as an artifact. It has **no** `Configure AWS Credentials` step. `deploy-plugins` checks out the **base branch**, consumes the artifact, and runs the trusted base-branch upload script.

### 2. Trust Boundary: Artifact Treated as Hostile Data (new)

Between jobs, the artifact is validated before use:

| Control | Purpose |
| --- | --- |
| Path validation | Rejects tarballs containing absolute paths or `../` traversal |
| Isolated extraction | Unpacks to `/tmp/staging`, never over the repo tree (`--no-same-owner --no-same-permissions`) |
| Allowlist promotion | Only `dist` / `manifest.json` for plugins **already present on the base branch** are promoted; `package.json`, `node_modules`, and `scripts` from the artifact are discarded |

This prevents a malicious build output from overwriting the trusted `upload-to-s3.sh` or dropping a `package.json` whose lifecycle scripts would later execute.

### 3. Companion Fix: `marketplace/scripts/upload-to-s3.sh`

```diff
- npm install --no-save --prefix "$MARKETPLACE_DIR" @aws-sdk/client-s3 @aws-sdk/lib-storage
+ npm install --no-save --ignore-scripts --prefix "$MARKETPLACE_DIR" @aws-sdk/client-s3 @aws-sdk/lib-storage
```

This `npm install` runs in the credentialed job. `--ignore-scripts` ensures no `package.json` lifecycle hook can execute there — a last line of defense behind the artifact isolation.

### 4. Removed: Manual Fork-Checkout Logic & Script-Injection Vectors

```diff
- env:
-   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-
- - name: Check if PR is from the same repo
-   run: echo "::set-output name=is_fork::$(if [[ '${{ github.event.pull_request.head.repo.full_name }}' != ... )"
-
- - name: Fetch the remote branch if it's a forked PR
-   run: |
-     git fetch origin pull/${{ github.event.number }}/head:${{ env.BRANCH_NAME }}
-     git checkout ${{ env.BRANCH_NAME }}
```

| Removed | Reason |
| --- | --- |
| `BRANCH_NAME` env var | Fork-controlled string interpolated **unquoted** into `git checkout` — a shell-injection vector. Checkout now uses the immutable `head.sha` passed as an action parameter, not a shell string |
| `full_name` comparison step | Interpolated a fork-controlled value into a shell command |
| `::set-output` syntax | Deprecated by GitHub |

### 5. Least-Privilege Permissions

```diff
+ permissions:
+   contents: read
```

The original had **no** `permissions` block, granting the default (often write) `GITHUB_TOKEN` scope to fork code. Now the build job is `contents: read` only; write scopes (`pull-requests`, `issues`) are granted solely to the deploy job that needs them for comments and labels.

### 6. Action Version Bumps

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v3 | v4 |
| `actions/setup-node` | v2 | v4 |
| `actions/github-script` | v5 / v6 | v7 |

## Files Changed

| File | Change |
| --- | --- |
| `.github/workflows/maketplace-plugins-deploy.yml` | Two-job split, artifact validation, least-privilege permissions, injection-vector removal |
| `marketplace/scripts/upload-to-s3.sh` | Added `--ignore-scripts` |
| `marketplace/scripts/upload-to-s3.js` | **Unchanged** — verified byte-only (reads files via `createReadStream` and uploads; no `require` / `import` / `eval` of plugin code) |



