### PR TITLE
test: run-cypress label + Slack report check

### DIFF
--- a/.github/RUN_CYPRESS_LABEL_TEST.md
+++ b/.github/RUN_CYPRESS_LABEL_TEST.md
@@ -1,0 +1,4 @@
+# run-cypress label test
+
+Throwaway PR to exercise the `run-cypress` label and the new Slack run report.
+Safe to close/delete once the notification is verified in the channel.


### PR DESCRIPTION
## 📝 What this does
Throwaway PR to verify the `run-cypress` label triggers the Cypress workflows and posts the new Slack run report. Close once verified.

## 🧪 How to test
- [ ] Confirm `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_ID` repo secrets are set.
- [ ] Add the `run-cypress` label to this PR.
- [ ] Expect: App-Builder (ce+ee), Platform (ee), Marketplace (ee) jobs run, each workflow posts one report to the Slack channel.