### PR TITLE
fix: add missing AbilityGuard to unprotected routes (#12397)

### DIFF
--- a/server/src/modules/templates/controller.ts
+++ b/server/src/modules/templates/controller.ts
@@ -54,13 +54,14 @@ export class TemplateAppsController {
 
   @InitFeature(FEATURE_KEY.FETCH_TEMPLATES_LIST)
   @Get()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, FeatureAbilityGuard)
   async index() {
     return { template_app_manifests: TemplateAppManifests };
   }
 
+  @InitFeature(FEATURE_KEY.FETCH_TEMPLATES_LIST)
   @Get(':identifier/plugins')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, FeatureAbilityGuard)
   async findDepedentPluginsFromTemplateDefinition(@Param('identifier') identifier) {
     const { pluginsToBeInstalled, pluginsListIdToDetailsMap } =
       await this.templatesService.findDepedentPluginsFromTemplateDefinition(identifier);

--- a/server/src/modules/white-labelling/controller.ts
+++ b/server/src/modules/white-labelling/controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Body, Put, Get, Param } from '@nestjs/common';
+import { Controller, Body, Put, Get, Param, UseGuards } from '@nestjs/common';
 import { UpdateWhiteLabellingDto } from './dto';
 import { IWhiteLabellingController } from './Interfaces/IController';
 import { NotFoundException } from '@nestjs/common';
@@ -9,12 +9,15 @@ import { FEATURE_KEY } from './constant';
 import { WhiteLabellingService } from './service';
 import { User as UserEntity } from '@entities/user.entity';
 import { User } from '@modules/app/decorators/user.decorator';
+import { JwtAuthGuard } from '@modules/session/guards/jwt-auth.guard';
+import { FeatureAbilityGuard } from './ability/guard';
 
 @Controller('white-labelling')
 @InitModule(MODULES.WHITE_LABELLING)
 export class WhiteLabellingController implements IWhiteLabellingController {
   constructor(protected readonly whiteLabellingService: WhiteLabellingService) {}
 
+  @UseGuards(JwtAuthGuard, FeatureAbilityGuard)
   @Get()
   @InitFeature(FEATURE_KEY.GET)
   async getInstanceWhiteLabelling() {
@@ -31,6 +34,7 @@ export class WhiteLabellingController implements IWhiteLabellingController {
     throw new NotFoundException();
   }
 
+  @UseGuards(JwtAuthGuard, FeatureAbilityGuard)
   @Get('/:organizationId')
   @InitFeature(FEATURE_KEY.GET_ORGANIZATION_WHITE_LABELS)
   async getWorkspaceWhiteLabelling(req: any) {

--- a/server/src/modules/workflows/controllers/workflow-executions.controller.ts
+++ b/server/src/modules/workflows/controllers/workflow-executions.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Query, Res, Sse } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, Res, Sse, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 import { IWorkflowExecutionController } from '../interfaces/IWorkflowExecutionController';
 import { CreateWorkflowExecutionDto } from '@dto/create-workflow-execution.dto';
@@ -10,6 +10,8 @@ import { MODULES } from '@modules/app/constants/modules';
 import { InitFeature } from '@modules/app/decorators/init-feature.decorator';
 import { FEATURE_KEY } from '@modules/workflows/constants';
 import { Observable } from 'rxjs';
+import { JwtAuthGuard } from '@modules/session/guards/jwt-auth.guard';
+import { FeatureAbilityGuard } from '../ability/app/guard';
 
 @InitModule(MODULES.WORKFLOWS)
 @Controller('workflow_executions')
@@ -17,6 +19,7 @@ export class WorkflowExecutionsController implements IWorkflowExecutionControlle
   constructor() {}
 
   @InitFeature(FEATURE_KEY.EXECUTE_WORKFLOW)
+  @UseGuards(JwtAuthGuard, FeatureAbilityGuard)
   @Post()
   async create(
     @User() user,

--- a/server/src/modules/workflows/controllers/workflow-webhooks.controller.ts
+++ b/server/src/modules/workflows/controllers/workflow-webhooks.controller.ts
@@ -1,10 +1,13 @@
-import { Controller, Post, Param, Body, Patch, Query, Res, Get, Sse, Req } from '@nestjs/common';
+import { Controller, Post, Param, Body, Patch, Query, Res, Get, Sse, Req, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 import { IWorkflowWebhooksController } from '../interfaces/IWorkflowWebhooksController';
 import { InitModule } from '@modules/app/decorators/init-module';
 import { MODULES } from '@modules/app/constants/modules';
 import { InitFeature } from '@modules/app/decorators/init-feature.decorator';
 import { FEATURE_KEY } from '@modules/workflows/constants';
+import { JwtAuthGuard } from '@modules/session/guards/jwt-auth.guard';
+import { FeatureAbilityGuard } from '../ability/app/guard';
+import { WebhookGuard } from '@modules/licensing/guards/webhook.guard';
 
 @Controller({
   path: 'webhooks',
@@ -15,6 +18,7 @@ export class WorkflowWebhooksController implements IWorkflowWebhooksController {
   constructor() {}
 
   @InitFeature(FEATURE_KEY.WEBHOOK_TRIGGER_WORKFLOW)
+  @UseGuards(WebhookGuard)
   @Post('workflows/:id/trigger')
   async triggerWorkflow(
     @Param('id') id: any,
@@ -53,6 +57,7 @@ export class WorkflowWebhooksController implements IWorkflowWebhooksController {
   }
 
   @InitFeature(FEATURE_KEY.UPDATE_WORKFLOW_WEBHOOK_DETAILS)
+  @UseGuards(JwtAuthGuard, FeatureAbilityGuard)
   @Patch('workflows/:id')
   async updateWorkflow(@Param('id') id, @Body() workflowValuesToUpdate): Promise<any> {
     throw new Error('Method not implemented.');


### PR DESCRIPTION
#closes #12397
**PR Description**

**Routes that were already protected (no changes needed):**
- `PATCH organizations/:id`
- `GET organization-constants/public/:slug`
- `GET organization-constants/:app_slug`
- `GET organization-constants/environment/:environmentId`
- `POST organization-constants/`
- `PATCH organization-constants/:id`
- `POST tooljet-db/organizations/:organizationId/table/:tableName/bulk-upload`

**Routes that are now protected with AbilityGuard:**
- `GET white-labelling/` — added `JwtAuthGuard + FeatureAbilityGuard`
- `GET white-labelling/:organizationId` — added `JwtAuthGuard + FeatureAbilityGuard`
- `GET library_apps/` — added `FeatureAbilityGuard` (had JwtAuthGuard only)
- `GET library_apps/:identifier/plugins` — added `@InitFeature + FeatureAbilityGuard` (had JwtAuthGuard only)
- `POST workflow_executions/` — added `JwtAuthGuard + FeatureAbilityGuard`
- `POST webhooks/workflows/:id/trigger` — added `WebhookGuard` (webhook-specific auth; JWT not applicable)
- `PATCH webhooks/workflows/:id` — added `JwtAuthGuard + FeatureAbilityGuard`

**Left as-is:**
- `GET audit-logs/` — no controller exists in this codebase; creating one would introduce a new route, which is outside the scope of this fix