### PR TITLE
Fix: Keep app builder sidebar panel headers pinned while scrolling

### DIFF
--- a/frontend/src/AppBuilder/LeftSidebar/Debugger/SidebarDebugger/debuggerHeader.scss
+++ b/frontend/src/AppBuilder/LeftSidebar/Debugger/SidebarDebugger/debuggerHeader.scss
@@ -2,6 +2,10 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--background-surface-layer-01);
 
   .debugger-header-top {
     display: flex;

--- a/frontend/src/AppBuilder/LeftSidebar/GlobalSettings/styles.scss
+++ b/frontend/src/AppBuilder/LeftSidebar/GlobalSettings/styles.scss
@@ -10,6 +10,10 @@
     justify-content: space-between;
     padding: 16px;
     border-bottom: 1px solid var(--border-weak, #e4e7eb);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--background-surface-layer-01);
 
     .global-settings-header-title {
       font-family: 'IBM Plex Sans', sans-serif;

--- a/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/styles.scss
+++ b/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/styles.scss
@@ -4,6 +4,10 @@
 	display: flex;
 	gap: 8px;
 	flex-direction: column;
+	position: sticky;
+	top: 0;
+	z-index: 10;
+	background: var(--background-surface-layer-01);
 
 	.inspector-header-top {
 		display: flex;

--- a/frontend/src/AppBuilder/RightSideBar/ComponentManagerTab/styles.scss
+++ b/frontend/src/AppBuilder/RightSideBar/ComponentManagerTab/styles.scss
@@ -6,6 +6,11 @@
   padding: 16px 16px 8px 16px; // top right bottom left - 8px bottom for gap before tabs
   min-height: 40px;
   gap: 8px;
+  // Stay pinned while the panel content scrolls
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--background-surface-layer-01);
 
   .panel-header-title {
     font-family: 'IBM Plex Sans', sans-serif;
@@ -42,6 +47,14 @@
   // Tab content styling only - tab header styles come from base tabs.scss
   .tab-content {
     border-top: none;
+  }
+
+  // Keep tab bar pinned below the sticky panel-header while the component list scrolls
+  .nav-tabs {
+    position: sticky;
+    top: 52px; // panel-header height
+    z-index: 10;
+    background: var(--background-surface-layer-01);
   }
 }
 

--- a/frontend/src/AppBuilder/RightSideBar/ComponentManagerTab/styles.scss
+++ b/frontend/src/AppBuilder/RightSideBar/ComponentManagerTab/styles.scss
@@ -1,3 +1,9 @@
+// Rendered height of .panel-header (confirmed in browser). Single source of
+// truth for anything that needs to sit flush beneath the sticky header.
+:root {
+  --panel-header-height: 52px;
+}
+
 // Panel Header - shared across all right sidebar panels
 .panel-header {
   display: flex;
@@ -52,7 +58,7 @@
   // Keep tab bar pinned below the sticky panel-header while the component list scrolls
   .nav-tabs {
     position: sticky;
-    top: 52px; // panel-header height
+    top: var(--panel-header-height);
     z-index: 10;
     background: var(--background-surface-layer-01);
   }

--- a/frontend/src/_styles/pages-sidebar.scss
+++ b/frontend/src/_styles/pages-sidebar.scss
@@ -3,6 +3,14 @@
 }
 
 .pages-settings {
+    // Keep tab bar pinned below the sticky panel-header while the panel scrolls
+    .nav-tabs {
+        position: sticky;
+        top: 52px; // panel-header height
+        z-index: 10;
+        background: var(--background-surface-layer-01);
+    }
+
     .label-style {
         width: unset !important;
 

--- a/frontend/src/_styles/pages-sidebar.scss
+++ b/frontend/src/_styles/pages-sidebar.scss
@@ -1,12 +1,15 @@
 :root {
     --tran-01: all 0.3s ease, background-color 0s, color 0s, border-color 0s;
+    // Rendered height of .panel-header (confirmed in browser). Single source of
+    // truth for anything that needs to sit flush beneath the sticky header.
+    --panel-header-height: 52px;
 }
 
 .pages-settings {
     // Keep tab bar pinned below the sticky panel-header while the panel scrolls
     .nav-tabs {
         position: sticky;
-        top: 52px; // panel-header height
+        top: var(--panel-header-height);
         z-index: 10;
         background: var(--background-surface-layer-01);
     }


### PR DESCRIPTION
## 📝 What this does
Panel headers in the app builder sidebars scrolled away with the panel content. This pins them (and the tab bars below them, where present) to the top of the panel so only the content scrolls.

Closes #17142

## 🔀 Changes
- Made left sidebar panel headers sticky: Inspector, Debugger, Global settings
- Made the shared right sidebar `panel-header` sticky, covering Components manager, component configuration, and Pages and navigation
- Pinned the tab bars in Components manager and Page settings just below the header
- Used the surface-layer-01 token as the pinned background so light and dark themes both render correctly

## 🧪 How to test
- [ ] Open an app in the builder
- [ ] Open the Inspector panel and scroll a long component tree — header stays pinned
- [ ] Scroll the Debugger and Global settings panels — headers stay pinned
- [ ] Scroll the Components manager list — header and tab bar stay pinned, list slides underneath
- [ ] Scroll Pages and navigation — header and tab bar stay pinned
- [ ] Repeat one panel in dark mode — pinned background matches the panel surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)