### PR TITLE
Fix: remove git-sync hard reloads and heal active branch after delete

### DIFF
--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -62,7 +62,6 @@ import { updateCurrentSession } from '@/_helpers/authorizeWorkspace';
 import { WorkspaceLockedBanner } from '@/_ui/WorkspaceLockedBanner';
 import { useWorkspaceBranchesStore } from '@/_stores/workspaceBranchesStore';
 import { subscribeLiveNotifications } from '@/_stores/notificationsStore';
-import { getActiveBranchId } from '@/_helpers/active-branch';
 import { WorkspaceSwitchBranchModal } from '@/_ui/WorkspaceBranchDropdown/SwitchBranchModal';
 import { TriangleAlert } from 'lucide-react';
 
@@ -287,17 +286,12 @@ class HomePageComponent extends React.Component {
     if (meta?.source !== 'git-sync' || n?.type !== 'success') return;
     const branchActions = useWorkspaceBranchesStore.getState().actions;
     switch (meta.action) {
-      case 'git-delete-branch': {
-        const wasActive = meta.branchId && meta.branchId === getActiveBranchId();
-        // fetchBranches self-heals to default; the activeBranchId change triggers the apps refetch above
-        branchActions.fetchBranches().then(() => {
-          if (wasActive) {
-            const healed = useWorkspaceBranchesStore.getState().currentBranch;
-            toast.success(`Branch '${meta.branchName}' was deleted. Switched to '${healed?.name || 'default'}'`);
-          }
-        });
+      case 'git-delete-branch':
+        // fetchBranches self-heals a deleted active branch to default; the
+        // activeBranchId change triggers the apps refetch above. Silent — the
+        // notification toast already announces the deletion.
+        branchActions.fetchBranches();
         break;
-      }
       case 'git-pull-branch':
         // same branch id — subscription won't fire, refetch directly
         this.fetchApps(1, this.state.currentFolder.id);

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -61,6 +61,8 @@ import { PermissionDeniedModal } from './PermissionDeniedModal/PermissionDeniedM
 import { updateCurrentSession } from '@/_helpers/authorizeWorkspace';
 import { WorkspaceLockedBanner } from '@/_ui/WorkspaceLockedBanner';
 import { useWorkspaceBranchesStore } from '@/_stores/workspaceBranchesStore';
+import { subscribeLiveNotifications } from '@/_stores/notificationsStore';
+import { getActiveBranchId } from '@/_helpers/active-branch';
 import { WorkspaceSwitchBranchModal } from '@/_ui/WorkspaceBranchDropdown/SwitchBranchModal';
 import { TriangleAlert } from 'lucide-react';
 
@@ -256,6 +258,12 @@ class HomePageComponent extends React.Component {
       }
     });
 
+    // Store is a singleton — refetch on dashboard return; active branch may have been deleted while away.
+    if (useWorkspaceBranchesStore.getState().isInitialized) {
+      useWorkspaceBranchesStore.getState().actions.fetchBranches();
+    }
+    this._liveNotificationsUnsubscribe = subscribeLiveNotifications(this.handleGitSyncNotification);
+
     const hasClosedBanner = localStorage.getItem('hasClosedGroupMigrationBanner');
 
     //Only show the banner once
@@ -268,7 +276,40 @@ class HomePageComponent extends React.Component {
     if (this._branchStoreUnsubscribe) {
       this._branchStoreUnsubscribe();
     }
+    if (this._liveNotificationsUnsubscribe) {
+      this._liveNotificationsUnsubscribe();
+    }
   }
