### PR TITLE
fix: handle optional renderCopilot prop in BaseQueryManagerBody

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -247,7 +247,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = null
         </div>
         {ElementToRender && (
           <ElementToRender
-            renderCopilot={(props) => renderCopilot({ ...props, selectedDataSource })}
+            renderCopilot={(props) => renderCopilot?.({ ...props, selectedDataSource })}
             key={selectedQuery?.id}
             pluginSchema={
               selectedDataSource?.plugin?.operations_file?.data ?? selectedQuery?.plugin?.operations_file?.data


### PR DESCRIPTION
Resolves - app consisting js and python query breaks while loading