### PR TITLE
Fix: Enable save buttons in Google Sheets v2 when only the datasource name is changed

### DIFF
--- a/frontend/src/_components/OAuthWrapper.jsx
+++ b/frontend/src/_components/OAuthWrapper.jsx
@@ -29,14 +29,20 @@ const OAuthWrapper = ({
   const [authStatus, setAuthStatus] = useState(null);
   const { t } = useTranslation();
   const [initialOptions, setInitialOptions] = useState(null);
+  const [initialName, setInitialName] = useState(null);
   useEffect(() => {
     if (selectedDataSource?.id && !initialOptions) {
       setInitialOptions(options);
+      setInitialName(selectedDataSource.name);
     }
   }, [selectedDataSource?.id, options, initialOptions]);
 
   const hasFieldsChanged = () => {
     if (!selectedDataSource?.id || !initialOptions) {
+      return true;
+    }
+
+    if (selectedDataSource?.name !== initialName) {
       return true;
     }
 


### PR DESCRIPTION
**Summary**
The save buttons in the Google Sheets v2 datasource configuration were remaining disabled when only the datasource name was changed, requiring a configuration field change to enable them.

* Added `initialName` state to `OAuthWrapper` to track the saved datasource name at load time.
* Updated `hasFieldsChanged()` to return `true` when the current name differs from the initial name, enabling the save buttons on name-only changes.

**Root Cause**
`hasFieldsChanged()` in `OAuthWrapper.jsx` only compared configuration option fields (`options`) against their initial values. The datasource name is managed separately and was never included in the check, so name changes went undetected and the buttons stayed disabled.

**Scope**
This change only affects the Google Sheets v2 datasource — `hasFieldsChanged()` is called exclusively inside the `selectedDataSource?.kind === 'googlesheetsv2'` branch in `OAuthWrapper`. No other datasources or plugins are affected.
