### PR TITLE
✨ feat: add banned terms check workflow and script

### DIFF
--- a/.github/workflows/banned-terms.yml
+++ b/.github/workflows/banned-terms.yml
@@ -1,0 +1,52 @@
+name: Banned Terms
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'frontend/**'
+      - 'scripts/check-banned-terms.js'
+      - '.github/workflows/banned-terms.yml'
+
+jobs:
+  scan:
+    name: Scan changed files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 22.15.1
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.15.1
+
+      - name: Collect changed files
+        id: files
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" \
+            | grep -E '^frontend/.*\.(js|jsx|ts|tsx)$' || true)
+          {
+            echo 'files<<EOF'
+            echo "$CHANGED"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip if no relevant files
+        if: steps.files.outputs.files == ''
+        run: echo "No frontend source files changed. Skipping."
+
+      - name: Run banned-terms check
+        if: steps.files.outputs.files != ''
+        env:
+          TOOLJET_BANNED_TERMS: ${{ secrets.TOOLJET_BANNED_TERMS }}
+        run: |
+          if [ -z "$TOOLJET_BANNED_TERMS" ]; then
+            echo "TOOLJET_BANNED_TERMS secret not set on this run (likely a fork PR). Skipping."
+            exit 0
+          fi
+          echo "${{ steps.files.outputs.files }}" | xargs node scripts/check-banned-terms.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "lint-staged": {
     "./frontend/src/**/*.{js,jsx}": [
       "eslint --fix"
-    ]
+    ],
+    "./frontend/**/*.{js,jsx,ts,tsx}": "node scripts/check-banned-terms.js"
   },
   "devDependencies": {
     "@tooljet/cli": "^0.0.13",

--- a/scripts/check-banned-terms.js
+++ b/scripts/check-banned-terms.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const envPath = path.join(__dirname, '..', '.env');
+if (!process.env.TOOLJET_BANNED_TERMS && fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const match = line.match(/^\s*TOOLJET_BANNED_TERMS\s*=\s*(.*)\s*$/);
+    if (match) {
+      process.env.TOOLJET_BANNED_TERMS = match[1].trim().replace(/^["']|["']$/g, '');
+      break;
+    }
+  }
+}
+
+const RAW = process.env.TOOLJET_BANNED_TERMS || '';
+const TERMS = RAW.split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+if (TERMS.length === 0) {
+  process.exit(0);
+}
+
+const files = process.argv.slice(2).filter((file) => fs.existsSync(file));
+
+if (files.length === 0) {
+  process.exit(0);
+}
+
+const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const BANNED_TERM_REGEX = new RegExp(`(${TERMS.map(escape).join('|')})`, 'gi');
+
+const violations = [];
+
+for (const file of files) {
+  const normalizedPath = file.split(path.sep).join('/');
+
+  const content = fs.readFileSync(file, 'utf8');
+  const fileLines = content.split('\n');
+
+  fileLines.forEach((line, index) => {
+    const matches = line.match(BANNED_TERM_REGEX);
+    if (matches) {
+      const unique = [...new Set(matches.map((m) => m.toLowerCase()))];
+      violations.push({
+        file: normalizedPath,
+        line: index + 1,
+        terms: unique,
+        text: line.trim(),
+      });
+    }
+  });
+}
+
+if (violations.length === 0) {
+  process.exit(0);
+}
+
+const report = violations.map((v) => `  ${v.file}:${v.line}  →  [${v.terms.join(', ')}]\n    ${v.text}`).join('\n');
+console.error(`\nDisallowed term references are not permitted in frontend source.\n${report}\n`);
+
+process.exit(1);


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow to scan for banned terms in frontend source files during pull requests.
- Added a script to check for disallowed terms in JavaScript and TypeScript files, ensuring compliance with content guidelines.
- Updated package.json to include the new script in lint-staged configuration.