### PR TITLE
fix: improve branch switching logic to prevent overwriting stored branch

### DIFF
--- a/frontend/src/AppBuilder/Header/BranchDropdown.jsx
+++ b/frontend/src/AppBuilder/Header/BranchDropdown.jsx
@@ -12,6 +12,7 @@ import { gitSyncService } from '@/_services';
 import OverflowTooltip from '@/_components/OverflowTooltip';
 import { AlertTriangle } from 'lucide-react';
 import { useWorkspaceBranchesStore } from '@/_stores/workspaceBranchesStore';
+import { getActiveBranch } from '@/_helpers/active-branch';
 
 export function BranchDropdown({ appId, organizationId }) {
   const [showDropdown, setShowDropdown] = useState(false);
@@ -211,7 +212,13 @@ export function BranchDropdown({ appId, organizationId }) {
       // so we compare workspaceActiveBranch.id against versionBranchId directly.
       if (versionBranchId && workspaceActiveBranch?.id !== versionBranchId) {
         initialBranchSwitchDone.current = true;
-        useWorkspaceBranchesStore.getState().actions.switchBranch(versionBranchId);
+        const storedBranch = getActiveBranch(organizationId);
+        // storedBranch was explicitly written by a branch switch before page reload.
+        // If it differs from the version's branch, it is the source of truth — skip
+        // overwriting it. Let initialize() restore workspace from storage instead.
+        if (!storedBranch?.id || storedBranch.id === versionBranchId) {
+          useWorkspaceBranchesStore.getState().actions.switchBranch(versionBranchId);
+        }
       }
       return;
     }


### PR DESCRIPTION
## Problem

Branch switching from a feature branch to `main` left the app in a broken state:
- Toast showed \"Switched to main\" ✓
- Canvas briefly showed main content ✓
- `localStorage` (`tj_active_branch_{orgId}`) never updated — still held feature branch UUID
- All subsequent API calls sent the old `x-branch-id` → backend returned feature branch content
- Header still showed the old branch name

## Root cause

`BranchDropdown` has an auto-sync effect that runs on mount to align the workspace branch store with the currently loaded version. When a branch-type version is already loaded (`isBranchTypeVersionForSwitch = true`) and the workspace store's active branch doesn't match the version's `branchId`, it called `switchBranch(versionBranchId)` to sync.

The bug: `initialize()` in `workspaceBranchesStore` is **async** (awaits API calls). The effect fires **before** `initialize()` completes, so `workspaceActiveBranch` is `null` in both scenarios:

| Scenario | `workspaceActiveBranch` at effect fire | `versionBranchId` | Result |
|---|---|---|---|
| Cold load (direct URL) | `null` | feature branch UUID | call `switchBranch` ✓ intended |
| Post-switch page reload | `null` | **stale** feature branch UUID | call `switchBranch` ✗ overwrites back |

On post-switch reload, `selectedVersion` still carries the old feature branch's `branchId` (stale), so the condition fired and overwrote `localStorage` back to the feature branch — undoing the switch.

## Fix

`setActiveBranch()` writes to `sessionStorage` + `localStorage` **synchronously** before `window.location.replace` fires. `getActiveBranch(orgId)` reads those synchronously — no async gap, no race condition.

This gives a reliable discriminator between the two scenarios:

| Scenario | `getActiveBranch(orgId)` | Correct action |
|---|---|---|
| Post-switch reload | `{ id: mainUUID }` — written by the switch | **skip** `switchBranch` |
| Cold load, empty storage | `null` | **call** `switchBranch` |
| Cold load, returning user | `{ id: featureBranchUUID }` = `versionBranchId` | **call** `switchBranch` |

Guard logic:
- `storedBranch.id === versionBranchId` → storage and version agree → sync workspace ✓
- `!storedBranch?.id` → cold load, no prior choice → sync workspace ✓  
- `storedBranch.id !== versionBranchId` → user explicitly switched to a different branch → skip, let `initialize()` restore from storage ✓

## Changes

**`frontend/src/AppBuilder/Header/BranchDropdown.jsx`**
- Import `getActiveBranch` from `@/_helpers/active-branch`
- In the `isBranchTypeVersionForSwitch` sync block: read `getActiveBranch(organizationId)` synchronously before deciding whether to call `switchBranch(versionBranchId)` — only proceed when storage is empty or already agrees with the version's branch