### PR TITLE
Add Asana datasource plugin with task, project, workspace, and attachment operations

### DIFF
--- a/marketplace/package-lock.json
+++ b/marketplace/package-lock.json
@@ -3229,6 +3229,12 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
+    },
     "node_modules/@mistralai/mistralai": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.15.1.tgz",
@@ -5386,6 +5392,12 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@sigstore/bundle": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
@@ -5840,6 +5852,10 @@
     },
     "node_modules/@tooljet-marketplace/anthropic": {
       "resolved": "plugins/anthropic",
+      "link": true
+    },
+    "node_modules/@tooljet-marketplace/asana": {
+      "resolved": "plugins/asana",
       "link": true
     },
     "node_modules/@tooljet-marketplace/authorizenet": {
@@ -7723,6 +7739,18 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/byte-counter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+      "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/byte-size": {
       "version": "8.1.1",
@@ -19227,6 +19255,241 @@
         "typescript": "^4.7.4"
       }
     },
+    "plugins/asana": {
+      "name": "@tooljet-marketplace/asana",
+      "version": "1.0.0",
+      "dependencies": {
+        "@tooljet-marketplace/common": "^1.0.0",
+        "got": "^14.4.7"
+      },
+      "devDependencies": {
+        "@vercel/ncc": "^0.34.0",
+        "typescript": "^4.7.4"
+      }
+    },
+    "plugins/asana/node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "plugins/asana/node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "plugins/asana/node_modules/cacheable-request": {
+      "version": "13.0.19",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
+      "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.2.0",
+        "get-stream": "^9.0.1",
+        "http-cache-semantics": "^4.2.0",
+        "keyv": "^5.6.0",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.1.1",
+        "responselike": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "plugins/asana/node_modules/decompress-response": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+      "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/asana/node_modules/form-data-encoder": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "plugins/asana/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/asana/node_modules/got": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+      "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^7.0.1",
+        "byte-counter": "^0.1.0",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^13.0.12",
+        "decompress-response": "^10.0.0",
+        "form-data-encoder": "^4.0.2",
+        "http2-wrapper": "^2.2.1",
+        "keyv": "^5.5.3",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^4.0.1",
+        "responselike": "^4.0.2",
+        "type-fest": "^4.26.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "plugins/asana/node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "plugins/asana/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/asana/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "plugins/asana/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/asana/node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/asana/node_modules/normalize-url": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/asana/node_modules/p-cancelable": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
+      "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "plugins/asana/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/asana/node_modules/responselike": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+      "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/asana/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "plugins/authorizenet": {
       "name": "@tooljet-marketplace/authorizenet",
       "version": "1.0.0",
@@ -20433,7 +20696,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tooljet-marketplace/common": "^1.0.0",
-        "openai": "^6.15.0"
+        "openai": "6.39.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.34.0",
@@ -20441,7 +20704,9 @@
       }
     },
     "plugins/openai/node_modules/openai": {
-      "version": "6.25.0",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
+      "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/marketplace/plugins/asana/lib/icon.svg
+++ b/marketplace/plugins/asana/lib/icon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="6" r="4" fill="#F06A6A"/>
+  <circle cx="6" cy="16" r="4" fill="#F06A6A"/>
+  <circle cx="18" cy="16" r="4" fill="#F06A6A"/>
+</svg>

--- a/marketplace/plugins/asana/lib/icon.svg
+++ b/marketplace/plugins/asana/lib/icon.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="12" cy="6" r="4" fill="#F06A6A"/>
-  <circle cx="6" cy="16" r="4" fill="#F06A6A"/>
-  <circle cx="18" cy="16" r="4" fill="#F06A6A"/>
+  <ellipse cx="5.22" cy="17.824" fill="#EF5350" rx="5.22" ry="5.176"/>
+  <ellipse cx="12" cy="6.176" fill="#EF5350" rx="5.22" ry="5.176"/>
+  <ellipse cx="18.78" cy="17.824" fill="#EF5350" rx="5.22" ry="5.176"/>
 </svg>

--- a/marketplace/plugins/asana/lib/index.ts
+++ b/marketplace/plugins/asana/lib/index.ts
@@ -1,0 +1,469 @@
+import {
+  QueryError,
+  QueryResult,
+  QueryService,
+  ConnectionTestResult,
+  OAuthUnauthorizedClientError,
+} from '@tooljet-marketplace/common';
+import { SourceOptions, QueryOptions } from './types';
+import got from 'got';
+
+const ASANA_BASE_URL = 'https://app.asana.com/api/1.0';
+const ASANA_AUTH_URL = 'https://app.asana.com/-/oauth_authorize';
+const ASANA_TOKEN_URL = 'https://app.asana.com/-/oauth_token';
+
+export default class Asana implements QueryService {
+  authUrl(source_options: SourceOptions): string {
+    const { clientId, redirectUri } = this.getOAuthCredentials(source_options);
+
+    if (!clientId) {
+      throw new Error('Asana OAuth client_id is missing');
+    }
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId,
+      redirect_uri: redirectUri,
+    });
+
+    return `${ASANA_AUTH_URL}?${params.toString()}`;
+  }
+
+  async accessDetailsFrom(authCode: string, source_options: SourceOptions): Promise<object> {
+    const { clientId, clientSecret, redirectUri } = this.getOAuthCredentials(source_options);
+
+    const data = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      code: authCode,
+    });
+
+    try {
+      const response = await got(ASANA_TOKEN_URL, {
+        method: 'post',
+        body: data.toString(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+      });
+
+      const result = JSON.parse(response.body);
+      const authDetails: [string, string][] = [];
+
+      if (result['access_token']) {
+        authDetails.push(['access_token', result['access_token']]);
+      }
+      if (result['refresh_token']) {
+        authDetails.push(['refresh_token', result['refresh_token']]);
+      }
+      if (result['expires_in']) {
+        authDetails.push(['expires_in', result['expires_in'].toString()]);
+      }
+      if (result['token_type']) {
+        authDetails.push(['token_type', result['token_type']]);
+      }
+
+      return authDetails;
+    } catch (error) {
+      throw new QueryError(
+        'Authorization Error',
+        error.response?.body || error.message,
+        { error: error.message }
+      );
+    }
+  }
+
+  async refreshToken(sourceOptions: SourceOptions): Promise<{ access_token: string; refresh_token?: string }> {
+    const refreshToken = sourceOptions.refresh_token;
+
+    if (!refreshToken) {
+      throw new QueryError('Refresh token not found', 'Refresh token is required to refresh the access token', {});
+    }
+
+    const { clientId, clientSecret } = this.getOAuthCredentials(sourceOptions);
+
+    const data = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+    });
+
+    try {
+      const response = await got(ASANA_TOKEN_URL, {
+        method: 'post',
+        body: data.toString(),
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+
+      const result = JSON.parse(response.body);
+
+      if (!result['access_token']) {
+        throw new QueryError('Refresh token failed', 'Access token not found in response', {});
+      }
+
+      return {
+        access_token: result['access_token'],
+        ...(result['refresh_token'] ? { refresh_token: result['refresh_token'] } : {}),
+      };
+    } catch (error) {
+      if (error instanceof QueryError) throw error;
+      throw new QueryError(
+        'Error refreshing access token',
+        error.response?.body || error.message,
+        {}
+      );
+    }
+  }
+
+  async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
+    try {
+      const response = await got(`${ASANA_BASE_URL}/users/me`, {
+        headers: this.authHeader(sourceOptions.access_token),
+      });
+      const data = JSON.parse(response.body);
+      if (data?.data?.gid) {
+        return { status: 'ok' };
+      }
+      throw new Error('Unexpected response from Asana');
+    } catch (error) {
+      throw new QueryError(
+        'Connection could not be established',
+        error.response?.body || error.message,
+        {}
+      );
+    }
+  }
+
+  async run(sourceOptions: SourceOptions, queryOptions: QueryOptions): Promise<QueryResult> {
+    const token = sourceOptions.access_token;
+    const { resource } = queryOptions;
+
+    let result: any;
+
+    try {
+      switch (resource) {
+        case 'task':
+          result = await this.handleTask(token, queryOptions);
+          break;
+        case 'project':
+          result = await this.handleProject(token, queryOptions);
+          break;
+        case 'workspace':
+          result = await this.handleWorkspace(token, queryOptions);
+          break;
+        case 'attachment':
+          result = await this.handleAttachment(token, queryOptions);
+          break;
+        default:
+          throw new QueryError('Unknown resource', `Resource "${resource}" is not supported`, {});
+      }
+    } catch (error) {
+      if (error instanceof QueryError) throw error;
+      if (error.response?.statusCode === 401) {
+        throw new OAuthUnauthorizedClientError('Unauthorized', error.message, {});
+      }
+      const body = this.parseErrorBody(error);
+      throw new QueryError('Query could not be completed', body?.errors?.[0]?.message || error.message, body);
+    }
+
+    return { status: 'ok', data: result };
+  }
+
+  // ─── Task handlers ───────────────────────────────────────────────────────────
+
+  private async handleTask(token: string, opts: QueryOptions): Promise<any> {
+    const { operation } = opts;
+
+    switch (operation) {
+      case 'list_tasks':
+        return this.get(token, '/tasks', this.clean({
+          project: opts.project_gid,
+          opt_fields: opts.opt_fields,
+          limit: opts.limit,
+          offset: opts.offset,
+        }));
+
+      case 'get_task':
+        return this.get(token, `/tasks/${opts.task_gid}`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'create_task': {
+        const body = this.parseBody(opts.body);
+        if (opts.workspace_gid) body['workspace'] = opts.workspace_gid;
+        return this.post(token, '/tasks', body);
+      }
+
+      case 'update_task':
+        return this.put(token, `/tasks/${opts.task_gid}`, this.parseBody(opts.body));
+
+      case 'delete_task':
+        return this.delete(token, `/tasks/${opts.task_gid}`);
+
+      case 'add_comment':
+        return this.post(token, `/tasks/${opts.task_gid}/stories`, {
+          text: opts.text || '',
+          is_pinned: opts.is_pinned === 'true',
+        });
+
+      case 'list_stories':
+        return this.get(token, `/tasks/${opts.task_gid}/stories`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'list_subtasks':
+        return this.get(token, `/tasks/${opts.task_gid}/subtasks`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'create_subtask': {
+        const body = this.parseBody(opts.body);
+        return this.post(token, `/tasks/${opts.task_gid}/subtasks`, body);
+      }
+
+      case 'add_to_project':
+        return this.post(token, `/tasks/${opts.task_gid}/addProject`, this.clean({
+          project: opts.project_gid,
+          section: opts.section_gid,
+        }));
+
+      case 'remove_from_project':
+        return this.post(token, `/tasks/${opts.task_gid}/removeProject`, {
+          project: opts.project_gid,
+        });
+
+      case 'add_followers':
+        return this.post(token, `/tasks/${opts.task_gid}/addFollowers`, {
+          followers: this.parseGidList(opts.followers),
+        });
+
+      case 'remove_followers':
+        return this.post(token, `/tasks/${opts.task_gid}/removeFollowers`, {
+          followers: this.parseGidList(opts.followers),
+        });
+
+      case 'duplicate_task':
+        return this.post(token, `/tasks/${opts.task_gid}/duplicate`, this.clean({
+          name: opts.name,
+          include: opts.include ? opts.include.split(',').map((s) => s.trim()) : undefined,
+        }));
+
+      case 'list_attachments':
+        return this.get(token, `/tasks/${opts.task_gid}/attachments`, {});
+
+      default:
+        throw new QueryError('Unknown operation', `Task operation "${operation}" is not supported`, {});
+    }
+  }
+
+  // ─── Project handlers ─────────────────────────────────────────────────────────
+
+  private async handleProject(token: string, opts: QueryOptions): Promise<any> {
+    const { operation } = opts;
+
+    switch (operation) {
+      case 'list_projects':
+        return this.get(token, '/projects', this.clean({
+          workspace: opts.workspace_gid,
+          opt_fields: opts.opt_fields,
+          limit: opts.limit,
+          offset: opts.offset,
+        }));
+
+      case 'get_project':
+        return this.get(token, `/projects/${opts.project_gid}`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'create_project': {
+        const body = this.parseBody(opts.body);
+        if (opts.workspace_gid) body['workspace'] = opts.workspace_gid;
+        return this.post(token, '/projects', body);
+      }
+
+      case 'update_project':
+        return this.put(token, `/projects/${opts.project_gid}`, this.parseBody(opts.body));
+
+      case 'delete_project':
+        return this.delete(token, `/projects/${opts.project_gid}`);
+
+      case 'list_sections':
+        return this.get(token, `/projects/${opts.project_gid}/sections`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      default:
+        throw new QueryError('Unknown operation', `Project operation "${operation}" is not supported`, {});
+    }
+  }
+
+  // ─── Workspace handlers ───────────────────────────────────────────────────────
+
+  private async handleWorkspace(token: string, opts: QueryOptions): Promise<any> {
+    const { operation } = opts;
+
+    switch (operation) {
+      case 'list_workspaces':
+        return this.get(token, '/workspaces', this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'list_users':
+        return this.get(token, `/workspaces/${opts.workspace_gid}/users`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'list_teams':
+        return this.get(token, `/workspaces/${opts.workspace_gid}/teams`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'list_tags':
+        return this.get(token, `/workspaces/${opts.workspace_gid}/tags`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'create_tag':
+        return this.post(token, '/tags', this.clean({
+          name: opts.name,
+          color: opts.color,
+          workspace: opts.workspace_gid,
+        }));
+
+      default:
+        throw new QueryError('Unknown operation', `Workspace operation "${operation}" is not supported`, {});
+    }
+  }
+
+  // ─── Attachment handlers ──────────────────────────────────────────────────────
+
+  private async handleAttachment(token: string, opts: QueryOptions): Promise<any> {
+    const { operation } = opts;
+
+    switch (operation) {
+      case 'get_attachment':
+        return this.get(token, `/attachments/${opts.attachment_gid}`, this.clean({
+          opt_fields: opts.opt_fields,
+        }));
+
+      case 'delete_attachment':
+        return this.delete(token, `/attachments/${opts.attachment_gid}`);
+
+      default:
+        throw new QueryError('Unknown operation', `Attachment operation "${operation}" is not supported`, {});
+    }
+  }
+
+  // ─── HTTP helpers ─────────────────────────────────────────────────────────────
+
+  private async get(token: string, path: string, searchParams: Record<string, any>): Promise<any> {
+    const response = await got(`${ASANA_BASE_URL}${path}`, {
+      method: 'GET',
+      headers: this.authHeader(token),
+      searchParams,
+    });
+    return JSON.parse(response.body);
+  }
+
+  private async post(token: string, path: string, data: Record<string, any>): Promise<any> {
+    const response = await got(`${ASANA_BASE_URL}${path}`, {
+      method: 'POST',
+      headers: this.authHeader(token),
+      json: { data },
+    });
+    return JSON.parse(response.body);
+  }
+
+  private async put(token: string, path: string, data: Record<string, any>): Promise<any> {
+    const response = await got(`${ASANA_BASE_URL}${path}`, {
+      method: 'PUT',
+      headers: this.authHeader(token),
+      json: { data },
+    });
+    return JSON.parse(response.body);
+  }
+
+  private async delete(token: string, path: string): Promise<any> {
+    const response = await got(`${ASANA_BASE_URL}${path}`, {
+      method: 'DELETE',
+      headers: this.authHeader(token),
+    });
+    if (!response.body) return { data: {} };
+    return JSON.parse(response.body);
+  }
+
+  // ─── Utility helpers ──────────────────────────────────────────────────────────
+
+  private authHeader(token: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+  }
+
+  private parseBody(body: string | Record<string, any> | undefined): Record<string, any> {
+    if (!body) return {};
+    if (typeof body === 'string') {
+      try {
+        return JSON.parse(body);
+      } catch {
+        return {};
+      }
+    }
+    return body;
+  }
+
+  private parseGidList(value: string | undefined): string[] {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+    return value.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+
+  private clean(params: Record<string, any>): Record<string, any> {
+    return Object.fromEntries(
+      Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== '')
+    );
+  }
+
+  private parseErrorBody(error: any): any {
+    if (!error.response?.body) return {};
+    try {
+      return JSON.parse(error.response.body);
+    } catch {
+      return { raw: error.response.body };
+    }
+  }
+
+  private normalizeSourceOptions(source_options: any): Record<string, any> {
+    if (!Array.isArray(source_options)) return source_options;
+    const normalized: Record<string, any> = {};
+    source_options.forEach((item: any) => {
+      normalized[item.key] = item.value;
+    });
+    return normalized;
+  }
+
+  private getOptionValue(option: any): any {
+    if (option?.value !== undefined) return option.value;
+    return option;
+  }
+
+  private getOAuthCredentials(source_options: SourceOptions) {
+    const options = this.normalizeSourceOptions(source_options);
+
+    const clientId = this.getOptionValue(options.client_id) as string;
+    const clientSecret = this.getOptionValue(options.client_secret) as string;
+
+    const host = process.env.TOOLJET_HOST || '';
+    const subpath = process.env.SUB_PATH || '';
+    const fullUrl = `${host}${subpath || '/'}`;
+    const redirectUri = `${fullUrl}oauth2/authorize`;
+
+    return { clientId, clientSecret, redirectUri };
+  }
+}

--- a/marketplace/plugins/asana/lib/index.ts
+++ b/marketplace/plugins/asana/lib/index.ts
@@ -29,7 +29,14 @@ export default class Asana implements QueryService {
     return `${ASANA_AUTH_URL}?${params.toString()}`;
   }
 
-  async accessDetailsFrom(authCode: string, source_options: SourceOptions): Promise<object> {
+  async accessDetailsFrom(authCode: string, source_options: SourceOptions, resetSecureData = false): Promise<object> {
+    if (resetSecureData) {
+      return [
+        ['access_token', ''],
+        ['refresh_token', ''],
+      ];
+    }
+
     const { clientId, clientSecret, redirectUri } = this.getOAuthCredentials(source_options);
 
     const data = new URLSearchParams({
@@ -76,8 +83,21 @@ export default class Asana implements QueryService {
     }
   }
 
-  async refreshToken(sourceOptions: SourceOptions): Promise<{ access_token: string; refresh_token?: string }> {
-    const refreshToken = sourceOptions.refresh_token;
+  async refreshToken(
+    sourceOptions: SourceOptions,
+    _dataSourceId?: string,
+    userId?: string,
+    isAppPublic?: boolean
+  ): Promise<{ access_token: string; refresh_token?: string }> {
+    let refreshToken: string;
+    if (sourceOptions.multiple_auth_enabled) {
+      const currentToken = sourceOptions.tokenData?.find((t) =>
+        isAppPublic && !userId ? true : t.user_id === userId
+      );
+      refreshToken = currentToken?.refresh_token;
+    } else {
+      refreshToken = sourceOptions.refresh_token;
+    }
 
     if (!refreshToken) {
       throw new QueryError('Refresh token not found', 'Refresh token is required to refresh the access token', {});
@@ -138,8 +158,26 @@ export default class Asana implements QueryService {
     }
   }
 
-  async run(sourceOptions: SourceOptions, queryOptions: QueryOptions): Promise<QueryResult> {
-    const token = sourceOptions.access_token;
+  async run(
+    sourceOptions: SourceOptions,
+    queryOptions: QueryOptions,
+    _dataSourceId?: string,
+    _updatedAt?: string,
+    context?: { user?: { id?: string }; app?: any }
+  ): Promise<QueryResult> {
+    let token: string;
+    if (sourceOptions.multiple_auth_enabled) {
+      const userId = context?.user?.id;
+      const currentToken = sourceOptions.tokenData?.find((t) =>
+        userId ? t.user_id === userId : true
+      );
+      if (!currentToken) {
+        return { status: 'needs_oauth', data: { auth_url: this.authUrl(sourceOptions) } } as any;
+      }
+      token = currentToken.access_token;
+    } else {
+      token = sourceOptions.access_token;
+    }
     const { resource } = queryOptions;
 
     let result: any;

--- a/marketplace/plugins/asana/lib/manifest.json
+++ b/marketplace/plugins/asana/lib/manifest.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/manifest.schema.json",
+  "title": "Asana",
+  "description": "Integrate with Asana for project and task management",
+  "type": "api",
+  "source": {
+    "name": "Asana",
+    "kind": "asana",
+    "exposedVariables": {
+      "isLoading": false,
+      "data": {},
+      "rawData": {}
+    },
+    "options": {
+      "client_secret": {
+        "type": "string",
+        "encrypted": true
+      },
+      "client_id": {
+        "type": "string"
+      }
+    },
+    "customTesting": true,
+    "hideSave": true
+  },
+  "defaults": {
+    "client_id": {
+      "value": ""
+    },
+    "client_secret": {
+      "value": ""
+    },
+    "oauth_type": {
+      "value": "custom_app"
+    },
+    "access_token_url": {
+      "value": "https://app.asana.com/-/oauth_token"
+    },
+    "redirect_url": {
+      "value": ""
+    },
+    "auth_url": {
+      "value": "https://app.asana.com/-/oauth_authorize"
+    },
+    "allowed_auth_types": {
+      "value": "oauth2"
+    },
+    "auth_type": {
+      "value": "oauth2"
+    },
+    "grant_type": {
+      "value": "authorization_code"
+    },
+    "access_token_custom_headers": {
+      "value": [
+        [
+          "Content-Type",
+          "application/x-www-form-urlencoded"
+        ]
+      ]
+    },
+    "scopes": {
+      "value": "default"
+    }
+  },
+  "properties": {
+    "oauth": {
+      "key": "oauth",
+      "type": "react-component-oauth",
+      "description": "OAuth configuration for Asana",
+      "oauth_configs": {
+        "allowed_field_groups": {
+          "authorization_code": [
+            "client_id",
+            "client_secret"
+          ]
+        },
+        "oauthTypes": {
+          "required": true,
+          "default_value": "custom_app",
+          "editions": {
+            "ce": [
+              "custom_app"
+            ],
+            "ee": [
+              "custom_app"
+            ],
+            "cloud": [
+              "custom_app"
+            ]
+          }
+        },
+        "allowed_auth_types": [
+          "oauth2"
+        ],
+        "allowed_grant_types": [
+          "authorization_code"
+        ],
+        "allowed_scope_field": false
+      }
+    }
+  },
+  "required": []
+}

--- a/marketplace/plugins/asana/lib/operations.json
+++ b/marketplace/plugins/asana/lib/operations.json
@@ -1,0 +1,783 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/operations.schema.json",
+  "title": "Asana datasource",
+  "description": "A schema defining Asana datasource",
+  "type": "api",
+  "defaults": {},
+  "properties": {
+    "resource": {
+      "label": "Resource",
+      "key": "resource",
+      "type": "dropdown-component-flip",
+      "description": "Select a resource",
+      "list": [
+        { "value": "task", "name": "Task" },
+        { "value": "project", "name": "Project" },
+        { "value": "workspace", "name": "Workspace" },
+        { "value": "attachment", "name": "Attachment" }
+      ]
+    },
+    "task": {
+      "operation": {
+        "label": "Operation",
+        "key": "operation",
+        "type": "dropdown-component-flip",
+        "description": "Select an operation",
+        "list": [
+          { "value": "list_tasks", "name": "List tasks" },
+          { "value": "get_task", "name": "Get task" },
+          { "value": "create_task", "name": "Create task" },
+          { "value": "update_task", "name": "Update task" },
+          { "value": "delete_task", "name": "Delete task" },
+          { "value": "add_comment", "name": "Add comment" },
+          { "value": "list_stories", "name": "List stories (comments)" },
+          { "value": "list_subtasks", "name": "List subtasks" },
+          { "value": "create_subtask", "name": "Create subtask" },
+          { "value": "add_to_project", "name": "Add to project" },
+          { "value": "remove_from_project", "name": "Remove from project" },
+          { "value": "add_followers", "name": "Add followers" },
+          { "value": "remove_followers", "name": "Remove followers" },
+          { "value": "duplicate_task", "name": "Duplicate task" },
+          { "value": "list_attachments", "name": "List attachments" }
+        ]
+      },
+      "list_tasks": {
+        "project_gid": {
+          "label": "Project GID",
+          "key": "project_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the project to filter tasks. At least one filter (project, section, tag, or assignee+workspace) is required by Asana.",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response. Default returns only gid, name, resource_type.",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,assignee,due_on,completed,notes"
+        },
+        "limit": {
+          "label": "Limit",
+          "key": "limit",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Maximum number of results to return (1–100)",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "20"
+        },
+        "offset": {
+          "label": "Offset token",
+          "key": "offset",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Pagination offset token from a previous response's next_page.offset",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": ""
+        }
+      },
+      "get_task": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task to retrieve",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,assignee,due_on,completed,notes,projects"
+        }
+      },
+      "create_task": {
+        "workspace_gid": {
+          "label": "Workspace GID",
+          "key": "workspace_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the workspace to create the task in. Required if projects is not provided.",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "body": {
+          "label": "Task data",
+          "key": "body",
+          "type": "codehinter",
+          "mode": "javascript",
+          "description": "Task fields. workspace_gid above is merged in automatically.",
+          "placeholder": "{\n  \"name\": \"My new task\",\n  \"notes\": \"Task description\",\n  \"assignee\": \"me\",\n  \"due_on\": \"2024-12-31\",\n  \"projects\": [\"1234567890\"]\n}",
+          "height": "200px"
+        }
+      },
+      "update_task": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task to update",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "body": {
+          "label": "Task data",
+          "key": "body",
+          "type": "codehinter",
+          "mode": "javascript",
+          "description": "Fields to update on the task",
+          "placeholder": "{\n  \"name\": \"Updated task name\",\n  \"completed\": true,\n  \"due_on\": \"2024-12-31\",\n  \"assignee\": \"me\"\n}",
+          "height": "200px"
+        }
+      },
+      "delete_task": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task to delete",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        }
+      },
+      "add_comment": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task to comment on",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "text": {
+          "label": "Comment text",
+          "key": "text",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Plain text body of the comment",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "This is a comment"
+        },
+        "is_pinned": {
+          "label": "Pin comment",
+          "key": "is_pinned",
+          "type": "dropdown",
+          "description": "Pin this comment to the task",
+          "list": [
+            { "value": "false", "name": "No" },
+            { "value": "true", "name": "Yes" }
+          ]
+        }
+      },
+      "list_stories": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task whose stories (comments + activity) to list",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "text,type,created_at,created_by"
+        }
+      },
+      "list_subtasks": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the parent task",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,assignee,completed,due_on"
+        }
+      },
+      "create_subtask": {
+        "task_gid": {
+          "label": "Parent Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the parent task",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "body": {
+          "label": "Subtask data",
+          "key": "body",
+          "type": "codehinter",
+          "mode": "javascript",
+          "description": "Subtask fields",
+          "placeholder": "{\n  \"name\": \"My subtask\",\n  \"assignee\": \"me\",\n  \"due_on\": \"2024-12-31\"\n}",
+          "height": "200px"
+        }
+      },
+      "add_to_project": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task to add to a project",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "project_gid": {
+          "label": "Project GID",
+          "key": "project_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the project to add the task to",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "section_gid": {
+          "label": "Section GID (optional)",
+          "key": "section_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the section within the project to place the task in",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": ""
+        }
+      },
+      "remove_from_project": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task to remove from a project",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "project_gid": {
+          "label": "Project GID",
+          "key": "project_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the project to remove the task from",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        }
+      },
+      "add_followers": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "followers": {
+          "label": "Follower GIDs",
+          "key": "followers",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of user GIDs to add as followers",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "111111,222222"
+        }
+      },
+      "remove_followers": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "followers": {
+          "label": "Follower GIDs",
+          "key": "followers",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of user GIDs to remove as followers",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "111111,222222"
+        }
+      },
+      "duplicate_task": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task to duplicate",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "name": {
+          "label": "New task name",
+          "key": "name",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Name for the duplicated task",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "Copy of My Task"
+        },
+        "include": {
+          "label": "Include fields",
+          "key": "include",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to copy: assignee, attachments, dates, dependencies, followers, notes, parent, projects, subtasks, tags",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "notes,assignee,subtasks"
+        }
+      },
+      "list_attachments": {
+        "task_gid": {
+          "label": "Task GID",
+          "key": "task_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the task whose attachments to list",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        }
+      }
+    },
+    "project": {
+      "operation": {
+        "label": "Operation",
+        "key": "operation",
+        "type": "dropdown-component-flip",
+        "description": "Select an operation",
+        "list": [
+          { "value": "list_projects", "name": "List projects" },
+          { "value": "get_project", "name": "Get project" },
+          { "value": "create_project", "name": "Create project" },
+          { "value": "update_project", "name": "Update project" },
+          { "value": "delete_project", "name": "Delete project" },
+          { "value": "list_sections", "name": "List sections" }
+        ]
+      },
+      "list_projects": {
+        "workspace_gid": {
+          "label": "Workspace GID",
+          "key": "workspace_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the workspace to filter projects",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,color,archived,due_date,owner"
+        },
+        "limit": {
+          "label": "Limit",
+          "key": "limit",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Maximum number of results to return (1–100)",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "20"
+        },
+        "offset": {
+          "label": "Offset token",
+          "key": "offset",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Pagination offset token from a previous response's next_page.offset",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": ""
+        }
+      },
+      "get_project": {
+        "project_gid": {
+          "label": "Project GID",
+          "key": "project_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the project to retrieve",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,color,archived,due_date,owner,team"
+        }
+      },
+      "create_project": {
+        "workspace_gid": {
+          "label": "Workspace GID",
+          "key": "workspace_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the workspace to create the project in",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "body": {
+          "label": "Project data",
+          "key": "body",
+          "type": "codehinter",
+          "mode": "javascript",
+          "description": "Project fields. workspace_gid above is merged in automatically.",
+          "placeholder": "{\n  \"name\": \"My Project\",\n  \"color\": \"light-green\",\n  \"public\": false,\n  \"default_view\": \"list\"\n}",
+          "height": "200px"
+        }
+      },
+      "update_project": {
+        "project_gid": {
+          "label": "Project GID",
+          "key": "project_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the project to update",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "body": {
+          "label": "Project data",
+          "key": "body",
+          "type": "codehinter",
+          "mode": "javascript",
+          "description": "Fields to update on the project",
+          "placeholder": "{\n  \"name\": \"Updated Project Name\",\n  \"color\": \"light-blue\",\n  \"archived\": false\n}",
+          "height": "200px"
+        }
+      },
+      "delete_project": {
+        "project_gid": {
+          "label": "Project GID",
+          "key": "project_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the project to delete",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        }
+      },
+      "list_sections": {
+        "project_gid": {
+          "label": "Project GID",
+          "key": "project_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the project whose sections to list",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,created_at"
+        }
+      }
+    },
+    "workspace": {
+      "operation": {
+        "label": "Operation",
+        "key": "operation",
+        "type": "dropdown-component-flip",
+        "description": "Select an operation",
+        "list": [
+          { "value": "list_workspaces", "name": "List workspaces" },
+          { "value": "list_users", "name": "List users" },
+          { "value": "list_teams", "name": "List teams" },
+          { "value": "list_tags", "name": "List tags" },
+          { "value": "create_tag", "name": "Create tag" }
+        ]
+      },
+      "list_workspaces": {
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,is_organization"
+        }
+      },
+      "list_users": {
+        "workspace_gid": {
+          "label": "Workspace GID",
+          "key": "workspace_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the workspace",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,email"
+        }
+      },
+      "list_teams": {
+        "workspace_gid": {
+          "label": "Workspace GID",
+          "key": "workspace_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the workspace",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,description"
+        }
+      },
+      "list_tags": {
+        "workspace_gid": {
+          "label": "Workspace GID",
+          "key": "workspace_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the workspace",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,color"
+        }
+      },
+      "create_tag": {
+        "workspace_gid": {
+          "label": "Workspace GID",
+          "key": "workspace_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the workspace to create the tag in",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "name": {
+          "label": "Tag name",
+          "key": "name",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Name of the tag",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "my-tag"
+        },
+        "color": {
+          "label": "Tag color (optional)",
+          "key": "color",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Color of the tag. E.g. dark-pink, dark-teal, dark-green, dark-red, dark-orange, dark-purple, dark-warm-gray, light-pink, light-teal, light-green, light-red, light-orange, light-purple, light-warm-gray",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "light-green"
+        }
+      }
+    },
+    "attachment": {
+      "operation": {
+        "label": "Operation",
+        "key": "operation",
+        "type": "dropdown-component-flip",
+        "description": "Select an operation",
+        "list": [
+          { "value": "get_attachment", "name": "Get attachment" },
+          { "value": "delete_attachment", "name": "Delete attachment" }
+        ]
+      },
+      "get_attachment": {
+        "attachment_gid": {
+          "label": "Attachment GID",
+          "key": "attachment_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the attachment to retrieve",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        },
+        "opt_fields": {
+          "label": "Fields (opt_fields)",
+          "key": "opt_fields",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "Comma-separated list of fields to include in the response",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "name,download_url,created_at,size"
+        }
+      },
+      "delete_attachment": {
+        "attachment_gid": {
+          "label": "Attachment GID",
+          "key": "attachment_gid",
+          "type": "codehinter",
+          "lineNumbers": false,
+          "description": "GID of the attachment to delete",
+          "width": "320px",
+          "height": "36px",
+          "className": "codehinter-plugins",
+          "placeholder": "1234567890"
+        }
+      }
+    }
+  }
+}

