### PR TITLE
Feature: add client/server search type toggle to dropdown, multiselect and tags input

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Select.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Select.jsx
@@ -637,6 +637,17 @@ export function Select({ componentMeta, darkMode, ...restProps }) {
             currentState,
             allComponents
           )}
+        {isTagsInput &&
+          renderElement(
+            component,
+            componentMeta,
+            paramUpdated,
+            dataQueries,
+            'serverSideSearch',
+            'properties',
+            currentState,
+            allComponents
+          )}
         {isRadioButton &&
           renderElement(
             component,

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Utils.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Utils.js
@@ -171,6 +171,7 @@ export function renderElement(
 
   if (
     componentConfig.component == 'DropDown' ||
+    componentConfig.component == 'DropdownV2' ||
     componentConfig.component == 'Form' ||
     componentConfig.component == 'Listview' ||
     componentConfig.component == 'Image' ||

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Utils.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Utils.js
@@ -172,6 +172,8 @@ export function renderElement(
   if (
     componentConfig.component == 'DropDown' ||
     componentConfig.component == 'DropdownV2' ||
+    componentConfig.component == 'MultiselectV2' ||
+    componentConfig.component == 'TagsInput' ||
     componentConfig.component == 'Form' ||
     componentConfig.component == 'Listview' ||
     componentConfig.component == 'Image' ||

--- a/frontend/src/AppBuilder/WidgetManager/widgets/TagsInput.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/TagsInput.js
@@ -160,6 +160,20 @@ export const tagsInputConfig = {
       },
       accordian: 'Tags',
     },
+    serverSideSearch: {
+      type: 'clientServerSwitch',
+      displayName: 'Search type',
+      options: [
+        { displayName: 'Client side', value: 'clientSide' },
+        { displayName: 'Server side', value: 'serverSide' },
+      ],
+      validation: { schema: { type: 'boolean' }, defaultValue: false },
+      section: 'additionalActions',
+      conditionallyRender: {
+        key: 'enableSearch',
+        value: true,
+      },
+    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -412,6 +426,7 @@ export const tagsInputConfig = {
       placeholder: { value: 'Add or select a tag' },
       dynamicHeight: { value: '{{true}}' },
       enableSearch: { value: '{{true}}' },
+      serverSideSearch: { value: '{{false}}' },
       visibility: { value: '{{true}}' },
 
       collapseWhenHidden: { value: '{{false}}' },

--- a/frontend/src/AppBuilder/WidgetManager/widgets/TagsInput.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/TagsInput.js
@@ -168,7 +168,7 @@ export const tagsInputConfig = {
         { displayName: 'Server side', value: 'serverSide' },
       ],
       validation: { schema: { type: 'boolean' }, defaultValue: false },
-      section: 'additionalActions',
+      accordian: 'Tags',
       conditionallyRender: {
         key: 'enableSearch',
         value: true,

--- a/frontend/src/AppBuilder/WidgetManager/widgets/dropdownV2.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/dropdownV2.js
@@ -89,7 +89,7 @@ export const dropdownV2Config = {
     },
     serverSideSearch: {
       type: 'clientServerSwitch',
-      displayName: 'Type',
+      displayName: 'Search type',
       options: [
         { displayName: 'Client side', value: 'clientSide' },
         { displayName: 'Server side', value: 'serverSide' },

--- a/frontend/src/AppBuilder/WidgetManager/widgets/dropdownV2.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/dropdownV2.js
@@ -87,6 +87,20 @@ export const dropdownV2Config = {
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
     },
+    serverSideSearch: {
+      type: 'clientServerSwitch',
+      displayName: 'Type',
+      options: [
+        { displayName: 'Client side', value: 'clientSide' },
+        { displayName: 'Server side', value: 'serverSide' },
+      ],
+      validation: { schema: { type: 'boolean' }, defaultValue: false },
+      section: 'additionalActions',
+      conditionallyRender: {
+        key: 'showSearchInput',
+        value: true,
+      },
+    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -425,6 +439,7 @@ export const dropdownV2Config = {
       placeholder: { value: 'Select an option' },
       showClearBtn: { value: '{{true}}' },
       showSearchInput: { value: '{{true}}' },
+      serverSideSearch: { value: '{{false}}' },
       visibility: { value: '{{true}}' },
 
       collapseWhenHidden: { value: '{{false}}' },

--- a/frontend/src/AppBuilder/WidgetManager/widgets/multiselectV2.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/multiselectV2.js
@@ -169,6 +169,20 @@ export const multiselectV2Config = {
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
     },
+    serverSideSearch: {
+      type: 'clientServerSwitch',
+      displayName: 'Search type',
+      options: [
+        { displayName: 'Client side', value: 'clientSide' },
+        { displayName: 'Server side', value: 'serverSide' },
+      ],
+      validation: { schema: { type: 'boolean' }, defaultValue: false },
+      section: 'additionalActions',
+      conditionallyRender: {
+        key: 'showSearchInput',
+        value: true,
+      },
+    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -417,6 +431,7 @@ export const multiselectV2Config = {
       showAllSelectedLabel: { value: '{{true}}' },
       showClearBtn: { value: '{{true}}' },
       showSearchInput: { value: '{{true}}' },
+      serverSideSearch: { value: '{{false}}' },
       visibility: { value: '{{true}}' },
 
       collapseWhenHidden: { value: '{{false}}' },

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/CustomOption.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/CustomOption.jsx
@@ -8,6 +8,9 @@ const CustomOption = (props) => {
   const caption = props.data?.caption;
   const hasCaption = caption !== null && caption !== undefined && caption !== '';
   const captionText = hasCaption ? String(caption) : '';
+  // Server-side search: results come pre-filtered from the backend, so skip client-side highlighting.
+  const serverSideSearch = props.selectProps.serverSideSearch;
+  const renderWithHighlight = (text) => (serverSideSearch ? text : highlightText(text, props.selectProps.inputValue));
   return (
     <components.Option
       {...props}
@@ -23,11 +26,11 @@ const CustomOption = (props) => {
         )}
         <div className="tw-min-w-0 tw-flex-1 tw-flex tw-flex-col">
           <span className="tw-truncate" style={{ color: 'unset' }} title={props.label?.toString()}>
-            {highlightText(props.label?.toString(), props.selectProps.inputValue)}
+            {renderWithHighlight(props.label?.toString())}
           </span>
           {hasCaption && (
             <span className="dropdownV2-option-caption tw-truncate" title={captionText}>
-              {highlightText(captionText, props.selectProps.inputValue)}
+              {renderWithHighlight(captionText)}
             </span>
           )}
         </div>

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/CustomOption.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/CustomOption.jsx
@@ -9,7 +9,7 @@ const CustomOption = (props) => {
   const hasCaption = caption !== null && caption !== undefined && caption !== '';
   const captionText = hasCaption ? String(caption) : '';
   // Server-side search: results come pre-filtered from the backend, so skip client-side highlighting.
-  const serverSideSearch = props.selectProps.serverSideSearch;
+  const serverSideSearch = props.selectProps.serverSideSearch === true;
   const renderWithHighlight = (text) => (serverSideSearch ? text : highlightText(text, props.selectProps.inputValue));
   return (
     <components.Option

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
@@ -569,7 +569,7 @@ export const DropdownV2 = ({
             }}
             options={selectOptions}
             filterOption={(option, input) => {
-              if (serverSideSearch) return true; // server mode: render all options, no client-side filtering
+              if (serverSideSearch === true) return true; // server mode: render all options, no client-side filtering
               if (!input) return true;
               const needle = input.toLowerCase();
               const label = String(option?.label ?? '').toLowerCase();

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
@@ -79,6 +79,7 @@ export const DropdownV2 = ({
     sort,
     showClearBtn,
     showSearchInput,
+    serverSideSearch,
   } = properties;
   const {
     selectedTextColor,
@@ -568,6 +569,7 @@ export const DropdownV2 = ({
             }}
             options={selectOptions}
             filterOption={(option, input) => {
+              if (serverSideSearch) return true; // server mode: render all options, no client-side filtering
               if (!input) return true;
               const needle = input.toLowerCase();
               const label = String(option?.label ?? '').toLowerCase();
@@ -585,6 +587,7 @@ export const DropdownV2 = ({
             aria-label={!labelAutoWidth && labelWidth == 0 && label?.length != 0 ? label : undefined}
             isLoading={isDropdownLoading}
             showSearchInput={showSearchInput}
+            serverSideSearch={serverSideSearch}
             onInputChange={onSearchTextChange}
             inputValue={searchInputValue}
             placeholder={placeholder}

--- a/frontend/src/AppBuilder/Widgets/MultiselectV2/CustomOption.jsx
+++ b/frontend/src/AppBuilder/Widgets/MultiselectV2/CustomOption.jsx
@@ -12,7 +12,7 @@ const CustomOption = (props) => {
   const captionText = hasCaption ? String(caption) : '';
   const isSelectAll = labelText.includes('Select all');
   // Server-side search: results come pre-filtered from the backend, so skip client-side highlighting.
-  const serverSideSearch = props.selectProps.serverSideSearch;
+  const serverSideSearch = props.selectProps.serverSideSearch === true;
   const renderWithHighlight = (text) => (serverSideSearch ? text : highlightText(text, props.selectProps.inputValue));
 
   return (

--- a/frontend/src/AppBuilder/Widgets/MultiselectV2/CustomOption.jsx
+++ b/frontend/src/AppBuilder/Widgets/MultiselectV2/CustomOption.jsx
@@ -11,6 +11,9 @@ const CustomOption = (props) => {
   const hasCaption = caption !== null && caption !== undefined && caption !== '';
   const captionText = hasCaption ? String(caption) : '';
   const isSelectAll = labelText.includes('Select all');
+  // Server-side search: results come pre-filtered from the backend, so skip client-side highlighting.
+  const serverSideSearch = props.selectProps.serverSideSearch;
+  const renderWithHighlight = (text) => (serverSideSearch ? text : highlightText(text, props.selectProps.inputValue));
 
   return (
     <Option
@@ -23,7 +26,7 @@ const CustomOption = (props) => {
         <FormCheck checked={props.isSelected} disabled={props?.isDisabled} />
         <div className="tw-min-w-0 tw-flex-1 tw-flex tw-flex-col" style={{ marginLeft: '5px' }}>
           <span className="tw-truncate" title={labelText}>
-            {isSelectAll ? 'Select all' : highlightText(labelText, props.selectProps.inputValue)}
+            {isSelectAll ? 'Select all' : renderWithHighlight(labelText)}
           </span>
           {!isSelectAll && hasCaption && (
             <span className="multiselectV2-option-caption tw-truncate" title={captionText}>

--- a/frontend/src/AppBuilder/Widgets/MultiselectV2/MultiselectV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/MultiselectV2/MultiselectV2.jsx
@@ -47,6 +47,7 @@ export const MultiselectV2 = ({
     showAllSelectedLabel,
     showClearBtn,
     showSearchInput,
+    serverSideSearch,
     maxLimit,
   } = properties;
   const {
@@ -573,6 +574,7 @@ export const MultiselectV2 = ({
             onChange={onChangeHandler}
             options={modifiedSelectOptions}
             filterOption={(option, input) => {
+              if (serverSideSearch) return true; // server mode: render all options, no client-side filtering
               if (!input) return true;
               const needle = input.toLowerCase();
               const label = String(option?.label ?? '').toLowerCase();
@@ -591,6 +593,7 @@ export const MultiselectV2 = ({
             // Only show loading when dynamic options are enabled
             isLoading={isMultiSelectLoading}
             showSearchInput={showSearchInput}
+            serverSideSearch={serverSideSearch}
             onInputChange={onSearchTextChange}
             inputValue={searchInputValue}
             menuIsOpen={isMultiselectOpen}

--- a/frontend/src/AppBuilder/Widgets/MultiselectV2/MultiselectV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/MultiselectV2/MultiselectV2.jsx
@@ -574,7 +574,7 @@ export const MultiselectV2 = ({
             onChange={onChangeHandler}
             options={modifiedSelectOptions}
             filterOption={(option, input) => {
-              if (serverSideSearch) return true; // server mode: render all options, no client-side filtering
+              if (serverSideSearch === true) return true; // server mode: render all options, no client-side filtering
               if (!input) return true;
               const needle = input.toLowerCase();
               const label = String(option?.label ?? '').toLowerCase();

--- a/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
@@ -51,6 +51,7 @@ const TagsInput = ({
     dynamicHeight,
     sort,
     enableSearch = true,
+    serverSideSearch,
   } = properties;
 
   const {
@@ -890,7 +891,7 @@ const TagsInput = ({
             isClearable={false}
             isMulti
             hideSelectedOptions={true}
-            filterOption={(option, inputValue) => option.label?.includes(inputValue)}
+            filterOption={(option, inputValue) => (serverSideSearch ? true : option.label?.includes(inputValue))}
             closeMenuOnSelect={false}
             tabSelectsValue={false}
             onKeyDown={handleKeyDown}

--- a/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
@@ -777,12 +777,14 @@ const TagsInput = ({
   const _width = getLabelWidthOfInput(widthType, labelWidth);
   const labelFontSizeValue = getLabelFontSize(labelFontSize);
 
-  // Filter options to exclude already selected and match input text
+  // Filter options to exclude already selected and match input text.
+  // In server-side search mode the backend owns filtering, so skip the
+  // client-side input match and render all non-selected options as-is.
   const filteredOptions = useMemo(() => {
     return allOptions
       .filter((opt) => !selected.some((s) => s.value === opt.value))
-      .filter((opt) => !inputValue || opt.label?.includes(inputValue));
-  }, [allOptions, selected, inputValue]);
+      .filter((opt) => serverSideSearch === true || !inputValue || opt.label?.includes(inputValue));
+  }, [allOptions, selected, inputValue, serverSideSearch]);
 
   return (
     <>

--- a/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
@@ -891,7 +891,9 @@ const TagsInput = ({
             isClearable={false}
             isMulti
             hideSelectedOptions={true}
-            filterOption={(option, inputValue) => (serverSideSearch ? true : option.label?.includes(inputValue))}
+            filterOption={(option, inputValue) =>
+              serverSideSearch === true ? true : option.label?.includes(inputValue)
+            }
             closeMenuOnSelect={false}
             tabSelectsValue={false}
             onKeyDown={handleKeyDown}

--- a/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
@@ -783,7 +783,7 @@ const TagsInput = ({
   const filteredOptions = useMemo(() => {
     return allOptions
       .filter((opt) => !selected.some((s) => s.value === opt.value))
-      .filter((opt) => serverSideSearch === true || !inputValue || opt.label?.includes(inputValue));
+      .filter((opt) => serverSideSearch === true || !inputValue || String(opt.label ?? '').includes(inputValue));
   }, [allOptions, selected, inputValue, serverSideSearch]);
 
   return (
@@ -894,7 +894,7 @@ const TagsInput = ({
             isMulti
             hideSelectedOptions={true}
             filterOption={(option, inputValue) =>
-              serverSideSearch === true ? true : option.label?.includes(inputValue)
+              serverSideSearch === true ? true : String(option.label ?? '').includes(inputValue)
             }
             closeMenuOnSelect={false}
             tabSelectsValue={false}

--- a/frontend/src/AppBuilder/Widgets/TagsInput/TagsInputMenuList.jsx
+++ b/frontend/src/AppBuilder/Widgets/TagsInput/TagsInputMenuList.jsx
@@ -31,8 +31,8 @@ const TagsInputMenuList = ({
   const trimmedInput = inputValue?.trim()?.toLowerCase();
   const isAlreadyExists =
     trimmedInput &&
-    (selectedValues.some((tag) => tag.value?.toLowerCase() === trimmedInput) ||
-      allOptions.some((opt) => opt.value?.toLowerCase() === trimmedInput));
+    (selectedValues.some((tag) => String(tag.value ?? '').toLowerCase() === trimmedInput) ||
+      allOptions.some((opt) => String(opt.value ?? '').toLowerCase() === trimmedInput));
 
   // Only show create footer if value doesn't already exist
   const showCreateFooter = allowNewTags && inputValue?.trim() && !isAlreadyExists;

--- a/server/src/modules/apps/services/widget-config/TagsInput.js
+++ b/server/src/modules/apps/services/widget-config/TagsInput.js
@@ -160,6 +160,20 @@ export const tagsInputConfig = {
       },
       accordian: 'Tags',
     },
+    serverSideSearch: {
+      type: 'clientServerSwitch',
+      displayName: 'Search type',
+      options: [
+        { displayName: 'Client side', value: 'clientSide' },
+        { displayName: 'Server side', value: 'serverSide' },
+      ],
+      validation: { schema: { type: 'boolean' }, defaultValue: false },
+      section: 'additionalActions',
+      conditionallyRender: {
+        key: 'enableSearch',
+        value: true,
+      },
+    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -412,6 +426,7 @@ export const tagsInputConfig = {
       placeholder: { value: 'Add or select a tag' },
       dynamicHeight: { value: '{{true}}' },
       enableSearch: { value: '{{true}}' },
+      serverSideSearch: { value: '{{false}}' },
       visibility: { value: '{{true}}' },
 
       collapseWhenHidden: { value: '{{false}}' },

--- a/server/src/modules/apps/services/widget-config/TagsInput.js
+++ b/server/src/modules/apps/services/widget-config/TagsInput.js
@@ -168,7 +168,7 @@ export const tagsInputConfig = {
         { displayName: 'Server side', value: 'serverSide' },
       ],
       validation: { schema: { type: 'boolean' }, defaultValue: false },
-      section: 'additionalActions',
+      accordian: 'Tags',
       conditionallyRender: {
         key: 'enableSearch',
         value: true,

--- a/server/src/modules/apps/services/widget-config/dropdownV2.js
+++ b/server/src/modules/apps/services/widget-config/dropdownV2.js
@@ -89,7 +89,7 @@ export const dropdownV2Config = {
     },
     serverSideSearch: {
       type: 'clientServerSwitch',
-      displayName: 'Type',
+      displayName: 'Search type',
       options: [
         { displayName: 'Client side', value: 'clientSide' },
         { displayName: 'Server side', value: 'serverSide' },

--- a/server/src/modules/apps/services/widget-config/dropdownV2.js
+++ b/server/src/modules/apps/services/widget-config/dropdownV2.js
@@ -87,6 +87,20 @@ export const dropdownV2Config = {
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
     },
+    serverSideSearch: {
+      type: 'clientServerSwitch',
+      displayName: 'Type',
+      options: [
+        { displayName: 'Client side', value: 'clientSide' },
+        { displayName: 'Server side', value: 'serverSide' },
+      ],
+      validation: { schema: { type: 'boolean' }, defaultValue: false },
+      section: 'additionalActions',
+      conditionallyRender: {
+        key: 'showSearchInput',
+        value: true,
+      },
+    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -425,6 +439,7 @@ export const dropdownV2Config = {
       placeholder: { value: 'Select an option' },
       showClearBtn: { value: '{{true}}' },
       showSearchInput: { value: '{{true}}' },
+      serverSideSearch: { value: '{{false}}' },
       visibility: { value: '{{true}}' },
 
       collapseWhenHidden: { value: '{{false}}' },

--- a/server/src/modules/apps/services/widget-config/multiselectV2.js
+++ b/server/src/modules/apps/services/widget-config/multiselectV2.js
@@ -169,6 +169,20 @@ export const multiselectV2Config = {
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
     },
+    serverSideSearch: {
+      type: 'clientServerSwitch',
+      displayName: 'Search type',
+      options: [
+        { displayName: 'Client side', value: 'clientSide' },
+        { displayName: 'Server side', value: 'serverSide' },
+      ],
+      validation: { schema: { type: 'boolean' }, defaultValue: false },
+      section: 'additionalActions',
+      conditionallyRender: {
+        key: 'showSearchInput',
+        value: true,
+      },
+    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -417,6 +431,7 @@ export const multiselectV2Config = {
       showAllSelectedLabel: { value: '{{true}}' },
       showClearBtn: { value: '{{true}}' },
       showSearchInput: { value: '{{true}}' },
+      serverSideSearch: { value: '{{false}}' },
       visibility: { value: '{{true}}' },
 
       collapseWhenHidden: { value: '{{false}}' },


### PR DESCRIPTION
## 📝 What this does
Adds a **Search type** toggle (Client side / Server side) to the **Dropdown**, **Multiselect**, and **Tags Input** widgets so search can be handed to a backend instead of filtering a pre-loaded list. In server mode the widget stops filtering and highlighting options locally, letting backend-filtered results render untouched, while still exposing `searchText` and firing `onSearchTextChanged`.

Closes ToolJet/tj-ee#5193

## 🔀 Changes
- Added a `serverSideSearch` client/server toggle to Dropdown and Multiselect (under "Show search in options") and Tags Input (under "Turn on search"), shown only when search is enabled.
- Skipped client-side option filtering in server mode so all returned options render; Tags also skips its pre-filtered options memo, not just react-select's filter.
- Skipped match highlighting in server mode on Dropdown and Multiselect (Tags renders plain option text).
- Mirrored the new property in each server-side widget config so it persists on save.
- Fixed `conditionallyRender` being ignored for Dropdown, Multiselect, and Tags in the inspector (the widgets were missing from the allowlist).

## 🧪 How to test
- [ ] On each widget, turn search off — the Search type toggle is hidden; turn it on — the toggle appears.
- [ ] Set Search type to Client side — search filters (and highlights, where applicable) options as before.
- [ ] Set Search type to Server side — typing renders all options unfiltered with no highlight, and `searchText` / `onSearchTextChanged` still update and fire.
- [ ] Wire a query to `searchText` on `onSearchTextChanged` and bind its result to the options — confirm results are not re-filtered client-side.