### PR TITLE
Fix: Data queries with SQL mode fails when a comment is combined with {{...}} references in SQL query

### DIFF
--- a/server/src/modules/data-queries/util.service.ts
+++ b/server/src/modules/data-queries/util.service.ts
@@ -564,11 +564,16 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
 
       // Case 3: String
       if (typeof obj === 'string') {
-        let resolvedValue = obj.replace(/\n/g, ' ');
+        // Preserve newlines in the query text itself.
+        // A newline-flattened form is only used for whole-string map lookups.
+        // Flattening the query text here would collapse a multi-line query into a single line,
+        // so a leading `-- comment` would then comment out the entire query.
+        let resolvedValue = obj;
+        const flattenedForLookup = obj.replace(/\n/g, ' ');
 
         // a: Handle strings with both {{ }} and %% (%% - deprecated removed) TODO: CHECK IF ITS NEEDED
         if (typeof resolvedValue === 'string' && resolvedValue.includes('{{') && resolvedValue.includes('}}')) {
-          const resolvedVar = options[resolvedValue];
+          const resolvedVar = options[flattenedForLookup];
           if (parent && key !== null) {
             parent[key] = resolvedVar;
           }
@@ -600,7 +605,7 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
               resolvedValue.endsWith('}}') &&
               (resolvedValue.match(/{{/g) || [])?.length === 1)) // Single variables
         ) {
-          resolvedValue = options[resolvedValue];
+          resolvedValue = options[flattenedForLookup];
           if (parent && key !== null) {
             parent[key] = resolvedValue;
           }


### PR DESCRIPTION
This pull request updates the variable resolution logic in the `DataQueriesUtilService` to better handle multi-line query strings. Specifically, it ensures that newlines are preserved in the query text itself, while a flattened (newline-removed) version is only used for map lookups. This prevents issues where flattening the query text could cause comments to unintentionally comment out entire queries.

**Improvements to variable resolution logic:**

* Preserves newlines in query strings by using the original string for the query text and only flattening it (removing newlines) for lookup in the `options` map. This avoids collapsing multi-line queries into a single line, which could otherwise cause issues with comment syntax.
* Updates all relevant lookups to use the flattened string for variable resolution, ensuring consistency and correctness when resolving variables with multi-line keys.