### PR TITLE
Perf: Stop CodeMirror stylesheet leak causing progressive editor slowdown

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
@@ -27,6 +27,7 @@ import { CodeHinterBtns } from './CodehinterOverlayTriggers';
 import useWorkflowStore from '@/_stores/workflowStore';
 import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
 import { TableColumnContext } from '@/AppBuilder/RightSideBar/Inspector/Components/Table/ColumnManager/TableColumnContext';
+import { useStableCallback } from '@/AppBuilder/_hooks/useStableCallback';
 
 const langSupport = Object.freeze({
   javascript: javascript(),
@@ -37,6 +38,22 @@ const langSupport = Object.freeze({
 });
 
 const lineWrappingExtension = EditorView.lineWrapping;
+
+// Hoisted to module scope so their identity never changes: anything fed into the
+// CodeMirror `extensions` prop must stay referentially stable, otherwise
+// react-codemirror dispatches a reconfigure on every render, which permanently
+// grows style-mod's shared stylesheet and degrades the whole session.
+const staticCustomKeyMaps = [
+  ...defaultKeymap.filter((keyBinding) => keyBinding.key !== 'Mod-Enter'), // Remove default keybinding for Mod-Enter
+  ...completionKeymap,
+  ...searchKeymap,
+];
+const searchExtension = search({
+  createPanel: handleSearchPanel,
+});
+const tooltipExtension = tooltips({
+  parent: document.body,
+});
 
 const MultiLineCodeEditor = (props) => {
   const {
@@ -132,10 +149,10 @@ const MultiLineCodeEditor = (props) => {
     };
   }, [editorView]);
 
-  const handleChange = (val) => {
+  const handleChange = useStableCallback((val) => {
     currentValueRef.current = val;
     onInputChange && onInputChange(val);
-  };
+  });
 
   const handleOnBlur = () => {
     if (!delayOnChange) return onChange(currentValueRef.current);
@@ -150,18 +167,21 @@ const MultiLineCodeEditor = (props) => {
   const theme = darkMode ? okaidia : githubLight;
   const langExtention = langSupport[lang] ?? null;
 
-  const setupConfig = {
-    lineNumbers: lineNumbers ?? true,
-    syntaxHighlighting: true,
-    bracketMatching: true,
-    foldGutter: foldGutter,
-    highlightActiveLine: false,
-    autocompletion: hideSuggestion ?? true,
-    highlightActiveLineGutter: false,
-    defaultKeymap: false,
-    completionKeymap: true,
-    searchKeymap: false,
-  };
+  const setupConfig = useMemo(
+    () => ({
+      lineNumbers: lineNumbers ?? true,
+      syntaxHighlighting: true,
+      bracketMatching: true,
+      foldGutter: foldGutter,
+      highlightActiveLine: false,
+      autocompletion: hideSuggestion ?? true,
+      highlightActiveLineGutter: false,
+      defaultKeymap: false,
+      completionKeymap: true,
+      searchKeymap: false,
+    }),
+    [lineNumbers, foldGutter, hideSuggestion]
+  );
 
   function autoCompleteExtensionConfig(context) {
     const hasWorkflowSuggestions =
@@ -182,37 +202,70 @@ const MultiLineCodeEditor = (props) => {
     return getSuggestionsForMultiLine(context, allHints, hints, lang, paramList);
   }
 
-  const customKeyMaps = [
-    ...defaultKeymap.filter((keyBinding) => keyBinding.key !== 'Mod-Enter'), // Remove default keybinding for Mod-Enter
-    ...completionKeymap,
-    ...searchKeymap,
-  ];
+  const customTabKeymap = useMemo(
+    () =>
+      keymap.of([
+        {
+          key: 'Tab',
+          run: (view) => {
+            if (completionStatus(view.state)) {
+              return acceptCompletion(view);
+            }
 
-  const customTabKeymap = keymap.of([
-    {
-      key: 'Tab',
-      run: (view) => {
-        if (completionStatus(view.state)) {
-          return acceptCompletion(view);
-        }
+            const { state } = view;
+            const { selection } = state;
+            const { anchor } = selection.main;
+            const tabSize = 2;
 
-        const { state } = view;
-        const { selection } = state;
-        const { anchor } = selection.main;
-        const tabSize = 2;
+            view.dispatch({
+              changes: { from: anchor, insert: ' '.repeat(tabSize) },
+              selection: { anchor: anchor + tabSize },
+            });
+            return true;
+          },
+        },
+        ...queryPanelKeybindings,
+      ]),
+    [queryPanelKeybindings]
+  );
 
-        view.dispatch({
-          changes: { from: anchor, insert: ' '.repeat(tabSize) },
-          selection: { anchor: anchor + tabSize },
-        });
-        return true;
-      },
-    },
-    ...queryPanelKeybindings,
-  ]);
+  // Stable identity, fresh values: the override function handed to CodeMirror never
+  // changes, but it always delegates to the latest closure (with current hints,
+  // suggestions and paramList). A changing identity here would invalidate the
+  // extensions and force a full editor reconfigure on every render.
+  const overRideFunction = useStableCallback(autoCompleteExtensionConfig);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const overRideFunction = React.useCallback((context) => autoCompleteExtensionConfig(context), [paramList]);
+  const editorExtensions = useMemo(
+    () => [
+      langExtention,
+      lineWrappingExtension,
+      searchExtension,
+      tooltipExtension,
+      javascriptLanguage.data.of({
+        autocomplete: overRideFunction,
+      }),
+      python().language.data.of({
+        autocomplete: overRideFunction,
+      }),
+      sql().language.data.of({
+        autocomplete: overRideFunction,
+      }),
+      sass().language.data.of({
+        autocomplete: sassCompletionSource,
+      }),
+      autocompletion({
+        override: [overRideFunction],
+        activateOnTyping: true,
+        compareCompletions: (a, b) => {
+          return a.section.rank - b.section.rank && a.label.localeCompare(b.label);
+        },
+      }),
+      customTabKeymap,
+      keymap.of([...staticCustomKeyMaps]),
+    ],
+    [langExtention, overRideFunction, customTabKeymap]
+  );
+
   const { handleTogglePopupExapand, isOpen, setIsOpen, forceUpdate } = portalProps;
   let cyLabel = paramLabel ? paramLabel.toLowerCase().trim().replace(/\s+/g, '-') : props.cyLabel;
 
@@ -248,6 +301,13 @@ const MultiLineCodeEditor = (props) => {
       currentLineObserverRef.current.observe(currentLineDiv);
     }
   }
+
+  // `onUpdate` is part of react-codemirror's reconfigure-effect dependencies, so it
+  // must keep a stable identity.
+  const handleEditorUpdate = useStableCallback((view) => {
+    setIsSearchPanelOpen(searchPanelOpen(view.state));
+    updateCurrentLineObserver(view);
+  });
 
   const onAiSuggestionAccept = (newValue) => {
     currentValueRef.current = newValue;
@@ -309,37 +369,7 @@ const MultiLineCodeEditor = (props) => {
                 {...(isInsideQueryPane ? { maxHeight: '100%' } : {})}
                 width="100%"
                 theme={theme}
-                extensions={[
-                  langExtention,
-                  lineWrappingExtension,
-                  search({
-                    createPanel: handleSearchPanel,
-                  }),
-                  tooltips({
-                    parent: document.body,
-                  }),
-                  javascriptLanguage.data.of({
-                    autocomplete: overRideFunction,
-                  }),
-                  python().language.data.of({
-                    autocomplete: overRideFunction,
-                  }),
-                  sql().language.data.of({
-                    autocomplete: overRideFunction,
-                  }),
-                  sass().language.data.of({
-                    autocomplete: sassCompletionSource,
-                  }),
-                  autocompletion({
-                    override: [overRideFunction],
-                    activateOnTyping: true,
-                    compareCompletions: (a, b) => {
-                      return a.section.rank - b.section.rank && a.label.localeCompare(b.label);
-                    },
-                  }),
-                  customTabKeymap,
-                  keymap.of([...customKeyMaps]),
-                ]}
+                extensions={editorExtensions}
                 onChange={handleChange}
                 onBlur={handleOnBlur}
                 basicSetup={setupConfig}
@@ -356,10 +386,7 @@ const MultiLineCodeEditor = (props) => {
                     setCodeEditorView(view);
                   }
                 }}
-                onUpdate={(view) => {
-                  setIsSearchPanelOpen(searchPanelOpen(view.state));
-                  updateCurrentLineObserver(view);
-                }}
+                onUpdate={handleEditorUpdate}
               />
             </div>
             {showPreview && (

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -35,6 +35,19 @@ import { useQueryPanelKeyHooks } from './useQueryPanelKeyHooks';
 import Icon from '@/_ui/Icon/solidIcons/index';
 import useWorkflowStore from '@/_stores/workflowStore';
 import { TableColumnContext } from '@/AppBuilder/RightSideBar/Inspector/Components/Table/ColumnManager/TableColumnContext';
+import { useStableCallback } from '@/AppBuilder/_hooks/useStableCallback';
+
+// Hoisted to module scope so their identity never changes: anything fed into the
+// CodeMirror `extensions` prop must stay referentially stable, otherwise
+// react-codemirror dispatches a reconfigure on every render, which permanently
+// grows style-mod's shared stylesheet and degrades the whole session.
+const staticCustomKeyMaps = [
+  ...defaultKeymap.filter((keyBinding) => keyBinding.key !== 'Mod-Enter'), // Remove default keybinding for Mod-Enter
+  ...completionKeymap,
+];
+const tooltipExtension = tooltips({
+  parent: document.body,
+});
 
 const SingleLineCodeEditor = ({ componentName, fieldMeta = {}, componentId, moduleId: moduleIdProp, ...restProps }) => {
   const { moduleId: contextModuleId } = useModuleContext();
@@ -372,60 +385,64 @@ const EditorInput = ({
     } else return getSuggestionsForMultiLine(context, hints, hintsWithoutParamHints, lang, paramHints); //Need multiline behaviour inside workflows editor, where suggestions are shown on each keystroke
   }
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const overRideFunction = React.useCallback(
-    (context) => autoCompleteExtensionConfig(context),
-    [isInsideQueryManager, paramHints]
+  // Stable identity, fresh values: the override function handed to CodeMirror never
+  // changes, but it always delegates to the latest closure (with current hints,
+  // suggestions and lang). A changing identity here would invalidate the extensions
+  // and force a full editor reconfigure on every render.
+  const overRideFunction = useStableCallback(autoCompleteExtensionConfig);
+
+  const autoCompleteConfig = useMemo(
+    () =>
+      autocompletion({
+        override: [overRideFunction],
+        compareCompletions: (a, b) => {
+          return a.section.rank - b.section.rank && a.label.localeCompare(b.label);
+        },
+        aboveCursor: false,
+        defaultKeymap: true,
+        positionInfo: () => {
+          return {
+            class: 'cm-completionInfo-top cm-custom-completion-info cm-custom-singleline-completion-info',
+          };
+        },
+        maxRenderedOptions: 10,
+      }),
+    [overRideFunction]
   );
 
-  const autoCompleteConfig = autocompletion({
-    override: [overRideFunction],
-    compareCompletions: (a, b) => {
-      return a.section.rank - b.section.rank && a.label.localeCompare(b.label);
-    },
-    aboveCursor: false,
-    defaultKeymap: true,
-    positionInfo: () => {
-      return {
-        class: 'cm-completionInfo-top cm-custom-completion-info cm-custom-singleline-completion-info',
-      };
-    },
-    maxRenderedOptions: 10,
+  const handleTabKey = useStableCallback((view) => {
+    if (completionStatus(view.state)) {
+      return acceptCompletion(view);
+    }
+    if (isOpen) {
+      const { state } = view;
+      const { selection } = state;
+      const { anchor } = selection.main;
+      const tabSize = 2;
+
+      view?.dispatch({
+        changes: { from: anchor, insert: ' '.repeat(tabSize) },
+        selection: { anchor: anchor + tabSize },
+      });
+      return true;
+    }
   });
 
-  const customKeyMaps = [
-    ...defaultKeymap.filter((keyBinding) => keyBinding.key !== 'Mod-Enter'), // Remove default keybinding for Mod-Enter
-    ...completionKeymap,
-  ];
-
-  const customTabKeymap = keymap.of([
-    {
-      key: 'Tab',
-      run: (view) => {
-        if (completionStatus(view.state)) {
-          return acceptCompletion(view);
-        }
-        if (isOpen) {
-          const { state } = view;
-          const { selection } = state;
-          const { anchor } = selection.main;
-          const tabSize = 2;
-
-          view?.dispatch({
-            changes: { from: anchor, insert: ' '.repeat(tabSize) },
-            selection: { anchor: anchor + tabSize },
-          });
-          return true;
-        }
-      },
-    },
-    ...queryPanelKeybindings,
-  ]);
+  const customTabKeymap = useMemo(
+    () => keymap.of([{ key: 'Tab', run: handleTabKey }, ...queryPanelKeybindings]),
+    [handleTabKey, queryPanelKeybindings]
+  );
 
   const handleOnChange = React.useCallback((val) => {
     setCurrentValue(val);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const handleEditorChange = useStableCallback((val) => {
+    setFirstTimeFocus(false);
+    handleOnChange(val);
+    onInputChange && onInputChange(val);
+  });
 
   const handleOnBlur = () => {
     !cursorInsidePreview && setShowPreview(false);
@@ -454,6 +471,46 @@ const EditorInput = ({
   const currentEditorHeightRef = useRef(null);
   const isInsideQueryPane = !!currentEditorHeightRef?.current?.closest('.query-details');
   const showLineNumbers = lang == 'jsx' || type === 'extendedSingleLine' || false;
+
+  const langExtension = useMemo(() => javascript({ jsx: lang === 'jsx' }), [lang]);
+
+  const editorExtensions = useMemo(
+    () =>
+      showSuggestions
+        ? [
+            langExtension,
+            autoCompleteConfig,
+            keymap.of([...staticCustomKeyMaps]),
+            customTabKeymap,
+            tooltipExtension,
+            // CSS forces visual wrapping for long values (e.g.
+            // REST URL with `{{...}}` interpolations). Without
+            // `lineWrapping`, CM6 still treats the doc as one
+            // unwrapped row and `drawSelection` paints a single
+            // rect for the logical line -- so selection rects
+            // miss the right-edge area on intermediate visual
+            // rows. Enable wrapping so per-row selection rects
+            // are generated.
+            EditorView.lineWrapping,
+          ]
+        : [langExtension, tooltipExtension, EditorView.lineWrapping],
+    [showSuggestions, langExtension, autoCompleteConfig, customTabKeymap]
+  );
+
+  const basicSetupConfig = useMemo(
+    () => ({
+      lineNumbers: showLineNumbers,
+      syntaxHighlighting: true,
+      bracketMatching: true,
+      foldGutter: false,
+      highlightActiveLine: false,
+      autocompletion: true,
+      defaultKeymap: false,
+      completionKeymap: true,
+      searchKeymap: false,
+    }),
+    [showLineNumbers]
+  );
 
   const customClassNames = cx('codehinter-input single-line-codehinter-input', {
     'border-danger': error,
@@ -556,50 +613,9 @@ const EditorInput = ({
               placeholder={placeholder}
               height={isInsideQueryPane ? '100%' : showLineNumbers ? '400px' : '100%'}
               width="100%"
-              extensions={
-                showSuggestions
-                  ? [
-                      javascript({ jsx: lang === 'jsx' }),
-                      autoCompleteConfig,
-                      keymap.of([...customKeyMaps]),
-                      customTabKeymap,
-                      tooltips({
-                        parent: document.body,
-                      }),
-                      // CSS forces visual wrapping for long values (e.g.
-                      // REST URL with `{{...}}` interpolations). Without
-                      // `lineWrapping`, CM6 still treats the doc as one
-                      // unwrapped row and `drawSelection` paints a single
-                      // rect for the logical line -- so selection rects
-                      // miss the right-edge area on intermediate visual
-                      // rows. Enable wrapping so per-row selection rects
-                      // are generated.
-                      EditorView.lineWrapping,
-                    ]
-                  : [
-                      javascript({ jsx: lang === 'jsx' }),
-                      tooltips({
-                        parent: document.body,
-                      }),
-                      EditorView.lineWrapping,
-                    ]
-              }
-              onChange={(val) => {
-                setFirstTimeFocus(false);
-                handleOnChange(val);
-                onInputChange && onInputChange(val);
-              }}
-              basicSetup={{
-                lineNumbers: showLineNumbers,
-                syntaxHighlighting: true,
-                bracketMatching: true,
-                foldGutter: false,
-                highlightActiveLine: false,
-                autocompletion: true,
-                defaultKeymap: false,
-                completionKeymap: true,
-                searchKeymap: false,
-              }}
+              extensions={editorExtensions}
+              onChange={handleEditorChange}
+              basicSetup={basicSetupConfig}
               onMouseDown={() => handleFocus()}
               onBlur={() => handleOnBlur()}
               className={customClassNames}

--- a/frontend/src/AppBuilder/CodeEditor/useQueryPanelKeyHooks.js
+++ b/frontend/src/AppBuilder/CodeEditor/useQueryPanelKeyHooks.js
@@ -1,56 +1,46 @@
 import { useModuleId } from '@/AppBuilder/_contexts/ModuleContext';
 import useStore from '@/AppBuilder/_stores/store';
-import { useCallback, useEffect, useState } from 'react';
+import { useStableCallback } from '@/AppBuilder/_hooks/useStableCallback';
+import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export const useQueryPanelKeyHooks = (onChange, value, type) => {
-  const queryPanelHeight = useStore((state) => state.queryPanel.queryPanelHeight);
-  const runQueryOnShortcut = useStore((state) => state.queryPanel.runQueryOnShortcut);
-  const previewQueryOnShortcut = useStore((state) => state.queryPanel.previewQueryOnShortcut);
   const moduleId = useModuleId();
   const location = useLocation();
   const { pathname } = location;
 
-  const [queryPanelKeybindings, setQueryPanelKeybindings] = useState([]);
-
-  const handleRunQuery = useCallback(
-    (view) => {
-      const isEditor = pathname.includes('/apps/');
-      if (queryPanelHeight !== 0 && isEditor) {
-        onChange(type === 'multiline' ? value.current : value);
+  // Keybindings end up inside the CodeMirror `extensions` prop, so the array must
+  // keep a stable identity (see useStableCallback). Store values are read at
+  // keystroke time instead of being subscribed to.
+  const runShortcut = useStableCallback((shortcutAction) => {
+    const { queryPanelHeight, runQueryOnShortcut, previewQueryOnShortcut } = useStore.getState().queryPanel;
+    const isEditor = pathname.includes('/apps/');
+    if (queryPanelHeight !== 0 && isEditor) {
+      onChange(type === 'multiline' ? value.current : value);
+      if (shortcutAction === 'run') {
         runQueryOnShortcut();
-      }
-      return true;
-    },
-    [queryPanelHeight, onChange, runQueryOnShortcut, value]
-  );
-
-  const handlePreviewQuery = useCallback(
-    (view) => {
-      const isEditor = pathname.includes('/apps/');
-      if (queryPanelHeight !== 0 && isEditor) {
-        onChange(type === 'multiline' ? value.current : value);
+      } else {
         previewQueryOnShortcut(moduleId);
       }
-      return true;
-    },
-    [queryPanelHeight, moduleId, onChange, previewQueryOnShortcut, value]
-  );
+    }
+    return true;
+  });
 
-  useEffect(() => {
-    setQueryPanelKeybindings([
+  const queryPanelKeybindings = useMemo(
+    () => [
       {
         key: 'Mod-Enter',
         preventDefault: true,
-        run: handleRunQuery,
+        run: () => runShortcut('run'),
       },
       {
         key: 'Mod-Shift-Enter',
         preventDefault: true,
-        run: handlePreviewQuery,
+        run: () => runShortcut('preview'),
       },
-    ]);
-  }, [handleRunQuery, handlePreviewQuery]);
+    ],
+    [runShortcut]
+  );
 
   return {
     queryPanelKeybindings,

--- a/frontend/src/AppBuilder/_hooks/useStableCallback.js
+++ b/frontend/src/AppBuilder/_hooks/useStableCallback.js
@@ -1,0 +1,14 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Returns a function with a stable identity that always delegates to the latest
+ * version of `fn`. Use this for callbacks that are placed into CodeMirror
+ * `extensions` or other reconfigure-effect dependencies: an identity change there
+ * forces react-codemirror to dispatch a full editor reconfigure, which permanently
+ * grows style-mod's shared stylesheet and degrades the whole session.
+ */
+export const useStableCallback = (fn) => {
+  const ref = useRef(fn);
+  ref.current = fn;
+  return useCallback((...args) => ref.current(...args), []);
+};

--- a/frontend/src/AppBuilder/_hooks/useStableCallback.ts
+++ b/frontend/src/AppBuilder/_hooks/useStableCallback.ts
@@ -7,8 +7,11 @@ import { useCallback, useRef } from 'react';
  * forces react-codemirror to dispatch a full editor reconfigure, which permanently
  * grows style-mod's shared stylesheet and degrades the whole session.
  */
-export const useStableCallback = (fn) => {
+export const useStableCallback = <Args extends unknown[], Return>(
+  fn: (...args: Args) => Return
+): ((...args: Args) => Return) => {
   const ref = useRef(fn);
   ref.current = fn;
-  return useCallback((...args) => ref.current(...args), []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useCallback((...args: Args) => ref.current(...args), []);
 };


### PR DESCRIPTION
## 📝 What this does
Fixes the multi-second lag when adding SQL parameters (and the general "editor gets slower the longer the session runs" degradation). Code editors were passing freshly-built extensions/configs/callbacks to CodeMirror on every render, making the library dispatch a full reconfigure each time — every reconfigure permanently registered a duplicate style module and rewrote the entire shared stylesheet, so each interaction got more expensive with session age. With this change the editor configuration is built once and reconfigures stop firing, so editor renders cost the same on hour five as on minute one.

Relates to: #16803

## 🔀 Changes
- Added a `useStableCallback` hook that gives callbacks a permanent identity while always delegating to the latest closure (the `useEffectEvent` pattern)
- Memoized the CodeMirror extensions, `basicSetup` config, and language/keymap/tooltip instances in both single-line and multi-line editors; static pieces hoisted to module scope
- Stabilized the autocomplete override, Tab handler, and change/update callbacks so they keep identity while reading live state
- Reworked the query panel keyboard shortcuts hook to build its keybindings once and read panel state at keystroke time instead of rebuilding on every keystroke

## 🧪 How to test
- [ ] Open an app with a PostgreSQL query, add several SQL parameters — each add should be near-instant regardless of how long the session has been open
- [ ] Run `[...document.querySelectorAll('style')].find(s => s.textContent.includes('ͼ')).textContent.length` in the console — the value should stay flat while typing in editors and adding parameters
- [ ] Verify autocomplete suggestions update after adding a new component or query
- [ ] Verify Cmd+Enter (run) and Cmd+Shift+Enter (preview) shortcuts inside query editors
- [ ] Verify Tab inserts spaces inside the popped-out (portal) editor and accepts autocomplete suggestions
- [ ] Verify the search panel and fx fields on canvas still work