### PR TITLE
fix: add missing jest config for marketplace plugin tests

### DIFF
--- a/marketplace/jest.config.cjs
+++ b/marketplace/jest.config.cjs
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+};


### PR DESCRIPTION
Closes #17048 

## Problem

`marketplace/package.json` already has `ts-jest`, but there's no Jest config at the `marketplace/` root. Because of that, running plugin tests falls back to Babel and fails on TypeScript syntax.

### Repro (before)

```bash id="f8sh6u"
cd marketplace
npx jest plugins/plivo
# SyntaxError: Unexpected token...
```

## Fix

Added `marketplace/jest.config.cjs` using the existing `ts-jest` setup from the newer plugin system.

Used `.cjs` since `marketplace/package.json` has `"type": "module"`.


