### PR TITLE
fix: display selected value in DropdownV2 when options are grouped (#17108)

### DIFF
--- a/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
@@ -14,7 +14,7 @@ import CustomMenuList from './CustomMenuList';
 import CustomOption from './CustomOption';
 import Label from '@/_ui/Label';
 import cx from 'classnames';
-import { getInputBackgroundColor, getInputBorderColor, getInputFocusedColor, sortArray } from './utils';
+import { getInputBackgroundColor, getInputBorderColor, getInputFocusedColor, sortArray, flattenSelectOptions } from './utils';
 import { useMenuWidth } from './useMenuWidth';
 import { getModifiedColor, getSafeRenderableValue } from '@/AppBuilder/Widgets/utils';
 import { isMobileDevice } from '@/_helpers/appUtils';
@@ -135,31 +135,56 @@ export const DropdownV2 = ({
     if (!Array.isArray(schema)) {
       _schema = [];
     }
-    const defaultItem = _schema?.find((item) => item?.visible === true && item?.default === true);
+    // Flatten grouped options so a `default` option nested inside a group is honoured.
+    const defaultItem = flattenSelectOptions(_schema)?.find(
+      (item) => item?.visible === true && item?.default === true
+    );
     return defaultItem?.value;
   }
 
   const selectOptions = useMemo(() => {
     let _options = advanced ? schema : options;
-    if (Array.isArray(_options)) {
-      let _selectOptions = _options
-        .filter((data) => data?.visible ?? true)
-        .map((data) => ({
-          ...data,
-          label: getSafeRenderableValue(data?.label),
-          value: data?.value,
-          caption: data?.caption ?? null,
-          isDisabled: data?.disable ?? false,
-        }));
-
-      return sortArray(_selectOptions, sort);
-    } else {
+    if (!Array.isArray(_options)) {
       return [];
     }
+
+    const mapOption = (data) => ({
+      ...data,
+      label: getSafeRenderableValue(data?.label),
+      value: data?.value,
+      caption: data?.caption ?? null,
+      isDisabled: data?.disable ?? false,
+    });
+
+    // Grouped options: [{ label, options: [...] }]. Keep the group structure
+    // (react-select renders groups from the nested `options` key) while mapping
+    // each leaf option exactly like a flat option.
+    const isGrouped = _options.some((option) => Array.isArray(option?.options));
+    if (isGrouped) {
+      return _options
+        .filter((group) => group?.visible ?? true)
+        .map((group) => ({
+          ...group,
+          label: getSafeRenderableValue(group?.label),
+          options: sortArray(
+            (Array.isArray(group?.options) ? group.options : [])
+              .filter((data) => data?.visible ?? true)
+              .map(mapOption),
+            sort
+          ),
+        }));
+    }
+
+    const _selectOptions = _options.filter((data) => data?.visible ?? true).map(mapOption);
+    return sortArray(_selectOptions, sort);
   }, [advanced, schema, options, sort]);
 
+  // Flat list of leaf options used for value lookups so a selected value can be
+  // resolved even when the options are grouped.
+  const flattenedSelectOptions = useMemo(() => flattenSelectOptions(selectOptions), [selectOptions]);
+
   function selectOption(value) {
-    const val = selectOptions.filter((option) => !option.isDisabled)?.find((option) => option.value === value);
+    const val = flattenedSelectOptions.filter((option) => !option.isDisabled)?.find((option) => option.value === value);
     if (val) {
       setInputValue(value);
       fireEvent('onSelect');
@@ -176,7 +201,7 @@ export const DropdownV2 = ({
 
   const setInputValue = (value) => {
     setCurrentValue(value);
-    const _selectedOption = selectOptions.find((option) => option.value === value);
+    const _selectedOption = flattenedSelectOptions.find((option) => option.value === value);
     setExposedVariables({
       value,
       selectedOption: _selectedOption
@@ -242,7 +267,7 @@ export const DropdownV2 = ({
 
   useEffect(() => {
     if (isInitialRender.current) return;
-    const _options = selectOptions?.map(({ label, value, caption }) => ({ label, value, caption: caption ?? null }));
+    const _options = flattenedSelectOptions?.map(({ label, value, caption }) => ({ label, value, caption: caption ?? null }));
     setExposedVariable('options', _options);
 
     setExposedVariable('selectOption', async function (value) {
@@ -296,7 +321,7 @@ export const DropdownV2 = ({
   }, [validate, currentValue, setExposedVariable]);
 
   useEffect(() => {
-    const _options = selectOptions?.map(({ label, value, caption }) => ({ label, value, caption: caption ?? null }));
+    const _options = flattenedSelectOptions?.map(({ label, value, caption }) => ({ label, value, caption: caption ?? null }));
     const exposedVariables = {
       clear: async function () {
         setInputValue(null);
@@ -336,7 +361,7 @@ export const DropdownV2 = ({
 
   const menuContentWidth = useMemo(() => {
     if (menuWidthMode !== 'matchContent') return null;
-    if (!Array.isArray(selectOptions) || selectOptions.length === 0) return null;
+    if (!Array.isArray(flattenedSelectOptions) || flattenedSelectOptions.length === 0) return null;
 
     try {
       const canvas = document.createElement('canvas');
@@ -346,7 +371,7 @@ export const DropdownV2 = ({
       const baseFont = window?.getComputedStyle?.(ref?.current || document.body)?.font || '14px Inter, sans-serif';
       context.font = baseFont;
 
-      const maxLabelWidth = selectOptions.reduce((acc, option) => {
+      const maxLabelWidth = flattenedSelectOptions.reduce((acc, option) => {
         const labelText = `${option?.label ?? ''}`;
         return Math.max(acc, context.measureText(labelText).width || 0);
       }, 0);
@@ -359,7 +384,7 @@ export const DropdownV2 = ({
     } catch (_e) {
       return null;
     }
-  }, [menuWidthMode, selectOptions, ref]);
+  }, [menuWidthMode, flattenedSelectOptions, ref]);
 
   const menuWidthStyle = useMenuWidth(menuWidthMode, menuCustomWidth, triggerWidth, menuContentWidth);
 
@@ -552,7 +577,7 @@ export const DropdownV2 = ({
             ref={selectRef}
             menuIsOpen={isMenuOpen}
             isDisabled={isDropdownDisabled}
-            value={selectOptions.filter((option) => option.value === currentValue)[0] ?? null}
+            value={flattenedSelectOptions.filter((option) => option.value === currentValue)[0] ?? null}
             onChange={(selectedOption, actionProps) => {
               if (actionProps.action === 'clear') {
                 setInputValue(null);

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/__tests__/utils.test.js
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/__tests__/utils.test.js
@@ -1,0 +1,56 @@
+import { flattenSelectOptions } from '../utils';
+
+describe('flattenSelectOptions', () => {
+  it('returns a flat list unchanged', () => {
+    const flat = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ];
+    expect(flattenSelectOptions(flat)).toEqual(flat);
+  });
+
+  it('flattens grouped options ([{ label, options: [...] }]) into their leaf options', () => {
+    const grouped = [
+      {
+        label: 'Fruits',
+        options: [
+          { value: 'apple', label: 'Apple' },
+          { value: 'orange', label: 'Orange' },
+        ],
+      },
+      {
+        label: 'Vegetables',
+        options: [{ value: 'carrot', label: 'Carrot' }],
+      },
+    ];
+
+    expect(flattenSelectOptions(grouped)).toEqual([
+      { value: 'apple', label: 'Apple' },
+      { value: 'orange', label: 'Orange' },
+      { value: 'carrot', label: 'Carrot' },
+    ]);
+  });
+
+  it('lets a selected value be resolved from grouped options', () => {
+    const grouped = [{ label: 'Fruits', options: [{ value: 'orange', label: 'Orange' }] }];
+    const selected = flattenSelectOptions(grouped).find((option) => option.value === 'orange');
+    expect(selected).toEqual({ value: 'orange', label: 'Orange' });
+  });
+
+  it('handles mixed flat and grouped entries', () => {
+    const mixed = [
+      { value: 'a', label: 'A' },
+      { label: 'Group', options: [{ value: 'b', label: 'B' }] },
+    ];
+    expect(flattenSelectOptions(mixed)).toEqual([
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]);
+  });
+
+  it('returns an empty array for non-array input', () => {
+    expect(flattenSelectOptions(undefined)).toEqual([]);
+    expect(flattenSelectOptions(null)).toEqual([]);
+    expect(flattenSelectOptions()).toEqual([]);
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
@@ -87,3 +87,18 @@ export const sortArray = (arr, sort) => {
   }
   return arr;
 };
+
+// Flatten grouped select options ([{ label, options: [...] }]) into a single flat
+// list of leaf options. Non-grouped (flat) options are returned unchanged. Used
+// for value lookups so a selected value can be resolved even when the options are
+// provided as grouped options.
+export const flattenSelectOptions = (selectOptions = []) => {
+  if (!Array.isArray(selectOptions)) return [];
+  return selectOptions.reduce((acc, option) => {
+    if (Array.isArray(option?.options)) {
+      return acc.concat(option.options);
+    }
+    acc.push(option);
+    return acc;
+  }, []);
+};


### PR DESCRIPTION
## Problem

`Dropdown` (DropdownV2) supports grouped options — `[{ label, options: [...] }]` — and the menu renders and highlights them correctly. But after selecting an option from a group, the selected value is **not shown in the input** (reported in #17108). The `onSelect` event fires and the option is highlighted, yet the control stays empty.

## Root cause

The widget builds a single **flat** `selectOptions` list and performs every value lookup against it:

- `value={selectOptions.filter((o) => o.value === currentValue)[0] ?? null}` — what react-select renders as the selected value
- `setInputValue` → `selectOptions.find((o) => o.value === value)` — the `selectedOption` exposed variable
- `selectOption` → `selectOptions...find((o) => o.value === value)` — programmatic selection
- exposed `options` variable and the `matchContent` menu-width measurement

When options are grouped, `selectOptions` contains the **group wrapper objects** (`{ label, options: [...] }`), which have no `value`. So none of these lookups ever match the selected leaf value → the input renders `null` and shows nothing.

## Fix

- `selectOptions` memo now detects grouped options and preserves the group structure react-select needs, while mapping each **leaf** option exactly like a flat option (safe label, `disable → isDisabled`, sorting within the group). Flat-options behaviour is byte-for-byte unchanged.
- Added a small pure helper `flattenSelectOptions(options)` (in `DropdownV2/utils.js`) that flattens grouped options into their leaf list, returning flat lists unchanged.
- All value lookups (`value=`, `setInputValue`, `selectOption`, exposed `options`, menu-width measurement) now resolve against the flattened leaf list, so a value selected from a group is matched and displayed.
- `findDefaultItem` also flattens, so a `default` option nested inside a group is honoured.

## How I verified

- Added unit tests for `flattenSelectOptions` (`DropdownV2/__tests__/utils.test.js`) covering flat pass-through, grouped flattening, mixed entries, resolving a selected grouped value, and non-array input.
- Verified the grouped `selectOptions` transform and value-resolution logic against the exact repro data from the issue (Fruits/Vegetables/Dairy): the selected leaf (`orange`) now resolves to its option object, and disabled leaves keep `isDisabled`.
- Confirmed flat-options mapping output is identical to the previous implementation (no regression to the common path).

Fixes #17108
