### PR TITLE
fix(security): sanitize XSS vectors in table cell, comment mention, helpText

### DIFF
--- a/frontend/src/AppBuilder/Shared/DataTypes/renderers/StringRenderer.jsx
+++ b/frontend/src/AppBuilder/Shared/DataTypes/renderers/StringRenderer.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { determineJustifyContentValue } from '@/_helpers/utils';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import { noop } from 'lodash';
+import DOMPurify from 'dompurify';
 
 /**
  * StringRenderer - Pure string value renderer with editing support
@@ -120,7 +121,7 @@ export const StringRenderer = ({
               e.stopPropagation();
             }}
             suppressContentEditableWarning={true}
-            dangerouslySetInnerHTML={{ __html: value }}
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(value) }}
           />
         ) : (
           <div

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -688,7 +688,9 @@ export function hasCircularDependency(obj, stack = new Set()) {
 
 export const hightlightMentionedUserInComment = (comment) => {
   var regex = /(\()([^)]+)(\))/g;
-  const safeComment = DOMPurify.sanitize(comment);
+  // Comments are plain text (composed via react-mentions); strip all HTML so a typed
+  // payload can't survive sanitize, then add only the mention highlight span.
+  const safeComment = DOMPurify.sanitize(comment, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
   return safeComment.replace(regex, '<span class="mentioned-user">$2</span>');
 };
 //   const currentPageId = _ref.currentPageId;

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -2,6 +2,7 @@
 import moment from 'moment';
 import _, { isEmpty } from 'lodash';
 import JSON5 from 'json5';
+import DOMPurify from 'dompurify';
 import { toast } from 'react-hot-toast';
 import { authenticationService } from '@/_services/authentication.service';
 import { workflowExecutionsService } from '@/_services';
@@ -687,7 +688,8 @@ export function hasCircularDependency(obj, stack = new Set()) {
 
 export const hightlightMentionedUserInComment = (comment) => {
   var regex = /(\()([^)]+)(\))/g;
-  return comment.replace(regex, '<span class=mentioned-user>$2</span>');
+  const safeComment = DOMPurify.sanitize(comment);
+  return safeComment.replace(regex, '<span class="mentioned-user">$2</span>');
 };
 //   const currentPageId = _ref.currentPageId;
 //   const currentComponents = _ref.appDefinition?.pages[currentPageId]?.components

--- a/frontend/src/_ui/Input-V3/index.js
+++ b/frontend/src/_ui/Input-V3/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import cx from 'classnames';
+import DOMPurify from 'dompurify';
 import OrgConstantVariablesPreviewBox from '../../_components/OrgConstantsVariablesResolver';
 import SolidIcon from '../Icon/SolidIcons';
 import { toast } from 'react-hot-toast';
@@ -88,7 +89,7 @@ const InputV3 = ({ helpText, ...props }) => {
         isFocused={isFocused}
         value={value}
       />
-      {helpText && <small className="text-muted" dangerouslySetInnerHTML={{ __html: helpText }} />}
+      {helpText && <small className="text-muted" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(helpText) }} />}
     </div>
   );
 };

--- a/frontend/src/_ui/Input/index.js
+++ b/frontend/src/_ui/Input/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import cx from 'classnames';
+import DOMPurify from 'dompurify';
 import OrgConstantVariablesPreviewBox from '../../_components/OrgConstantsVariablesResolver';
 import SolidIcon from '../Icon/SolidIcons';
 import { toast } from 'react-hot-toast';
@@ -14,7 +15,10 @@ const Input = ({ classes, helpText, onBlur, ...props }) => {
   const iconType = showPassword ? 'eye' : 'eyedisable';
 
   useEffect(() => {
-    if (isWorkspaceConstant || (typeof value === 'string' && value.startsWith('{{') && (type === 'password' || encrypted))) {
+    if (
+      isWorkspaceConstant ||
+      (typeof value === 'string' && value.startsWith('{{') && (type === 'password' || encrypted))
+    ) {
       setShowPassword(true);
     }
   }, [isWorkspaceConstant, value]);
@@ -79,7 +83,7 @@ const Input = ({ classes, helpText, onBlur, ...props }) => {
         isFocused={isFocused}
         value={value}
       />
-      {helpText && <small className="text-muted" dangerouslySetInnerHTML={{ __html: helpText }} />}
+      {helpText && <small className="text-muted" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(helpText) }} />}
     </div>
   );
 };

--- a/frontend/src/_ui/Textarea/index.js
+++ b/frontend/src/_ui/Textarea/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import OrgConstantVariablesPreviewBox from '../../_components/OrgConstantsVariablesResolver';
+import DOMPurify from 'dompurify';
 
 const Textarea = ({ helpText, ...props }) => {
   const { workspaceVariables, workspaceConstants, value } = props;
@@ -14,7 +15,7 @@ const Textarea = ({ helpText, ...props }) => {
         isFocused={isFocused}
         value={value}
       />
-      {helpText && <small className="text-muted" dangerouslySetInnerHTML={{ __html: helpText }} />}
+      {helpText && <small className="text-muted" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(helpText) }} />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Patches 3 confirmed stored/reflected XSS findings from the `lts-3.16` security audit. All are raw-HTML sinks (`dangerouslySetInnerHTML`) fed by user- or query-controlled data, now wrapped with `DOMPurify.sanitize()`.

| # | Severity | Sink | Fix |
|---|---|---|---|
| 1 | 🔴 High | `StringRenderer` editable table cell renders query result as raw HTML | sanitize `value` |
| 3 | 🔴 High | `hightlightMentionedUserInComment` injects stored comment text unsanitized (notification panel) | sanitize `comment` at root in `utils.js` before regex |
| 4 | 🔴 High | `Input` / `Input-V3` / `Textarea` render `helpText` prop as raw HTML | sanitize `helpText` |

Finding 3 is fixed at the **root helper** (`utils.js`), so every caller — `Notification.jsx` included — is covered, not just the notification panel.

## Not changed
- **Finding 2 (HTMLRenderer):** already sanitized via `getCellValue()` → `DOMPurify.sanitize()`. Report was stale; no change needed.
- Tokens / SMTP findings (5,6,7) are backend and tracked separately — heavier (token hashing + migrations).

## Notes
- `dompurify ^3.0.0` already a dependency; no new package.
- Pre-commit `eslint --fix` also reformatted one pre-existing prettier nit in `Input/index.js`.

## Test plan
- [ ] Table widget string column with `<img src=x onerror=alert(1)>` in a query result → no script execution
- [ ] Comment mention containing a `<script>` payload → renders inert in notification panel
- [ ] Datasource form `helpText` with HTML payload → sanitized

