### PR TITLE
Fix Google Sheets delete filter placeholder

### DIFF
--- a/plugins/packages/googlesheetsv2/lib/operations.json
+++ b/plugins/packages/googlesheetsv2/lib/operations.json
@@ -249,7 +249,7 @@
         "description": "Enter Filter",
         "height": "36px",
         "className": "codehinter-plugins",
-        "placeholder": "Enter Filter"
+        "placeholder": "[{\"a1Range\": \"Sheet1!A28:B28\"}]"
       }
     },
     "bulk_update_by_primary_key": {


### PR DESCRIPTION
## 📝 Description

Updates the placeholder for the Google Sheets "Delete data from a spreadsheet by data filter" operation to display the correct syntax example.

### Changes
- Replaced `Enter Filter` with:
  `[{"a1Range": "Sheet1!A28:B28"}]`

Closes #16854

## ✅ Testing
- Verified the placeholder value in `operations.json`.