### PR TITLE
Fix: git-sync header race condition on rapid app switching

### DIFF
--- a/frontend/src/AppBuilder/_hooks/useGitSyncConfig.js
+++ b/frontend/src/AppBuilder/_hooks/useGitSyncConfig.js
@@ -1,8 +1,16 @@
 import useStore from '@/AppBuilder/_stores/store';
+import { useWorkspaceBranchesStore } from '@/_stores/workspaceBranchesStore';
 
 export const useGitSyncConfig = () => {
   const orgGit = useStore((state) => state.orgGit);
-  const isGitSyncEnabled = orgGit?.git_ssh?.is_enabled || orgGit?.git_https?.is_enabled || orgGit?.git_lab?.is_enabled;
+  const orgGitConfig = useWorkspaceBranchesStore((state) => state.orgGitConfig);
+
+  const isGitSyncEnabled =
+    orgGit?.git_ssh?.is_enabled ||
+    orgGit?.git_https?.is_enabled ||
+    orgGit?.git_lab?.is_enabled ||
+    !!(orgGitConfig?.isEnabled ?? orgGitConfig?.is_enabled);
+
   const defaultBranch = orgGit?.git_https?.github_branch || orgGit?.git_ssh?.github_branch || 'main';
   return { isGitSyncEnabled, defaultBranch };
 };


### PR DESCRIPTION
## 📝 What this does
Fixes a race condition where rapidly navigating between app editors in a git-sync enabled workspace causes the header to briefly flash non-git state (showing both branch dropdown and version dropdown simultaneously).

## 🔀 Changes
- Added `workspaceBranchesStore.orgGitConfig` as a fallback in `useGitSyncConfig` hook when the AppBuilder store's `orgGit` is null during the reset→fetchAppGit gap

## 🧪 How to test
- [ ] Enable git-sync on a workspace with multiple apps
- [ ] Open an app editor, then press Cmd+← to go back
- [ ] Immediately click Edit on another app
- [ ] Verify the header shows only the branch dropdown (git-sync state) without briefly flashing the version dropdown