### PR TITLE
CI: Slack run report for Cypress (Platform, Marketplace, App-Builder)

### DIFF
--- a/.github/scripts/build-slack-payload.js
+++ b/.github/scripts/build-slack-payload.js
@@ -1,0 +1,188 @@
+// Builds the Slack chat.postMessage payload for the notify-slack job.
+//
+// Reads every summaries/<artifact>/summary.json produced by the matrix cells,
+// renders a per-cell pass/fail/duration breakdown plus totals, and writes the
+// complete Block Kit payload to payload.json (consumed via the action's
+// payload-file-path input). Driven entirely by env vars set in the workflow.
+
+const fs = require("fs");
+const path = require("path");
+
+const env = process.env;
+const SUMMARY_DIR = "summaries";
+
+// Collect each cell's summary.json (one per artifact subdirectory). Missing or
+// malformed files are skipped — the overall headline still reflects reality
+// via the OVERALL job result.
+function loadCells() {
+  const cells = [];
+  let entries = [];
+  try {
+    entries = fs.readdirSync(SUMMARY_DIR);
+  } catch {
+    return cells;
+  }
+  for (const entry of entries) {
+    const file = path.join(SUMMARY_DIR, entry, "summary.json");
+    try {
+      cells.push(JSON.parse(fs.readFileSync(file, "utf8")));
+    } catch {
+      // no readable summary for this cell — ignore
+    }
+  }
+  // Stable, readable order regardless of artifact download order.
+  return cells.sort((a, b) => String(a.cell).localeCompare(String(b.cell)));
+}
+
+function fmtDuration(ms) {
+  if (!ms && ms !== 0) return "—";
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${Math.round(s - m * 60)}s`;
+}
+
+const cells = loadCells();
+
+const totals = { tests: 0, passes: 0, failures: 0, pending: 0, duration: 0 };
+for (const c of cells) {
+  const s = c.stats;
+  if (!s) continue;
+  totals.tests += s.tests || 0;
+  totals.passes += s.passes || 0;
+  totals.failures += s.failures || 0;
+  totals.pending += s.pending || 0;
+  totals.duration += s.duration || 0;
+}
+
+// Render the per-browser results as an aligned, monospaced code block. Unicode
+// emoji (✅/❌/⚠️) render inside code blocks; failures (and pendings) are shown
+// inline next to the passed count.
+const nameWidth = cells.length
+  ? Math.max(...cells.map((c) => String(c.cell).length))
+  : 0;
+const rows = cells.map((c) => {
+  const s = c.stats;
+  const name = String(c.cell).padEnd(nameWidth);
+  if (!s) return `⚠️  ${name}  no results (run crashed)`;
+  const status = (s.failures || 0) > 0 ? "❌" : "✅";
+  let detail = `${s.passes || 0} passed`;
+  if (s.failures) detail += `, ${s.failures} failed`;
+  if (s.pending) detail += `, ${s.pending} pending`;
+  detail += `  (${fmtDuration(s.duration)})`;
+  return `${status}  ${name}  ${detail}`;
+});
+
+const passed = env.OVERALL === "success";
+// Coloured bar down the left of the attachment — instant green/red signal.
+const color = passed ? "#2eb67d" : "#e01e5a";
+const statusIcon = passed ? "✅" : "❌";
+const statusWord = passed ? "Passed" : "Failed";
+const breakdown = rows.length
+  ? "```\n" + rows.join("\n") + "\n```"
+  : "_No cell summaries found._";
+
+const totalsLine =
+  `*${totals.passes}/${totals.tests}* tests passed` +
+  (totals.failures ? ` · *${totals.failures} failed*` : "") +
+  (totals.pending ? ` · ${totals.pending} pending` : "") +
+  ` · ⏱ ${fmtDuration(totals.duration)}`;
+
+const commitUrl = `${env.SERVER_URL}/${env.REPO}/commit/${env.SHA}`;
+const runUrl = `${env.SERVER_URL}/${env.REPO}/actions/runs/${env.RUN_ID}`;
+const shortSha = String(env.SHA || "").slice(0, 7);
+
+const isPR = env.EVENT === "pull_request" && env.PR_NUMBER;
+const branch = (isPR && env.PR_BRANCH) || env.BRANCH;
+
+// The headline block answers "did this PR pass?" — bold, linked PR title up
+// top so the result is scannable in the channel without opening anything.
+const subjectBlock = isPR
+  ? {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*<${env.PR_URL}|${env.PR_TITLE}>*  ·  <${env.PR_URL}|#${env.PR_NUMBER}>`,
+      },
+    }
+  : {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Push to \`${branch}\`*  ·  <${commitUrl}|${shortSha}>`,
+      },
+    };
+
+// Action buttons: jump straight to the PR (when relevant) and the run logs.
+const buttons = [];
+if (isPR) {
+  buttons.push({
+    type: "button",
+    text: { type: "plain_text", emoji: true, text: "📋 View PR" },
+    url: env.PR_URL,
+    style: passed ? "primary" : "danger",
+  });
+}
+buttons.push({
+  type: "button",
+  text: { type: "plain_text", emoji: true, text: "🔍 View run" },
+  url: runUrl,
+  ...(isPR ? {} : { style: passed ? "primary" : "danger" }),
+});
+
+const subjectText = isPR
+  ? `PR #${env.PR_NUMBER}: ${env.PR_TITLE}`
+  : `Push to ${branch}`;
+
+// Everything lives inside one coloured attachment so the bar spans the
+// whole message. The header block gives a big, scannable status line.
+const payload = {
+  channel: env.CHANNEL,
+  text: `${statusIcon} Cypress ${statusWord} — ${subjectText} (${totals.passes}/${totals.tests} passed)`,
+  attachments: [
+    {
+      color,
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            emoji: true,
+            text: `${statusIcon} Cypress ${statusWord}`,
+          },
+        },
+        subjectBlock,
+        {
+          type: "context",
+          elements: [
+            { type: "mrkdwn", text: `📦 \`${env.REPO}\`` },
+            { type: "mrkdwn", text: `🌿 \`${branch}\`` },
+            { type: "mrkdwn", text: `👤 ${env.ACTOR}` },
+          ],
+        },
+        { type: "divider" },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: totalsLine },
+        },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: `*Results by browser*\n${breakdown}` },
+        },
+        { type: "actions", elements: buttons },
+        {
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: `Commit <${commitUrl}|${shortSha}> • run <${runUrl}|#${env.RUN_ID}>`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+fs.writeFileSync("payload.json", JSON.stringify(payload, null, 2));
+console.log(fs.readFileSync("payload.json", "utf8"));

--- a/.github/workflows/cypress-appbuilder.yml
+++ b/.github/workflows/cypress-appbuilder.yml
@@ -157,7 +157,7 @@ jobs:
         env:
           CELL: "App Builder / ${{ matrix.edition }}"
           CONFIG_FILE: cypress-app-builder.config.js
-          CYPRESS_CONFIG: "baseUrl=http://localhost:8082"
+          CYPRESS_CONFIG: "baseUrl=http://localhost:3000"
         run: node cy-ci-run.js
 
       - name: Ensure run summary exists

--- a/.github/workflows/cypress-appbuilder.yml
+++ b/.github/workflows/cypress-appbuilder.yml
@@ -146,12 +146,36 @@ jobs:
           json: ${{ secrets.CYPRESS_SECRETS }}
           dir: "./cypress-tests"
 
-      - name: App builder
+      - name: Install Cypress & deps
         uses: cypress-io/github-action@v6
         with:
           working-directory: ./cypress-tests
-          config: "baseUrl=http://localhost:8082"
-          config-file: cypress-app-builder.config.js
+          runTests: false
+
+      - name: App builder
+        working-directory: ./cypress-tests
+        env:
+          CELL: "App Builder / ${{ matrix.edition }}"
+          CONFIG_FILE: cypress-app-builder.config.js
+          CYPRESS_CONFIG: "baseUrl=http://localhost:8082"
+        run: node cy-ci-run.js
+
+      - name: Ensure run summary exists
+        if: always()
+        working-directory: ./cypress-tests
+        run: |
+          if [ ! -f summary.json ]; then
+            printf '{"cell":"App Builder / %s","result":"failure","stats":null}\n' '${{ matrix.edition }}' > summary.json
+          fi
+          cat summary.json
+
+      - name: Upload run summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-summary-appbuilder-${{ matrix.edition }}
+          path: cypress-tests/summary.json
+          retention-days: 7
 
       - name: Capture Screenshots
         uses: actions/upload-artifact@v4
@@ -192,3 +216,51 @@ jobs:
   #       with:
   #         name: screenshots
   #         path: cypress-tests/cypress/screenshots
+
+  notify-slack:
+    needs: Cypress-App-Builder
+    # Run after the matrix whenever the test job actually ran (not skipped —
+    # avoids posting on unrelated labels).
+    if: always() && needs.Cypress-App-Builder.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      # This job runs separately from the matrix, so check out just the script.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Download run summaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cypress-summary-*
+          path: summaries
+
+      - name: Build Slack payload
+        env:
+          CHANNEL: ${{ secrets.SLACK_CHANNEL_ID }}
+          OVERALL: ${{ needs.Cypress-App-Builder.result }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          # Normalise pull_request_target → pull_request so the script renders PR context.
+          EVENT: ${{ github.event_name == 'pull_request_target' && 'pull_request' || github.event_name }}
+          SHA: ${{ github.sha }}
+          SERVER_URL: ${{ github.server_url }}
+          RUN_ID: ${{ github.run_id }}
+          # PR context — populated only on pull_request events; empty on push.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          BRANCH: ${{ github.ref_name }}
+        run: node .github/scripts/build-slack-payload.js
+
+      - name: Post result to Slack
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Fail the step (and surface the Slack API error) instead of
+          # silently swallowing ok:false responses like not_in_channel.
+          errors: true
+          payload-file-path: payload.json

--- a/.github/workflows/cypress-marketplace.yml
+++ b/.github/workflows/cypress-marketplace.yml
@@ -406,13 +406,37 @@ jobs:
           json: ${{ secrets.CYPRESS_SECRETS_MARKETPLACE }}
           dir: "./cypress-tests"
 
-      - name: Marketplace
+      - name: Install Cypress & deps
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome
           working-directory: ./cypress-tests
-          config: "baseUrl=http://localhost:3000"
-          config-file: cypress-marketplace.config.js
+          runTests: false
+
+      - name: Marketplace
+        working-directory: ./cypress-tests
+        env:
+          CELL: "Marketplace / ${{ matrix.edition }}"
+          BROWSER: chrome
+          CONFIG_FILE: cypress-marketplace.config.js
+          CYPRESS_CONFIG: "baseUrl=http://localhost:3000"
+        run: node cy-ci-run.js
+
+      - name: Ensure run summary exists
+        if: always()
+        working-directory: ./cypress-tests
+        run: |
+          if [ ! -f summary.json ]; then
+            printf '{"cell":"Marketplace / %s","result":"failure","stats":null}\n' '${{ matrix.edition }}' > summary.json
+          fi
+          cat summary.json
+
+      - name: Upload run summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-summary-marketplace-${{ matrix.edition }}
+          path: cypress-tests/summary.json
+          retention-days: 7
 
       - name: Capture Screenshots
         uses: actions/upload-artifact@v4
@@ -512,12 +536,36 @@ jobs:
           json: ${{ secrets.CYPRESS_SECRETS }}
           dir: "./cypress-tests"
 
-      - name: Marketplace subpath
-        uses: cypress-io/github-action@v5
+      - name: Install Cypress & deps
+        uses: cypress-io/github-action@v6
         with:
           working-directory: ./cypress-tests
-          config: "baseUrl=http://localhost:80/apps/tooljet/"
-          config-file: cypress-marketplace.config.js
+          runTests: false
+
+      - name: Marketplace subpath
+        working-directory: ./cypress-tests
+        env:
+          CELL: "Marketplace subpath"
+          CONFIG_FILE: cypress-marketplace.config.js
+          CYPRESS_CONFIG: "baseUrl=http://localhost:80/apps/tooljet/"
+        run: node cy-ci-run.js
+
+      - name: Ensure run summary exists
+        if: always()
+        working-directory: ./cypress-tests
+        run: |
+          if [ ! -f summary.json ]; then
+            printf '{"cell":"Marketplace subpath","result":"failure","stats":null}\n' > summary.json
+          fi
+          cat summary.json
+
+      - name: Upload run summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-summary-marketplace-subpath
+          path: cypress-tests/summary.json
+          retention-days: 7
 
       - name: Capture Screenshots
         uses: actions/upload-artifact@v4
@@ -525,3 +573,60 @@ jobs:
         with:
           name: screenshots
           path: cypress-tests/cypress/screenshots
+
+  notify-slack:
+    needs:
+      - Cypress-Marketplace
+      - Cypress-Marketplace-Subpath
+    # Run after the matrix whenever at least one test job actually ran (not all
+    # skipped — avoids posting on unrelated labels).
+    if: >-
+      always() &&
+      (needs.Cypress-Marketplace.result != 'skipped' ||
+       needs.Cypress-Marketplace-Subpath.result != 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      # This job runs separately from the matrix, so check out just the script.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Download run summaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cypress-summary-*
+          path: summaries
+
+      - name: Build Slack payload
+        env:
+          CHANNEL: ${{ secrets.SLACK_CHANNEL_ID }}
+          # Red unless every test job that ran passed (skipped cells don't count).
+          OVERALL: >-
+            ${{ (needs.Cypress-Marketplace.result == 'failure' ||
+                 needs.Cypress-Marketplace-Subpath.result == 'failure')
+                && 'failure' || 'success' }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          # Normalise pull_request_target → pull_request so the script renders PR context.
+          EVENT: ${{ github.event_name == 'pull_request_target' && 'pull_request' || github.event_name }}
+          SHA: ${{ github.sha }}
+          SERVER_URL: ${{ github.server_url }}
+          RUN_ID: ${{ github.run_id }}
+          # PR context — populated only on pull_request events; empty on push.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          BRANCH: ${{ github.ref_name }}
+        run: node .github/scripts/build-slack-payload.js
+
+      - name: Post result to Slack
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Fail the step (and surface the Slack API error) instead of
+          # silently swallowing ok:false responses like not_in_channel.
+          errors: true
+          payload-file-path: payload.json

--- a/.github/workflows/cypress-marketplace.yml
+++ b/.github/workflows/cypress-marketplace.yml
@@ -20,7 +20,8 @@ jobs:
   Cypress-Marketplace:
     runs-on: ubuntu-22.04
 
-    if: contains(github.event.pull_request.labels.*.name, 'run-cypress-marketplace-ee')
+    if: contains(github.event.pull_request.labels.*.name, 'run-cypress') ||
+      contains(github.event.pull_request.labels.*.name, 'run-cypress-marketplace-ee')
 
     strategy:
       fail-fast: false
@@ -428,8 +429,7 @@ jobs:
   Cypress-Marketplace-Subpath:
     runs-on: ubuntu-22.04
 
-    if: contains(github.event.pull_request.labels.*.name, 'run-cypress') ||
-      contains(github.event.pull_request.labels.*.name, 'run-cypress-marketplace-subpath')
+    if: contains(github.event.pull_request.labels.*.name, 'run-cypress-marketplace-subpath')
 
     steps:
       - name: Checkout

--- a/.github/workflows/cypress-platform.yml
+++ b/.github/workflows/cypress-platform.yml
@@ -385,17 +385,39 @@ jobs:
           json: ${{ toJSON(matrix.edition == 'ce' && fromJSON(secrets.CYPRESS_SECRETS) || fromJSON(secrets.CYPRESS_EE_SECRETS)) }}
           dir: "./cypress-tests"
 
-      - name: Run Cypress tests
+      - name: Install Cypress & deps
         uses: cypress-io/github-action@v6
-        id: cypress-tests
         with:
-          browser: chrome
           working-directory: ./cypress-tests
-          config: "baseUrl=http://localhost:3000"
-          config-file: ${{ matrix.label == 'gitsync' && 'cypress-gitsync.config.js' || matrix.edition == 'ee' && 'cypress-ee-platform.config.js' || 'cypress-platform.config.js' }}
+          runTests: false
+
+      - name: Run Cypress tests
+        working-directory: ./cypress-tests
         env:
+          CELL: "Platform / ${{ matrix.edition }}"
+          BROWSER: chrome
+          CONFIG_FILE: ${{ matrix.label == 'gitsync' && 'cypress-gitsync.config.js' || matrix.edition == 'ee' && 'cypress-ee-platform.config.js' || 'cypress-platform.config.js' }}
+          CYPRESS_CONFIG: "baseUrl=http://localhost:3000"
           GITHUB_TOKEN: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_RECORD_KEY: "ca6a0d5f-b763-4be7-b554-3425a973104e"
+        run: node cy-ci-run.js
+
+      - name: Ensure run summary exists
+        if: always()
+        working-directory: ./cypress-tests
+        run: |
+          if [ ! -f summary.json ]; then
+            printf '{"cell":"Platform / %s","result":"failure","stats":null}\n' '${{ matrix.edition }}' > summary.json
+          fi
+          cat summary.json
+
+      - name: Upload run summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-summary-platform-${{ matrix.edition }}
+          path: cypress-tests/summary.json
+          retention-days: 7
 
       - name: Capture Screenshots
         uses: actions/upload-artifact@v4
@@ -775,17 +797,39 @@ jobs:
           echo ""
           echo "========================================="
 
-      - name: Run Cypress tests
+      - name: Install Cypress & deps
         uses: cypress-io/github-action@v6
-        id: cypress-tests-subpath
         with:
-          browser: chrome
           working-directory: ./cypress-tests
-          config: "baseUrl=http://localhost:3000/apps"
-          config-file: ${{ matrix.edition == 'ee' && 'cypress-ee-platform.config.js' || 'cypress-platform.config.js' }}
+          runTests: false
+
+      - name: Run Cypress tests
+        working-directory: ./cypress-tests
         env:
+          CELL: "Platform subpath / ${{ matrix.edition }}"
+          BROWSER: chrome
+          CONFIG_FILE: ${{ matrix.edition == 'ee' && 'cypress-ee-platform.config.js' || 'cypress-platform.config.js' }}
+          CYPRESS_CONFIG: "baseUrl=http://localhost:3000/apps"
           GITHUB_TOKEN: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_RECORD_KEY: "ca6a0d5f-b763-4be7-b554-3425a973104e"
+        run: node cy-ci-run.js
+
+      - name: Ensure run summary exists
+        if: always()
+        working-directory: ./cypress-tests
+        run: |
+          if [ ! -f summary.json ]; then
+            printf '{"cell":"Platform subpath / %s","result":"failure","stats":null}\n' '${{ matrix.edition }}' > summary.json
+          fi
+          cat summary.json
+
+      - name: Upload run summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-summary-platform-subpath-${{ matrix.edition }}
+          path: cypress-tests/summary.json
+          retention-days: 7
 
       - name: Capture Screenshots
         uses: actions/upload-artifact@v4
@@ -1180,18 +1224,40 @@ jobs:
           echo ""
           echo "========================================="
 
-      - name: Run Cypress tests
+      - name: Install Cypress & deps
         uses: cypress-io/github-action@v6
-        id: cypress-tests-proxy
         with:
-          browser: chrome
           working-directory: ./cypress-tests
-          config: "baseUrl=http://localhost:4001,server_host=http://localhost:3000"
-          config-file: ${{ matrix.edition == 'ee' && 'cypress-ee-platform.config.js' || 'cypress-platform.config.js' }}
+          runTests: false
+
+      - name: Run Cypress tests
+        working-directory: ./cypress-tests
         env:
+          CELL: "Platform proxy / ${{ matrix.edition }}"
+          BROWSER: chrome
+          CONFIG_FILE: ${{ matrix.edition == 'ee' && 'cypress-ee-platform.config.js' || 'cypress-platform.config.js' }}
+          CYPRESS_CONFIG: "baseUrl=http://localhost:4001,server_host=http://localhost:3000"
           CYPRESS_proxy: true
           GITHUB_TOKEN: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_RECORD_KEY: "ca6a0d5f-b763-4be7-b554-3425a973104e"
+        run: node cy-ci-run.js
+
+      - name: Ensure run summary exists
+        if: always()
+        working-directory: ./cypress-tests
+        run: |
+          if [ ! -f summary.json ]; then
+            printf '{"cell":"Platform proxy / %s","result":"failure","stats":null}\n' '${{ matrix.edition }}' > summary.json
+          fi
+          cat summary.json
+
+      - name: Upload run summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-summary-platform-proxy-${{ matrix.edition }}
+          path: cypress-tests/summary.json
+          retention-days: 7
 
       - name: Capture Screenshots
         uses: actions/upload-artifact@v4
@@ -1587,18 +1653,40 @@ jobs:
           echo ""
           echo "========================================="
 
-      - name: Run Cypress tests
+      - name: Install Cypress & deps
         uses: cypress-io/github-action@v6
-        id: cypress-tests-proxy-subpath
         with:
-          browser: chrome
           working-directory: ./cypress-tests
-          config: "baseUrl=http://localhost:4001/apps,server_host=http://localhost:3000/apps"
-          config-file: ${{ matrix.edition == 'ee' && 'cypress-ee-platform.config.js' || 'cypress-platform.config.js' }}
+          runTests: false
+
+      - name: Run Cypress tests
+        working-directory: ./cypress-tests
         env:
+          CELL: "Platform proxy-subpath / ${{ matrix.edition }}"
+          BROWSER: chrome
+          CONFIG_FILE: ${{ matrix.edition == 'ee' && 'cypress-ee-platform.config.js' || 'cypress-platform.config.js' }}
+          CYPRESS_CONFIG: "baseUrl=http://localhost:4001/apps,server_host=http://localhost:3000/apps"
           CYPRESS_proxy: true
           GITHUB_TOKEN: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_RECORD_KEY: "ca6a0d5f-b763-4be7-b554-3425a973104e"
+        run: node cy-ci-run.js
+
+      - name: Ensure run summary exists
+        if: always()
+        working-directory: ./cypress-tests
+        run: |
+          if [ ! -f summary.json ]; then
+            printf '{"cell":"Platform proxy-subpath / %s","result":"failure","stats":null}\n' '${{ matrix.edition }}' > summary.json
+          fi
+          cat summary.json
+
+      - name: Upload run summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-summary-platform-proxy-subpath-${{ matrix.edition }}
+          path: cypress-tests/summary.json
+          retention-days: 7
 
       - name: Capture Screenshots
         uses: actions/upload-artifact@v4
@@ -1607,3 +1695,66 @@ jobs:
           name: screenshots-${{ matrix.edition }}-proxy-subpath-${{ env.TIMESTAMP }}
           path: cypress-tests/cypress/screenshots
           retention-days: 7
+
+  notify-slack:
+    needs:
+      - Cypress-Platform
+      - Cypress-Platform-Subpath
+      - Cypress-Platform-Proxy
+      - Cypress-Platform-Proxy-Subpath
+    # Run after the matrix whenever at least one test job actually ran (not all
+    # skipped — avoids posting on unrelated labels).
+    if: >-
+      always() &&
+      (needs.Cypress-Platform.result != 'skipped' ||
+       needs.Cypress-Platform-Subpath.result != 'skipped' ||
+       needs.Cypress-Platform-Proxy.result != 'skipped' ||
+       needs.Cypress-Platform-Proxy-Subpath.result != 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      # This job runs separately from the matrix, so check out just the script.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Download run summaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cypress-summary-*
+          path: summaries
+
+      - name: Build Slack payload
+        env:
+          CHANNEL: ${{ secrets.SLACK_CHANNEL_ID }}
+          # Red unless every test job that ran passed (skipped cells don't count).
+          OVERALL: >-
+            ${{ (needs.Cypress-Platform.result == 'failure' ||
+                 needs.Cypress-Platform-Subpath.result == 'failure' ||
+                 needs.Cypress-Platform-Proxy.result == 'failure' ||
+                 needs.Cypress-Platform-Proxy-Subpath.result == 'failure')
+                && 'failure' || 'success' }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          # Normalise pull_request_target → pull_request so the script renders PR context.
+          EVENT: ${{ github.event_name == 'pull_request_target' && 'pull_request' || github.event_name }}
+          SHA: ${{ github.sha }}
+          SERVER_URL: ${{ github.server_url }}
+          RUN_ID: ${{ github.run_id }}
+          # PR context — populated only on pull_request events; empty on push.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          BRANCH: ${{ github.ref_name }}
+        run: node .github/scripts/build-slack-payload.js
+
+      - name: Post result to Slack
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Fail the step (and surface the Slack API error) instead of
+          # silently swallowing ok:false responses like not_in_channel.
+          errors: true
+          payload-file-path: payload.json

--- a/.github/workflows/cypress-platform.yml
+++ b/.github/workflows/cypress-platform.yml
@@ -32,10 +32,10 @@ jobs:
       matrix:
         edition:
           - ${{
-            (contains(github.event.pull_request.labels.*.name, 'run-cypress') ||
-            contains(github.event.pull_request.labels.*.name, 'run-cypress-platform-ce') ||
+            (contains(github.event.pull_request.labels.*.name, 'run-cypress-platform-ce') ||
             contains(github.event.pull_request.labels.*.name, 'run-cypress-ce')) && 'ce' ||
-            contains(github.event.pull_request.labels.*.name, 'run-cypress-platform-ee') && 'ee' ||
+            (contains(github.event.pull_request.labels.*.name, 'run-cypress') ||
+            contains(github.event.pull_request.labels.*.name, 'run-cypress-platform-ee')) && 'ee' ||
             contains(github.event.pull_request.labels.*.name, 'run-cypress-git-sync-ee') && 'ee' || ''
             }}
         label:

--- a/cypress-tests/cy-ci-run.js
+++ b/cypress-tests/cy-ci-run.js
@@ -1,0 +1,66 @@
+// cy-ci-run.js — run Cypress via the module API and write summary.json.
+//
+// Replaces the `cypress-io/github-action` run step so each CI cell can emit a
+// machine-readable result for the Slack notifier. The action only installs the
+// binary now (runTests: false); this script does the actual run and captures
+// counts the built-in `--reporter json` can't write to a file.
+//
+// Driven by env vars (all optional except CELL is recommended):
+//   CELL           human label for the cell, e.g. "Platform / ee"
+//   CONFIG_FILE    --config-file value, e.g. cypress-ee-platform.config.js
+//   CYPRESS_CONFIG comma-separated --config string, e.g.
+//                  "baseUrl=http://localhost:4001,server_host=http://localhost:3000"
+//   BROWSER        --browser value, e.g. chrome (omit for the Cypress default)
+// CYPRESS_* env vars (e.g. CYPRESS_proxy) are picked up by Cypress automatically.
+const fs = require("fs");
+const cypress = require("cypress");
+
+const cell = process.env.CELL || "cypress";
+const write = (s) => fs.writeFileSync("summary.json", JSON.stringify(s));
+
+// Parse "k1=v1,k2=v2" into a config object, mirroring the action's `config:`
+// input. Equivalent to `cypress run --config k1=v1,k2=v2` — same validation.
+function parseConfig(str) {
+  const config = {};
+  if (!str) return config;
+  for (const pair of str.split(",")) {
+    const idx = pair.indexOf("=");
+    if (idx === -1) continue;
+    config[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim();
+  }
+  return config;
+}
+
+const runOptions = { config: parseConfig(process.env.CYPRESS_CONFIG) };
+if (process.env.CONFIG_FILE) runOptions.configFile = process.env.CONFIG_FILE;
+if (process.env.BROWSER) runOptions.browser = process.env.BROWSER;
+
+cypress
+  .run(runOptions)
+  .then((results) => {
+    // status:"failed" means Cypress itself could not run (e.g. config/build
+    // error) — there are no test counts to report.
+    if (results.status === "failed") {
+      console.error(results.message);
+      write({ cell, result: "failure", stats: null });
+      process.exit(1);
+    }
+    write({
+      cell,
+      result: results.totalFailed > 0 ? "failure" : "success",
+      stats: {
+        tests: results.totalTests,
+        passes: results.totalPassed,
+        failures: results.totalFailed,
+        pending: results.totalPending,
+        skipped: results.totalSkipped,
+        duration: results.totalDuration,
+      },
+    });
+    process.exit(results.totalFailed > 0 ? 1 : 0);
+  })
+  .catch((err) => {
+    console.error(err);
+    write({ cell, result: "failure", stats: null });
+    process.exit(1);
+  });


### PR DESCRIPTION
## 📝 What this does
Posts a single, formatted Cypress run report to Slack after the Platform, Marketplace, and App-Builder workflows finish — pass or fail — with a per-cell (edition / deployment variant) results breakdown. Also repurposes the `run-cypress` label so it runs Platform (ee) + Marketplace (ee) main jobs alongside App-Builder.

Port of #16863 (lts-3.16) onto `main`; the Platform git-sync matrix variant on `main` is preserved.

## 🔀 Changes
- Each test job now runs Cypress via the module API (`cy-ci-run.js`) and emits a `summary.json` with pass/fail/duration counts.
- Added a `notify-slack` job to all three workflows that aggregates the per-job summaries into a Block Kit message and posts via `chat.postMessage`.
- `run-cypress` now resolves Platform to ee (was ce) and gates the main Marketplace job; the Marketplace subpath job keeps its own dedicated label.
- Normalised `pull_request_target` to `pull_request` so the message renders PR title, link, and button.

## 🧪 How to test
- [ ] Add repo secrets `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID`.
- [ ] Merge so `.github/scripts/build-slack-payload.js` exists on the base branch (notify-slack checks out base on `pull_request_target`).
- [ ] Label a PR `run-cypress` and confirm one report posts per workflow with the correct green/red bar and breakdown.