### PR TITLE
fix: hydrated feature-branch app 404s on refresh in git-sync workspaces

### DIFF
--- a/server/src/modules/apps/guards/private-app-auth.guard.ts
+++ b/server/src/modules/apps/guards/private-app-auth.guard.ts
@@ -29,7 +29,21 @@ export class PrivateAppAuthGuard extends AuthGuard('jwt') {
       throw new NotFoundException('App not found. Invalid app id');
     }
 
-    let app = await this.appRepository.findAppBySlug(slug);
+    // When the requesting workspace is known, try a workspace-scoped +
+    // branch-aware lookup first. Feature-branch slugs can be shared across
+    // orgs that pulled from the same git source, so a cross-workspace lookup
+    // (findAppBySlug) would non-deterministically return whichever org's row
+    // was updated most recently. The org-scoped path resolves correctly.
+    const workspaceId = request.headers['tj-workspace-id'] as string;
+    const branchId = request.headers['x-branch-id'] as string;
+
+    let app = workspaceId
+      ? await this.appRepository.findBySlug(slug, workspaceId, undefined, branchId)
+      : null;
+
+    if (!app && !workspaceId) {
+      app = await this.appRepository.findAppBySlug(slug);
+    }
     if (!app) {
       app = await this.appRepository.findByAppId(slug);
     }

--- a/server/src/modules/apps/guards/private-app-auth.guard.ts
+++ b/server/src/modules/apps/guards/private-app-auth.guard.ts
@@ -29,11 +29,13 @@ export class PrivateAppAuthGuard extends AuthGuard('jwt') {
       throw new NotFoundException('App not found. Invalid app id');
     }
 
-    // When the requesting workspace is known, try a workspace-scoped +
-    // branch-aware lookup first. Feature-branch slugs can be shared across
-    // orgs that pulled from the same git source, so a cross-workspace lookup
-    // (findAppBySlug) would non-deterministically return whichever org's row
-    // was updated most recently. The org-scoped path resolves correctly.
+    // Lookup waterfall:
+    //   1. workspaceId present → workspace-scoped findBySlug (+ optional branchId).
+    //      On a miss we stop here — falling through to the cross-org findAppBySlug
+    //      would risk returning a different org's app and overwriting the workspace
+    //      header with a foreign org ID before JWT validation.
+    //   2. workspaceId absent → cross-org findAppBySlug (default/branchless rows only).
+    //   3. Either path → findByAppId as UUID fallback.
     const workspaceId = request.headers['tj-workspace-id'] as string;
     const branchId = request.headers['x-branch-id'] as string;
 

--- a/server/src/modules/apps/guards/valid-app.guard.ts
+++ b/server/src/modules/apps/guards/valid-app.guard.ts
@@ -4,9 +4,10 @@ import { User } from '@entities/user.entity';
 import { isUUID } from 'class-validator';
 
 // Use this Guard IF
-// - param id is passed as app id
+// - param id is passed as app id OR as a slug (replaceEditorURL swaps the URL
+//   from /apps/<uuid> to /apps/<slug>; refresh sends the slug in :id position)
 // - param slug is passed as app slug
-// IF slug is passed as id/slug -> USE validSlugGuard
+// Non-UUID :id values are treated as slugs via findBySlug (org-scoped).
 // This Guard should be used after jwt auth guard
 @Injectable()
 export class ValidAppGuard implements CanActivate {

--- a/server/src/modules/apps/guards/valid-app.guard.ts
+++ b/server/src/modules/apps/guards/valid-app.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable, CanActivate, ExecutionContext, BadRequestException, NotFoundException } from '@nestjs/common';
 import { AppsRepository } from '../repository';
 import { User } from '@entities/user.entity';
+import { isUUID } from 'class-validator';
 
 // Use this Guard IF
 // - param id is passed as app id
@@ -25,11 +26,16 @@ export class ValidAppGuard implements CanActivate {
       throw new BadRequestException('App id or slug must be provided');
     }
 
-    // Fetch the app based on the id or slug
+    // Fetch the app based on the id or slug.
+    // When the editor URL is synced from UUID to slug (replaceEditorURL), refresh
+    // sends the slug string in the :id param. isUUID guards against a TypeORM
+    // UUID parse error — non-UUID ids are treated as slugs via findBySlug.
     const app =
       request.tj_app ||
       (id
-        ? await this.appRepository.findById(id, user.organizationId, versionId, branchId)
+        ? isUUID(id)
+          ? await this.appRepository.findById(id, user.organizationId, versionId, branchId)
+          : await this.appRepository.findBySlug(id, user.organizationId, versionId, branchId)
         : await this.appRepository.findBySlug(slug, user.organizationId, versionId, branchId));
 
     // If app is not found, throw NotFoundException

