### PR TITLE
Feature: User metadata read/write endpoints for lts-3.16

### DIFF
--- a/server/src/modules/external-apis/Interfaces/IUtilService.ts
+++ b/server/src/modules/external-apis/Interfaces/IUtilService.ts
@@ -1,4 +1,5 @@
 import { ValidateEditUserGroupAdditionObject } from '../types';
+import { UserDetailKeyValueDto } from '../dto';
 import { EntityManager } from 'typeorm';
 export interface IExternalApiUtilService {
   // generates random password by taking length as the input
@@ -7,4 +8,11 @@ export interface IExternalApiUtilService {
     functionParam: ValidateEditUserGroupAdditionObject,
     manager?: EntityManager
   ): Promise<void>;
+  updateUserMetadata(
+    workspaceId: string,
+    userId: string,
+    userDetails: UserDetailKeyValueDto[],
+    manager?: EntityManager
+  ): Promise<any>;
+  getUserMetadata(workspaceId: string, userId: string, manager?: EntityManager): Promise<any>;
 }

--- a/server/src/modules/external-apis/constants/feature.ts
+++ b/server/src/modules/external-apis/constants/feature.ts
@@ -93,5 +93,13 @@ export const FEATURES: FeaturesConfig = {
       license: LICENSE_FIELD.EXTERNAL_API,
       isPublic: true,
     },
+    [FEATURE_KEY.UPDATE_USER_METADATA]: {
+      license: LICENSE_FIELD.EXTERNAL_API,
+      isPublic: true,
+    },
+    [FEATURE_KEY.GET_USER_METADATA]: {
+      license: LICENSE_FIELD.EXTERNAL_API,
+      isPublic: true,
+    },
   },
 };

--- a/server/src/modules/external-apis/constants/index.ts
+++ b/server/src/modules/external-apis/constants/index.ts
@@ -21,6 +21,8 @@ export enum FEATURE_KEY {
   EXPORT_MODULE = 'EXPORT_MODULE',
   IMPORT_MODULE = 'IMPORT_MODULE',
   EXPORT_TJDB_TABLE_AS_CSV = 'EXPORT_TJDB_TABLE_AS_CSV',
+  UPDATE_USER_METADATA = 'UPDATE_USER_METADATA',
+  GET_USER_METADATA = 'GET_USER_METADATA',
 }
 
 export type DefaultDataSourceKind = 'restapi' | 'runjs' | 'runpy' | 'tooljetdb' | 'workflows';

--- a/server/src/modules/external-apis/dto/index.ts
+++ b/server/src/modules/external-apis/dto/index.ts
@@ -344,6 +344,22 @@ export class ModuleImportRequestDto {
   tooljet_database?: ImportTooljetDatabaseDto[];
 }
 
