### PR TITLE
Fix codehinter expanded title for success message

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx
@@ -4,6 +4,8 @@ import CodeHinter from '@/AppBuilder/CodeEditor';
 
 export default function SuccessNotificationInputs({ currentState, options, darkMode, optionchanged }) {
   const { t } = useTranslation();
+  const successMessageLabel = t('editor.queryManager.successMessage', 'Success Message');
+
   if (!options?.showSuccessNotification) {
     return <div className="mb-3"></div>;
   }
@@ -11,7 +13,7 @@ export default function SuccessNotificationInputs({ currentState, options, darkM
     <div className="flex-grow-1" style={{ margin: '16px 0px' }}>
       <div className="d-flex" style={{ marginBottom: '16px' }}>
         <label className="form-label align-items-center" data-cy={'label-success-message-input'} style={{ width: 150 }}>
-          {t('editor.queryManager.successMessage', 'Message')}
+          {successMessageLabel}
         </label>
         <div className="flex-grow-1" style={{ maxWidth: '460px' }}>
           <CodeHinter
@@ -19,6 +21,7 @@ export default function SuccessNotificationInputs({ currentState, options, darkM
             initialValue={options.successMessage}
             onChange={(value) => optionchanged('successMessage', value)}
             placeholder={t('editor.queryManager.queryRanSuccessfully', 'Query ran successfully')}
+            componentName={successMessageLabel}
             cyLabel={'success-message'}
           />
         </div>


### PR DESCRIPTION
## Summary
- Pass the translated Success Message label to the success notification CodeHinter so the expanded editor header shows the field name instead of Editor.
- Reuse the same label for the inline field text and popup header.

Fixes #6655

## Testing
- `npx --yes esbuild@0.25.9 frontend/src/AppBuilder/QueryManager/Components/SuccessNotificationInputs.jsx --loader:.jsx=jsx --format=esm --outfile=NUL --log-level=error`
- `git diff --check`

Not run: full frontend lint/test suite, because dependencies are not installed in this sparse checkout.