### PR TITLE
fix(plugins/databricks): handle fx expressions gracefully in listColumns invocation

### DIFF
--- a/plugins/packages/databricks/lib/index.ts
+++ b/plugins/packages/databricks/lib/index.ts
@@ -614,6 +614,7 @@ export default class Databricks implements QueryService {
     if (methodName === 'listColumns') {
       const table = args?.values?.table || '';
       if (!table) return [];
+        if (table.includes('{{') && table.includes('}}')) return [];
       if (authType === 'oauth_u2m') {
         const httpPath = sourceOptions.http_path || '';
         if (!httpPath)


### PR DESCRIPTION
Closes #16960.

This PR adds a validation guard to handle unresolved FX expression templates ({{ ... }}) gracefully in the listColumns method for the Databricks plugin. This prevents un-evaluated properties from hitting the string-splitting logic and breaking the inspection metadata pipeline.