### PR TITLE
Fix: resolve multiline {{ }} expressions nested inside static content

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/utils.js
+++ b/frontend/src/AppBuilder/CodeEditor/utils.js
@@ -201,7 +201,7 @@ function resolveCode(code, customObjects = {}, withError = false, reservedKeywor
 
 function getDynamicVariables(text) {
   /* eslint-disable no-useless-escape */
-  const matchedParams = text.match(/\{\{(.*?)\}\}/g) || text.match(/\%\%(.*?)\%\%/g);
+  const matchedParams = text.match(/\{\{(.*?)\}\}/gs) || text.match(/\%\%(.*?)\%\%/gs);
   return matchedParams;
 }
 const resolveMultiDynamicReferences = (code, lookupTable = {}, queryHasJSCode, customResolvers = {}) => {

--- a/frontend/src/AppBuilder/CodeEditor/utils.js
+++ b/frontend/src/AppBuilder/CodeEditor/utils.js
@@ -200,8 +200,7 @@ function resolveCode(code, customObjects = {}, withError = false, reservedKeywor
 }
 
 function getDynamicVariables(text) {
-  /* eslint-disable no-useless-escape */
-  const matchedParams = text.match(/\{\{(.*?)\}\}/g) || text.match(/\%\%(.*?)\%\%/g);
+  const matchedParams = text.match(/\{\{(.*?)\}\}/gs) || text.match(/%%(.*?)%%/gs);
   return matchedParams;
 }
 const resolveMultiDynamicReferences = (code, lookupTable = {}, queryHasJSCode, customResolvers = {}) => {

--- a/frontend/src/AppBuilder/_stores/utils.js
+++ b/frontend/src/AppBuilder/_stores/utils.js
@@ -190,7 +190,7 @@ export const resolveCode = (
 //     output: ["{{name}}", "{{city}}"]
 export const getDynamicVariables = (text) => {
   /* eslint-disable no-useless-escape */
-  const matchedParams = text.match(/\{\{(.*?)\}\}/g) || text.match(/\%\%(.*?)\%\%/g);
+  const matchedParams = text.match(/\{\{(.*?)\}\}/gs) || text.match(/\%\%(.*?)\%\%/gs);
   return matchedParams;
 };
 

--- a/frontend/src/AppBuilder/_stores/utils.js
+++ b/frontend/src/AppBuilder/_stores/utils.js
@@ -190,8 +190,7 @@ export const resolveCode = (
 // Eg, input: "Hello, {{name}}! Welcome to {{city}}."
 //     output: ["{{name}}", "{{city}}"]
 export const getDynamicVariables = (text) => {
-  /* eslint-disable no-useless-escape */
-  const matchedParams = text.match(/\{\{(.*?)\}\}/g) || text.match(/\%\%(.*?)\%\%/g);
+  const matchedParams = text.match(/\{\{(.*?)\}\}/gs) || text.match(/%%(.*?)%%/gs);
   return matchedParams;
 };
 

--- a/frontend/src/AppBuilder/_utils/queryPanel.js
+++ b/frontend/src/AppBuilder/_utils/queryPanel.js
@@ -171,7 +171,7 @@ function extractRefsFromValue(obj) {
   const refs = new Set();
   const walk = (value) => {
     if (typeof value === 'string') {
-      const matches = value.match(/\{\{(.*?)\}\}/g);
+      const matches = value.match(/\{\{(.*?)\}\}/gs);
       if (matches) matches.forEach((m) => refs.add(m));
     } else if (Array.isArray(value)) {
       value.forEach(walk);

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -311,7 +311,7 @@ export function resolveReferences(
 }
 
 export function getDynamicVariables(text) {
-  const matchedParams = text.match(/\{\{(.*?)\}\}/g) || text.match(/\%\%(.*?)\%\%/g);
+  const matchedParams = text.match(/\{\{(.*?)\}\}/gs) || text.match(/\%\%(.*?)\%\%/gs);
   return matchedParams;
 }
 

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -311,7 +311,7 @@ export function resolveReferences(
 }
 
 export function getDynamicVariables(text) {
-  const matchedParams = text.match(/\{\{(.*?)\}\}/g) || text.match(/\%\%(.*?)\%\%/g);
+  const matchedParams = text.match(/\{\{(.*?)\}\}/gs) || text.match(/%%(.*?)%%/gs);
   return matchedParams;
 }
 

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -148,7 +148,7 @@ export function resolveString(str, state, customObjects, reservedKeyword, withEr
   let resolvedStr = str;
 
   // Resolve {{object}}
-  const codeRegex = /(\{\{.+?\}\})/g;
+  const codeRegex = /(\{\{.+?\}\})/gs;
   const codeMatches = resolvedStr.match(codeRegex);
 
   if (codeMatches) {

--- a/server/src/modules/data-queries/util.service.ts
+++ b/server/src/modules/data-queries/util.service.ts
@@ -438,7 +438,12 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
     }
   }
 
-  async listTables(user: User, dataSource: DataSource, environmentId: string, listTablesOptions?: ListTablesDto): Promise<object> {
+  async listTables(
+    user: User,
+    dataSource: DataSource,
+    environmentId: string,
+    listTablesOptions?: ListTablesDto
+  ): Promise<object> {
     if (!dataSource) {
       throw new UnauthorizedException();
     }
@@ -465,12 +470,12 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
       sourceOptions,
       `${dataSource.id}-${dataSourceOptions.environmentId}`,
       dataSourceOptions.updatedAt,
-      { 
-        schema: listTablesOptions?.schema, 
+      {
+        schema: listTablesOptions?.schema,
         datasetId: listTablesOptions?.datasetId,
-        search: listTablesOptions?.search, 
-        page: listTablesOptions?.page, 
-        limit: listTablesOptions?.limit 
+        search: listTablesOptions?.search,
+        page: listTablesOptions?.page,
+        limit: listTablesOptions?.limit,
       }
     );
   }
@@ -677,13 +682,16 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
         // c: Replace all occurrences of {{ }} variables
         else if (
           typeof resolvedValue === 'string' &&
-          resolvedValue?.match(/\{\{(.*?)\}\}/g)?.length > 0 &&
+          resolvedValue?.match(/\{\{(.*?)\}\}/gs)?.length > 0 &&
           !resolvedValue.match(/^\{\{[^}]*\}\}$/) // Only exclude if entire string is one template variable
         ) {
-          const variables = resolvedValue.match(/\{\{(.*?)\}\}/g);
+          const variables = resolvedValue.match(/\{\{(.*?)\}\}/gs);
 
           for (const variable of variables || []) {
-            let replacement = options[variable];
+            // Lookup keys are built from newline-flattened text (see `flattenedForLookup` above),
+            // so a variable matched across multiple lines must be flattened the same way to find it.
+            const lookupKey = variable.replace(/\n/g, ' ');
+            let replacement = (options as any)[lookupKey];
 
             // Check if the replacement is an object
             if (typeof replacement === 'object' && replacement !== null) {


### PR DESCRIPTION
## 📝 What this does

Fixes https://github.com/ToolJet/tj-ee/issues/5288

Multiline `{{ }}` dynamic-code expressions embedded inside static content (e.g. an HTML component with a `.map()` returning a multiline template literal) were being mis-detected and evaluated as raw JavaScript instead of resolved, throwing a syntax error and leaking the query's internal ID into the output.

## 🔀 Changes
- Added the dotAll (`s`) regex flag to the three duplicate `getDynamicVariables` implementations so `{{ }}` expressions whose content spans multiple lines are correctly detected
- This lets the existing single-embedded-expression resolution path handle multiline expressions the same way it already handles single-line ones

## 🧪 How to test
- [ ] Add a query returning array data (any datasource)
- [ ] Add an HTML/Text component with content like:
  ```
  <body>
  {{queries.yourQuery.data.map((row, i) => `<tr>
  <td>${i + 1}</td>
  <td>${row.someField}</td>
  </tr>`).join('')}}
  </body>
  ```
- [ ] Confirm it renders the mapped rows instead of throwing `SyntaxError: Unexpected token '<'` or leaking the query UUID