### PR TITLE
ci: pin third-party actions (packer, setup-docker) to full commit SHAs

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 18.18.2
 
       - name: Set up Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: docker-practice/actions-setup-docker@509de4a162d8fd24b2721a9fb3721131a6a4776b # master
 
       - name: Run PostgreSQL Database Docker Container
         run: |

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -74,7 +74,7 @@ jobs:
 
       # Initialize Packer templates
       - name: Initialize Packer Template
-        uses: hashicorp/packer-github-actions@master
+        uses: hashicorp/packer-github-actions@8c999b2ff7c48cce2adc5fe43ad7fd8a80e6a8b5 # master
         with:
           command: init
           target: .
@@ -82,7 +82,7 @@ jobs:
 
       # validate templates
       - name: Validate Template
-        uses: hashicorp/packer-github-actions@master
+        uses: hashicorp/packer-github-actions@8c999b2ff7c48cce2adc5fe43ad7fd8a80e6a8b5 # master
         with:
           command: validate
           arguments: -syntax-only
@@ -101,7 +101,7 @@ jobs:
       # build artifact
       - name: Build Artifact
         id: packer-build
-        uses: hashicorp/packer-github-actions@master
+        uses: hashicorp/packer-github-actions@8c999b2ff7c48cce2adc5fe43ad7fd8a80e6a8b5 # master
         with:
           command: build
           #The the below argument is specific for building EE AMI image


### PR DESCRIPTION
### What

Pin the third-party actions currently referenced by `@master` to their current `master` commit SHA
(tag kept in a trailing comment):

| Action | Pinned to | Where |
|---|---|---|
| `hashicorp/packer-github-actions@master` | `8c999b2…` | `packer-build.yml` (×3) |
| `docker-practice/actions-setup-docker@master` | `509de4a…` | `code-coverage.yml` |

### Why

`@master` is a moving reference — whatever it points to at run time runs in the job. The
`packer-build.yml` ("AWS AMI build") uses run right after AWS credentials are configured
([lines 68-104](https://github.com/tooljet/tooljet/blob/dec86c7df6429cd62ae82cbd84be4a35a4f067b9/.github/workflows/packer-build.yml#L68-L104)) and go on to build and publish ToolJet Enterprise AMIs. If that action's `master` were moved
(compromise or an accidental change), the new code would run with those AWS credentials and image-build
context — the class of issue behind the 2025 `tj-actions/changed-files` incident.

(Worth noting: `hashicorp/packer-github-actions`' active default branch is now `main`, so `@master` is
also a somewhat stale ref — pinning to the SHA removes that ambiguity too.)

### Scope / safety

- Behaviour unchanged — each SHA is the current tip of that action's `master`.
- Only third-party actions are touched; `actions/*` refs are left as-is. Renovate/Dependabot can still
  bump a SHA pin (the tag comment keeps it readable). Signed-off.

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the AWS-credential exposure, and the pinned SHAs myself.</sub>
