### PR TITLE
feat: update query revision handling in QueryManager for better state…

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -232,7 +232,9 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = () =
         </div>
         <ElementToRender
           renderCopilot={(props) => renderCopilot({ ...props, selectedDataSource })}
-          key={selectedQuery?.id}
+          // revision is bumped only on external updates (e.g. AI-generated query changes),
+          // forcing a remount so editors holding options in local state pick up the change
+          key={`${selectedQuery?.id}-${selectedQuery?.revision ?? 0}`}
           pluginSchema={selectedDataSource?.plugin?.operations_file?.data}
           selectedDataSource={selectedDataSource}
           options={selectedQuery?.options}

--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerHeader.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerHeader.jsx
@@ -26,6 +26,7 @@ const GENERATE_QUERY_SUPPORTED_KINDS = [
   'mssql',
   'snowflake',
   'runjs',
+  'restapi',
 ];
 
 export const QueryManagerHeader = forwardRef(({ darkMode, setActiveTab, activeTab }, ref) => {

--- a/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
@@ -614,7 +614,10 @@ export const createDataQuerySlice = (set, get) => ({
 
                 state.modules[moduleId].queryIdNameMapping[query.id] = updatedQuery.name;
 
-                return { ...updatedQuery, options: { ...newOptions } };
+                // Bump the client-side revision so editors keyed on it (QueryManagerBody)
+                // remount and re-read options; editors that snapshot options into local
+                // state (e.g. Restapi, Openapi) would otherwise render stale values.
+                return { ...updatedQuery, options: { ...newOptions }, revision: (query.revision ?? 0) + 1 };
               }
 
               return query;


### PR DESCRIPTION
This pull request introduces improvements to how query option changes are managed and reflected in the UI, especially for editors that cache options in local state. It also adds support for a new data source kind and updates a submodule reference.

**State management and UI updates:**
- The `revision` property is now incremented on client-side query option updates, ensuring that editors (like those for Restapi and Openapi) that snapshot options into local state will remount and pick up changes, preventing stale renders. (`frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js`)
- The `key` used for the main query editor component now includes both the query `id` and its `revision`, so the component remounts whenever options change externally. (`frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx`)

**Feature support:**
- Added `'restapi'` to the list of supported kinds for AI query generation. (`frontend/src/AppBuilder/QueryManager/Components/QueryManagerHeader.jsx`)

**Dependency update:**
- Updated the `server/ee` submodule to a new commit. (`server/ee`)… management