### PR TITLE
Banned user signup issue fixed

### DIFF
--- a/server/src/modules/onboarding/util.service.ts
+++ b/server/src/modules/onboarding/util.service.ts
@@ -191,13 +191,16 @@ export class OnboardingUtilService implements IOnboardingUtilService {
         (ou) => ou.organizationId === targetOrg?.id
       );
 
+      if (existingUser.status === USER_STATUS.ARCHIVED) {
+        throw new NotAcceptableException('This account has been banned. Contact your administrator.');
+      } 
+
       if (membershipInCurrentOrg?.status === WORKSPACE_USER_STATUS.INVITED) {
         throw new NotAcceptableException(
           'The user is already registered. Please check your inbox for the activation link'
         );
       }
 
-      // 2. If already active here, block as "already exists"
       if (membershipInCurrentOrg?.status === WORKSPACE_USER_STATUS.ACTIVE) {
         throw new NotAcceptableException('Email already exists in this workspace');
       }


### PR DESCRIPTION
closes #17086 
Added an early check in 
`whatIfTheSignUpIsAtTheWorkspaceLevel():`
`if (existingUser.status === USER_STATUS.ARCHIVED) {
    throw new NotAcceptableException('This account has been banned. Contact your administrator.');
}`

This catches banned (archived) users before the workspace membership checks (INVITED/ACTIVE), which were the only guards — and those only block if the user still has a workspace membership, which they don't after being banned from all workspaces. Without this fix, the signup flow falls through to activateUserWithPassword() which resets status to 'active', effectively un-banning them.