### PR TITLE
Fix: Install libxml2 in Cypress runtime Docker images

### DIFF
--- a/cypress-tests/cypress-lts.Dockerfile
+++ b/cypress-tests/cypress-lts.Dockerfile
@@ -89,6 +89,7 @@ RUN apt-get update && \
         postgresql-client \
         redis \
         libaio1 \
+        libxml2 \
         git \
         openssh-client \
         freetds-dev \

--- a/cypress-tests/cypress-main.Dockerfile
+++ b/cypress-tests/cypress-main.Dockerfile
@@ -88,6 +88,7 @@ RUN apt-get update && \
         postgresql-client \
         redis \
         libaio1 \
+        libxml2 \
         git \
         openssh-client \
         freetds-dev \


### PR DESCRIPTION
## 📝 What this does
Fixes the Cypress AppBuilder workflow failing on the LTS release branch — the ToolJet container never booted because the `ibm_db` plugin's native ODBC binding needs `libxml2.so.2`, which the `debian:12-slim` runtime image doesn't ship. Migrations crashed with `ERR_DLOPEN_FAILED`, so the workflow timed out after 700s waiting for the app (see [run 29106233021](https://github.com/ToolJet/ToolJet/actions/runs/29106233021)).

## 🔀 Changes
- Added `libxml2` to the apt package list in the runtime stage of `cypress-tests/cypress-lts.Dockerfile` and `cypress-tests/cypress-main.Dockerfile`

## 🧪 How to test
- [ ] Re-run the Cypress AppBuilder workflow against this branch and confirm the ToolJet container starts and specs execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)