### PR TITLE
Fix: fx fields depending on a component's default value not resolving on load

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
@@ -471,55 +471,56 @@ export const createResolvedSlice = (set, get) => {
     },
 
     setExposedValues: (id, type, values, moduleId = 'canvas') => {
-      // `existing` is the currently committed exposed-value object for the `component`
-      const existing = get().resolvedStore.modules[moduleId].exposedValues[type][id];
-
-      // "Collect writes and dependency paths only for keys that are an actual change. A key is skipped when:
-      //   - it's a function (setValue/clear etc. are action handlers, never dependency sources), or
-      //   - its value deep-equals the currently resolved value — re-publishing an unchanged value
-      //     (e.g. a component re-emitting its default on mount/reload) must not count as a change,
-      //     otherwise queries with "Run on dependency change" fire on app load.
-      // When `existing` is undefined (first publish) or an array (stale ListView structure) there's
-      // no comparable prior value, so every non-function key counts as changed.
-      const writes = [];
-      const depPaths = [];
-
-      Object.entries(values).forEach(([key, value]) => {
-        const isFunction = typeof value === 'function';
-        const unchanged = existing !== undefined && !Array.isArray(existing) && _.isEqual(value, existing[key]);
-
-        if (!isFunction && unchanged) return;
-        writes.push([key, value]);
-
-        if (!isFunction) depPaths.push({ path: `components.${id}.${key}`, moduleId });
-      });
-
-      if (writes.length === 0) return;
-
-      // Replaces a missing entry, or a stale array (Immer can't set named keys on an array), with a fresh object before assigning each changed key.
-      const mutation = (state) => {
-        const entities = state.resolvedStore.modules[moduleId].exposedValues[type];
-        writes.forEach(([key, value]) => {
-          if (entities[id] === undefined || Array.isArray(entities[id])) {
-            // Initialize as plain object. The Array.isArray check handles the case where a
-            // component was previously inside a ListView (exposed values stored as a per-row
-            // array) and is moved to the canvas — the stale array must be replaced with a
-            // plain object before setting named properties, otherwise Immer throws because
-            // arrays only support numeric indices.
-            entities[id] = { [key]: value };
-          } else {
-            entities[id][key] = value;
+      if (_exposedValueBatch.isBatching()) {
+        const depPaths = [];
+        Object.entries(values).forEach(([key, value]) => {
+          if (typeof value !== 'function') {
+            depPaths.push({ path: `components.${id}.${key}`, moduleId });
           }
         });
-      };
-
-      if (_exposedValueBatch.isBatching()) {
-        _exposedValueBatch.bufferMutation(mutation, depPaths);
+        _exposedValueBatch.bufferMutation((state) => {
+          Object.entries(values).forEach(([key, value]) => {
+            if (state.resolvedStore.modules[moduleId].exposedValues[type][id] === undefined)
+              state.resolvedStore.modules[moduleId].exposedValues[type][id] = { [key]: value };
+            else state.resolvedStore.modules[moduleId].exposedValues[type][id][key] = value;
+          });
+        }, depPaths);
         return;
       }
 
-      set(mutation, false, { type: 'setExposedValues', payload: { id, type, values, moduleId } });
-      depPaths.forEach(({ path }) => scheduleDependencyUpdate(path, moduleId));
+      const skipKeys = new Set();
+      set(
+        (state) => {
+          Object.entries(values).forEach(([key, value]) => {
+            const existing = state.resolvedStore.modules[moduleId].exposedValues[type][id];
+            if (existing === undefined || Array.isArray(existing)) {
+              // Initialize as plain object. The Array.isArray check handles the case where a
+              // component was previously inside a ListView (exposed values stored as a per-row
+              // array) and is moved to the canvas — the stale array must be replaced with a
+              // plain object before setting named properties, otherwise Immer throws because
+              // arrays only support numeric indices.
+              state.resolvedStore.modules[moduleId].exposedValues[type][id] = {
+                [key]: value,
+              };
+            } else {
+              // _.isEqual on an Immer proxy is safe here: Immer's proxy traps are synchronous
+              // and lodash's deep comparison works correctly against them.
+              if (_.isEqual(value, existing[key])) {
+                skipKeys.add(key);
+              } else existing[key] = value;
+            }
+          });
+        },
+        false,
+        {
+          type: 'setExposedValues',
+          payload: { id, type, values, moduleId },
+        }
+      );
+      Object.entries(values).forEach(([key, value]) => {
+        if (typeof value !== 'function' && !skipKeys.has(key))
+          scheduleDependencyUpdate(`components.${id}.${key}`, moduleId);
+      });
     },
 
     setDefaultExposedValues: (id, parentId, componentType, moduleId = 'canvas') => {


### PR DESCRIPTION
Issue: https://github.com/ToolJet/tj-ee/issues/5246

Reverts few changes from PR -> https://github.com/ToolJet/ToolJet/pull/16943

On load, `setExposedValues` was skipping the dependency cascade for any key whose published value equalled what was already stored. Since a component publishes values matching its pre-populated defaults on mount, the cascade for `components.textinput1.value` was skipped. But the button's disable fx is resolved by that cascade and had never been evaluated against the input's value yet — so it stayed at its own default (false = enabled).

The dedup conflated "value equals the stored default" with "dependents are already up to date," which is false on the first load when dependents haven't resolved.

Reverted `setExposedValues` to its original form so the initial publish always cascades and dependents resolve on load. (The unrelated "run query on dependency change fires on load" behavior is handled separately by the per-module suppress-on-load window and does not rely on this dedup.)