### PR TITLE
Fix: Workflow Released Issue

### DIFF
--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -51,6 +51,8 @@ const QUERY_OPTION_KEYS_TO_NORMALIZE = [
   'notificationDuration',
   'disableQuery',
   'disabledMessage',
+  'workflowId',
+  'workflowVersionId',
 ];
 
 const snakeCase = (camel) => camel.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);

--- a/server/test/helpers/setup.ts
+++ b/server/test/helpers/setup.ts
@@ -319,7 +319,9 @@ const ENTERPRISE_TEST_TERMS: Partial<Terms> = {
   permissions: { customGroups: true },
   observability: { enabled: true },
   workflows: {
-    enabled: true, execution_timeout: 0,
+    // workflowExecutionTimeout is a literal timeout ceiling, not a sentinel like the
+    // 'UNLIMITED' fields above -- 0 means "time out immediately", not "no limit".
+    enabled: true, execution_timeout: 3600,
     workspace: { total: 'UNLIMITED', daily_executions: 'UNLIMITED', monthly_executions: 'UNLIMITED' },
     instance: { total: 'UNLIMITED', daily_executions: 'UNLIMITED', monthly_executions: 'UNLIMITED' },
   },

--- a/server/test/modules/workflows/e2e/workflow-executions.spec.ts
+++ b/server/test/modules/workflows/e2e/workflow-executions.spec.ts
@@ -5,6 +5,7 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { getDataSourceToken } from '@nestjs/typeorm';
 import { WorkflowExecution } from '../../../../src/entities/workflow_execution.entity';
+import { Component } from '../../../../src/entities/component.entity';
 import { setupPolly } from 'setup-polly-jest';
 import * as NodeHttpAdapter from '@pollyjs/adapter-node-http';
 import * as FSPersister from '@pollyjs/persister-fs';
@@ -21,6 +22,12 @@ import {
   WorkflowEdge,
   WorkflowQuery,
   closeTestApp,
+  createApplication,
+  createApplicationVersion,
+  createDataSource,
+  createDataQuery,
+  markVersionAsReleased,
+  getDefaultDataSource,
 } from 'test-helper';
 
 const executeWorkflow = async (
@@ -1855,6 +1862,181 @@ result = pydash.sum_(sorted_numbers)
       expect(nodesResponse.statusCode).toBe(200);
       expect(nodesResponse.body).toHaveProperty('data');
       expect(Array.isArray(nodesResponse.body.data)).toBe(true);
+    });
+  });
+
+  describe('POST /api/workflow_executions/:id/trigger | trigger a workflow from an app or module query', () => {
+    // Regression coverage for WorkflowTriggerAuthGuard: public apps (and modules embedded
+    // in a public parent app) must allow unauthenticated workflow triggers.
+
+    const buildTargetWorkflow = async (user: any, name: string) => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: 'start-1',
+          type: 'input',
+          data: { nodeType: 'start', label: 'Start trigger' },
+          position: { x: 100, y: 250 },
+          sourcePosition: 'right'
+        },
+        {
+          id: 'response-1',
+          type: 'output',
+          data: {
+            nodeType: 'response',
+            label: 'Response',
+            code: 'return { message: "Workflow executed successfully" }',
+            nodeName: 'response1'
+          },
+          position: { x: 400, y: 250 },
+          targetPosition: 'left'
+        }
+      ];
+
+      const edges: WorkflowEdge[] = [
+        { id: 'edge-1', source: 'start-1', target: 'response-1', type: 'workflow' }
+      ];
+
+      return await createCompleteWorkflow(app, user, { name, nodes, edges, queries: [] });
+    };
+
+    // Embeds a "trigger this workflow" query (kind: 'workflows') on the given host/module
+    // app version, mirroring what the query editor persists for a workflow query.
+    const embedWorkflowQuery = async (hostAppVersion: any, workflow: any, workflowVersion: any) => {
+      const dataSource = await createDataSource(app, {
+        name: 'trigger-workflow',
+        kind: 'workflows',
+        appVersion: hostAppVersion,
+      });
+
+      return await createDataQuery(app, {
+        name: 'workflows1',
+        dataSource,
+        appVersion: hostAppVersion,
+        options: {
+          workflowId: workflow.id,
+          workflowVersionId: workflowVersion.id,
+          params: [],
+        },
+      });
+    };
+
+    const triggerViaQuery = (workflow: any, workflowVersion: any, workflowQuery: any) =>
+      request(app.getHttpServer())
+        .post(`/api/workflow_executions/${workflow.id}/trigger`)
+        .send({
+          appId: workflow.id,
+          appVersionId: workflowVersion.id,
+          executeUsing: 'app',
+          queryId: workflowQuery.id,
+          environmentId: workflowVersion.currentEnvironmentId,
+          syncExecution: true,
+        });
+
+    it('allows an unauthenticated trigger when the embedding front-end app is public', async () => {
+      const { user } = await setupOrganizationAndUser(app, {
+        email: 'admin@tooljet.io',
+        password: 'password',
+        firstName: 'Admin',
+        lastName: 'User'
+      });
+      user.organizationId = user.organizationId || user.defaultOrganizationId;
+
+      const { app: workflow, appVersion: workflowVersion } = await buildTargetWorkflow(user, 'Public App Target Workflow');
+
+      const hostApp = await createApplication(app, { name: 'Public host app', user, isPublic: true, type: 'front-end' }, false);
+      const hostVersion = await createApplicationVersion(app, hostApp as any);
+      const workflowQuery = await embedWorkflowQuery(hostVersion, workflow, workflowVersion);
+
+      const response = await triggerViaQuery(workflow, workflowVersion, workflowQuery);
+
+      expect(response.statusCode).toBe(201);
+      expect(response.body.result?.executionId).toBeDefined();
+
+      const { execution } = await getWorkflowExecutionDetails(app, response.body.result.executionId);
+      expect(execution.executed).toBe(true);
+    });
+
+    it('rejects an unauthenticated trigger when the embedding front-end app is not public', async () => {
+      const { user } = await setupOrganizationAndUser(app, {
+        email: 'admin@tooljet.io',
+        password: 'password',
+        firstName: 'Admin',
+        lastName: 'User'
+      });
+      user.organizationId = user.organizationId || user.defaultOrganizationId;
+
+      const { app: workflow, appVersion: workflowVersion } = await buildTargetWorkflow(user, 'Private App Target Workflow');
+
+      const hostApp = await createApplication(app, { name: 'Private host app', user, isPublic: false, type: 'front-end' }, false);
+      const hostVersion = await createApplicationVersion(app, hostApp as any);
+      const workflowQuery = await embedWorkflowQuery(hostVersion, workflow, workflowVersion);
+
+      const response = await triggerViaQuery(workflow, workflowVersion, workflowQuery);
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('allows an unauthenticated trigger when the query lives in a module embedded in a public parent app', async () => {
+      const { user } = await setupOrganizationAndUser(app, {
+        email: 'admin@tooljet.io',
+        password: 'password',
+        firstName: 'Admin',
+        lastName: 'User'
+      });
+      user.organizationId = user.organizationId || user.defaultOrganizationId;
+
+      const { app: workflow, appVersion: workflowVersion } = await buildTargetWorkflow(user, 'Module Target Workflow');
+
+      // Module app: never marked public itself -- only the public parent makes it reachable.
+      const moduleApp = await createApplication(app, { name: 'Embedded module', user, isPublic: false, type: 'module' }, false);
+      const moduleVersion = await createApplicationVersion(app, moduleApp as any);
+      const workflowQuery = await embedWorkflowQuery(moduleVersion, workflow, workflowVersion);
+
+      // Parent app: public, embeds the module via a ModuleViewer component.
+      const parentApp = await createApplication(app, { name: 'Public parent app', user, isPublic: true, type: 'front-end' }, false);
+      const parentVersion = await createApplicationVersion(app, parentApp as any);
+      await markVersionAsReleased(parentApp.id, parentVersion.id);
+
+      const ds = getDefaultDataSource();
+      const componentRepository = ds.getRepository(Component);
+      await componentRepository.save(
+        componentRepository.create({
+          name: 'module1',
+          type: 'ModuleViewer',
+          pageId: parentVersion.homePageId,
+          properties: {
+            moduleAppId: { value: moduleApp.id },
+            moduleVersionId: { value: moduleVersion.id },
+          },
+          styles: {},
+          validation: {},
+        })
+      );
+
+      const response = await triggerViaQuery(workflow, workflowVersion, workflowQuery);
+
+      expect(response.statusCode).toBe(201);
+      expect(response.body.result?.executionId).toBeDefined();
+    });
+
+    it('rejects an unauthenticated trigger when the module is not embedded in any public app', async () => {
+      const { user } = await setupOrganizationAndUser(app, {
+        email: 'admin@tooljet.io',
+        password: 'password',
+        firstName: 'Admin',
+        lastName: 'User'
+      });
+      user.organizationId = user.organizationId || user.defaultOrganizationId;
+
+      const { app: workflow, appVersion: workflowVersion } = await buildTargetWorkflow(user, 'Orphan Module Target Workflow');
+
+      const moduleApp = await createApplication(app, { name: 'Standalone module', user, isPublic: false, type: 'module' }, false);
+      const moduleVersion = await createApplicationVersion(app, moduleApp as any);
+      const workflowQuery = await embedWorkflowQuery(moduleVersion, workflow, workflowVersion);
+
+      const response = await triggerViaQuery(workflow, workflowVersion, workflowQuery);
+
+      expect(response.statusCode).toBe(401);
     });
   });
 });


