### PR TITLE
fix: Apps - store app name as plain text on rename instead of HTML-escaping

### DIFF
--- a/server/src/modules/apps/dto/index.ts
+++ b/server/src/modules/apps/dto/index.ts
@@ -44,10 +44,7 @@ export class AppUpdateDto {
 
   @IsString()
   @IsOptional()
-  @Transform(({ value }) => {
-    const newValue = sanitizeInput(value);
-    return newValue.trim();
-  })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsNotEmpty({ message: 'App name should not be empty' })
   @MaxLength(50, { message: 'Maximum length has been reached.' })
   name: string;


### PR DESCRIPTION
closes: https://github.com/ToolJet/tj-ee/issues/5201