### PR TITLE
fix: change cursor to pointer on visibility toggle button in workspace constants

### DIFF
--- a/frontend/src/modules/WorkspaceSettings/components/ManageOrgConstantsSettings/ConstantTable.jsx
+++ b/frontend/src/modules/WorkspaceSettings/components/ManageOrgConstantsSettings/ConstantTable.jsx
@@ -144,6 +144,7 @@ const ConstantTable = ({
                             <div
                               onClick={() => toggleShowValue(constant.id)}
                               data-cy={`${constant.name.toLowerCase().replace(/\s+/g, '-')}-constant-visibility`}
+                              style={{ cursor: 'pointer' }}
                             >
                               {!showValues[constant.id] ? (
                                 <EyeHide


### PR DESCRIPTION
## Description
This PR fixes the cursor style for the visibility toggle button (eye icon) in the workspace constants list. Previously, the cursor remained as the default arrow when hovering over the clickable eye icon, making it unclear that it was interactive.

### Changes
- Added `cursor: pointer` style to the visibility toggle button div in `ConstantTable.jsx`

### Related Issue
Fixes #16717

### Screenshots
Before: Cursor stays as default arrow on hover
After: Cursor changes to pointer on hover, indicating the element is clickable