--- a/marketplace/plugins/asana/lib/types.ts
+++ b/marketplace/plugins/asana/lib/types.ts
@@ -1,0 +1,45 @@
+export type SourceOptions = {
+  client_id: { value: string } | string;
+  client_secret: { value: string } | string;
+  access_token: string;
+  refresh_token: string;
+  oauth_type: { value: string } | string;
+};
+
+export type QueryOptions = {
+  resource: string;
+  operation: string;
+
+  // GID identifiers
+  task_gid?: string;
+  project_gid?: string;
+  workspace_gid?: string;
+  section_gid?: string;
+  attachment_gid?: string;
+
+  // Common GET params
+  opt_fields?: string;
+  limit?: string;
+  offset?: string;
+
+  // Task body (create/update)
+  body?: string | Record<string, any>;
+
+  // Comment
+  text?: string;
+  is_pinned?: string;
+
+  // Followers
+  followers?: string;
+
+  // Duplicate task
+  name?: string;
+  include?: string;
+
+  // Add to project
+  insert_before?: string;
+  insert_after?: string;
+
+  // Tag
+  color?: string;
+};

--- a/marketplace/plugins/asana/lib/types.ts
+++ b/marketplace/plugins/asana/lib/types.ts
@@ -4,6 +4,8 @@ export type SourceOptions = {
   access_token: string;
   refresh_token: string;
   oauth_type: { value: string } | string;
+  multiple_auth_enabled?: boolean;
+  tokenData?: Array<{ user_id: string; access_token: string; refresh_token: string; [key: string]: any }>;
 };
 
 export type QueryOptions = {

--- a/marketplace/plugins/asana/package.json
+++ b/marketplace/plugins/asana/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@tooljet-marketplace/asana",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "build": "ncc build lib/index.ts -o dist",
+    "watch": "ncc build lib/index.ts -o dist --watch"
+  },
+  "homepage": "https://github.com/tooljet/tooljet#readme",
+  "dependencies": {
+    "@tooljet-marketplace/common": "^1.0.0",
+    "got": "^14.4.7"
+  },
+  "devDependencies": {
+    "@vercel/ncc": "^0.34.0",
+    "typescript": "^4.7.4"
+  }
+}

