### PR TITLE
Fix: `Go to app` event not working when params contain {{...}} values

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/eventsSlice.js
@@ -670,7 +670,11 @@ export const createEventsSlice = (set, get) => ({
                 (result, queryParam) => ({
                   ...result,
                   ...{
-                    [getResolvedValue(queryParam[0])]: getResolvedValue(queryParam[1], undefined, customVariables),
+                    [getResolvedValue(queryParam[0], customVariables, moduleId)]: getResolvedValue(
+                      queryParam[1],
+                      customVariables,
+                      moduleId
+                    ),
                   },
                 }),
                 {}

--- a/server/src/modules/versions/services/create.service.ts
+++ b/server/src/modules/versions/services/create.service.ts
@@ -642,7 +642,11 @@ export class VersionsCreateService implements IVersionsCreateService {
     for (const event of allEvents) {
       const eventDefinition = updateEntityReferences(event.event, mappings);
 
-      if (eventDefinition?.actionId === 'run-query') {
+      if (
+        eventDefinition?.actionId === 'run-query' ||
+        eventDefinition?.actionId === 'reset-query' ||
+        eventDefinition?.actionId === 'abort-query'
+      ) {
         eventDefinition.queryId = oldDataQueryToNewMapping[eventDefinition.queryId];
       }
 


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/5223 https://github.com/ToolJet/tj-ee/issues/5224

This pull request introduces improvements to how event parameters are resolved in the frontend and expands query action handling in the backend service. The main changes are:

**Frontend event parameter resolution:**

* Updated `getResolvedValue` calls in `eventsSlice.js` to consistently pass `customVariables` and `moduleId` for both key and value resolution, ensuring more accurate and context-aware event parameter mapping.

**Backend query action handling:**

* Enhanced the `VersionsCreateService` so that, in addition to `'run-query'`, it now also updates `queryId` references for `'reset-query'` and `'abort-query'` actions, improving support for additional query-related events during version creation.