### PR TITLE
feat(i18n): add Japanese (ja) translation

### DIFF
--- a/frontend/assets/translations/ja.json
+++ b/frontend/assets/translations/ja.json
@@ -1,0 +1,1068 @@
+{
+    "globals": {
+        "readDocumentation": "ドキュメントを読む",
+        "cancel": "キャンセル",
+        "save": "保存",
+        "savechanges": "変更を保存",
+        "execute": "実行",
+        "Build": "ビルド",
+        "back": "戻る",
+        "edit": "編集",
+        "search": "検索",
+        "update": "更新",
+        "delete": "削除",
+        "remove": "削除",
+        "add": "追加",
+        "view": "表示",
+        "create": "作成",
+        "enabled": "有効",
+        "disabled": "無効",
+        "yes": "はい",
+        "submit": "送信",
+        "select": "選択",
+        "environmentVar": "ワークスペース定数／変数",
+        "saving": "保存中...",
+        "saveDatasource": "データソースを保存",
+        "authorize": "認証",
+        "connect": "接続",
+        "reconnect": "再接続",
+        "components": "コンポーネント",
+        "send": "送信",
+        "noConnection": "接続できませんでした",
+        "connectionVerified": "接続を確認しました",
+        "left": "左",
+        "center": "中央",
+        "right": "右",
+        "justified": "両端揃え",
+        "host": "ホスト",
+        "operation": "操作",
+        "header": "ヘッダー",
+        "path": "パス",
+        "query": "クエリ",
+        "requestBody": "リクエストボディ",
+        "page": "ページ",
+        "searchItem": "このワークスペース内のアプリを検索",
+        "workflowsSearchItem": "このワークスペース内のワークフローを検索",
+        "searchComponents": "コンポーネントを検索",
+        "promote": "昇格",
+        "release": "リリース"
+    },
+    "errorBoundary": "問題が発生しました。",
+    "viewer": "申し訳ありません。このアプリは現在メンテナンス中です",
+    "app": {
+        "updateAvailable": "アップデートがあります",
+        "newVersionReleased": "ToolJet の新しいバージョンがリリースされました。",
+        "readReleaseNotes": "リリースノートを読んで更新",
+        "skipVersion": "このバージョンをスキップ"
+    },
+    "stripe": "Stripe の OpenAPI 仕様を読み込んでいます。しばらくお待ちください。",
+    "openApi": {
+        "noValidOpenApi": "有効な OpenAPI 仕様が利用できません。",
+        "selectHost": "ホストを選択",
+        "selectOperation": "操作を選択"
+    },
+    "slack": {
+        "authorize": "認証",
+        "connectToolJetToSlack": "{{whiteLabelText}} は Slack に接続して、ユーザーの一覧取得やメッセージ送信などを行えます。適切な権限スコープを選択してください。",
+        "chatWrite": "chat:write",
+        "listUsersAndSendMessage": "{{whiteLabelText}} アプリは、ユーザーの一覧取得や、ユーザー・チャンネルへのメッセージ送信ができるようになります。",
+        "connectSlack": "Slack に接続"
+    },
+    "googleSheets": {
+        "readOnly": "読み取り専用",
+        "enableReadAndWrite": "{{whiteLabelText}} アプリで Google スプレッドシートを編集したい場合は、読み取りと書き込みのアクセス権を選択してください",
+        "readDataFromSheets": "{{whiteLabelText}} アプリは Google スプレッドシートからデータを読み取ることのみ可能です",
+        "readWrite": "読み取りと書き込み",
+        "readModifySheets": "{{whiteLabelText}} アプリはシートからのデータ読み取り、シートの編集などが可能です。",
+        "toGoogleSheets": "Google スプレッドシートへ"
+    },
+    "zendesk": {
+        "enableReadAndWrite": "{{whiteLabelText}} アプリで Zendesk のリソースを編集したい場合は、読み取りと書き込みのアクセス権を選択してください",
+        "readDataFromResources": "{{whiteLabelText}} アプリはリソースからデータを読み取ることのみ可能です",
+        "readModifySheets": "{{whiteLabelText}} アプリはリソースからのデータ読み取り、リソースの編集などが可能です。"
+    },
+    "profile": {
+        "profileSettings": "プロフィール設定"
+    },
+    "verificationSuccessPage": {
+        "workEmail": "メールアドレス",
+        "enterFullName": "氏名を入力してください",
+        "enterNewPassword": "新しいパスワードを入力してください",
+        "name": "名前",
+        "password": "パスワード",
+        "acceptInvite": "招待を承諾",
+        "successfullyVerifiedEmail": "メールアドレスの確認が完了しました",
+        "setupTooljet": "{{whiteLabelText}} をセットアップ"
+    },
+    "loginSignupPage": {
+        "forgotPassword": "パスワードをお忘れですか",
+        "emailAddress": "メールアドレス",
+        "enterEmail": "メールアドレスを入力",
+        "dontHaveAccount": "アカウントをお持ちではありませんか？",
+        "enterBusinessEmail": "ビジネス用メールアドレスを入力してください",
+        "alreadyHaveAnAccount": "すでにアカウントをお持ちですか？",
+        "resetPassword": "パスワードをリセット",
+        "signIn": "サインイン",
+        "signUp": "サインアップ",
+        "createToolJetAccount": "アカウントを作成",
+        "password": "パスワード",
+        "showPassword": "パスワードを表示",
+        "loginTo": "ログイン",
+        "yourAccount": "アカウント",
+        "noLoginMethodsEnabled": "このワークスペースでは有効なログイン方法がありません",
+        "emailConfirmLink": "確認用リンクを記載したメールをご確認ください",
+        "newPassword": "新しいパスワード",
+        "passwordConfirmation": "パスワードの確認",
+        "newToTooljet": "{{whiteLabelText}} は初めてですか？",
+        "newToWorkspace": "このワークスペースは初めてですか？",
+        "enterWorkEmail": "勤務先のメールアドレスを入力してください",
+        "enterPassword": "パスワードを入力",
+        "forgot": "お忘れですか？",
+        "workEmail": "メールアドレス",
+        "joinTooljet": "{{whiteLabelText}} に参加",
+        "getStartedForFree": "無料で始める",
+        "passwordCharacter": "パスワードは 5 文字以上で入力してください",
+        "enterFullName": "氏名を入力してください",
+        "enterNewPassword": "新しいパスワードを入力してください"
+    },
+    "editor": {
+        "preview": "プレビュー",
+        "share": "共有",
+        "shareModal": {
+            "makeApplicationPublic": "アプリケーションを公開する",
+            "shareableLink": "共有可能なアプリリンク",
+            "copy": "コピー",
+            "embeddableLink": "埋め込み用アプリリンク",
+            "manageUsers": "ユーザー"
+        },
+        "appVersionManager": {
+            "version": "バージョン",
+            "currentlyReleased": "現在リリース中",
+            "createVersion": "バージョンを作成",
+            "saveVersion": "バージョンを保存",
+            "createDraftVersion": "下書きバージョンを作成",
+            "versionName": "バージョン名",
+            "versionDescription": "バージョンの説明",
+            "createVersionFrom": "元にするバージョン",
+            "save": "保存",
+            "create": "バージョンを作成",
+            "editVersion": "バージョンを編集",
+            "deleteVersion": "このバージョン（{{version}}）を本当に削除しますか？",
+            "enterVersionName": "バージョン名を入力してください",
+            "enterVersionDescription": "バージョンの説明を入力してください",
+            "versionNameHelper": "バージョン名は一意かつ 25 文字以内である必要があります",
+            "versionDescriptionHelper": "説明は 500 文字以内で入力してください",
+            "versionAlreadyReleased": "すでにリリース済みのバージョンは変更できません。\n 変更したい場合は、新しいバージョンを作成するか、別のバージョンに切り替えてください。"
+        },
+        "queries": "クエリ",
+        "inspectComponent": "検査するコンポーネントを選択してください",
+        "release": "リリース",
+        "searchQueries": "クエリを検索",
+        "createQuery": "クエリを作成",
+        "queryManager": {
+            "general": "一般",
+            "advanced": "詳細",
+            "preview": "プレビュー",
+            "Save": "保存",
+            "selectDatasource": "データソースを選択",
+            "addDatasource": "データソースを追加",
+            "dataSourceManager": {
+                "toast": {
+                    "success": {
+                        "dataSourceAdded": "データソースを追加しました",
+                        "dataSourceSaved": "データソースを保存しました"
+                    },
+                    "error": {
+                        "noEmptyDsName": "データソース名は空にできません"
+                    }
+                },
+                "suggestDataSource": "データソースを提案",
+                "suggestAnIntegration": "連携を提案",
+                "whatLookingFor": "お探しのものを教えてください",
+                "noResultFound": "お探しのものが見つかりませんか？",
+                "suggest": "提案",
+                "addNewDataSource": "新しいデータソースを追加",
+                "whiteListIP": "データソースが外部から直接アクセスできない場合は、当社の IP アドレスを許可リストに追加してください",
+                "copied": "コピーしました",
+                "copy": "コピー",
+                "saving": "保存中",
+                "noResultsFor": "次の検索結果はありません",
+                "noteTaken": "ありがとうございます。確かに承りました！",
+                "goToAllDatasources": "すべてのデータソースへ",
+                "send": "送信"
+            },
+            "runQueryOnApplicationLoad": "アプリケーション読み込み時にこのクエリを実行する",
+            "confirmBeforeQueryRun": "クエリ実行前に確認する",
+            "notificationOnSuccess": "成功時に通知を表示する",
+            "successMessage": "成功メッセージ",
+            "queryRanSuccessfully": "クエリが正常に実行されました",
+            "notificationDuration": "通知の表示時間（秒）",
+            "events": "イベント",
+            "transformation": {
+                "transformationToolTip": "変換（Transformation）を有効にすると、クエリの結果を変換できます。ToolJet では JavaScript と Python の 2 つのプログラミング言語でクエリ結果を変換できます",
+                "transformations": "変換"
+            }
+        },
+        "inspector": {
+            "eventManager": {
+                "event": "イベント",
+                "action": "アクション",
+                "debounce": "デバウンス",
+                "actionOptions": "アクションオプション",
+                "message": "メッセージ",
+                "alertType": "アラートの種類",
+                "url": "URL",
+                "modal": "モーダル",
+                "text": "テキスト",
+                "query": "クエリ",
+                "key": "キー",
+                "value": "値",
+                "type": "種類",
+                "fileName": "ファイル名",
+                "data": "データ",
+                "table": "テーブル",
+                "pageIndex": "ページインデックス",
+                "component": "コンポーネント",
+                "addHandler": "新しいイベントハンドラー",
+                "addNewEvent": "新しいイベントを追加",
+                "addEventHandler": "+ イベントハンドラーを追加",
+                "emptyMessage": "この {{componentName}} にはイベントハンドラーがありません",
+                "page": "ページ",
+                "addKeyValueParam": "{{parameter}} を追加"
+            }
+        }
+    },
+    "header": {
+        "darkModeToggle": {
+            "activateLightMode": "ライトモードに切り替え",
+            "activateDarkMode": "ダークモードに切り替え"
+        },
+        "languageSelection": {
+            "changeLanguage": "言語を変更",
+            "searchLanguage": "言語を検索"
+        },
+        "notificationCenter": {
+            "notifications": "通知",
+            "markAllAs": "すべてを",
+            "read": "既読にする",
+            "un": "未",
+            "youDontHaveany": "ありません",
+            "youAreCaughtUp": "すべて確認済みです！",
+            "view": "表示"
+        },
+        "organization": {
+            "addNewWorkSpace": "新しいワークスペースを追加",
+            "loadOrganizations": "組織を読み込む",
+            "createWorkspace": "ワークスペースを作成",
+            "workspaceName": "ワークスペース名",
+            "editWorkspace": "ワークスペースを編集",
+            "menus": {
+                "addWorkspace": "ワークスペースを追加",
+                "instanceLogout": {
+                    "title": "インスタンスからログアウト",
+                    "customLogoutUrl": {
+                        "label": "カスタムログアウト URL",
+                        "helperText": "このインスタンスからログアウトするユーザー向けに、専用のログアウト URL を設定します。"
+                    }
+                },
+                "menusList": {
+                    "manageUsers": "ユーザー",
+                    "manageGroups": "グループ",
+                    "manageSso": "SSO",
+                    "manageEnv": "ワークスペース変数"
+                },
+                "manageUsers": {
+                    "usersAndPermission": "ユーザーと権限",
+                    "inviteNewUser": "1 人のユーザーを招待",
+                    "inviteUsers": "ユーザーを招待",
+                    "name": "名前",
+                    "email": "メールアドレス",
+                    "status": "ステータス",
+                    "archive": "アーカイブ",
+                    "unarchive": "アーカイブ解除",
+                    "addNewUser": "ユーザーを追加",
+                    "emailAddress": "メールアドレス",
+                    "createUser": "ユーザーを作成",
+                    "enterFirstName": "名を入力してください",
+                    "enterLastName": "姓を入力してください",
+                    "enterEmail": "メールアドレスを入力してください",
+                    "enterFullName": "氏名を入力してください",
+                    "inviteNewUsers": "新しいユーザーを招待"
+                },
+                "manageGroups": {
+                    "permissions": {
+                        "userGroups": "ユーザーグループ",
+                        "createNewGroup": "新しいグループを作成",
+                        "updateGroup": "グループを更新",
+                        "addNewGroup": "新しいグループを追加",
+                        "enterName": "グループ名を入力してください",
+                        "createGroup": "グループを作成",
+                        "name": "名前"
+                    },
+                    "permissionResources": {
+                        "userGroup": "ユーザーグループ",
+                        "apps": "アプリ",
+                        "workflows": "ワークフロー",
+                        "users": "ユーザー",
+                        "permissions": "権限",
+                        "addAppsToGroup": "グループに追加するアプリを選択",
+                        "addWorkflowsToGroup": "グループに追加するワークフローを選択",
+                        "name": "名前",
+                        "addUsersToGroup": "グループに追加するユーザーを選択",
+                        "email": "メールアドレス",
+                        "resource": "リソース",
+                        "createUpdateDelete": "作成／更新／削除",
+                        "folder": "フォルダ",
+                        "dataSource": "データソース"
+                    },
+                    "groupOptions": {
+                        "deleteGroup": "グループを削除",
+                        "duplicateGroup": "グループを複製"
+                    }
+                },
+                "manageSSO": {
+                    "manageSso": "SSO",
+                    "generalSettings": {
+                        "title": "一般設定",
+                        "enableSignup": "サインアップを有効にする",
+                        "newAccountWillBeCreated": "ユーザーが初めて SSO でサインインする際に、新しいアカウントが作成されます",
+                        "allowedDomains": "許可するドメイン",
+                        "enterDomains": "ドメインを入力してください",
+                        "supportMultiDomains": "複数のドメインに対応しています。ドメイン名をカンマで区切って入力してください。例: tooljet.com,tooljet.io,yourorganization.com",
+                        "loginUrl": "ログイン URL",
+                        "workspaceLogin": "この URL を使うと、このワークスペースに直接ログインできます",
+                        "allowDefaultSso": "デフォルト SSO を許可する",
+                        "ssoAuth": "デフォルト SSO によるユーザー認証を許可します。デフォルト SSO の設定は、\n ワークスペース単位の SSO で上書きできます。",
+                        "customLogoutUrl": "カスタムログアウト URL"
+                    },
+                    "google": {
+                        "title": "Google",
+                        "enabled": "有効",
+                        "disabled": "無効",
+                        "clientId": "クライアント ID",
+                        "enterClientId": "クライアント ID を入力してください",
+                        "redirectUrl": "リダイレクト URL"
+                    },
+                    "github": {
+                        "title": "GitHub",
+                        "hostName": "ホスト名",
+                        "enterHostName": "ホスト名を入力してください",
+                        "requiredGithub": "GitHub をセルフホストしている場合は必須です",
+                        "clientId": "クライアント ID",
+                        "enterClientId": "クライアント ID を入力してください",
+                        "clientSecret": "クライアントシークレット",
+                        "enterClientSecret": "クライアントシークレットを入力してください",
+                        "encrypted": "暗号化済み",
+                        "redirectUrl": "リダイレクト URL"
+                    },
+                    "passwordLogin": "パスワードログイン",
+                    "environmentVar": {
+                        "noEnvConfig": "ワークスペース変数がまだ設定されていません。「新しい変数を追加」ボタンを押して作成してください",
+                        "envWillBeDeleted": "変数が削除されます。続行しますか？",
+                        "addNewVariable": "新しい変数を追加",
+                        "variableForm": {
+                            "addNewVariable": "新しい変数を追加",
+                            "updatevariable": "変数を更新",
+                            "name": "名前",
+                            "value": "値",
+                            "enterVariableName": "変数名を入力してください",
+                            "enterValue": "値を入力してください",
+                            "type": "種類",
+                            "enableEncryption": "暗号化を有効にする",
+                            "addVariable": "変数を追加"
+                        },
+                        "variableTable": {
+                            "name": "名前",
+                            "value": "値",
+                            "type": "種類",
+                            "secret": "シークレット"
+                        }
+                    }
+                }
+            }
+        },
+        "profileSettingPage": {
+            "profileSettings": "プロフィール設定",
+            "firstName": "名",
+            "lastName": "姓",
+            "enterFirstName": "名を入力してください",
+            "enterLastName": "姓を入力してください",
+            "email": "メールアドレス",
+            "avatar": "アバター",
+            "update": "更新",
+            "profile": "プロフィール",
+            "changePassword": "パスワードを変更",
+            "currentPassword": "現在のパスワード",
+            "newPassword": "新しいパスワード",
+            "confirmNewPassword": "新しいパスワードの確認",
+            "enterCurrentPassword": "現在のパスワードを入力してください",
+            "enterNewPassword": "新しいパスワードを入力してください",
+            "inviteUsers": "ユーザーを招待"
+        },
+        "profile": "プロフィール",
+        "logout": "ログアウト"
+    },
+    "homePage": {
+        "appCard": {
+            "changeIcon": "アイコンを変更",
+            "addToFolder": "フォルダに追加",
+            "move": "移動",
+            "to": "へ",
+            "selectFolder": "フォルダを選択",
+            "deleteApp": "アプリを削除",
+            "exportApp": "アプリをエクスポート",
+            "cloneApp": "アプリを複製",
+            "launch": "起動",
+            "maintenance": "メンテナンス",
+            "noDeployedVersion": "このアプリにはデプロイ済みのバージョンがありません",
+            "openInAppViewer": "アプリビューアーで開く",
+            "removeFromFolder": "フォルダから削除"
+        },
+        "blankPage": {
+            "welcomeToToolJet": "新しい ToolJet ワークスペースへようこそ",
+            "getStartedCreateNewApp": "新しいアプリケーションを作成するか、ToolJet ライブラリのテンプレートを使ってアプリケーションを作成することで始められます。",
+            "importApplication": "アプリをインポート"
+        },
+        "foldersSection": {
+            "allApplications": "すべてのアプリケーション",
+            "folders": "フォルダ",
+            "createNewFolder": "+ 新規作成",
+            "noFolders": "フォルダがまだ作成されていません。フォルダを使ってアプリを整理しましょう",
+            "createFolder": "フォルダを作成",
+            "updateFolder": "フォルダを更新",
+            "editFolder": "フォルダを編集",
+            "deleteFolder": "フォルダを削除",
+            "folderName": "フォルダ名",
+            "wishToDeleteFolder": "フォルダ {{folderName}} を削除してもよろしいですか？フォルダ内のアプリは削除されません。"
+        },
+        "header": {
+            "createNewApplication": "アプリを作成",
+            "import": "端末からインポート",
+            "chooseFromTemplate": "テンプレートから選択"
+        },
+        "pagination": {
+            "showing": "表示中",
+            "of": "／",
+            "to": "〜"
+        },
+        "noApplicationFound": "アプリケーションが見つかりません",
+        "noWorkflowFound": "ワークフローが見つかりません",
+        "thisFolderIsEmpty": "このフォルダは空です",
+        "nonAccessibleFolderApps": "このフォルダ内のアプリケーションにアクセスする権限がありません。",
+        "deleteAppAndData": "アプリ {{appName}} と関連データは完全に削除されます。続行しますか？",
+        "deleteWorkflowAndData": "ワークフロー {{appName}} と関連データは完全に削除されます。続行しますか？",
+        "removeAppFromFolder": "このアプリはフォルダから削除されます。続行しますか？",
+        "change": "変更",
+        "templateCard": {
+            "use": "使用",
+            "preview": "プレビュー",
+            "leadGeneretion": "リード獲得"
+        },
+        "templateLibraryModal": {
+            "select": "テンプレートを選択",
+            "createAppfromTemplate": "テンプレートからアプリケーションを作成"
+        }
+    },
+    "workflowsDashboard": {
+        "appCard": {
+            "run": "実行",
+            "openInWorkflowEditor": "ワークフローエディターで開く"
+        },
+        "blankPage": {
+            "welcomeToToolJet": "新しい ToolJet ワークスペースへようこそ",
+            "getStartedCreateNewApp": "新しいアプリケーションを作成するか、ToolJet ライブラリのテンプレートを使ってアプリケーションを作成することで始められます。",
+            "importApplication": "アプリケーションをインポート"
+        },
+        "foldersSection": {
+            "allApplications": "すべてのワークフロー",
+            "folders": "フォルダ",
+            "createNewFolder": "+ 新規作成",
+            "noFolders": "フォルダがまだ作成されていません。フォルダを使ってアプリを整理しましょう",
+            "createFolder": "フォルダを作成",
+            "updateFolder": "フォルダを更新",
+            "editFolder": "フォルダを編集",
+            "deleteFolder": "フォルダを削除",
+            "folderName": "フォルダ名",
+            "wishToDeleteFolder": "このフォルダを削除してもよろしいですか？フォルダ内のアプリは削除されません。"
+        },
+        "header": {
+            "createNewApplication": "新しいワークフローを作成",
+            "import": "インポート",
+            "chooseFromTemplate": "テンプレートから選択"
+        },
+        "pagination": {
+            "showing": "表示中",
+            "of": "／",
+            "to": "〜"
+        },
+        "noApplicationFound": "アプリケーションが見つかりません",
+        "thisFolderIsEmpty": "このフォルダは空です",
+        "deleteAppAndData": "アプリと関連データは完全に削除されます。続行しますか？",
+        "removeAppFromFolder": "このアプリはフォルダから削除されます。続行しますか？",
+        "change": "変更",
+        "templateCard": {
+            "use": "使用",
+            "preview": "プレビュー",
+            "leadGeneretion": "リード獲得"
+        },
+        "templateLibraryModal": {
+            "select": "テンプレートを選択",
+            "createAppfromTemplate": "テンプレートからアプリケーションを作成"
+        }
+    },
+    "confirmationPage": {
+        "setupAccount": "アカウントをセットアップ",
+        "signupWithGoogle": "Google でサインアップ",
+        "signupWithGitHub": "GitHub でサインアップ",
+        "signupWithOpenid": "次でサインアップ:",
+        "or": "または",
+        "firstName": "名",
+        "lastName": "姓",
+        "company": "会社",
+        "role": "役職",
+        "pleaseSelect": "選択してください",
+        "password": "パスワード",
+        "confirmPassword": "パスワードの確認",
+        "clickAndAgree": "下のボタンをクリックすると、以下に同意したことになります:",
+        "termsAndConditions": "利用規約",
+        "finishAccountSetup": "アカウント設定を完了",
+        "acceptInvite": "招待を承諾",
+        "accountExists": "すでにアカウントをお持ちですか？",
+        "and": "および"
+    },
+    "onBoarding": {
+        "finishToolJetInstallation": "ToolJet のインストールを完了",
+        "organization": "組織",
+        "name": "名前",
+        "email": "メールアドレス",
+        "receiveUpdatesFromToolJet": "ToolJet チームからのお知らせを受け取ります（月に 1〜2 通のメール。スパムは送りません）",
+        "finishSetup": "セットアップを完了",
+        "skip": "スキップ"
+    },
+    "redirectSso": {
+        "upgradingTov1.13.0": "v1.13.0 以降へのアップグレード。",
+        "fromV1.13.0": "v1.13.0 より、次の機能を導入しました",
+        "multiWorkspace": "マルチワークスペース",
+        "singleSignOnConfig": "シングルサインオン（SSO）関連の設定は、ワークスペース変数からデータベースへ移行されました。詳しくは次を参照してください",
+        "link": "リンク",
+        "toConfigureSSO": "（SSO を設定するため）。",
+        "haveGoogleGithubSSo": "アップグレード前に Google または GitHub の SSO を設定しており、マルチワークスペースを無効にしている場合、SSO 設定はアップグレード時に移行されますが、SSO プロバイダー側でリダイレクト URL を再設定する必要があります。各 SSO のリダイレクト URL は以下のとおりです。",
+        "isMultiWorkspaceEnabled": "マルチワークスペースを有効にしている場合、SSO 設定はアップグレード時に移行されないため、各ワークスペースで SSO を再設定する必要があります。",
+        "youHaveEnabled": "有効になっています",
+        "setupSsoWorkspace": "パスワードでログインのうえ、ワークスペースから SSO を設定してください",
+        "manageSsoMenu": "「SSO 管理」メニュー。",
+        "youHaveDisabled": "無効になっています",
+        "configureRedirectUrl": "SSO プロバイダー側でリダイレクト URL を設定してください。",
+        "google": "Google",
+        "redirectUrl": "リダイレクト URL:",
+        "gitHub": "GitHub"
+    },
+    "oAuth2": {
+        "pleaseWait": "お待ちください...",
+        "authSuccess": "認証に成功しました。このタブを閉じてかまいません。",
+        "authFailed": "認証に失敗しました"
+    },
+    "widgetManager": {
+        "commonlyUsed": "よく使うもの",
+        "layouts": "レイアウト",
+        "forms": "フォーム",
+        "integrations": "連携",
+        "others": "その他",
+        "noResults": "結果が見つかりません",
+        "tryAdjustingFilterMessage": "検索条件やフィルターを調整して、お探しのものを見つけてください。",
+        "clearQuery": "クエリをクリア"
+    },
+    "widget": {
+        "common": {
+            "properties": "プロパティ",
+            "events": "イベント",
+            "layout": "レイアウト",
+            "devices": "デバイス",
+            "styles": "スタイル",
+            "general": "一般",
+            "validation": "バリデーション",
+            "structure": "構造",
+            "data": "データ",
+            "additionalActions": "追加アクション",
+            "documentation": "{{componentMeta}} のドキュメントを読む",
+            "widgetNameEmptyError": "ウィジェット名は空にできません",
+            "componentNameExistsError": "コンポーネント名はすでに存在します",
+            "invalidWidgetName": "ウィジェット名が無効です。一意で、英字・数字・アンダースコアのみを使用してください。"
+        },
+        "commonProperties": {
+            "visibility": "表示／非表示",
+            "disable": "無効化",
+            "borderRadius": "角丸",
+            "transformation": "変換",
+            "boxShadow": "ボックスシャドウ",
+            "tooltip": "ツールチップ",
+            "showOnDesktop": "デスクトップで表示",
+            "showOnMobile": "モバイルで表示",
+            "showLoadingState": "読み込み状態を表示",
+            "backgroundColor": "背景色",
+            "textColor": "文字色",
+            "loaderColor": "ローダーの色",
+            "defaultValue": "初期値",
+            "placeholder": "プレースホルダー",
+            "label": "ラベル",
+            "title": "タイトル",
+            "code": "コード",
+            "data": "データ",
+            "tableData": "テーブルデータ",
+            "tableColumns": "テーブルの列",
+            "loadingState": "読み込み状態",
+            "serverSidePagination": "サーバーサイドページネーション",
+            "clientSidePagination": "クライアントサイドページネーション",
+            "serverSideSearch": "サーバーサイド検索",
+            "showSearchBox": "検索ボックスを表示",
+            "showDownloadButton": "ダウンロードボタンを表示",
+            "showFilterButton": "フィルターボタンを表示",
+            "showBulkUpdateActions": "更新ボタンを表示",
+            "bulkSelection": "一括選択",
+            "highlightSelectedRow": "選択した行をハイライト",
+            "actionButtonRadius": "アクションボタンの角丸",
+            "tableType": "テーブルの種類",
+            "cellSize": "セルサイズ",
+            "setPage": "ページを設定",
+            "page": "ページ",
+            "buttonText": "ボタンのテキスト",
+            "click": "クリック",
+            "setText": "テキストを設定",
+            "text": "テキスト",
+            "markerColor": "マーカーの色",
+            "showAxes": "軸を表示",
+            "showGridLines": "グリッド線を表示",
+            "chartType": "グラフの種類",
+            "jsonDescription": "JSON 記述",
+            "usePlotlyJsonSchema": "Plotly の JSON スキーマを使用",
+            "padding": "余白",
+            "hideTitleBar": "タイトルバーを非表示",
+            "hideCloseButton": "閉じるボタンを非表示",
+            "hideOnEscape": "Esc キーで非表示にする",
+            "modalSize": "モーダルのサイズ",
+            "open": "開く",
+            "close": "閉じる",
+            "regex": "正規表現",
+            "minLength": "最小文字数",
+            "maxLength": "最大文字数",
+            "customValidation": "カスタムバリデーション",
+            "clear": "クリア",
+            "minimumValue": "最小値",
+            "maximumValue": "最大値",
+            "format": "フォーマット",
+            "enableTimeSelection": "時刻の選択を有効にしますか？",
+            "enableDateSelection": "日付の選択を有効にしますか？",
+            "disabledDates": "無効にする日付",
+            "minDate": "最小日付",
+            "maxDate": "最大日付",
+            "makeThisFieldMandatory": "この項目を必須にする",
+            "setChecked": "チェック状態を設定",
+            "status": "ステータス",
+            "defaultStatus": "初期ステータス",
+            "checkboxColor": "チェックボックスの色",
+            "optionValues": "選択肢の値",
+            "optionLabels": "選択肢のラベル",
+            "activeColor": "アクティブ時の色",
+            "selectOption": "選択肢を選ぶ",
+            "option": "選択肢",
+            "toggleSwitchColor": "トグルスイッチの色",
+            "defaultStartDate": "初期の開始日",
+            "defaultEndDate": "初期の終了日",
+            "textSize": "文字サイズ",
+            "alignText": "テキストの揃え",
+            "url": "URL",
+            "alternativeText": "代替テキスト",
+            "zoomButton": "ズームボタン",
+            "borderType": "枠線の種類",
+            "imageFit": "画像の表示方法",
+            "optionsLoadingState": "選択肢の読み込み状態",
+            "selectedTextColor": "選択時の文字色",
+            "select": "選択",
+            "deselectOption": "選択を解除",
+            "clearSelections": "選択をすべてクリア",
+            "enableSelectAllOption": "「すべて選択」を有効にする",
+            "initialLocation": "初期位置",
+            "defaultMarkers": "初期マーカー",
+            "addNewMarkers": "新しいマーカーを追加",
+            "searchForPlaces": "場所を検索",
+            "setLocation": "位置を設定",
+            "latitude": "緯度",
+            "longitude": "経度",
+            "numberOfStars": "星の数",
+            "defaultNoOfSelectedStars": "初期で選択する星の数",
+            "enableHalfStar": "半分の星を有効にする",
+            "tooltips": "ツールチップ",
+            "starColor": "星の色",
+            "labelColor": "ラベルの色",
+            "dividerColor": "区切り線の色",
+            "clearFiles": "ファイルをクリア",
+            "instructionText": "説明テキスト",
+            "useDropZone": "ドロップゾーンを使用",
+            "useFilePicker": "ファイルピッカーを使用",
+            "pickMultipleFiles": "複数ファイルを選択",
+            "maxFileCount": "最大ファイル数",
+            "acceptFileTypes": "許可するファイル形式",
+            "maxSizeLimitBytes": "最大サイズ制限（バイト）",
+            "minSizeLimitBytes": "最小サイズ制限（バイト）",
+            "parseContent": "内容を解析",
+            "fileType": "ファイル形式",
+            "dateFormat": "日付フォーマット",
+            "timeFormat": "時刻フォーマット",
+            "displayIn": "表示先",
+            "storeIn": "保存先",
+            "defaultDate": "初期日付",
+            "events": "イベント",
+            "resources": "リソース",
+            "defaultView": "初期表示",
+            "startTimeOnWeekAndDayView": "週・日表示での開始時刻",
+            "endTimeOnWeekAndDayView": "週・日表示での終了時刻",
+            "showToolbar": "ツールバーを表示",
+            "showViewSwitcher": "表示切り替えを表示",
+            "highlightToday": "今日をハイライト",
+            "showPopoverWhenEventIsClicked": "イベントクリック時にポップオーバーを表示",
+            "cellSizeInViewsClassifiedByResource": "リソース別表示でのセルサイズ",
+            "headerDateFormatOnWeekView": "週表示でのヘッダー日付フォーマット",
+            "showLineNumber": "行番号を表示",
+            "mode": "モード",
+            "tabs": "タブ",
+            "defaultTab": "初期タブ",
+            "hideTabs": "タブを非表示",
+            "highlightColor": "ハイライトの色",
+            "tabWidth": "タブの幅",
+            "setCurrentTab": "現在のタブを設定",
+            "id": "ID",
+            "timerType": "タイマーの種類",
+            "listData": "リストデータ",
+            "rowHeight": "行の高さ",
+            "showBottomBorder": "下罫線を表示",
+            "tags": "タグ",
+            "numberOfPages": "ページ数",
+            "defaultPageIndex": "初期ページインデックス",
+            "progress": "進捗",
+            "color": "色",
+            "strokeWidth": "線の太さ",
+            "counterClockwise": "反時計回り",
+            "circleRatio": "円の比率",
+            "colour": "色",
+            "size": "サイズ",
+            "primaryValueLabel": "主要値のラベル",
+            "primaryValue": "主要値",
+            "hideSecondaryValue": "副次値を非表示",
+            "secondaryValueLabel": "副次値のラベル",
+            "secondaryValue": "副次値",
+            "secondarySignDisplay": "副次値の符号表示",
+            "primaryLabelColour": "主要ラベルの色",
+            "primaryTextColour": "主要テキストの色",
+            "secondaryLabelColour": "副次ラベルの色",
+            "secondaryTextColour": "副次テキストの色",
+            "min": "最小",
+            "max": "最大",
+            "value": "値",
+            "twoHandles": "ハンドルを 2 つにする",
+            "lineColor": "線の色",
+            "handleColor": "ハンドルの色",
+            "trackColor": "トラックの色",
+            "timelineData": "タイムラインデータ",
+            "hideDate": "日付を非表示",
+            "svgData": "SVG データ",
+            "rawHtml": "生の HTML",
+            "values": "値",
+            "labels": "ラベル",
+            "defaultSelected": "初期選択",
+            "enableMultipleSelection": "複数選択を有効にする",
+            "selectedTextColour": "選択時の文字色",
+            "selectedBackgroundColor": "選択時の背景色",
+            "fileUrl": "ファイル URL",
+            "scalePageToWidth": "ページを幅に合わせる",
+            "showPageControls": "ページ操作を表示",
+            "steps": "ステップ",
+            "currentStep": "現在のステップ",
+            "stepsSelectable": "ステップを選択可能にする",
+            "theme": "テーマ",
+            "columns": "列",
+            "cardData": "カードデータ",
+            "enableAddCard": "カードの追加を有効にする",
+            "width": "幅",
+            "minWidth": "最小幅",
+            "accentColor": "アクセントカラー",
+            "defaultColor": "初期色",
+            "setColor": "色を設定",
+            "structure": "構造",
+            "checkedValues": "チェック済みの値",
+            "expandedValues": "展開した値"
+        },
+        "Table": {
+            "displayName": "テーブル",
+            "description": "ページネーション付きの表データを表示",
+            "columnType": "列の種類",
+            "columnName": "列名",
+            "overflow": "オーバーフロー",
+            "key": "キー",
+            "textColor": "文字色",
+            "validation": "バリデーション",
+            "regex": "正規表現",
+            "minLength": "最小文字数",
+            "maxLength": "最大文字数",
+            "customRule": "カスタムルール",
+            "values": "値",
+            "labels": "ラベル",
+            "cellBgColor": "セルの背景色",
+            "dateDisplayformat": "日付フォーマット",
+            "dateParseformat": "日付",
+            "showTime": "時刻を表示",
+            "makeEditable": "編集可能にする",
+            "buttonText": "ボタンのテキスト",
+            "buttonPosition": "ボタンの位置",
+            "remove": "削除",
+            "addButton": "+ ボタンを追加",
+            "addColumn": "列を追加",
+            "addNewColumn": "新しい列を追加",
+            "noActionMessage": "このテーブルにはアクションボタンがありません",
+            "horizontalAlignment": "水平方向の揃え",
+            "textAlignment": "テキストの揃え",
+            "deciamalPlaces": "小数点以下の桁数",
+            "imageFit": "画像の表示方法"
+        },
+        "Button": {
+            "displayName": "ボタン",
+            "description": "クエリ、アラート、変数の設定などのアクションを実行します。"
+        },
+        "Chart": {
+            "displayName": "グラフ",
+            "description": "データを可視化"
+        },
+        "Modal": {
+            "displayName": "モーダル",
+            "description": "ポップアップウィンドウを表示"
+        },
+        "TextInput": {
+            "displayName": "テキスト入力",
+            "description": "ユーザーのテキスト入力欄"
+        },
+        "NumberInput": {
+            "displayName": "数値入力",
+            "description": "数値の入力欄"
+        },
+        "PasswordInput": {
+            "displayName": "パスワード入力",
+            "description": "セキュアなテキスト入力"
+        },
+        "Datepicker": {
+            "displayName": "日付ピッカー",
+            "description": "日付と時刻を選択"
+        },
+        "Checkbox": {
+            "displayName": "チェックボックス",
+            "description": "単一のチェックボックス"
+        },
+        "Radio-button": {
+            "displayName": "ラジオボタン",
+            "description": "複数の選択肢から 1 つを選択"
+        },
+        "ToggleSwitch": {
+            "displayName": "トグルスイッチ",
+            "description": "ユーザー操作によるオン・オフスイッチ"
+        },
+        "Textarea": {
+            "displayName": "テキストエリア",
+            "description": "複数行のテキスト入力"
+        },
+        "DateRangePicker": {
+            "displayName": "日付範囲ピッカー",
+            "description": "日付の範囲を選択"
+        },
+        "Text": {
+            "displayName": "テキスト",
+            "description": "テキストまたは HTML を表示"
+        },
+        "Image": {
+            "displayName": "画像",
+            "description": "画像ファイルを表示"
+        },
+        "Container": {
+            "displayName": "コンテナ",
+            "description": "コンポーネントをグループ化"
+        },
+        "Dropdown": {
+            "displayName": "ドロップダウン",
+            "description": "単一項目のセレクター"
+        },
+        "Multiselect": {
+            "displayName": "複数選択",
+            "description": "複数項目のセレクター"
+        },
+        "RichTextEditor": {
+            "displayName": "テキストエディター",
+            "description": "リッチテキストエディター"
+        },
+        "Map": {
+            "displayName": "地図",
+            "description": "地図上の位置を表示"
+        },
+        "QrScanner": {
+            "displayName": "QR スキャナー",
+            "description": "QR コードを読み取り、そのデータを保持"
+        },
+        "StarRating": {
+            "displayName": "評価",
+            "description": "星による評価"
+        },
+        "Divider": {
+            "displayName": "区切り線",
+            "description": "コンポーネント間の区切り"
+        },
+        "FilePicker": {
+            "displayName": "ファイルピッカー",
+            "description": "ファイルピッカー"
+        },
+        "Calendar": {
+            "displayName": "カレンダー",
+            "description": "カレンダーの予定を表示"
+        },
+        "Iframe": {
+            "displayName": "Iframe",
+            "description": "外部コンテンツを埋め込み"
+        },
+        "CodeEditor": {
+            "displayName": "コードエディター",
+            "description": "ソースコードを編集"
+        },
+        "Tabs": {
+            "displayName": "タブ",
+            "description": "コンテンツをタブで整理"
+        },
+        "Timer": {
+            "displayName": "タイマー",
+            "description": "カウントダウンまたはストップウォッチ"
+        },
+        "Listview": {
+            "displayName": "リストビュー",
+            "description": "複数の項目を一覧表示"
+        },
+        "Tags": {
+            "displayName": "タグ",
+            "description": "タグラベルを表示"
+        },
+        "Pagination": {
+            "displayName": "ページネーション",
+            "description": "ページを移動"
+        },
+        "CircularProgressbar": {
+            "displayName": "円形プログレスバー",
+            "description": "円形の進捗を表示"
+        },
+        "Spinner": {
+            "displayName": "スピナー",
+            "description": "読み込み状態を表示"
+        },
+        "Statistics": {
+            "displayName": "統計",
+            "description": "主要な指標を表示"
+        },
+        "RangeSlider": {
+            "displayName": "範囲スライダー",
+            "description": "値の範囲を調整"
+        },
+        "Timeline": {
+            "displayName": "タイムライン",
+            "description": "イベントのタイムラインを表示"
+        },
+        "SvgImage": {
+            "displayName": "SVG 画像",
+            "description": "SVG グラフィックを表示"
+        },
+        "Html": {
+            "displayName": "HTML ビューアー",
+            "description": "HTML コンテンツを表示"
+        },
+        "VerticalDivider": {
+            "displayName": "縦の区切り線",
+            "description": "縦線の区切り"
+        },
+        "CustomComponent": {
+            "displayName": "カスタムコンポーネント",
+            "description": "React コンポーネントを作成"
+        },
+        "ButtonGroup": {
+            "displayName": "ボタングループ",
+            "description": "ボタンのグループ"
+        },
+        "PDF": {
+            "displayName": "PDF",
+            "description": "PDF ドキュメントを埋め込み"
+        },
+        "Steps": {
+            "displayName": "ステップ",
+            "description": "ステップごとのナビゲーション補助"
+        },
+        "KanbanBoard": {
+            "displayName": "カンバンボード",
+            "description": "タスク管理ボード"
+        },
+        "ColorPicker": {
+            "displayName": "カラーピッカー",
+            "description": "パレットから色を選択"
+        },
+        "TreeSelect": {
+            "displayName": "ツリーセレクト",
+            "description": "階層型の項目セレクター"
+        }
+    },
+    "leftSidebar": {
+        "Inspector": {
+            "text": "インスペクター",
+            "tip": "インスペクター"
+        },
+        "Sources": {
+            "text": "データソース",
+            "tip": "データソースの追加・編集",
+            "dataSources": "データソース",
+            "addDataSource": "+ データソースを追加"
+        },
+        "Debugger": {
+            "text": "デバッガー",
+            "tip": "デバッガー",
+            "errors": "エラー",
+            "noErrors": "エラーは見つかりませんでした",
+            "noLogs": "ログは見つかりませんでした",
+            "clear": "クリア"
+        },
+        "Comments": {
+            "text": "コメント",
+            "tip": "コメントの表示切り替え",
+            "commentBody": "表示するコメントはありません",
+            "typeComment": "ここにコメントを入力してください"
+        },
+        "Settings": {
+            "text": "トリガー",
+            "tip": "全体設定",
+            "hideHeader": "起動したアプリでヘッダーを非表示にする",
+            "maintenanceMode": "メンテナンスモード",
+            "maxWidthOfCanvas": "キャンバスの最大幅",
+            "maxHeightOfCanvas": "キャンバスの最大高さ",
+            "backgroundColorOfCanvas": "キャンバスの背景",
+            "appMode": "アプリモード",
+            "exportApp": "アプリをエクスポート"
+        },
+        "Back": {
+            "text": "戻る",
+            "tip": "ホームに戻る"
+        }
+    },
+    "datepicker": {
+        "months": {
+            "january": "1月",
+            "february": "2月",
+            "march": "3月",
+            "april": "4月",
+            "may": "5月",
+            "june": "6月",
+            "july": "7月",
+            "august": "8月",
+            "september": "9月",
+            "october": "10月",
+            "november": "11月",
+            "december": "12月"
+        }
+    }
+}