--- a/marketplace/plugins/asana/tsconfig.json
+++ b/marketplace/plugins/asana/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "lib"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/server/src/assets/marketplace/plugins.json
+++ b/server/src/assets/marketplace/plugins.json
@@ -1,13 +1,5 @@
 [
   {
-    "name": "Asana",
-    "description": "Plugin for Asana project and task management",
-    "version": "1.0.0",
-    "id": "asana",
-    "author": "Tooljet",
-    "timestamp": "Sun, 29 Jun 2025 00:00:00 GMT"
-  },
-  {
     "name": "Plivo",
     "description": "Plugin for Plivo APIs",
     "version": "1.0.0",
@@ -371,5 +363,13 @@
     "id": "intercom",
     "author": "Tooljet",
     "timestamp": "Wed, 16 Apr 2026 10:00:00 GMT"
+  },
+  {
+    "name": "Asana",
+    "description": "Plugin for Asana project and task management",
+    "version": "1.0.0",
+    "id": "asana",
+    "author": "Tooljet",
+    "timestamp": "Sun, 29 Jun 2025 00:00:00 GMT"
   }
 ]

--- a/server/src/assets/marketplace/plugins.json
+++ b/server/src/assets/marketplace/plugins.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "Asana",
+    "description": "Plugin for Asana project and task management",
+    "version": "1.0.0",
+    "id": "asana",
+    "author": "Tooljet",
+    "timestamp": "Sun, 29 Jun 2025 00:00:00 GMT"
+  },
+  {
     "name": "Plivo",
     "description": "Plugin for Plivo APIs",
     "version": "1.0.0",

--- a/server/src/modules/data-sources/util.service.ts
+++ b/server/src/modules/data-sources/util.service.ts
@@ -644,6 +644,7 @@ export class DataSourcesUtilService implements IDataSourcesUtilService {
         'xero',
         'bigquery',
         'databricks',
+        'asana',
       ].includes(dataSource.kind)
     ) {
       const newTokenData = await this.fetchAPITokenFromPlugins(


### PR DESCRIPTION

This PR adds support for the Asana datasource in ToolJet using OAuth 2.0 authentication. Users can connect their Asana account and perform common task, project, workspace, and attachment management operations directly from ToolJet.

### Implemented Operations

#### Task (15)

* List tasks
* Get task
* Create task
* Update task
* Delete task
* Add comment
* List stories (comments/activity)
* List subtasks
* Create subtask
* Add to project
* Remove from project
* Add followers
* Remove followers
* Duplicate task
* List attachments

#### Project (6)

* List projects
* Get project
* Create project
* Update project
* Delete project
* List sections

#### Workspace (5)

* List workspaces
* List users
* List teams
* List tags
* Create tag

#### Attachment (2)

* Get attachment
* Delete attachment

### Authentication

* Added OAuth 2.0 support for Asana.
* Users can authenticate using Client ID and Client Secret from the Asana Developer Console.
* Access token and refresh token handling are managed through ToolJet's OAuth flow.

### Testing

Verified all implemented operations against a test Asana workspace using OAuth authentication.
