### PR TITLE
fix: Allow expanding the table's last column header & body rows until it fills up the available space incase the table's width is more than total width of all columns

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/_components/TableHeader.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/_components/TableHeader.jsx
@@ -72,7 +72,6 @@ const DraggableHeader = ({ header, darkMode, id, table, fireEvent, setExposedVar
     transition: 'width transform 0.2s ease-in-out',
     whiteSpace: 'nowrap',
     width: header.column.getSize(),
-    flex: '0 0 auto',
     zIndex: isDragging ? 15 : pinnedStyles.zIndex ?? 0,
     backgroundColor: columnBackgroundColor,
     color: columnTitleColor,

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/_components/TableRow.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/_components/TableRow.jsx
@@ -86,7 +86,6 @@ export const TableRow = ({
           alignItems: 'center',
           textAlign: isButtonColumn ? undefined : cell.column.columnDef?.meta?.horizontalAlignment,
           width: cell.column.getSize(),
-          flex: '0 0 auto',
           ...pinnedStyles,
         };
 


### PR DESCRIPTION
Issue: https://github.com/ToolJet/tj-ee/issues/5237