--- a/server/src/modules/apps/repository.ts
+++ b/server/src/modules/apps/repository.ts
@@ -107,20 +107,32 @@ export class AppsRepository extends Repository<App> {
         .orderBy('av.updated_at', 'DESC')
         .getOne();
 
-      // 2) Fall back to any row with this slug. Step 1 confirmed no
-      //    default-branch row holds it anywhere on the instance, so any
-      //    match here is unambiguous (feature-branch or legacy branchless).
+      // 2) Fall back to a branchless row — but only when the candidate app's
+      //    own workspace has no default branch (git sync still off for that
+      //    org). The branchless row is the canonical slug holder in that
+      //    case; if the org has since enabled git, step 1 would have found
+      //    the default-branch row already and this fallback would (correctly)
+      //    not apply.
+      //    Feature-branch rows are deliberately excluded here: the same slug
+      //    can appear on multiple orgs' feature branches (pulled from the same
+      //    git source), so accepting them without org context risks returning
+      //    the wrong workspace's app. The caller (PrivateAppAuthGuard) handles
+      //    feature-branch slugs via a workspace-scoped findBySlug call first.
       if (!resolvedVersion) {
         const candidate = await this.dataSource
           .getRepository(AppVersion)
           .createQueryBuilder('av')
           .innerJoinAndSelect('av.app', 'app')
           .where('av.slug = :slug', { slug })
+          .andWhere('av.branch_id IS NULL')
           .orderBy('av.updated_at', 'DESC')
           .getOne();
 
         if (candidate?.app) {
-          resolvedVersion = candidate;
+          const orgDefaultBranchId = await this.getDefaultBranchId(this.manager, candidate.app.organizationId);
+          if (!orgDefaultBranchId) {
+            resolvedVersion = candidate;
+          }
         }
       }
     } else {
@@ -428,6 +440,7 @@ export class AppsRepository extends Repository<App> {
       .innerJoinAndSelect('av.app', 'app')
       .leftJoinAndSelect('app.appVersions', 'appVersions')
       .where('av.slug = :slug', { slug: idOrSlug })
+      .orderBy('av.updated_at', 'DESC')
       .getOne();
 
     if (candidate?.app) {

--- a/server/src/modules/apps/repository.ts
+++ b/server/src/modules/apps/repository.ts
@@ -107,27 +107,20 @@ export class AppsRepository extends Repository<App> {
         .orderBy('av.updated_at', 'DESC')
         .getOne();
 
-      // 2) Fall back to a branchless row — but only when the candidate app's
-      //    own workspace has no default branch (git sync still off for that
-      //    org). The branchless row is the canonical slug holder in that
-      //    case; if the org has since enabled git, step 1 would have found
-      //    the default-branch row already and this fallback would (correctly)
-      //    not apply.
+      // 2) Fall back to any row with this slug. Step 1 confirmed no
+      //    default-branch row holds it anywhere on the instance, so any
+      //    match here is unambiguous (feature-branch or legacy branchless).
       if (!resolvedVersion) {
         const candidate = await this.dataSource
           .getRepository(AppVersion)
           .createQueryBuilder('av')
           .innerJoinAndSelect('av.app', 'app')
           .where('av.slug = :slug', { slug })
-          .andWhere('av.branch_id IS NULL')
           .orderBy('av.updated_at', 'DESC')
           .getOne();
 
         if (candidate?.app) {
-          const orgDefaultBranchId = await this.getDefaultBranchId(this.manager, candidate.app.organizationId);
-          if (!orgDefaultBranchId) {
-            resolvedVersion = candidate;
-          }
+          resolvedVersion = candidate;
         }
       }
     } else {
@@ -451,7 +444,7 @@ export class AppsRepository extends Repository<App> {
           .where('av.slug = :slug', { slug: idOrSlug })
           .andWhere('av.branch_id = :branchId', { branchId: defaultBranchId })
           .getOne();
-        if (!resolved?.app) return null;
+        if (!resolved?.app) resolved = candidate;
       }
 
       const app = resolved.app;

--- a/server/test/modules/app/unit/private-app-auth.guard.spec.ts
+++ b/server/test/modules/app/unit/private-app-auth.guard.spec.ts
@@ -1,0 +1,195 @@
+// server/test/modules/app/unit/private-app-auth.guard.spec.ts
+import { NotFoundException, BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common';
+import { PrivateAppAuthGuard } from '@modules/apps/guards/private-app-auth.guard';
+import { WORKSPACE_STATUS } from '@modules/users/constants/lifecycle';
+
+/** @group platform */
+describe('PrivateAppAuthGuard', () => {
+  let guard: PrivateAppAuthGuard;
+  let mockAppRepository: {
+    findBySlug: jest.Mock;
+    findAppBySlug: jest.Mock;
+    findByAppId: jest.Mock;
+  };
+  let mockOrgRepository: { findOne: jest.Mock };
+  let mockAppUtilService: object;
+
+  const makeContext = (
+    slug: string,
+    headers: Record<string, string> = {}
+  ): ExecutionContext => {
+    const request: Record<string, any> = { params: { slug }, headers: { ...headers } };
+    return {
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext;
+  };
+
+  const makeApp = (overrides = {}) => ({
+    id: 'app-uuid-1',
+    slug: 'my-app',
+    isPublic: false,
+    organizationId: 'org-uuid-1',
+    ...overrides,
+  });
+
+  const makeOrg = (overrides = {}) => ({
+    id: 'org-uuid-1',
+    status: WORKSPACE_STATUS.ACTIVE,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    mockAppRepository = {
+      findBySlug: jest.fn(),
+      findAppBySlug: jest.fn(),
+      findByAppId: jest.fn(),
+    };
+    mockOrgRepository = { findOne: jest.fn() };
+    mockAppUtilService = {};
+    guard = new PrivateAppAuthGuard(
+      mockAppUtilService as any,
+      mockOrgRepository as any,
+      mockAppRepository as any
+    );
+    // Default: JWT passes
+    jest
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(guard)), 'canActivate')
+      .mockResolvedValue(true);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('slug missing', () => {
+    it('throws NotFoundException before any repo call', async () => {
+      const ctx = makeContext('');
+      await expect(guard.canActivate(ctx)).rejects.toThrow(NotFoundException);
+      expect(mockAppRepository.findBySlug).not.toHaveBeenCalled();
+      expect(mockAppRepository.findAppBySlug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('workspace-scoped lookup (tj-workspace-id present)', () => {
+    it('resolves via findBySlug and skips findAppBySlug entirely', async () => {
+      const app = makeApp();
+      mockAppRepository.findBySlug.mockResolvedValue(app);
+      mockOrgRepository.findOne.mockResolvedValue(makeOrg());
+
+      const ctx = makeContext('my-app', { 'tj-workspace-id': 'org-uuid-1' });
+      await guard.canActivate(ctx);
+
+      expect(mockAppRepository.findBySlug).toHaveBeenCalledWith('my-app', 'org-uuid-1', undefined, undefined);
+      expect(mockAppRepository.findAppBySlug).not.toHaveBeenCalled();
+    });
+
+    it('forwards x-branch-id to findBySlug when present', async () => {
+      const app = makeApp();
+      mockAppRepository.findBySlug.mockResolvedValue(app);
+      mockOrgRepository.findOne.mockResolvedValue(makeOrg());
+
+      const ctx = makeContext('my-app', {
+        'tj-workspace-id': 'org-uuid-1',
+        'x-branch-id': 'branch-uuid-1',
+      });
+      await guard.canActivate(ctx);
+
+      expect(mockAppRepository.findBySlug).toHaveBeenCalledWith('my-app', 'org-uuid-1', undefined, 'branch-uuid-1');
+      expect(mockAppRepository.findAppBySlug).not.toHaveBeenCalled();
+    });
+
+    // Security: when the workspace-scoped lookup misses (slug exists only on a
+    // feature branch but no branchId was sent, or slug doesn't exist in this org),
+    // the guard must NOT fall through to the cross-org findAppBySlug. Doing so
+    // could return a different org's app and overwrite the workspace header with a
+    // foreign org ID before JWT validation.
+    it('does NOT call findAppBySlug when workspaceId is present but scoped lookup returns null', async () => {
+      mockAppRepository.findBySlug.mockResolvedValue(null);
+      mockAppRepository.findByAppId.mockResolvedValue(null);
+
+      const ctx = makeContext('my-app', { 'tj-workspace-id': 'org-uuid-1' });
+      await expect(guard.canActivate(ctx)).rejects.toThrow(NotFoundException);
+
+      expect(mockAppRepository.findAppBySlug).not.toHaveBeenCalled();
+    });
+
+    it('falls through to findByAppId (UUID path) when scoped slug lookup misses', async () => {
+      const app = makeApp();
+      mockAppRepository.findBySlug.mockResolvedValue(null);
+      mockAppRepository.findByAppId.mockResolvedValue(app);
+      mockOrgRepository.findOne.mockResolvedValue(makeOrg());
+
+      const ctx = makeContext('app-uuid-1', { 'tj-workspace-id': 'org-uuid-1' });
+      await guard.canActivate(ctx);
+
+      expect(mockAppRepository.findByAppId).toHaveBeenCalledWith('app-uuid-1');
+    });
+  });
+
+  describe('cross-workspace lookup (tj-workspace-id absent)', () => {
+    it('skips findBySlug and calls findAppBySlug directly', async () => {
+      const app = makeApp();
+      mockAppRepository.findAppBySlug.mockResolvedValue(app);
+      mockOrgRepository.findOne.mockResolvedValue(makeOrg());
+
+      const ctx = makeContext('my-app');
+      await guard.canActivate(ctx);
+
+      expect(mockAppRepository.findBySlug).not.toHaveBeenCalled();
+      expect(mockAppRepository.findAppBySlug).toHaveBeenCalledWith('my-app');
+    });
+
+    it('falls through to findByAppId when findAppBySlug also misses', async () => {
+      const app = makeApp();
+      mockAppRepository.findAppBySlug.mockResolvedValue(null);
+      mockAppRepository.findByAppId.mockResolvedValue(app);
+      mockOrgRepository.findOne.mockResolvedValue(makeOrg());
+
+      const ctx = makeContext('app-uuid-1');
+      await guard.canActivate(ctx);
+
+      expect(mockAppRepository.findByAppId).toHaveBeenCalledWith('app-uuid-1');
+    });
+
+    it('throws NotFoundException when all three lookups miss', async () => {
+      mockAppRepository.findAppBySlug.mockResolvedValue(null);
+      mockAppRepository.findByAppId.mockResolvedValue(null);
+
+      const ctx = makeContext('unknown');
+      await expect(guard.canActivate(ctx)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('post-resolution behaviour', () => {
+    it('overwrites tj-workspace-id header with the resolved app orgId before JWT validation', async () => {
+      const app = makeApp({ organizationId: 'real-org-uuid' });
+      mockAppRepository.findAppBySlug.mockResolvedValue(app);
+      mockOrgRepository.findOne.mockResolvedValue(makeOrg({ id: 'real-org-uuid' }));
+
+      const req: Record<string, any> = { params: { slug: 'my-app' }, headers: {} };
+      const ctx = {
+        switchToHttp: () => ({ getRequest: () => req }),
+      } as unknown as ExecutionContext;
+
+      await guard.canActivate(ctx);
+
+      expect(req.headers['tj-workspace-id']).toBe('real-org-uuid');
+    });
+
+    it('throws BadRequestException when resolved org is archived', async () => {
+      mockAppRepository.findAppBySlug.mockResolvedValue(makeApp());
+      mockOrgRepository.findOne.mockResolvedValue(makeOrg({ status: WORKSPACE_STATUS.ARCHIVED }));
+
+      await expect(guard.canActivate(makeContext('my-app'))).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws UnauthorizedException when JWT validation fails', async () => {
+      mockAppRepository.findAppBySlug.mockResolvedValue(makeApp());
+      mockOrgRepository.findOne.mockResolvedValue(makeOrg());
+      jest
+        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(guard)), 'canActivate')
+        .mockRejectedValue(new UnauthorizedException());
+
+      await expect(guard.canActivate(makeContext('my-app'))).rejects.toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/server/test/modules/app/unit/valid-app.guard.spec.ts
+++ b/server/test/modules/app/unit/valid-app.guard.spec.ts
@@ -1,0 +1,160 @@
+// server/test/modules/app/unit/valid-app.guard.spec.ts
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common';
+import { ValidAppGuard } from '@modules/apps/guards/valid-app.guard';
+
+/** @group platform */
+describe('ValidAppGuard', () => {
+  let guard: ValidAppGuard;
+  let mockAppRepository: {
+    findById: jest.Mock;
+    findBySlug: jest.Mock;
+  };
+
+  const UUID = '550e8400-e29b-41d4-a716-446655440000';
+  const ORG_ID = 'org-550e8400-e29b-41d4-a716-446655440001';
+
+  const makeContext = (params: { id?: string; slug?: string; versionId?: string } = {}, headers: Record<string, string> = {}): ExecutionContext => {
+    const request: Record<string, any> = {
+      params,
+      headers,
+      user: { organizationId: ORG_ID },
+    };
+    return {
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext;
+  };
+
+  const makeApp = (overrides = {}) => ({
+    id: UUID,
+    slug: 'my-app',
+    organizationId: ORG_ID,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    mockAppRepository = {
+      findById: jest.fn(),
+      findBySlug: jest.fn(),
+    };
+    guard = new ValidAppGuard(mockAppRepository as any);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('missing id, slug, and user', () => {
+    it('throws BadRequestException', async () => {
+      const request: Record<string, any> = { params: {}, headers: {}, user: null };
+      const ctx = { switchToHttp: () => ({ getRequest: () => request }) } as unknown as ExecutionContext;
+      await expect(guard.canActivate(ctx)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe(':id param is a valid UUID', () => {
+    it('calls findById — not findBySlug', async () => {
+      mockAppRepository.findById.mockResolvedValue(makeApp());
+
+      await guard.canActivate(makeContext({ id: UUID }));
+
+      expect(mockAppRepository.findById).toHaveBeenCalledWith(UUID, ORG_ID, undefined, undefined);
+      expect(mockAppRepository.findBySlug).not.toHaveBeenCalled();
+    });
+
+    it('forwards versionId and branchId to findById', async () => {
+      mockAppRepository.findById.mockResolvedValue(makeApp());
+
+      await guard.canActivate(
+        makeContext({ id: UUID, versionId: 'ver-uuid' }, { 'x-branch-id': 'branch-uuid' })
+      );
+
+      expect(mockAppRepository.findById).toHaveBeenCalledWith(UUID, ORG_ID, 'ver-uuid', 'branch-uuid');
+    });
+
+    it('throws NotFoundException when findById returns null', async () => {
+      mockAppRepository.findById.mockResolvedValue(null);
+
+      await expect(guard.canActivate(makeContext({ id: UUID }))).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe(':id param is a non-UUID string (slug in id position)', () => {
+    // replaceEditorURL swaps the browser URL from /apps/<uuid> to /apps/<slug>.
+    // On refresh the slug lands in :id. Previously this caused a TypeORM UUID
+    // parse error; now it routes to findBySlug instead.
+    it('calls findBySlug with the id value — not findById', async () => {
+      mockAppRepository.findBySlug.mockResolvedValue(makeApp());
+
+      await guard.canActivate(makeContext({ id: 'my-app-slug' }));
+
+      expect(mockAppRepository.findBySlug).toHaveBeenCalledWith('my-app-slug', ORG_ID, undefined, undefined);
+      expect(mockAppRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it('forwards branchId when x-branch-id header is present', async () => {
+      mockAppRepository.findBySlug.mockResolvedValue(makeApp());
+
+      await guard.canActivate(
+        makeContext({ id: 'my-app-slug' }, { 'x-branch-id': 'branch-uuid' })
+      );
+
+      expect(mockAppRepository.findBySlug).toHaveBeenCalledWith('my-app-slug', ORG_ID, undefined, 'branch-uuid');
+    });
+
+    it('throws NotFoundException (not a 500) when slug does not match any app', async () => {
+      mockAppRepository.findBySlug.mockResolvedValue(null);
+
+      await expect(guard.canActivate(makeContext({ id: 'no-such-slug' }))).rejects.toThrow(NotFoundException);
+      expect(mockAppRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('slug param (no :id)', () => {
+    it('calls findBySlug with the slug value', async () => {
+      mockAppRepository.findBySlug.mockResolvedValue(makeApp());
+
+      await guard.canActivate(makeContext({ slug: 'my-app' }));
+
+      expect(mockAppRepository.findBySlug).toHaveBeenCalledWith('my-app', ORG_ID, undefined, undefined);
+      expect(mockAppRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('request.tj_app already populated', () => {
+    it('skips all repo calls and returns true', async () => {
+      const app = makeApp();
+      const request: Record<string, any> = {
+        params: { id: UUID },
+        headers: {},
+        user: { organizationId: ORG_ID },
+        tj_app: app,
+      };
+      const ctx = { switchToHttp: () => ({ getRequest: () => request }) } as unknown as ExecutionContext;
+
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(mockAppRepository.findById).not.toHaveBeenCalled();
+      expect(mockAppRepository.findBySlug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successful resolution', () => {
+    it('attaches app to request.tj_app and sets tj_resource_id', async () => {
+      const app = makeApp();
+      mockAppRepository.findById.mockResolvedValue(app);
+
+      const request: Record<string, any> = {
+        params: { id: UUID },
+        headers: {},
+        user: { organizationId: ORG_ID },
+      };
+      const ctx = { switchToHttp: () => ({ getRequest: () => request }) } as unknown as ExecutionContext;
+
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(request.tj_app).toBe(app);
+      expect(request.tj_resource_id).toBe(app.id);
+    });
+  });
+});

--- a/server/test/modules/apps/e2e/apps-repository.spec.ts
+++ b/server/test/modules/apps/e2e/apps-repository.spec.ts
@@ -83,9 +83,10 @@ describe('AppsRepository', () => {
   describe('feature-branch slug resolution (PR #16818 regression)', () => {
     let nestApp: INestApplication;
     let appsRepository: AppsRepository;
-    let testApp: App;
+    let testApp: App & { organizationId: string };
     let mainBranchId: string;
     let featBranchId: string;
+    let orgId: string;
     const featureSlug = 'hydrated-feat-branch-slug';
 
     beforeAll(async () => {
@@ -93,8 +94,8 @@ describe('AppsRepository', () => {
       appsRepository = nestApp.get<AppsRepository>(AppsRepository);
 
       const admin = await createAdmin(nestApp, 'apps-repo-branch-slug@tooljet.io');
-      const orgId = admin.user.organizationId;
-      testApp = await createApplication(nestApp, { name: 'branch-slug-test-app', user: admin.user });
+      orgId = admin.user.organizationId;
+      testApp = await createApplication(nestApp, { name: 'branch-slug-test-app', user: admin.user }) as App & { organizationId: string };
 
       // Default branch — simulates a git-sync-enabled workspace.
       const mainBranch = await saveEntity(WorkspaceBranch, { organizationId: orgId, name: 'main', isDefault: true });
@@ -106,11 +107,11 @@ describe('AppsRepository', () => {
 
       // Default-branch version: slug = apps.id (PR #16818 stub placeholder).
       // chk_app_versions_branch_metadata requires app_name when branch_id is set.
-      const mainVersion = await createApplicationVersion(nestApp, testApp as App & { organizationId: string });
+      const mainVersion = await createApplicationVersion(nestApp, testApp);
       await updateEntity(AppVersion, mainVersion.id, { branchId: mainBranchId, slug: testApp.id, appName: 'branch-slug-test-app' });
 
       // Feature-branch version: holds the real canonical slug.
-      const featVersion = await createApplicationVersion(nestApp, testApp as App & { organizationId: string });
+      const featVersion = await createApplicationVersion(nestApp, testApp);
       await updateEntity(AppVersion, featVersion.id, { branchId: featBranchId, slug: featureSlug, appName: 'branch-slug-test-app' });
     });
 
@@ -137,6 +138,109 @@ describe('AppsRepository', () => {
       const result = await appsRepository.findByIdOrSlug(featureSlug);
       expect(result).not.toBeNull();
       expect(result!.id).toBe(testApp.id);
+    });
+
+    // When both branches carry the same slug, findByIdOrSlug must resolve via the
+    // default-branch row (the inner join with is_default=true wins). overlayMetadata
+    // stamps app.name from the resolved AppVersion.appName, so setting distinct
+    // appName values on each branch lets us verify which row was used.
+    it('findByIdOrSlug prefers the default-branch row when both branches carry the same slug', async () => {
+      const sharedSlug = 'shared-branch-slug';
+
+      const admin = await createAdmin(nestApp, 'apps-repo-branch-pref@tooljet.io');
+      const prefOrgId = admin.user.organizationId;
+      const prefApp = await createApplication(nestApp, { name: 'branch-pref-app', user: admin.user }) as App & { organizationId: string };
+
+      const mainBranch = await saveEntity(WorkspaceBranch, { organizationId: prefOrgId, name: 'main', isDefault: true });
+      const featBranch = await saveEntity(WorkspaceBranch, { organizationId: prefOrgId, name: 'feat/pref', isDefault: false });
+
+      const mainVer = await createApplicationVersion(nestApp, prefApp);
+      await updateEntity(AppVersion, mainVer.id, {
+        branchId: mainBranch.id,
+        slug: sharedSlug,
+        appName: 'from-default-branch',
+      });
+
+      const featVer = await createApplicationVersion(nestApp, prefApp);
+      await updateEntity(AppVersion, featVer.id, {
+        branchId: featBranch.id,
+        slug: sharedSlug,
+        appName: 'from-feature-branch',
+      });
+
+      const result = await appsRepository.findByIdOrSlug(sharedSlug);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(prefApp.id);
+      // overlayMetadata sets app.name from the resolved AppVersion.appName.
+      // If the default-branch row was used, name is 'from-default-branch'.
+      expect(result!.name).toBe('from-default-branch');
+    });
+
+    it('findBySlug resolves a feature-branch slug when orgId and branchId are both provided', async () => {
+      const result = await appsRepository.findBySlug(featureSlug, orgId, undefined, featBranchId);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(testApp.id);
+    });
+
+    it('findBySlug returns null for a feature-branch slug when branchId is absent (default-branch-only path)', async () => {
+      // Slug lives only on the feature branch; without branchId the function
+      // queries the default branch — nothing found.
+      const result = await appsRepository.findBySlug(featureSlug, orgId, undefined, undefined);
+      expect(result).toBeNull();
+    });
+
+    it('findBySlug returns null when the slug exists in a different org (cross-org isolation)', async () => {
+      // The slug was created under testApp's org in beforeAll. Querying with a
+      // different orgId must return null — no cross-org data leak.
+      const otherAdmin = await createAdmin(nestApp, 'apps-repo-crossorg@tooljet.io');
+      const result = await appsRepository.findBySlug(featureSlug, otherAdmin.user.organizationId, undefined, featBranchId);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('no-git-sync regression', () => {
+    let nestApp: INestApplication;
+    let appsRepository: AppsRepository;
+    let branchlessApp: App & { organizationId: string };
+    const branchlessSlug = 'branchless-custom-slug';
+
+    beforeAll(async () => {
+      ({ app: nestApp } = await initTestApp());
+      appsRepository = nestApp.get<AppsRepository>(AppsRepository);
+
+      // Workspace with no WorkspaceBranch rows — simulates git-sync OFF.
+      const admin = await createAdmin(nestApp, 'apps-repo-nogitsync@tooljet.io');
+      branchlessApp = await createApplication(nestApp, { name: 'no-gitsync-app', user: admin.user }) as App & { organizationId: string };
+      const version = await createApplicationVersion(nestApp, branchlessApp);
+      await updateEntity(AppVersion, version.id, { slug: branchlessSlug });
+    });
+
+    afterAll(async () => {
+      await closeTestApp(nestApp);
+    }, 60000);
+
+    it('findBySlug resolves a branchless app by slug', async () => {
+      const result = await appsRepository.findBySlug(branchlessSlug, branchlessApp.organizationId);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(branchlessApp.id);
+    });
+
+    it('findAppBySlug resolves a branchless app by slug', async () => {
+      const result = await appsRepository.findAppBySlug(branchlessSlug);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(branchlessApp.id);
+    });
+
+    it('findByIdOrSlug resolves a branchless app by slug', async () => {
+      const result = await appsRepository.findByIdOrSlug(branchlessSlug);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(branchlessApp.id);
+    });
+
+    it('findByIdOrSlug resolves a branchless app by UUID', async () => {
+      const result = await appsRepository.findByIdOrSlug(branchlessApp.id);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(branchlessApp.id);
     });
   });
 });

--- a/server/test/modules/apps/e2e/apps-repository.spec.ts
+++ b/server/test/modules/apps/e2e/apps-repository.spec.ts
@@ -8,11 +8,13 @@ import {
   createApplication,
   createApplicationVersion,
   updateEntity,
+  saveEntity,
 } from 'test-helper';
 import { INestApplication } from '@nestjs/common';
 import { AppsRepository } from '@modules/apps/repository';
 import { App } from 'src/entities/app.entity';
 import { AppVersion } from 'src/entities/app_version.entity';
+import { WorkspaceBranch } from 'src/entities/workspace_branch.entity';
 
 // initTestApp() can exceed 60s when Jest restarts the worker to free memory
 jest.setTimeout(120_000);
@@ -71,6 +73,66 @@ describe('AppsRepository', () => {
 
         expect(result).toBeNull();
       });
+    });
+  });
+
+  // Regression: PR #16818 changed import to write apps.id as the default-branch
+  // stub slug, so the real slug lives only on the feature-branch row. Both
+  // findAppBySlug (PrivateAppAuthGuard) and findByIdOrSlug (external API) must
+  // fall back to that row instead of returning null.
+  describe('feature-branch slug resolution (PR #16818 regression)', () => {
+    let nestApp: INestApplication;
+    let appsRepository: AppsRepository;
+    let testApp: App;
+    let mainBranchId: string;
+    let featBranchId: string;
+    const featureSlug = 'hydrated-feat-branch-slug';
+
+    beforeAll(async () => {
+      ({ app: nestApp } = await initTestApp());
+      appsRepository = nestApp.get<AppsRepository>(AppsRepository);
+
+      const admin = await createAdmin(nestApp, 'apps-repo-branch-slug@tooljet.io');
+      const orgId = admin.user.organizationId;
+      testApp = await createApplication(nestApp, { name: 'branch-slug-test-app', user: admin.user });
+
+      // Default branch — simulates a git-sync-enabled workspace.
+      const mainBranch = await saveEntity(WorkspaceBranch, { organizationId: orgId, name: 'main', isDefault: true });
+      mainBranchId = mainBranch.id;
+
+      // Feature branch.
+      const featBranch = await saveEntity(WorkspaceBranch, { organizationId: orgId, name: 'feature/test', isDefault: false });
+      featBranchId = featBranch.id;
+
+      // Default-branch version: slug = apps.id (PR #16818 stub placeholder).
+      // chk_app_versions_branch_metadata requires app_name when branch_id is set.
+      const mainVersion = await createApplicationVersion(nestApp, testApp as App & { organizationId: string });
+      await updateEntity(AppVersion, mainVersion.id, { branchId: mainBranchId, slug: testApp.id, appName: 'branch-slug-test-app' });
+
+      // Feature-branch version: holds the real canonical slug.
+      const featVersion = await createApplicationVersion(nestApp, testApp as App & { organizationId: string });
+      await updateEntity(AppVersion, featVersion.id, { branchId: featBranchId, slug: featureSlug, appName: 'branch-slug-test-app' });
+    });
+
+    afterAll(async () => {
+      await closeTestApp(nestApp);
+    }, 60000);
+
+    it('findAppBySlug resolves via the feature-branch row when default-branch has a different slug', async () => {
+      const result = await appsRepository.findAppBySlug(featureSlug);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(testApp.id);
+    });
+
+    it('findAppBySlug returns null for a completely unknown slug', async () => {
+      const result = await appsRepository.findAppBySlug('completely-unknown-slug-xyz');
+      expect(result).toBeNull();
+    });
+
+    it('findByIdOrSlug resolves via the feature-branch row when default-branch has a different slug', async () => {
+      const result = await appsRepository.findByIdOrSlug(featureSlug);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(testApp.id);
     });
   });
 });

--- a/server/test/modules/apps/e2e/apps-repository.spec.ts
+++ b/server/test/modules/apps/e2e/apps-repository.spec.ts
@@ -118,10 +118,14 @@ describe('AppsRepository', () => {
       await closeTestApp(nestApp);
     }, 60000);
 
-    it('findAppBySlug resolves via the feature-branch row when default-branch has a different slug', async () => {
+    it('findAppBySlug returns null for a feature-branch slug (cross-org safety)', async () => {
+      // findAppBySlug is cross-workspace. Accepting feature-branch rows without
+      // org context risks returning the wrong org's app when the same slug exists
+      // in multiple orgs pulled from the same git source. The guard resolves this
+      // via workspace-scoped findBySlug instead; findAppBySlug correctly returns
+      // null so the guard can take over.
       const result = await appsRepository.findAppBySlug(featureSlug);
-      expect(result).not.toBeNull();
-      expect(result!.id).toBe(testApp.id);
+      expect(result).toBeNull();
     });
 
     it('findAppBySlug returns null for a completely unknown slug', async () => {


### PR DESCRIPTION
## Summary

- **Root cause**: PR #16818 changed app import to write `apps.id` as the default-branch stub slug placeholder, breaking the "default-branch is authoritative for slug lookup" invariant. After hydration, the real slug exists only on the feature-branch `app_versions` row. Two repository methods that enforce this invariant both returned `null` for feature-branch slugs, causing 404 on any refresh or back-navigation.

- **`findAppBySlug`** (`PrivateAppAuthGuard` → `validate-private-app-access` path — the primary refresh path): step-2 fallback was restricted to `branch_id IS NULL` rows with an additional `!orgDefaultBranchId` gate. Step 1 already JOINs `WorkspaceBranch` with `is_default = true` and returned null — meaning no default-branch row anywhere on the instance holds this slug. Any row step 2 finds is therefore unambiguous. Removed the `branch_id IS NULL` filter and the `orgDefaultBranchId` gate.

- **`findByIdOrSlug`** (external API / `getAppAuthenticationConfig` path): when the default-branch re-query returns no row, fall back to the original candidate. The candidate is unambiguous when the default row's slug differs from the queried slug — no disambiguation needed.

- **`ValidAppGuard`** (`GET /apps/:id`): guard non-UUID values in the `:id` param with `isUUID()` so slugs set by `replaceEditorURL` route to `findBySlug` instead of triggering a TypeORM UUID parse error.

## Regression window

Works on v3.21.45-beta-ee, broken from v3.21.46-beta+ (PR #16818 / commit `7642847bbc`).

## Test plan

- [x] Open a git-sync workspace on a non-default branch
- [x] Open an app hydrated from another workspace's feature branch (first load should work)
- [x] Refresh the page → should no longer 404
- [x] Back-navigate to the same app → should no longer 404
- [x] Verify non-git-sync workspaces unaffected (slug resolution still works)
- [x] Verify released/public apps still accessible via `validate-released-app-access`

**QA Checklist** 

- [x] Integration Testing. 
- [x] Smoke Testing. 
- [ ] Bug Fixes Verification. 
- [ ] Cross browser UI check. (Firefox, safari, chrome)
- [ ] Verify features on Dark and Light mode.
- [ ] Test feature on CE, EE, cloud
- [x] Platform Automation Testing: [Action URL](https://github.com/ToolJet/ToolJet/actions/runs/28352920951?pr=16981) - the fix is available for failing case, it's merged in another PR, not a blocker for current release
- [x] Marketplace Automation Testing: [Action URL](https://github.com/ToolJet/ToolJet/actions/runs/28352920976?pr=16981) - `dynamodbHappyPath` spec has 3 failed cases because of UI issue
- [ ] Migration testing.
- [x] Added tested Label for PR
- [ ] Import/Export/GitSync/Cloning
- [ ] Test System Upgrade/Staging Instance(for cloud) (Sanity + Test System Specific. Cases)
- [ ] Performance Benchmark
- [ ] Cross-Platform Dependency Update