### PR DESCRIPTION
## Summary

Triggering a workflow query from a public app (or from a module used inside a public app) returned 401/403 instead of executing. Two independent bugs were involved:

**1. `WorkflowTriggerAuthGuard` didn't honor public apps**
- `POST /workflow_executions/:id/trigger` required a valid JWT unconditionally, regardless of `app.isPublic` — unlike the sibling `POST /workflow_executions` endpoint, which already had no auth guard specifically to support public-app triggers.
- Even after bypassing the JWT check for public apps, the guard never set `request.tj_app`, so the downstream `FeatureAbilityGuard` couldn't see `app.isPublic` and rejected with 403 anyway.
- Modules are never marked public themselves, so a workflow query embedded in a module still 401'd even when the module's parent app was public.

**2. Frontend snake_case/camelCase drift for module-embedded workflow queries**
- Workflow query options (`workflowId`, `workflowVersionId`) come back snake_case (`workflow_id`, `workflow_version_id`) on the public/released/module-embedded read path, same as several other query option keys already normalized client-side — these two keys were just never added to that normalization list. This made `workflowId` resolve to `undefined` for a workflow query living inside a module, producing `POST /workflow_executions/undefined/trigger`.

## Fixes

- `server/ee/workflows/guards/workflow-trigger-auth.guard.ts`
  - Sets `request.tj_app` / `request.tj_resource_id` after resolving the app, so downstream ability checks see its public status.
  - Returns immediately for public apps instead of forcing a JWT check.
  - For module apps, mirrors `QueryAuthGuard`'s existing pattern: try JWT first, and on failure fall back to checking whether the module is embedded (via this query) in a public parent app before rejecting.
