### PR TITLE
Fix OpenAI image size type error

### DIFF
--- a/marketplace/plugins/openai/lib/query_operations.ts
+++ b/marketplace/plugins/openai/lib/query_operations.ts
@@ -16,11 +16,23 @@ const GPT_IMAGE_2_MODELS = new Set(['gpt-image-2', 'gpt-image-2-2026-04-21']);
 
 const GPT_IMAGE_2_SIZE_RE = /^\d+x\d+$/;
 
-const getSizeEnum = (model: string | undefined, size: string | undefined): string => {
+// All known literal sizes across every supported model and SDK version.
+// Using a local type keeps us compatible with openai@4.x, @6.25.x, and @6.39.x — each of
+// which defines ImageGenerateParams.size as a strict literal union (no string & {}).
+type ImageSize =
+  | 'auto'
+  | '1024x1024' | '1536x1024' | '1024x1536'
+  | '256x256'   | '512x512'
+  | '1792x1024' | '1024x1792';
+
+const getSizeEnum = (model: string | undefined, size: string | undefined): ImageSize => {
   // gpt-image-2: pass through any valid WIDTHxHEIGHT string or 'auto'; default 1024x1024
+  // `as ImageSize` is needed because gpt-image-2 accepts arbitrary WIDTHxHEIGHT strings
+  // that cannot be expressed as a subtype of a finite literal union. The regex validates
+  // the value before this point, so the assertion is safe at runtime.
   if (GPT_IMAGE_2_MODELS.has(model ?? '')) {
     const s = size?.trim() ?? '';
-    if (s === 'auto' || GPT_IMAGE_2_SIZE_RE.test(s)) return s;
+    if (s === 'auto' || GPT_IMAGE_2_SIZE_RE.test(s)) return s as ImageSize;
     return '1024x1024';
   }
 


### PR DESCRIPTION
## Problem

- PR #16592 added support for `gpt-image-2`, which requires handling arbitrary image sizes.
- `getSizeEnum` was updated to return `string` to support values like `1920x1080`.
- During Marketplace builds, some OpenAI SDK versions define `ImageGenerateParams.size` as a strict literal union, causing a TypeScript error:
  - `Type 'string' is not assignable to type ...`

## Changes

- Added a local `ImageSize` type in `query_operations.ts`.
- Updated `getSizeEnum` to return `ImageSize` instead of `string`.
- Added a scoped `as ImageSize` cast only for the `gpt-image-2` arbitrary-size path after regex validation.
- No functional or runtime behavior changes.

## Verification

- Reproduced the TypeScript build error with the previous implementation.
- Verified type checking passes with the updated `ImageSize` typing.
- Verified the Marketplace OpenAI plugin builds successfully.