### PR TITLE
fix: Button column On Click event doesn't fire when Table is inside a Module (#17232)

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/Table.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/Table.jsx
@@ -126,7 +126,7 @@ const Table = memo(
     const prevFirstRowOfTable = usePrevious(firstRowOfTable);
 
     // Get all app events. Needed for certain events like onBulkUpdate
-    const allAppEvents = useEvents();
+    const allAppEvents = useEvents(moduleId);
 
     const shouldAutogenerateColumns = useRef(false);
     const hasDataChanged = useRef(false);


### PR DESCRIPTION
## Summary
Fixes #17232

When a `Table` with a **Button-type column** lives inside a Module embedded in a parent app, clicking the button did nothing — no error, no network request, no action fired.

## Root Cause

`useEvents()` in `Table.jsx` was called without a `moduleId` argument, so it always read events from the `'canvas'` scope. When the Table is inside a Module, its event handlers are stored under `eventsSlice.module['<moduleId>']` — not `'canvas'`. This caused `tableColumnEvents` to always be **empty**, so the button click had nothing to execute.

Other events (`Row Clicked`, plain `Button` widget `onClick`) were unaffected because they call `eventsSlice.fireEvent` at runtime with the correct module scope. Only `table_column` events use a **pre-fetched cache** that was broken by the missing `moduleId`.

## Fix

```diff
// frontend/src/AppBuilder/Widgets/NewTable/Table.jsx

- const allAppEvents = useEvents();
+ const allAppEvents = useEvents(moduleId);