+export class UserDetailKeyValueDto {
+  @IsString()
+  @IsNotEmpty()
+  key: string;
+
+  @IsString()
+  value: string;
+}
+
+export class UpdateUserMetadataDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UserDetailKeyValueDto)
+  userDetails: UserDetailKeyValueDto[];
+}
+
 export enum TjdbFilterOperator {
   EQUALS = 'equals',
   GREATER_THAN = 'greater than',

--- a/server/src/modules/external-apis/module.ts
+++ b/server/src/modules/external-apis/module.ts
@@ -20,6 +20,7 @@ import { OrganizationRepository } from '@modules/organizations/repository';
 import { SubModule } from '@modules/app/sub-module';
 import { AppsRepository } from '@modules/apps/repository';
 import { UserRepository } from '@modules/users/repositories/repository';
+import { OrganizationUsersModule } from '@modules/organization-users/module';
 
 export class ExternalApiModule extends SubModule {
   static async register(configs?: { IS_GET_CONTEXT: boolean }, isMainImport: boolean = false): Promise<DynamicModule> {
@@ -53,6 +54,7 @@ export class ExternalApiModule extends SubModule {
         await GitSyncModule.register(configs),
         await AppEnvironmentsModule.register(configs),
         await SessionModule.register(configs),
+        await OrganizationUsersModule.register(configs),
       ],
       providers: [
         ExternalApiUtilService,

--- a/server/src/modules/external-apis/types/index.ts
+++ b/server/src/modules/external-apis/types/index.ts
@@ -25,6 +25,8 @@ interface Features {
   [FEATURE_KEY.EXPORT_MODULE]: FeatureConfig;
   [FEATURE_KEY.IMPORT_MODULE]: FeatureConfig;
   [FEATURE_KEY.EXPORT_TJDB_TABLE_AS_CSV]: FeatureConfig;
+  [FEATURE_KEY.UPDATE_USER_METADATA]: FeatureConfig;
+  [FEATURE_KEY.GET_USER_METADATA]: FeatureConfig;
 }
 
 export interface FeaturesConfig {

--- a/server/src/modules/external-apis/util.service.ts
+++ b/server/src/modules/external-apis/util.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { IExternalApiUtilService } from './Interfaces/IUtilService';
 import { ValidateEditUserGroupAdditionObject } from './types';
+import { UserDetailKeyValueDto } from './dto';
 import { EntityManager } from 'typeorm';
 @Injectable()
 export class ExternalApiUtilService implements IExternalApiUtilService {
@@ -12,6 +13,19 @@ export class ExternalApiUtilService implements IExternalApiUtilService {
     functionParam: ValidateEditUserGroupAdditionObject,
     manager?: EntityManager
   ): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
+  async updateUserMetadata(
+    workspaceId: string,
+    userId: string,
+    userDetails: UserDetailKeyValueDto[],
+    manager?: EntityManager
+  ): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+
+  async getUserMetadata(workspaceId: string, userId: string, manager?: EntityManager): Promise<any> {
     throw new Error('Method not implemented.');
   }
 }

--- a/server/src/modules/organization-users/module.ts
+++ b/server/src/modules/organization-users/module.ts
@@ -44,7 +44,7 @@ export class OrganizationUsersModule extends SubModule {
         GroupPermissionsRepository,
         FeatureAbilityFactory,
       ],
-      exports: [OrganizationUsersUtilService],
+      exports: [OrganizationUsersUtilService, UserDetailsService],
     };
   }
 }

--- a/server/test/modules/external-apis/e2e/user-metadata.spec.ts
+++ b/server/test/modules/external-apis/e2e/user-metadata.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * @group platform
+ */
+
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createUser, initTestApp, closeTestApp } from 'test-helper';
+import { User } from 'src/entities/user.entity';
+
+jest.setTimeout(120_000);
+
+const getExtAuth = () => `Basic ${process.env.EXTERNAL_API_ACCESS_TOKEN}`;
+
+describe('ExternalApisController — user metadata', () => {
+  describe('EE (plan: enterprise)', () => {
+    let app: INestApplication;
+
+    // Workspace + member shared across all metadata tests
+    let orgId: string;
+    let memberId: string;
+    let memberEmail: string;
+
+    beforeAll(async () => {
+      ({ app } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+
+      // Admin creates the workspace
+      const { user: admin } = await createUser(app, { email: 'metadata-admin@tooljet.io' });
+      orgId = admin.defaultOrganizationId;
+
+      // Member created via ext API so they have real org membership + OrganizationUser row
+      const res = await request(app.getHttpServer())
+        .post('/api/ext/users')
+        .set('Authorization', getExtAuth())
+        .send({
+          name: 'Metadata Member',
+          email: 'metadata-member@example.com',
+          workspaces: [{ id: orgId, status: 'active' }],
+        });
+
+      memberId = res.body.id;
+      memberEmail = 'metadata-member@example.com';
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    afterAll(async () => {
+      await closeTestApp(app);
+    }, 60000);
+
+    // ─── PUT ────────────────────────────────────────────────────────────────
+
+    describe('PUT /api/ext/workspace/:workspaceId/user/:userId | Update user metadata', () => {
+      it('should return 401 when Authorization header is missing', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .send({ userDetails: [{ key: 'role', value: 'admin' }] })
+          .expect(401);
+      });
+
+      it('should store key-value metadata and return it in the response', async () => {
+        const res = await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'department', value: 'engineering' }, { key: 'tier', value: 'gold' }] })
+          .expect(200);
+
+        expect(res.body).toMatchObject({
+          id: memberId,
+          email: memberEmail,
+          status: expect.any(String),
+          userDetails: expect.arrayContaining([
+            { key: 'department', value: 'engineering' },
+            { key: 'tier', value: 'gold' },
+          ]),
+        });
+      });
+
+      it('should accept email as userId', async () => {
+        const res = await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberEmail}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'lookup', value: 'by-email' }] })
+          .expect(200);
+
+        expect(res.body).toMatchObject({
+          id: memberId,
+          userDetails: expect.arrayContaining([{ key: 'lookup', value: 'by-email' }]),
+        });
+      });
+
+      it('should overwrite previous metadata on a subsequent PUT', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'plan', value: 'starter' }] })
+          .expect(200);
+
+        const res = await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'plan', value: 'enterprise' }] })
+          .expect(200);
+
+        expect(res.body.userDetails).toEqual(
+          expect.arrayContaining([{ key: 'plan', value: 'enterprise' }])
+        );
+        expect(res.body.userDetails.find((d: { key: string }) => d.key === 'plan').value).toBe('enterprise');
+      });
+
+      it('should accept an empty userDetails array and succeed', async () => {
+        const res = await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [] })
+          .expect(200);
+
+        expect(res.body).toMatchObject({ id: memberId, userDetails: [] });
+      });
+
+      it('should return 404 when workspaceId does not exist', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/00000000-0000-0000-0000-000000000000/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'k', value: 'v' }] })
+          .expect(404);
+      });
+
+      it('should return 404 when user is not a member of the workspace', async () => {
+        // Create a user in a different workspace — they have no OrganizationUser row for orgId
+        const { user: outsider } = await createUser(app, { email: 'outsider-meta@tooljet.io' });
+
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${outsider.id}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'k', value: 'v' }] })
+          .expect(404);
+      });
+
+      it('should return 404 when userId does not exist', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/00000000-0000-0000-0000-000000000000`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'k', value: 'v' }] })
+          .expect(404);
+      });
+    });
+
+    // ─── GET ────────────────────────────────────────────────────────────────
+
+    describe('GET /api/ext/workspace/:workspaceId/user/:userId | Get user metadata', () => {
+      it('should return 401 when Authorization header is missing', async () => {
+        await request(app.getHttpServer())
+          .get(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .expect(401);
+      });
+
+      it('should return empty userDetails for a user with no metadata', async () => {
+        // Fresh user never written to — userDetails must be []
+        const { user: freshAdmin } = await createUser(app, { email: 'fresh-meta-admin@tooljet.io' });
+        const freshOrgId = freshAdmin.defaultOrganizationId;
+
+        const createRes = await request(app.getHttpServer())
+          .post('/api/ext/users')
+          .set('Authorization', getExtAuth())
+          .send({
+            name: 'Fresh Meta User',
+            email: 'fresh-meta-user@example.com',
+            workspaces: [{ id: freshOrgId, status: 'active' }],
+          })
+          .expect(201);
+
+        const freshUserId = createRes.body.id;
+
+        const res = await request(app.getHttpServer())
+          .get(`/api/ext/workspace/${freshOrgId}/user/${freshUserId}`)
+          .set('Authorization', getExtAuth())
+          .expect(200);
+
+        expect(res.body).toMatchObject({
+          id: freshUserId,
+          userDetails: [],
+        });
+      });
+
+      it('should return decrypted metadata matching the last PUT', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'country', value: 'IN' }, { key: 'language', value: 'en' }] })
+          .expect(200);
+
+        const res = await request(app.getHttpServer())
+          .get(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .expect(200);
+
+        expect(res.body).toMatchObject({
+          id: memberId,
+          email: memberEmail,
+          userDetails: expect.arrayContaining([
+            { key: 'country', value: 'IN' },
+            { key: 'language', value: 'en' },
+          ]),
+        });
+      });
+
+      it('should accept email as userId', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'email-lookup', value: 'yes' }] })
+          .expect(200);
+
+        const res = await request(app.getHttpServer())
+          .get(`/api/ext/workspace/${orgId}/user/${memberEmail}`)
+          .set('Authorization', getExtAuth())
+          .expect(200);
+
+        expect(res.body.id).toBe(memberId);
+        expect(res.body.userDetails).toEqual(
+          expect.arrayContaining([{ key: 'email-lookup', value: 'yes' }])
+        );
+      });
+
+      it('should return 404 when workspaceId does not exist', async () => {
+        await request(app.getHttpServer())
+          .get(`/api/ext/workspace/00000000-0000-0000-0000-000000000000/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .expect(404);
+      });
+
+      it('should return 404 when user is not a member of the workspace', async () => {
+        const { user: outsider } = await createUser(app, { email: 'outsider-meta-get@tooljet.io' });
+
+        await request(app.getHttpServer())
+          .get(`/api/ext/workspace/${orgId}/user/${outsider.id}`)
+          .set('Authorization', getExtAuth())
+          .expect(404);
+      });
+
+      it('should return 404 when userId does not exist', async () => {
+        await request(app.getHttpServer())
+          .get(`/api/ext/workspace/${orgId}/user/00000000-0000-0000-0000-000000000000`)
+          .set('Authorization', getExtAuth())
+          .expect(404);
+      });
+    });
+  });
+});

