### PR TITLE
Fix: resolve globals.appVersion.name to branch name in preview mode

### DIFF
--- a/server/src/modules/versions/repository.ts
+++ b/server/src/modules/versions/repository.ts
@@ -158,6 +158,7 @@ export class VersionRepository extends Repository<AppVersion> {
       where: { id },
       relations: [
         'app',
+        'branch',
         'dataQueries',
         'dataQueries.dataSource',
         'dataQueries.plugins',
@@ -196,6 +197,7 @@ export class VersionRepository extends Repository<AppVersion> {
       .createQueryBuilder(AppVersion, 'appVersion')
       .where('appVersion.id = :id', { id })
       .leftJoinAndSelect('appVersion.app', 'app')
+      .leftJoinAndSelect('appVersion.branch', 'branch')
       .leftJoinAndSelect('appVersion.dataQueries', 'dataQueries')
       .leftJoinAndSelect('dataQueries.dataSource', 'dataSource')
       .leftJoinAndSelect('dataQueries.plugins', 'plugins')
@@ -330,6 +332,7 @@ export class VersionRepository extends Repository<AppVersion> {
       where: { appId: app.id },
       relations: [
         'app',
+        'branch',
         'dataQueries',
         'dataQueries.dataSource',
         'dataQueries.plugins',

--- a/server/src/modules/versions/service.ts
+++ b/server/src/modules/versions/service.ts
@@ -228,6 +228,12 @@ export class VersionService implements IVersionService {
 
       const editingVersion = camelizeKeys(appCurrentEditingVersion);
 
+      // For branch-type versions, expose the human-readable branch name so
+      // globals.appVersion.name resolves correctly on the frontend.
+      if (appVersion?.versionType === AppVersionType.BRANCH && appVersion.branch?.name) {
+        editingVersion['displayName'] = appVersion.branch.name;
+      }
+
       // Inject app theme
       const appTheme = await this.organizationThemesUtilService.getTheme(
         user.organizationId,


### PR DESCRIPTION
## 📝 What this does
Fixes `globals.appVersion.name` showing a UUID instead of the branch name when previewing an app. The `/v2/apps/:id/versions/:versionId` endpoint never set `displayName` on the editing version response.
- [ee-server](https://github.com/ToolJet/ee-server/pull/671)
- [ee-frontend](no changes)

## 🔀 Changes
- Added `branch` relation to `findVersion`, `findVersionWithQueryPermissions`, and `findVersionsFromApp` in VersionRepository
- Set `editingVersion.displayName` from branch name in CE and EE `getVersion` methods for branch-type versions

## 🧪 How to test
- [ ] Enable git sync, switch to a feature branch
- [ ] Preview the app and inspect `globals.appVersion.name` — should show the branch name, not a UUID