### PR TITLE
Fix: export modal shows correct versions based on branch context

### DIFF
--- a/server/src/modules/versions/repository.ts
+++ b/server/src/modules/versions/repository.ts
@@ -5,7 +5,7 @@ import { dbTransactionWrap } from '@helpers/database.helper';
 import { DataBaseConstraints } from '@helpers/db_constraints.constants';
 import { catchDbException } from '@helpers/utils.helper';
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { DataSource, EntityManager, Repository } from 'typeorm';
+import { DataSource, EntityManager, IsNull, Repository } from 'typeorm';
 import { decode } from 'js-base64';
 import { App } from '@entities/app.entity';
 import { WorkspaceBranch } from '@entities/workspace_branch.entity';
@@ -236,7 +236,11 @@ export class VersionRepository extends Repository<AppVersion> {
 
   getVersionsInApp(appId: string, branchId?: string, manager?: EntityManager): Promise<AppVersion[]> {
     const m = manager ?? this.manager;
-    const where = branchId ? { appId, branchId, isStub: false } : { appId, isStub: false };
+    // When branchId is provided, also include versions with null branchId
+    // (created before branching was enabled) so they remain visible on the default branch.
+    const where = branchId
+      ? [{ appId, branchId, isStub: false }, { appId, branchId: IsNull(), isStub: false }]
+      : { appId, isStub: false };
     return m.find(AppVersion, { where, order: { createdAt: 'DESC' }, relations: ['branch'] });
   }
 

--- a/server/src/modules/versions/service.ts
+++ b/server/src/modules/versions/service.ts
@@ -125,10 +125,22 @@ export class VersionService implements IVersionService {
   }
   async getAllVersions(app: App, branchId?: string): Promise<{ versions: Array<AppVersion> }> {
     const effectiveBranchId = app.type === 'workflow' ? undefined : branchId;
-    const result =
+    let result =
       app.type === APP_TYPES.MODULE
         ? await listModuleVersions(this.versionRepository.manager, app, branchId, app.organizationId)
         : await this.versionRepository.getVersionsInApp(app.id, effectiveBranchId);
+
+    // On non-default branches, only show the branch's own version(s).
+    // Saved versions (VERSION-type) are only relevant on the default branch.
+    if (effectiveBranchId) {
+      const branch = await this.versionRepository.manager.findOne(WorkspaceBranch, {
+        where: { id: effectiveBranchId },
+        select: ['id', 'isDefault'],
+      });
+      if (branch && !branch.isDefault) {
+        result = result.filter((v) => v.versionType === AppVersionType.BRANCH);
+      }
+    }
 
     // For branch-type versions, the `name` column holds a UUID used as an internal
     // unique key. Replace it with the human-readable branch name from WorkspaceBranch


### PR DESCRIPTION
## 📝 What this does
Fixes the export modal version listing to respect branch context — on feature branches only the current version is shown, while on the default branch all saved versions (v1, v2, v3) are correctly displayed.

## 🔀 Changes
- `getVersionsInApp` now includes versions with null branchId alongside branch-specific ones, so legacy saved versions created before branching remain visible on the default branch
- `getAllVersions` filters out VERSION-type (saved) versions on non-default branches, showing only the branch's own version in the export modal

## 🧪 How to test
- [ ] On the default branch, open export modal — should show current version + all saved versions (v1, v2, v3)
- [ ] Switch to a feature branch, open export modal — should show only the current branch version
- [ ] Rename an app from the homepage — should still pick the correct editing version