+
+  // Aftermath for git-sync background jobs — live WS arrivals only, REST backfill never reaches here.
+  handleGitSyncNotification = (n) => {
+    const meta = n?.metadata;
+    if (meta?.source !== 'git-sync' || n?.type !== 'success') return;
+    const branchActions = useWorkspaceBranchesStore.getState().actions;
+    switch (meta.action) {
+      case 'git-delete-branch': {
+        const wasActive = meta.branchId && meta.branchId === getActiveBranchId();
+        // fetchBranches self-heals to default; the activeBranchId change triggers the apps refetch above
+        branchActions.fetchBranches().then(() => {
+          if (wasActive) {
+            const healed = useWorkspaceBranchesStore.getState().currentBranch;
+            toast.success(`Branch '${meta.branchName}' was deleted. Switched to '${healed?.name || 'default'}'`);
+          }
+        });
+        break;
+      }
+      case 'git-pull-branch':
+        // same branch id — subscription won't fire, refetch directly
+        this.fetchApps(1, this.state.currentFolder.id);
+        this.fetchFolders();
+        break;
+      case 'git-create-branch':
+        branchActions.fetchBranches();
+        break;
+      default:
+        break;
+    }
+  };
 
   componentDidUpdate(prevProps, prevState) {
     if (prevProps.appType != this.props.appType) {

--- a/frontend/src/_helpers/active-branch.js
+++ b/frontend/src/_helpers/active-branch.js
@@ -62,8 +62,11 @@ let _focusSyncListener = null;
  * from sessionStorage to localStorage whenever the tab becomes visible.
  * This ensures new tabs opened from this tab inherit its active branch.
  * Safe to call multiple times — removes any existing listener before re-registering.
+ *
+ * isKnownBranchId(id) => true | false | null (injected by the branches store; avoids circular import).
+ * false = branch deleted: drop stale sessionStorage instead of re-poisoning localStorage with a dead id.
  */
-export function registerBranchFocusSync() {
+export function registerBranchFocusSync(isKnownBranchId) {
   if (_focusSyncListener) {
     document.removeEventListener('visibilitychange', _focusSyncListener);
   }
@@ -76,14 +79,45 @@ export function registerBranchFocusSync() {
       const sessionStored = sessionStorage.getItem(key);
       // Only write to localStorage if sessionStorage has a value — avoids
       // wiping the localStorage seed when a fresh tab hasn't initialised yet
-      if (sessionStored) {
-        localStorage.setItem(key, sessionStored);
+      if (!sessionStored) return;
+      const branchId = JSON.parse(sessionStored)?.id;
+      if (branchId && isKnownBranchId?.(branchId) === false) {
+        sessionStorage.removeItem(key);
+        return;
       }
+      localStorage.setItem(key, sessionStored);
     } catch {
       // ignore storage errors
     }
   };
   document.addEventListener('visibilitychange', _focusSyncListener);
+}
+
+// Cross-tab heal: adopt another tab's localStorage write into this tab's sessionStorage.
+let _storageSyncListener = null;
+export function registerBranchStorageSync(onBranchChanged) {
+  if (_storageSyncListener) {
+    window.removeEventListener('storage', _storageSyncListener);
+  }
+  _storageSyncListener = (e) => {
+    const id = getOrgId();
+    if (!id || e.key !== `${BRANCH_KEY_PREFIX}${id}` || !e.newValue) return;
+    try {
+      if (e.newValue === sessionStorage.getItem(e.key)) return;
+      sessionStorage.setItem(e.key, e.newValue);
+      onBranchChanged?.(JSON.parse(e.newValue));
+    } catch {
+      // ignore storage errors
+    }
+  };
+  window.addEventListener('storage', _storageSyncListener);
+}
+
+export function unregisterBranchStorageSync() {
+  if (_storageSyncListener) {
+    window.removeEventListener('storage', _storageSyncListener);
+    _storageSyncListener = null;
+  }
 }
 
 export function unregisterBranchFocusSync() {

--- a/frontend/src/_helpers/active-branch.js
+++ b/frontend/src/_helpers/active-branch.js
@@ -93,7 +93,9 @@ export function registerBranchFocusSync(isKnownBranchId) {
   document.addEventListener('visibilitychange', _focusSyncListener);
 }
 
-// Cross-tab heal: adopt another tab's localStorage write into this tab's sessionStorage.
+// Cross-tab heal: another tab changed the shared branch value — reconcile from THIS
+// tab's own sessionStorage (valid id keeps the tab's branch; deleted id self-heals).
+// Never copy the other tab's value in: deliberate switches must not propagate.
 let _storageSyncListener = null;
 export function registerBranchStorageSync(onBranchChanged) {
   if (_storageSyncListener) {
@@ -102,13 +104,8 @@ export function registerBranchStorageSync(onBranchChanged) {
   _storageSyncListener = (e) => {
     const id = getOrgId();
     if (!id || e.key !== `${BRANCH_KEY_PREFIX}${id}` || !e.newValue) return;
-    try {
-      if (e.newValue === sessionStorage.getItem(e.key)) return;
-      sessionStorage.setItem(e.key, e.newValue);
-      onBranchChanged?.(JSON.parse(e.newValue));
-    } catch {
-      // ignore storage errors
-    }
+    if (e.newValue === sessionStorage.getItem(e.key)) return;
+    onBranchChanged?.();
   };
   window.addEventListener('storage', _storageSyncListener);
 }

--- a/frontend/src/_stores/notificationsStore.js
+++ b/frontend/src/_stores/notificationsStore.js
@@ -23,6 +23,13 @@ let reconnectTimer = null;
 let manualClose = false;
 const RECONNECT_MS = 5000;
 
+// Fired only for fresh WS deliveries — never REST backfill.
+const liveSubscribers = new Set();
+export function subscribeLiveNotifications(cb) {
+  liveSubscribers.add(cb);
+  return () => liveSubscribers.delete(cb);
+}
+
 function notificationsWsUrl() {
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
   const isSecure = /https?:\/\//g.test(config.apiUrl);
@@ -159,6 +166,15 @@ export const useNotificationsStore = create(
           if (added && withToast) {
             const action = detailAction(n);
             showNotificationToast(n, action ? { onViewDetails: (notif) => get().actions.openDetail(notif) } : {});
+          }
+          if (added) {
+            liveSubscribers.forEach((cb) => {
+              try {
+                cb(n);
+              } catch (err) {
+                console.error('notification effect failed:', err);
+              }
+            });
           }
         },
       },

--- a/frontend/src/_stores/workspaceBranchesStore.js
+++ b/frontend/src/_stores/workspaceBranchesStore.js
@@ -7,6 +7,8 @@ import {
   cleanupStaleBranchKeys,
   registerBranchFocusSync,
   unregisterBranchFocusSync,
+  registerBranchStorageSync,
+  unregisterBranchStorageSync,
 } from '@/_helpers/active-branch';
 
 const initialState = {
@@ -25,6 +27,22 @@ const initialState = {
   isDeletingBranch: false,
   deleteBranchError: null,
 };
+
+// Validator lets focus-sync drop deleted branch ids instead of re-poisoning localStorage from a stale tab.
+function activateBranchSync(get, currentBranch) {
+  if (currentBranch) setActiveBranch(currentBranch);
+  registerBranchFocusSync((branchId) => {
+    const known = get().branches;
+    return known?.length ? known.some((b) => b.id === branchId) : null;
+  });
+  registerBranchStorageSync(() => get().actions.fetchBranches());
+}
+
+function deactivateBranchSync() {
+  unregisterBranchFocusSync();
+  unregisterBranchStorageSync();
+  setActiveBranch(null);
+}
 
 // Helper to resolve current branch from branches list + active ID
 function resolveCurrentBranch(branches, activeBranchId) {
@@ -67,11 +85,9 @@ export const useWorkspaceBranchesStore = create(
             const currentBranch = isGitSyncEnabled ? resolveCurrentBranch(branches, effectiveActiveBranchId) : null;
 
             if (isGitSyncEnabled) {
-              if (currentBranch) setActiveBranch(currentBranch);
-              registerBranchFocusSync();
+              activateBranchSync(get, currentBranch);
             } else {
-              unregisterBranchFocusSync();
-              setActiveBranch(null);
+              deactivateBranchSync();
             }
 
             set({
@@ -96,6 +112,13 @@ export const useWorkspaceBranchesStore = create(
             const serverActiveBranchId = data?.active_branch_id || data?.activeBranchId || null;
             const effectiveActiveBranchId = storedBranch?.id || serverActiveBranchId;
             const currentBranch = resolveCurrentBranch(branches, effectiveActiveBranchId);
+            // Stored branch deleted in background — persist fallback so we stop sending a dead id.
+            // Guards keep a transient empty list from clobbering a valid stored branch.
+            const gitStatus = get().orgGitConfig;
+            const isGitSyncEnabled = !!(gitStatus?.isEnabled ?? gitStatus?.is_enabled);
+            if (isGitSyncEnabled && branches.length > 0 && currentBranch && currentBranch.id !== storedBranch?.id) {
+              setActiveBranch(currentBranch);
+            }
             set({ branches, activeBranchId: currentBranch?.id || effectiveActiveBranchId, currentBranch });
           } catch (error) {
             console.error('Failed to fetch branches:', error);
@@ -242,14 +265,12 @@ export const useWorkspaceBranchesStore = create(
         },
 
         clearActiveBranchContext() {
-          unregisterBranchFocusSync();
-          setActiveBranch(null);
+          deactivateBranchSync();
           set({ activeBranchId: null, currentBranch: null });
         },
 
         reset() {
-          unregisterBranchFocusSync();
-          setActiveBranch(null);
+          deactivateBranchSync();
           set(initialState);
         },
 
@@ -269,11 +290,9 @@ export const useWorkspaceBranchesStore = create(
             const currentBranch = isGitSyncEnabled ? resolveCurrentBranch(branches, effectiveActiveBranchId) : null;
 
             if (isGitSyncEnabled) {
-              if (currentBranch) setActiveBranch(currentBranch);
-              registerBranchFocusSync();
+              activateBranchSync(get, currentBranch);
             } else {
-              unregisterBranchFocusSync();
-              setActiveBranch(null);
+              deactivateBranchSync();
             }
 
             set({

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -6385,8 +6385,10 @@ a.step-item-disabled {
 .notification-center-badge {
   position: absolute;
   top: 2px;
-  left: 16px;
-  right: auto;
+  // right-anchored so the 99+ pill grows leftward instead of clipping at the
+  // 48px sidebar's overflow-x: hidden edge
+  left: auto;
+  right: -2px;
   margin: 0;
   padding: 2px 4px;
   height: 13px;

--- a/frontend/src/_ui/WorkspaceBranchDropdown/DeleteBranchConfirmModal.jsx
+++ b/frontend/src/_ui/WorkspaceBranchDropdown/DeleteBranchConfirmModal.jsx
@@ -15,7 +15,7 @@ export function DeleteBranchConfirmModal({ branchToDelete, onCancel, onDelete, o
 
   const wasDeletingRef = useRef(false);
 
-  // Auto-close and redirect on successful deletion
+  // Auto-close on successful enqueue — the delete-success notification drives any reconciliation
   useEffect(() => {
     if (wasDeletingRef.current && !isDeletingBranch && !deleteBranchError && branchToDelete) {
       const deletedName = branchToDelete.name;
@@ -26,10 +26,6 @@ export function DeleteBranchConfirmModal({ branchToDelete, onCancel, onDelete, o
         duration: 8000,
         style: { maxWidth: '420px', fontSize: '15px', fontWeight: 400 },
       });
-      const workspacePath = window.location.pathname.split('/')[1];
-      setTimeout(() => {
-        window.location.href = `/${workspacePath}`;
-      }, 1500);
     }
     wasDeletingRef.current = isDeletingBranch;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/_ui/WorkspaceBranchDropdown/SwitchBranchModal.jsx
+++ b/frontend/src/_ui/WorkspaceBranchDropdown/SwitchBranchModal.jsx
@@ -152,8 +152,8 @@ export function WorkspaceSwitchBranchModal({ show, onClose, onBranchSwitch }) {
       if (onBranchSwitch) {
         onBranchSwitch(branch);
       } else {
+        // dashboard refetches apps/folders via its branch-store subscription
         onClose();
-        window.location.reload();
       }
     } catch (error) {
       console.error('Error switching branch:', error);

--- a/frontend/src/_ui/WorkspaceGitSyncModal/index.jsx
+++ b/frontend/src/_ui/WorkspaceGitSyncModal/index.jsx
@@ -95,6 +95,8 @@ export function WorkspaceGitSyncModal({ isOnDefaultBranch, initialTab = 'push', 
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key !== 'Enter' || isPushing || isPulling) return;
+      // Stop native form submission — it reloads the page mid-push.
+      e.preventDefault();
       if (activeTab === 'push' && commitMessage.trim()) {
         handlePush();
       } else if (activeTab === 'pull' && checkingForUpdate?.status === UPDATE_STATUS.AVAILABLE && !actionChoiceMode) {
@@ -198,8 +200,8 @@ export function WorkspaceGitSyncModal({ isOnDefaultBranch, initialTab = 'push', 
         // Current app doesn't exist in that branch — go to homepage
         window.location.href = `/${pathParts[1]}`;
       } else {
-        // Already on homepage — just reload
-        window.location.reload();
+        // homepage refetches apps via its branch-store subscription; pulled content lands via the success notification
+        actions.fetchBranches();
       }
     } catch (error) {
       if (error?.statusCode === 409) {
@@ -338,7 +340,11 @@ export function WorkspaceGitSyncModal({ isOnDefaultBranch, initialTab = 'push', 
   // ---- Pull section content ----
   const renderPullSection = () => (
     <div className="pull-section">
-      <form noValidate className="d-flex w-100 align-items-start justify-content-start">
+      <form
+        noValidate
+        onSubmit={(e) => e.preventDefault()}
+        className="d-flex w-100 align-items-start justify-content-start"
+      >
         <div className="d-flex flex-column w-100" style={{ gap: '12px' }}>
           {/* PULL INTO */}
           <div className="import-in-row">
@@ -437,7 +443,7 @@ export function WorkspaceGitSyncModal({ isOnDefaultBranch, initialTab = 'push', 
 
   // ---- Push section content ----
   const renderPushSection = () => (
-    <form noValidate>
+    <form noValidate onSubmit={(e) => e.preventDefault()}>
       <div className="push-section mb-2">
         <div className="d-flex flex-column w-100 align-items-start">
           <div className="form-group mb-2 w-100">

--- a/frontend/src/modules/dataSources/components/List/index.jsx
+++ b/frontend/src/modules/dataSources/components/List/index.jsx
@@ -12,6 +12,7 @@ import FolderSkeleton from '@/_ui/FolderSkeleton/FolderSkeleton';
 import Modal from '@/HomePage/Modal';
 import { Button } from '@/components/ui/Button/Button';
 import { useWorkspaceBranchesStore } from '@/_stores/workspaceBranchesStore';
+import { subscribeLiveNotifications } from '@/_stores/notificationsStore';
 import { WorkspaceSwitchBranchModal } from '@/_ui/WorkspaceBranchDropdown/SwitchBranchModal';
 
 export const List = ({ updateSelectedDatasource }) => {
@@ -56,6 +57,16 @@ export const List = ({ updateSelectedDatasource }) => {
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [environments]);
+
+  // pulled content lands in a background job — refetch when it succeeds
+  useEffect(() => {
+    return subscribeLiveNotifications((n) => {
+      if (n?.metadata?.source === 'git-sync' && n?.type === 'success' && n?.metadata?.action === 'git-pull-branch') {
+        fetchDataSources(false).catch(() => {});
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchDataSources]);
 
   useEffect(() => {
     setFilteredData([...dataSources]);

--- a/frontend/src/modules/dataSources/components/List/index.jsx
+++ b/frontend/src/modules/dataSources/components/List/index.jsx
@@ -58,11 +58,16 @@ export const List = ({ updateSelectedDatasource }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [environments]);
 
-  // pulled content lands in a background job — refetch when it succeeds
+  // git-sync jobs finish in the background — react to their success notifications
   useEffect(() => {
     return subscribeLiveNotifications((n) => {
-      if (n?.metadata?.source === 'git-sync' && n?.type === 'success' && n?.metadata?.action === 'git-pull-branch') {
+      if (n?.metadata?.source !== 'git-sync' || n?.type !== 'success') return;
+      if (n.metadata.action === 'git-pull-branch') {
         fetchDataSources(false).catch(() => {});
+      } else if (n.metadata.action === 'git-delete-branch') {
+        // fetchBranches self-heals a deleted active branch to default; the page's
+        // activeBranchId effect then refetches the list under the healed branch
+        useWorkspaceBranchesStore.getState().actions.fetchBranches();
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## 📝 What this does
Removes the leftover full-page reloads from the git-sync branch flows (delete, switch, homepage pull) and makes the dashboard react to job-success notifications instead — including silently switching to the default branch when the branch you were on gets deleted, which fixes the stale branch_id false-empty workspace.
- [ee-server](https://github.com/ToolJet/ee-server/pull/690)
- ee-frontend — no changes

Closes #16820

## 🔀 Changes
- Removed the enqueue-time redirect after branch delete and the reloads after branch switch and homepage pull
- Dashboard now subscribes to live git-sync success notifications: refetches the branch list, silently switches to the default branch when the deleted branch was active, and refreshes apps after a pull
- Data sources page reacts to git-sync completions too: refetches its list on pull success and heals a deleted active branch to default without a dashboard visit
- Branch list fetch self-heals a stored active-branch id that no longer exists; focus-sync validates ids before writing to localStorage and a storage listener re-checks this tab's own branch when another tab changes the shared value — deleted branches heal, deliberate switches never propagate
- Enter on the push-commit modal no longer triggers a native form submit that reloaded the page mid-push
- Notification badge no longer clips at 99+ (right-anchored so the wider pill grows into the sidebar, not past its edge)

## 🧪 How to test
- [x] Run with `WORKER=true`; delete a non-active branch from the default-branch dashboard — info toast, no redirect, no reload
- [x] Switch to a branch and delete it — after the success notification, the dashboard silently switches to the default branch and the apps list refreshes
- [x] Open two tabs on the same branch, delete it from one — the other tab's stored branch heals on its next branch fetch
- [x] Pull on the homepage — no reload; apps refresh when the pull succeeds
- [x] Pull while on the data sources page — the list refetches when the pull succeeds; the success notification no longer says "Please refresh"
- [x] Delete the active branch while on the data sources page — it heals to the default branch and the list reloads in place
- [x] On the data sources page, type a commit message and press Enter — commit pushes without a page refresh
- [x] Open two tabs on different branches, switch a branch in one — the other tab keeps its own branch

> Stacked on #17185 (server/ee pointer restore) — merge that first; GitHub will retarget this PR back to the release branch automatically.