- `frontend/src/AppBuilder/_hooks/useAppData.js`
  - Added `workflowId` / `workflowVersionId` to `QUERY_OPTION_KEYS_TO_NORMALIZE`.

## Test coverage

New e2e coverage in `server/test/modules/workflows/e2e/workflow-executions.spec.ts` for `POST /api/workflow_executions/:id/trigger`:
- ✅ unauthenticated trigger succeeds when the embedding front-end app is public
- ✅ unauthenticated trigger is rejected (401) when it isn't
- ✅ unauthenticated trigger succeeds when the query lives in a module embedded in a public parent app (module itself stays non-public)
- ✅ unauthenticated trigger is rejected (401) when the module isn't embedded in any public app

All 4 new tests pass. Full spec suite: 19/20 pass — the 1 pre-existing failure (`should execute workflow with Python setup script using numpy`) is an unrelated local numpy build issue, not a regression from this change.

## QA verification steps

1. Build a public app with a workflow query, load it unauthenticated (incognito), trigger the query → should execute successfully (previously 401).
2. Build a module containing a workflow query, embed the module in a public app, load the public app unauthenticated, trigger the query from inside the module → should execute successfully (previously 401 with `.../workflow_executions/undefined/trigger`).
3. Confirm a workflow query on a **private** app still requires authentication when triggered unauthenticated (401).
4. Confirm a module embedded only in **non-public** apps still requires authentication when its workflow query is triggered unauthenticated (401).