--- a/frontend/assets/translations/languages.json
+++ b/frontend/assets/translations/languages.json
@@ -8,6 +8,7 @@
   { "lang": "Ukrainian", "code": "uk", "nativeLang": "Українська" },
   { "lang": "Russian", "code": "ru", "nativeLang": "Русский" },
   { "lang": "German", "code": "de", "nativeLang": "Deutsch" },
-  { "lang": "Chinese", "code": "zh", "nativeLang": "Chinese" }
+  { "lang": "Chinese", "code": "zh", "nativeLang": "Chinese" },
+  { "lang": "Japanese", "code": "ja", "nativeLang": "日本語" }
   ]
 }


### PR DESCRIPTION
## Problem

ToolJet ships 9 UI languages (en, fr, es, it, id, uk, ru, de, zh) but not Japanese, so Japanese users get an English-only builder/admin.

## Change

Adds Japanese (`ja`), mirroring the existing Korean (#16753) and zh-TW (#16551) locale additions:
- New `ja.json` — all 822 keys translated to Japanese. Every `{{placeholder}}` preserved verbatim; product/technical names kept in Latin (ToolJet, Stripe, Slack, JavaScript, Python); `\n` preserved; UI tone consistent (です/ます).
- Registers Japanese in `languages.json` (`{ "lang": "Japanese", "code": "ja", "nativeLang": "日本語" }`).

Follows `docs/contributing-guide/l10n.md`.

## Testing

- `ja.json` validated as valid JSON; 822 leaf keys, structurally identical to `en.json`; all placeholders preserved (verified programmatically); LF line endings.

