### PR TITLE
fix: Allow expanding the table's last column header & body rows until it fills up the available space incase the table's width is more than total width of all columns

### DIFF
--- a/frontend/src/_styles/table-component.scss
+++ b/frontend/src/_styles/table-component.scss
@@ -497,6 +497,10 @@
 
       tbody {
         display: inline-block;
+
+        tr td:last-child {
+          flex: 1 1 auto !important;
+        }
       }
     }
 


### PR DESCRIPTION
Issue: https://github.com/ToolJet/tj-ee/issues/5237