### PR TITLE
Fix: Dynamic height breaking for `JSONEditor` and `JSONExplorer` components

### DIFF
--- a/frontend/src/AppBuilder/Widgets/JSONEditor/JSONEditor.jsx
+++ b/frontend/src/AppBuilder/Widgets/JSONEditor/JSONEditor.jsx
@@ -133,6 +133,7 @@ export const JSONEditor = function JSONEditor(props) {
       {
         '.cm-scroller': {
           backgroundColor: backgroundColor,
+          flexGrow: 1,
         },
       },
       { dark: darkMode }

--- a/frontend/src/AppBuilder/Widgets/JSONExplorer/JSONExplorer.jsx
+++ b/frontend/src/AppBuilder/Widgets/JSONExplorer/JSONExplorer.jsx
@@ -70,6 +70,7 @@ export const JSONExplorer = function JSONExplorer(props) {
 
   const containerComputedStyles = {
     height: isDynamicHeightEnabled ? '100%' : height,
+    ...(isDynamicHeightEnabled ? { minHeight: `${height}px` } : {}),
     backgroundColor,
     border: `1px solid ${borderColor}`,
     borderRadius: `${borderRadius}px`,


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/5199

This pull request introduces minor improvements to the layout and style handling of the `JSONEditor` and `JSONExplorer` components to ensure better sizing and flexibility, especially when dynamic height is enabled.

Layout and style enhancements:

* Added `flexGrow: 1` to the `.cm-scroller` style in `JSONEditor` to improve its flexibility within flex layouts.
* Updated `JSONExplorer` to apply a `minHeight` equal to the specified height when dynamic height is enabled, ensuring the component doesn't shrink below the intended size.