### PR TITLE
Fix: show branch name instead of UUID in preview URL

### DIFF
--- a/frontend/src/AppBuilder/Header/AppVersionsManager/AppVersionsManager.jsx
+++ b/frontend/src/AppBuilder/Header/AppVersionsManager/AppVersionsManager.jsx
@@ -114,7 +114,10 @@ export const AppVersionsManager = ({ darkMode, disabled = false }) => {
           const selectedVersionObj = versionsPromotedToEnvironment.find((v) => v.id === id);
           if (selectedVersionObj) {
             const searchParams = new URLSearchParams(location.search);
-            searchParams.set('version', selectedVersionObj.name);
+            searchParams.set(
+              'version',
+              selectedVersionObj.display_name || selectedVersionObj.displayName || selectedVersionObj.name
+            );
             navigate(
               {
                 pathname: location.pathname,

--- a/frontend/src/AppBuilder/Header/RightTopHeaderButtons/RightTopHeaderButtons.jsx
+++ b/frontend/src/AppBuilder/Header/RightTopHeaderButtons/RightTopHeaderButtons.jsx
@@ -71,7 +71,7 @@ export const PreviewAndShareIcons = () => {
 
   useEffect(() => {
     const previewQuery = queryString.stringify({
-      version: selectedVersion?.name,
+      version: selectedVersion?.display_name || selectedVersion?.displayName || selectedVersion?.name,
       ...(featureAccess?.multiEnvironment ? { env: selectedEnvironment?.name } : {}),
     });
     setAppPreviewLink(

--- a/frontend/src/_hooks/useAppPreviewLink.js
+++ b/frontend/src/_hooks/useAppPreviewLink.js
@@ -48,7 +48,7 @@ export function useAppPreviewLink() {
     const suppressBranchId = currentBranch && !isBranchVersion && !isDraft;
 
     const previewQuery = queryString.stringify({
-      version: selectedVersion?.name,
+      version: selectedVersion?.display_name || selectedVersion?.displayName || selectedVersion?.name,
       ...(!isBasicPlan ? { env: selectedEnvironment?.name } : {}),
       ...(suppressBranchId ? { is_branch: false } : {}),
     });

--- a/server/src/modules/app-environments/util.service.ts
+++ b/server/src/modules/app-environments/util.service.ts
@@ -3,8 +3,9 @@ import { EntityManager, FindOptionsOrderValue } from 'typeorm';
 import { AppEnvironment } from 'src/entities/app_environments.entity';
 import { dbTransactionWrap, getConnectionInstance } from 'src/helpers/database.helper';
 import { IAppEnvironmentUtilService } from './interfaces/IUtilService';
-import { AppVersion } from '@entities/app_version.entity';
+import { AppVersion, AppVersionType } from '@entities/app_version.entity';
 import { App } from '@entities/app.entity';
+import { WorkspaceBranch } from '@entities/workspace_branch.entity';
 import { FindOneOptions } from 'typeorm';
 import { defaultAppEnvironments } from '@helpers/utils.helper';
 import { LICENSE_FIELD } from '@modules/licensing/constants';
@@ -150,7 +151,15 @@ export class AppEnvironmentUtilService implements IAppEnvironmentUtilService {
 
     const result = await manager
       .createQueryBuilder(AppVersion, 'appVersion')
-      .select(['appVersion.name', 'appVersion.id', 'appVersion.currentEnvironmentId'])
+      .select([
+        'appVersion.name',
+        'appVersion.id',
+        'appVersion.currentEnvironmentId',
+        'appVersion.versionType',
+        'appVersion.branchId',
+      ])
+      .addSelect('branch.branch_name', 'branch_name')
+      .leftJoin(WorkspaceBranch, 'branch', 'appVersion.branch_id = branch.id')
       .innerJoin(AppEnvironment, 'env', 'appVersion.currentEnvironmentId = env.id')
       .where(`env.priority >= (${subquery.getQuery()})`)
       .setParameters(subquery.getParameters())
@@ -163,10 +172,16 @@ export class AppEnvironmentUtilService implements IAppEnvironmentUtilService {
       return null;
     }
 
+    const versionType = result.appVersion_version_type;
+    const branchName = result.branch_name;
+
     return {
       name: result.appVersion_name,
       id: result.appVersion_id,
       currentEnvironmentId: result.appVersion_current_environment_id,
+      current_environment_id: result.appVersion_current_environment_id,
+      versionType,
+      ...(versionType === AppVersionType.BRANCH && branchName ? { displayName: branchName } : {}),
     };
   }
 

--- a/server/src/modules/versions/repository.ts
+++ b/server/src/modules/versions/repository.ts
@@ -70,12 +70,28 @@ export class VersionRepository extends Repository<AppVersion> {
     });
   }
 
-  findByName(name: string, appId: string, relations?: string[], manager?: EntityManager): Promise<AppVersion> {
+  async findByName(name: string, appId: string, relations?: string[], manager?: EntityManager): Promise<AppVersion> {
     const m = manager ?? this.manager;
-    return m.findOneOrFail(AppVersion, {
+    // Direct lookup by the `name` column (works for regular versions and legacy UUID-based URLs)
+    const version = await m.findOne(AppVersion, {
       where: { name, appId },
       ...(relations?.length ? { relations } : {}),
     });
+    if (version) return version;
+
+    // For branch-type versions the URL carries the human-readable branch name,
+    // but the `name` column stores a UUID. Fall back to a branch-name lookup.
+    const branchVersion = await m
+      .createQueryBuilder(AppVersion, 'v')
+      .innerJoin(WorkspaceBranch, 'b', 'v.branch_id = b.id')
+      .where('v.app_id = :appId', { appId })
+      .andWhere('b.branch_name = :branchName', { branchName: name })
+      .andWhere('v.version_type = :versionType', { versionType: AppVersionType.BRANCH })
+      .getOne();
+    if (branchVersion) return branchVersion;
+
+    // Neither matched — throw the same EntityNotFoundError the caller expects
+    return m.findOneOrFail(AppVersion, { where: { name, appId } });
   }
 
   async findLatestVersionForEnvironment(


### PR DESCRIPTION
## 📝 What this does
Fixes the preview URL showing a UUID instead of the human-readable branch name in the `?version=` query parameter. Also updates the backend to resolve branch names from the URL back to the correct app version.

## 🔀 Changes
- Used `displayName` (branch name) instead of `name` (UUID) in preview URL construction across `useAppPreviewLink`, `RightTopHeaderButtons`, and `AppVersionsManager`
- Updated `findByName` in VersionRepository to fall back to a branch-name lookup via JOIN on workspace branches when direct name match fails
- Updated `getSelectedVersion` in AppEnvironmentUtilService to include `versionType` and `displayName` from the branch relation

## 🧪 How to test
- [ ] Enable git sync, switch to a feature branch
- [ ] Click Preview in the editor — URL should show `?version=feature/my-branch` not a UUID
- [ ] Refresh the preview page — app should load correctly from the branch-name URL
- [ ] Switch versions in the preview dropdown — URL should update with the branch name
- [ ] Old bookmarked URLs with UUIDs should still work (backward compat)