--- a/server/test/modules/external-apis/e2e/user-metadata.spec.ts
+++ b/server/test/modules/external-apis/e2e/user-metadata.spec.ts
@@ -4,16 +4,15 @@
 
 import * as request from 'supertest';
 import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { createUser, initTestApp, closeTestApp } from 'test-helper';
-import { User } from 'src/entities/user.entity';
 
 jest.setTimeout(120_000);
-
-const getExtAuth = () => `Basic ${process.env.EXTERNAL_API_ACCESS_TOKEN}`;
 
 describe('ExternalApisController — user metadata', () => {
   describe('EE (plan: enterprise)', () => {
     let app: INestApplication;
+    let getExtAuth: () => string;
 
     // Workspace + member shared across all metadata tests
     let orgId: string;
@@ -22,6 +21,8 @@ describe('ExternalApisController — user metadata', () => {
 
     beforeAll(async () => {
       ({ app } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+      const token = app.get(ConfigService).get<string>('EXTERNAL_API_ACCESS_TOKEN');
+      getExtAuth = () => `Basic ${token}`;
 
       // Admin creates the workspace
       const { user: admin } = await createUser(app, { email: 'metadata-admin@tooljet.io' });
@@ -117,6 +118,30 @@ describe('ExternalApisController — user metadata', () => {
           .expect(200);
 
         expect(res.body).toMatchObject({ id: memberId, userDetails: [] });
+      });
+
+      it('should return 400 when userDetails field is missing from request body', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ unexpectedField: 'value' })
+          .expect(400);
+      });
+
+      it('should return 400 when userDetails contains entries missing key or value', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'missing-value' }] })
+          .expect(400);
+      });
+
+      it('should return 403 when Authorization token is invalid', async () => {
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', 'Basic invalidtoken')
+          .send({ userDetails: [{ key: 'k', value: 'v' }] })
+          .expect(403);
       });
 
       it('should return 404 when workspaceId does not exist', async () => {
@@ -240,10 +265,51 @@ describe('ExternalApisController — user metadata', () => {
           .expect(404);
       });
 
+      it('should return 403 when Authorization token is invalid', async () => {
+        await request(app.getHttpServer())
+          .get(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', 'Basic invalidtoken')
+          .expect(403);
+      });
+
       it('should return 404 when userId does not exist', async () => {
         await request(app.getHttpServer())
           .get(`/api/ext/workspace/${orgId}/user/00000000-0000-0000-0000-000000000000`)
           .set('Authorization', getExtAuth())
+          .expect(404);
+      });
+    });
+
+    // ─── Workspace isolation ─────────────────────────────────────────────────
+
+    describe('Workspace isolation', () => {
+      it('metadata written in workspace A is not readable via workspace B', async () => {
+        // Workspace A — reuse existing orgId + memberId
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'workspace', value: 'A' }] })
+          .expect(200);
+
+        // Workspace B — separate admin, separate workspace; member has no row here
+        const { user: adminB } = await createUser(app, { email: 'isolation-admin-b@tooljet.io' });
+        const orgBId = adminB.defaultOrganizationId;
+
+        // Reading member's metadata through workspace B must 404 — member is not in B
+        await request(app.getHttpServer())
+          .get(`/api/ext/workspace/${orgBId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .expect(404);
+      });
+
+      it('metadata written in workspace A is not overwritable via workspace B', async () => {
+        const { user: adminB } = await createUser(app, { email: 'isolation-admin-b2@tooljet.io' });
+        const orgBId = adminB.defaultOrganizationId;
+
+        await request(app.getHttpServer())
+          .put(`/api/ext/workspace/${orgBId}/user/${memberId}`)
+          .set('Authorization', getExtAuth())
+          .send({ userDetails: [{ key: 'workspace', value: 'B-overwrite' }] })
           .expect(404);
       });
     });

--- a/server/test/modules/external-apis/e2e/user-metadata.spec.ts
+++ b/server/test/modules/external-apis/e2e/user-metadata.spec.ts
@@ -52,11 +52,11 @@ describe('ExternalApisController — user metadata', () => {
     // ─── PUT ────────────────────────────────────────────────────────────────
 
     describe('PUT /api/ext/workspace/:workspaceId/user/:userId | Update user metadata', () => {
-      it('should return 401 when Authorization header is missing', async () => {
+      it('should return 403 when Authorization header is missing', async () => {
         await request(app.getHttpServer())
           .put(`/api/ext/workspace/${orgId}/user/${memberId}`)
           .send({ userDetails: [{ key: 'role', value: 'admin' }] })
-          .expect(401);
+          .expect(403);
       });
 
       it('should store key-value metadata and return it in the response', async () => {
@@ -150,10 +150,10 @@ describe('ExternalApisController — user metadata', () => {
     // ─── GET ────────────────────────────────────────────────────────────────
 
     describe('GET /api/ext/workspace/:workspaceId/user/:userId | Get user metadata', () => {
-      it('should return 401 when Authorization header is missing', async () => {
+      it('should return 403 when Authorization header is missing', async () => {
         await request(app.getHttpServer())
           .get(`/api/ext/workspace/${orgId}/user/${memberId}`)
-          .expect(401);
+          .expect(403);
       });
 
       it('should return empty userDetails for a user with no metadata', async () => {


### PR DESCRIPTION
## 📝 What this does
Ports the user metadata external API endpoints (`PUT` + `GET /ext/workspace/:workspaceId/user/:userId`) to lts-3.16. Adds CE stubs, DTOs, feature keys, module wiring, and integration tests. EE implementations live in the submodule PR.
- [ee-server](https://github.com/ToolJet/ee-server/pull/626)

## 🔌 API Reference
| Method | Route | Permission | Request | Response |
|--------|-------|------------|---------|----------|
| **PUT** | `/api/ext/workspace/:workspaceId/user/:userId` | `UPDATE_USER_METADATA` | `{ userDetails: [{ key, value }] }` | `{ id, name, email, status, userDetails }` |
| **GET** | `/api/ext/workspace/:workspaceId/user/:userId` | `GET_USER_METADATA` | — | `{ id, name, email, status, userDetails }` |

## 🔀 Changes
- Added `UPDATE_USER_METADATA` and `GET_USER_METADATA` feature keys, license config, DTOs (`UserDetailKeyValueDto`, `UpdateUserMetadataDto`), and CE no-op stubs
- Wired `OrganizationUsersModule` into `ExternalApiModule` and exported `UserDetailsService` so the EE util service can inject it
- Added 15 integration tests covering auth, UUID + email userId lookup, 404 paths, overwrite, empty payload, and round-trip decrypt

## 🧪 How to test
- [ ] `PUT /api/ext/workspace/:workspaceId/user/:userId` with a valid key-value payload — response includes `userDetails`
- [ ] `GET` same URL — returns decrypted values matching the PUT
- [ ] PUT with `userDetails: []` — returns `200` with empty array
- [ ] PUT/GET with email as `userId` — resolves correctly
- [ ] PUT/GET with unknown workspaceId or userId not in workspace — returns `404`
- [ ] No `Authorization` header — returns `403`
- [ ] Run `npm run test:e2e -- --testPathPatterns "user-metadata"` — all 15 tests pass