### PR TITLE
fix: show property name in code hinter header instead of Editor

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/MultiLineCodeEditor.jsx
@@ -340,6 +340,7 @@ const MultiLineCodeEditor = (props) => {
           isOpen={isOpen}
           callback={setIsOpen}
           componentName={componentName}
+          paramLabel={paramLabel}
           key={componentName}
           forceUpdate={forceUpdate}
           optionalProps={{ styles: { height: 300 }, cls: '' }}

--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -579,6 +579,7 @@ const EditorInput = ({
         isOpen={isOpen}
         callback={setIsOpen}
         componentName={componentName}
+        paramLabel={paramLabel}
         key={componentName}
         customComponent={renderPreview}
         forceUpdate={forceUpdate}

--- a/frontend/src/AppBuilder/CodeEditor/TJDBHinter.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/TJDBHinter.jsx
@@ -165,6 +165,7 @@ const TJDBCodeEditor = (props) => {
           isOpen={isOpen}
           callback={setIsOpen}
           componentName={componentName}
+          paramLabel={paramLabel}
           key={componentName}
           forceUpdate={forceUpdate}
           optionalProps={{ styles: { height: 300 }, cls: 'tjdb-hinter-portal' }}

--- a/frontend/src/_components/Portal/Portal.jsx
+++ b/frontend/src/_components/Portal/Portal.jsx
@@ -21,6 +21,7 @@ const Portal = ({ children, ...restProps }) => {
     isCopilotEnabled,
     onPortalDimensionsChange = noop,
     canRefresh = false,
+    paramLabel,
   } = restProps;
 
   const [name, setName] = React.useState(componentName);
@@ -60,6 +61,7 @@ const Portal = ({ children, ...restProps }) => {
           darkMode={darkMode}
           styles={styles}
           componentName={name}
+          paramLabel={paramLabel}
           dragResizePortal={dragResizePortal}
           callgpt={callgpt}
           isCopilotEnabled={isCopilotEnabled}
@@ -83,6 +85,7 @@ const Modal = ({
   portalStyles,
   styles,
   componentName,
+  paramLabel,
   darkMode,
   dragResizePortal,
   callgpt,
@@ -120,7 +123,7 @@ const Modal = ({
             className="codehinder-popup-badge"
             data-cy="codehinder-popup-badge"
           >
-            {componentName ?? 'Editor'}
+            {paramLabel || componentName || 'Editor'}
           </span>
         </div>
 

--- a/frontend/src/_hooks/use-portal.jsx
+++ b/frontend/src/_hooks/use-portal.jsx
@@ -6,6 +6,7 @@ const usePortal = ({ children, ...restProps }) => {
     isOpen,
     callback,
     componentName,
+    paramLabel,
     key = '',
     customComponent = () => null,
     forceUpdate,
@@ -40,6 +41,7 @@ const usePortal = ({ children, ...restProps }) => {
           isOpen={isOpen}
           trigger={callback}
           componentName={componentName}
+          paramLabel={paramLabel}
           dragResizePortal={dragResizePortal}
           callgpt={callgpt}
           isCopilotEnabled={isCopilotEnabled}


### PR DESCRIPTION
fixes #6655

When the code hinter is expanded (popped out), the header text now shows the property name (e.g. 'Success Message') instead of 'Editor'.

The fix passes the `paramLabel` prop through the component chain (SingleLineCodeEditor, MultiLineCodeEditor, TJDBHinter → usePortal → Portal → Modal) and uses it as the header title with the fallback chain: `paramLabel || componentName || 'Editor'`.