### PR TITLE
fix(apps): load appVersions in findByIdOrSlug slug path (fixes ext auto-release by slug)

### DIFF
--- a/server/src/modules/apps/repository.ts
+++ b/server/src/modules/apps/repository.ts
@@ -424,11 +424,16 @@ export class AppsRepository extends Repository<App> {
       }
     }
 
-    // Slug path: resolve through app_versions.slug
+    // Slug path: resolve through app_versions.slug. Load app.appVersions in the
+    // same join so callers reading app.appVersions (e.g. external-api
+    // autoDeployApp) get a shape consistent with the UUID/workflow paths — no
+    // separate re-fetch. The av.slug filter only narrows the matched version
+    // row; app.appVersions still hydrates the app's full version collection.
     const candidate = await manager
       .getRepository(AppVersion)
       .createQueryBuilder('av')
       .innerJoinAndSelect('av.app', 'app')
+      .leftJoinAndSelect('app.appVersions', 'appVersions')
       .where('av.slug = :slug', { slug: idOrSlug })
       .getOne();
 
@@ -442,6 +447,7 @@ export class AppsRepository extends Repository<App> {
           .getRepository(AppVersion)
           .createQueryBuilder('av')
           .innerJoinAndSelect('av.app', 'app')
+          .leftJoinAndSelect('app.appVersions', 'appVersions')
           .where('av.slug = :slug', { slug: idOrSlug })
           .andWhere('av.branch_id = :branchId', { branchId: defaultBranchId })
           .getOne();

--- a/server/test/modules/apps/e2e/apps-repository.spec.ts
+++ b/server/test/modules/apps/e2e/apps-repository.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * @group platform
+ */
+import {
+  initTestApp,
+  closeTestApp,
+  createAdmin,
+  createApplication,
+  createApplicationVersion,
+  updateEntity,
+} from 'test-helper';
+import { INestApplication } from '@nestjs/common';
+import { AppsRepository } from '@modules/apps/repository';
+import { App } from 'src/entities/app.entity';
+import { AppVersion } from 'src/entities/app_version.entity';
+
+// initTestApp() can exceed 60s when Jest restarts the worker to free memory
+jest.setTimeout(120_000);
+
+describe('AppsRepository', () => {
+  describe('EE (plan: enterprise)', () => {
+    let nestApp: INestApplication;
+    let appsRepository: AppsRepository;
+    let app: App;
+    let version: AppVersion;
+    const versionSlug = 'release-regression-slug';
+
+    beforeAll(async () => {
+      ({ app: nestApp } = await initTestApp());
+      appsRepository = nestApp.get<AppsRepository>(AppsRepository);
+
+      const admin = await createAdmin(nestApp, 'apps-repo-admin@tooljet.io');
+      app = await createApplication(nestApp, { name: 'release-regression-app', user: admin.user });
+      version = await createApplicationVersion(nestApp, app as App & { organizationId: string });
+      // Slug resolution is keyed on app_versions.slug; the factory leaves it null.
+      await updateEntity(AppVersion, version.id, { slug: versionSlug });
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    afterAll(async () => {
+      await closeTestApp(nestApp);
+    }, 60000);
+
+    describe('findByIdOrSlug()', () => {
+      // Regression: the slug path resolved the app through an `av.app` join that
+      // never loaded the `appVersions` collection, so consumers reading
+      // `app.appVersions` (e.g. external-api autoDeployApp) broke on slug input.
+      it('should load appVersions when resolved by slug', async () => {
+        const result = await appsRepository.findByIdOrSlug(versionSlug);
+
+        expect(result).not.toBeNull();
+        expect(result!.id).toBe(app.id);
+        expect(Array.isArray(result!.appVersions)).toBe(true);
+        expect(result!.appVersions.map((v) => v.id)).toContain(version.id);
+      });
+
+      it('should load appVersions when resolved by UUID', async () => {
+        const result = await appsRepository.findByIdOrSlug(app.id);
+
+        expect(result).not.toBeNull();
+        expect(result!.id).toBe(app.id);
+        expect(Array.isArray(result!.appVersions)).toBe(true);
+        expect(result!.appVersions.map((v) => v.id)).toContain(version.id);
+      });
+
+      it('should return null for an unknown slug', async () => {
+        const result = await appsRepository.findByIdOrSlug('does-not-exist-slug');
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+});

--- a/server/test/modules/external-apis/e2e/apps.spec.ts
+++ b/server/test/modules/external-apis/e2e/apps.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * @group platform
+ */
+import {
+  initTestApp,
+  closeTestApp,
+  createAdmin,
+  createApplication,
+  createApplicationVersion,
+  updateEntity,
+} from 'test-helper';
+import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as request from 'supertest';
+import { App } from 'src/entities/app.entity';
+import { AppVersion, AppVersionStatus } from 'src/entities/app_version.entity';
+
+// initTestApp() can exceed 60s when Jest restarts the worker to free memory
+jest.setTimeout(120_000);
+
+describe('ExternalApisAppsController', () => {
+  describe('EE (plan: enterprise)', () => {
+    let app: INestApplication;
+    let appEntity: App;
+    let version: AppVersion;
+    const versionSlug = 'release-ext-slug';
+    // ExternalApiSecurityGuard validates `Authorization: Basic <EXTERNAL_API_ACCESS_TOKEN>`.
+    // Read the token from the same ConfigService the guard resolves it from — the
+    // app's ConfigModule and process.env can diverge (different env files), so
+    // ConfigService is the single source of truth.
+    let authHeader: string;
+
+    beforeAll(async () => {
+      ({ app } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+      authHeader = `Basic ${app.get(ConfigService).get<string>('EXTERNAL_API_ACCESS_TOKEN')}`;
+
+      const admin = await createAdmin(app, 'ext-apps-admin@tooljet.io');
+      appEntity = await createApplication(app, { name: 'ext-release-app', user: admin.user });
+      version = await createApplicationVersion(app, appEntity as App & { organizationId: string });
+      // Slug resolution is keyed on app_versions.slug. The release endpoint also
+      // rejects DRAFT versions, so seed a non-draft, slug-bearing version.
+      await updateEntity(AppVersion, version.id, { slug: versionSlug, status: AppVersionStatus.PUBLISHED });
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    afterAll(async () => {
+      await closeTestApp(app);
+    }, 60000);
+
+    describe('POST /api/ext/apps/:appIdOrSlug/git-sync/release | Auto-release app', () => {
+      // Regression: findByIdOrSlug's slug branch did not load app.appVersions,
+      // so autoDeployApp could not resolve the target version and returned 404
+      // for slug input even though the version existed.
+      it('should release by versionId when the app is addressed by slug', async () => {
+        const res = await request
+          .agent(app.getHttpServer())
+          .post(`/api/ext/apps/${versionSlug}/git-sync/release`)
+          .set('Authorization', authHeader)
+          .send({ versionId: version.id });
+
+        expect(res.status).toBe(201);
+        expect(res.body).toMatchObject({ id: appEntity.id });
+      });
+
+      it('should release by versionName when the app is addressed by slug', async () => {
+        const res = await request
+          .agent(app.getHttpServer())
+          .post(`/api/ext/apps/${versionSlug}/git-sync/release`)
+          .set('Authorization', authHeader)
+          .send({ versionName: version.name });
+
+        expect(res.status).toBe(201);
+        expect(res.body).toMatchObject({ id: appEntity.id });
+      });
+
+      it('should release by versionId when the app is addressed by UUID', async () => {
+        const res = await request
+          .agent(app.getHttpServer())
+          .post(`/api/ext/apps/${appEntity.id}/git-sync/release`)
+          .set('Authorization', authHeader)
+          .send({ versionId: version.id });
+
+        expect(res.status).toBe(201);
+        expect(res.body).toMatchObject({ id: appEntity.id });
+      });
+
+      it('should return 404 for an unknown slug', async () => {
+        const res = await request
+          .agent(app.getHttpServer())
+          .post('/api/ext/apps/does-not-exist-slug/git-sync/release')
+          .set('Authorization', authHeader)
+          .send({ versionId: version.id });
+
+        expect(res.status).toBe(404);
+      });
+
+      it('should return 403 when the authorization header is missing', async () => {
+        const res = await request
+          .agent(app.getHttpServer())
+          .post(`/api/ext/apps/${versionSlug}/git-sync/release`)
+          .send({ versionId: version.id });
+
+        expect(res.status).toBe(403);
+      });
+
+      it('should return 403 when the access token is wrong', async () => {
+        const res = await request
+          .agent(app.getHttpServer())
+          .post(`/api/ext/apps/${versionSlug}/git-sync/release`)
+          .set('Authorization', 'Basic wrong-token')
+          .send({ versionId: version.id });
+
+        expect(res.status).toBe(403);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Problem
`POST /ext/apps/:appIdOrSlug/git-sync/release` (→ `autoDeployApp`) returned a false **404/400** when the app was addressed by **slug** with an explicit `versionId`/`versionName`, and silently did a **redundant git pull** on the no-version path. UUID input worked.

## Root cause
`AppsRepository.findByIdOrSlug` has three branches:
| Branch | App loaded with `appVersions`? |
|---|---|
| UUID | ✅ `relations: ['appVersions']` |
| **slug** | ❌ `av.app` join hydrates only the app row |
| workflow | ✅ `relations: ['appVersions']` |

`autoDeployApp` reads `app.appVersions` to resolve the target version, so for slug input it was `undefined` → version not found.

Introduced in `f0817cdb51` (branch-aware metadata refactor), which replaced the slug lookup's `findOne(App, {relations:['appVersions']})` with the join and dropped the relation. No test covered it.

## Fix
Re-fetch the resolved app by id with the `appVersions` relation so all three branches return a consistent shape. One extra `findOne` on the slug path.

## Tests (both red before fix, green after)
- `test/modules/apps/e2e/apps-repository.spec.ts` — `findByIdOrSlug` loads `appVersions` by slug and by UUID; null for unknown slug.
- `test/modules/external-apis/e2e/apps.spec.ts` — auto-release by slug (`versionId` + `versionName`), UUID control, 404 unknown slug, 403 auth (missing/wrong token).

```
Test Suites: 2 passed, 2 total
Tests:       9 passed, 9 total
```

## Notes
- `saveAppVersion` also calls `findByIdOrSlug` but only reads `app.id`/`organizationId`, so it was not affected by this bug — covered here as a shared-resolver guard.
- A git-enabled extension to the `git-sync.spec` lifecycle test was considered but dropped: that lifecycle block is stale and breaks at multiple points, so it offers no reliable signal.