### PR TITLE
fix: on row click event of table does not store correct value in a variable if it depends on selectedRow and selectedRowId exposed variable

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/TableData.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/TableData.jsx
@@ -33,6 +33,7 @@ export const TableData = ({
   canvasWidth,
 }) => {
   const getResolvedValue = useStore((state) => state.getResolvedValue);
+  const flushExposedValueBatch = useStore((state) => state.flushExposedValueBatch);
 
   const isMaxRowHeightAuto = useTableStore((state) => state.getTableStyles(id)?.isMaxRowHeightAuto, shallow);
   const rowStyle = useTableStore((state) => state.getTableStyles(id)?.rowStyle, shallow);
@@ -136,6 +137,7 @@ export const TableData = ({
         selectedRow: row?.original ?? {},
         selectedRowId: isNaN(row.index) ? String(row.index) : row.index,
       });
+      flushExposedValueBatch();
       fireEvent('onRowClicked');
       return;
     }

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -34,6 +34,7 @@ export const TableExposedVariables = ({
   const clearEditedRows = useTableStore((state) => state.clearEditedRows, shallow);
 
   const setComponentProperty = useStore((state) => state.setComponentProperty, shallow);
+  const flushExposedValueBatch = useStore((state) => state.flushExposedValueBatch);
 
   const mounted = useMounted();
 
@@ -292,9 +293,12 @@ export const TableExposedVariables = ({
     // onRowClicked event will be fired when a row is clicked
     // it should be triggered even when allowSelection is false which is handled in the handleRowClick()
     if (allowSelection && Object.keys(lastClickedRow).length > 0) {
+      // Flush any buffered exposed-value mutations (e.g. selectedRow/selectedRowId from the
+      // previous effect) so the store is up-to-date before the event handler resolves variables.
+      flushExposedValueBatch();
       fireEvent('onRowClicked');
     }
-  }, [lastClickedRow, fireEvent, allowSelection]);
+  }, [lastClickedRow, fireEvent, allowSelection, flushExposedValueBatch]);
 
   useEffect(() => {
     function selectRow(key, value) {


### PR DESCRIPTION
Resolves: https://github.com/ToolJet/tj-ee/issues/5256