### PR TITLE
fix: scope datasource connection cache by user when multi-auth is enabled (#14452)

### DIFF
--- a/plugins/packages/bigquery/lib/index.ts
+++ b/plugins/packages/bigquery/lib/index.ts
@@ -276,8 +276,11 @@ export default class Bigquery implements QueryService {
       if (connection) {
         return connection;
       } else {
+        const cacheKeyPrefix = isMultiAuthEnabled && userId
+          ? `${dataSourceId}_${userId}_`
+          : `${dataSourceId}_`;
         connection = await this.buildConnection(sourceOptions, userId, isAppPublic);
-        cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection);
+        cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection, cacheKeyPrefix);
         return connection;
       }
     } else {

--- a/plugins/packages/common/lib/utils.helper.ts
+++ b/plugins/packages/common/lib/utils.helper.ts
@@ -18,8 +18,8 @@ export function cacheConnection(dataSourceId: string, connection: any): any {
   CACHED_CONNECTIONS[dataSourceId] = { connection, updatedAt };
 }
 
-export function generateSourceOptionsHash(sourceOptions) {
-  const sortedEntries = Object.entries(sourceOptions)
+export function generateSourceOptionsHash(sourceOptions: any) {
+  const sortedEntries = Object.entries(sourceOptions || {})
     .filter(([_, value]) => value !== undefined && value !== null && value !== '')
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => `${key}:${value}`)
@@ -28,11 +28,20 @@ export function generateSourceOptionsHash(sourceOptions) {
   return crypto.createHash('sha256').update(sortedEntries).digest('hex').substring(0, 16);
 }
 
-export function cacheConnectionWithConfiguration(dataSourceId: string, enhancedCacheKey: string, connection: any): any {
+export function cacheConnectionWithConfiguration(
+  dataSourceId: string,
+  enhancedCacheKey: string,
+  connection: any,
+  cacheKeyPrefix?: string
+): any {
   const updatedAt = new Date();
   const allKeys = Object.keys(CACHED_CONNECTIONS);
+
+  // If no prefix provided, fall back to dataSourceId_ to evict all entries for this datasource
+  const effectivePrefix = cacheKeyPrefix ?? `${dataSourceId}_`;
+
   const oldKeysForThisDatasource = allKeys.filter(
-    (key) => key.startsWith(`${dataSourceId}_`) && key !== enhancedCacheKey
+    (key) => key.startsWith(effectivePrefix) && key !== enhancedCacheKey
   );
   oldKeysForThisDatasource.forEach((oldKey) => delete CACHED_CONNECTIONS[oldKey]);
 
@@ -56,7 +65,7 @@ export function getCachedConnection(cacheKey: string | number, dataSourceUpdated
   }
 }
 
-export function cleanSensitiveData(data, keys) {
+export function cleanSensitiveData(data: any, keys: any) {
   if (!data || typeof data !== 'object') return;
 
   const dataObj = { ...data };
@@ -64,7 +73,7 @@ export function cleanSensitiveData(data, keys) {
   return dataObj;
 }
 
-function clearData(data, keys) {
+function clearData(data: any, keys: any) {
   if (!data || typeof data !== 'object') return;
 
   for (const key in data) {
@@ -86,7 +95,7 @@ export function isEmpty(value: number | null | undefined | string) {
   );
 }
 
-export const getCurrentToken = (isMultiAuthEnabled: boolean, tokenData: any, userId: string, isAppPublic: boolean) => {
+export const getCurrentToken = (isMultiAuthEnabled: boolean, tokenData: any, userId: string, isAppPublic?: boolean) => {
   if (isMultiAuthEnabled) {
     if (!tokenData || !Array.isArray(tokenData)) return null;
     return !isAppPublic
@@ -104,8 +113,8 @@ export const sanitizeHeaders = (
   queryOptions: any,
   hasDataSource = true
 ): { [k: string]: string } => {
-  const cleanHeaders = (headers) => headers.filter(([k, _]) => k !== '').map(([k, v]) => [k.trim(), v]);
-  const filterValidHeaderEntries = (headers) => {
+  const cleanHeaders = (headers: any[]) => headers.filter(([k, _]) => k !== '').map(([k, v]) => [k.trim(), v]);
+  const filterValidHeaderEntries = (headers: any[]) => {
     return headers.filter(([_, value]) => {
       if (value == null) return false;
       if (typeof value === 'string') return true;
@@ -114,7 +123,7 @@ export const sanitizeHeaders = (
     });
   };
 
-  const processHeaders = (rawHeaders) => {
+  const processHeaders = (rawHeaders: any) => {
     const cleaned = cleanHeaders(rawHeaders || []);
     const validHeaders = filterValidHeaderEntries(cleaned);
     return Object.fromEntries(validHeaders);
@@ -130,8 +139,8 @@ export const sanitizeHeaders = (
 };
 
 export const sanitizeCookies = (sourceOptions: any, queryOptions: any, hasDataSource = true): object => {
-  const _cookies = (queryOptions.cookies || []).filter((o) => {
-    return o.some((e) => !isEmpty(e));
+  const _cookies = (queryOptions.cookies || []).filter((o: any[]) => {
+    return o.some((e: any) => !isEmpty(e));
   });
 
   if (!hasDataSource) return Object.fromEntries(_cookies);
@@ -150,32 +159,33 @@ export const cookiesToString = (cookies: object): string => {
 };
 
 export const sanitizeSearchParams = (sourceOptions: any, queryOptions: any, hasDataSource = true): Array<string> => {
-  const _urlParams = (queryOptions.url_params || []).filter((o) => {
-    return o.some((e) => !isEmpty(e));
+  const _urlParams = (queryOptions.url_params || []).filter((o: any[]) => {
+    return o.some((e: any) => !isEmpty(e));
   });
 
   if (!hasDataSource) return _urlParams;
-  const sanitisedUrlParamsFromSourceOptions = (sourceOptions.url_params || []).filter((o) => {
-    return o.some((e) => !isEmpty(e));
+  const sanitisedUrlParamsFromSourceOptions = (sourceOptions.url_params || []).filter((o: any[]) => {
+    return o.some((e: any) => !isEmpty(e));
   });
 
   const urlParams = _urlParams.concat(sanitisedUrlParamsFromSourceOptions || []);
   return urlParams;
 };
 
-export const sanitizeSortPairs = (options): Array<[string, string]> => {
-  const sanitizedOptions = (options || []).filter((o) => {
-    return o.every((e) => !isEmpty(e));
+export const sanitizeSortPairs = (options: any): Array<[string, string]> => {
+  const sanitizedOptions = (options || []).filter((o: any[]) => {
+    return o.every((e: any) => !isEmpty(e));
   });
   return sanitizedOptions;
 };
 
 export const fetchHttpsCertsForCustomCA = () => {
-  if (!process.env.NODE_EXTRA_CA_CERTS) return {};
+  const caCertPath = process.env.NODE_EXTRA_CA_CERTS;
+  if (!caCertPath) return {};
 
   return {
     https: {
-      certificateAuthority: [...tls.rootCertificates, readFileSync(process.env.NODE_EXTRA_CA_CERTS)].join('\n'),
+      certificateAuthority: [...tls.rootCertificates, readFileSync(caCertPath)].join('\n'),
     },
   };
 };
@@ -262,7 +272,7 @@ const headersToRedact = [
   'authentication-info', // Provides additional authentication details
 ];
 
-export const redactHeaders = (headers) => {
+export const redactHeaders = (headers: any) => {
   const redactedHeaders = { ...headers };
   headersToRedact.forEach((key) => {
     if (Object.prototype.hasOwnProperty.call(redactedHeaders, key)) {

--- a/plugins/packages/mariadb/lib/index.ts
+++ b/plugins/packages/mariadb/lib/index.ts
@@ -8,6 +8,8 @@ import {
   generateSourceOptionsHash,
   createQueryBuilder,
   isEmpty,
+  User,
+  App,
 } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import { Client } from 'ssh2';
@@ -98,7 +100,8 @@ export default class Mariadb implements QueryService {
     sourceOptions: SourceOptions,
     queryOptions: QueryOptions,
     dataSourceId: string,
-    dataSourceUpdatedAt: string
+    dataSourceUpdatedAt: string,
+    context?: { user?: User; app?: App }
   ): Promise<QueryResult> {
     // ── Dynamic connection parameter overrides ────────────────────────────────
     if (sourceOptions.allow_dynamic_connection_parameters) {
@@ -108,7 +111,7 @@ export default class Mariadb implements QueryService {
 
     const checkCache = !sourceOptions.allow_dynamic_connection_parameters;
     let conn;
-    const pool = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt);
+    const pool = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt, context?.user?.id);
 
     try {
       conn = await pool.getConnection();
@@ -638,16 +641,23 @@ export default class Mariadb implements QueryService {
     options: any,
     checkCache: boolean,
     dataSourceId?: string,
-    dataSourceUpdatedAt?: string
+    dataSourceUpdatedAt?: string,
+    userId?: string
   ): Promise<any> {
     if (checkCache) {
       const optionsHash = generateSourceOptionsHash(sourceOptions);
-      const enhancedCacheKey = `${dataSourceId}_${optionsHash}`;
+      const isMultiAuth = !!sourceOptions['multiple_auth_enabled'];
+      const enhancedCacheKey = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_${optionsHash}`
+        : `${dataSourceId}_${optionsHash}`;
+      const cacheKeyPrefix = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_`
+        : `${dataSourceId}_`;
       const cachedPool = await getCachedConnection(enhancedCacheKey, dataSourceUpdatedAt);
       if (cachedPool) return cachedPool;
 
       const pool = await this.buildConnectionPool(sourceOptions);
-      cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, pool);
+      cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, pool, cacheKeyPrefix);
       return pool;
     }
     return this.buildConnectionPool(sourceOptions);

--- a/plugins/packages/mssql/lib/index.ts
+++ b/plugins/packages/mssql/lib/index.ts
@@ -116,7 +116,8 @@ export default class MssqlQueryService implements QueryService {
     sourceOptions: SourceOptions,
     queryOptions: QueryOptions,
     dataSourceId: string,
-    dataSourceUpdatedAt: string
+    dataSourceUpdatedAt: string,
+    context?: { user?: User; app?: App }
   ): Promise<QueryResult> {
     let knexInstance: Knex | undefined;
     let checkCache: boolean;
@@ -134,7 +135,7 @@ export default class MssqlQueryService implements QueryService {
     // eslint-disable-next-line prefer-const
     checkCache = sourceOptions.allow_dynamic_connection_parameters ? false : true;
     try {
-      knexInstance = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt);
+      knexInstance = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt, context?.user?.id);
       switch (queryOptions.mode) {
         case 'sql':
           return await this.handleRawQuery(knexInstance, queryOptions);
@@ -675,18 +676,25 @@ export default class MssqlQueryService implements QueryService {
     options: any,
     checkCache: boolean,
     dataSourceId?: string,
-    dataSourceUpdatedAt?: string
+    dataSourceUpdatedAt?: string,
+    userId?: string
   ): Promise<Knex> {
     if (checkCache) {
       const optionsHash = generateSourceOptionsHash(sourceOptions);
-      const enhancedCacheKey = `${dataSourceId}_${optionsHash}`;
+      const isMultiAuth = !!sourceOptions['multiple_auth_enabled'];
+      const enhancedCacheKey = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_${optionsHash}`
+        : `${dataSourceId}_${optionsHash}`;
+      const cacheKeyPrefix = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_`
+        : `${dataSourceId}_`;
       let connection = await getCachedConnection(enhancedCacheKey, dataSourceUpdatedAt);
 
       if (connection) {
         return connection;
       } else {
         connection = await this.buildConnection(sourceOptions);
-        cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection);
+        cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection, cacheKeyPrefix);
         return connection;
       }
     } else {

--- a/plugins/packages/mysql/lib/index.ts
+++ b/plugins/packages/mysql/lib/index.ts
@@ -96,7 +96,8 @@ export default class MysqlQueryService implements QueryService {
     sourceOptions: SourceOptions,
     queryOptions: QueryOptions,
     dataSourceId: string,
-    dataSourceUpdatedAt: string
+    dataSourceUpdatedAt: string,
+    context?: { user?: User; app?: App }
   ): Promise<QueryResult> {
     let checkCache, knexInstance;
     if (sourceOptions['allow_dynamic_connection_parameters']) {
@@ -111,7 +112,7 @@ export default class MysqlQueryService implements QueryService {
     try {
       // If dynamic connection parameters is toggled on - We don't cache the connection also destroy the connection created.
       checkCache = sourceOptions['allow_dynamic_connection_parameters'] ? false : true;
-      knexInstance = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt);
+      knexInstance = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt, context?.user?.id);
 
       switch (queryOptions.mode) {
         case 'sql':
@@ -733,16 +734,23 @@ export default class MysqlQueryService implements QueryService {
     options: any,
     checkCache: boolean,
     dataSourceId?: string,
-    dataSourceUpdatedAt?: string
+    dataSourceUpdatedAt?: string,
+    userId?: string
   ): Promise<Knex> {
     if (checkCache) {
       const optionsHash = generateSourceOptionsHash(sourceOptions);
-      const enhancedCacheKey = `${dataSourceId}_${optionsHash}`;
+      const isMultiAuth = !!sourceOptions['multiple_auth_enabled'];
+      const enhancedCacheKey = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_${optionsHash}`
+        : `${dataSourceId}_${optionsHash}`;
+      const cacheKeyPrefix = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_`
+        : `${dataSourceId}_`;
       const cachedConnection = await getCachedConnection(enhancedCacheKey, dataSourceUpdatedAt);
       if (cachedConnection) return cachedConnection;
 
       const connection = await this.buildConnection(sourceOptions);
-      cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection);
+      cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection, cacheKeyPrefix);
       return connection;
     }
 

--- a/plugins/packages/oracledb/lib/index.ts
+++ b/plugins/packages/oracledb/lib/index.ts
@@ -12,6 +12,8 @@ import {
   QueryService,
   QueryResult,
   QueryError,
+  User,
+  App,
 } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 
@@ -48,7 +50,8 @@ export default class OracledbQueryService implements QueryService {
     sourceOptions: SourceOptions,
     queryOptions: QueryOptions,
     dataSourceId: string,
-    dataSourceUpdatedAt: string
+    dataSourceUpdatedAt: string,
+    context?: { user?: User; app?: App }
   ): Promise<QueryResult> {
     let result = {
       rows: [],
@@ -99,7 +102,7 @@ export default class OracledbQueryService implements QueryService {
     try {
       checkCache = true;
 
-      knexInstance = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt);
+      knexInstance = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt, context?.user?.id);
 
       result = await knexInstance.raw(query, binds);
 
@@ -268,18 +271,25 @@ export default class OracledbQueryService implements QueryService {
     options: any,
     checkCache: boolean,
     dataSourceId?: string,
-    dataSourceUpdatedAt?: string
+    dataSourceUpdatedAt?: string,
+    userId?: string
   ): Promise<any> {
     if (checkCache) {
       const optionsHash = generateSourceOptionsHash(sourceOptions);
-      const enhancedCacheKey = `${dataSourceId}_${optionsHash}`;
+      const isMultiAuth = !!sourceOptions['multiple_auth_enabled'];
+      const enhancedCacheKey = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_${optionsHash}`
+        : `${dataSourceId}_${optionsHash}`;
+      const cacheKeyPrefix = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_`
+        : `${dataSourceId}_`;
       let connection = await getCachedConnection(enhancedCacheKey, dataSourceUpdatedAt);
 
       if (connection) {
         return connection;
       } else {
         connection = await this.buildConnection(sourceOptions);
-        cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection);
+        cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection, cacheKeyPrefix);
         return connection;
       }
     } else {

--- a/plugins/packages/postgresql/lib/index.ts
+++ b/plugins/packages/postgresql/lib/index.ts
@@ -8,6 +8,8 @@ import {
   QueryError,
   getTooljetEdition,
   createQueryBuilder,
+  User,
+  App,
 } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import knex, { Knex } from 'knex';
@@ -119,7 +121,8 @@ export default class PostgresqlQueryService implements QueryService {
     sourceOptions: SourceOptions,
     queryOptions: QueryOptions,
     dataSourceId: string,
-    dataSourceUpdatedAt: string
+    dataSourceUpdatedAt: string,
+    context?: { user?: User; app?: App }
   ): Promise<QueryResult> {
     let pgPool, pgConnection, checkCache, knexInstance;
 
@@ -138,7 +141,7 @@ export default class PostgresqlQueryService implements QueryService {
     try {
       // If dynamic connection parameters is toggled on - We don't cache the connection also destroy the connection created.
       checkCache = sourceOptions['allow_dynamic_connection_parameters'] ? false : true;
-      knexInstance = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt);
+      knexInstance = await this.getConnection(sourceOptions, {}, checkCache, dataSourceId, dataSourceUpdatedAt, context?.user?.id);
 
       switch (queryOptions.mode) {
         case 'sql': {
@@ -885,16 +888,23 @@ export default class PostgresqlQueryService implements QueryService {
     options: any,
     checkCache: boolean,
     dataSourceId?: string,
-    dataSourceUpdatedAt?: string
+    dataSourceUpdatedAt?: string,
+    userId?: string
   ): Promise<Knex> {
     if (checkCache) {
       const optionsHash = generateSourceOptionsHash(sourceOptions);
-      const enhancedCacheKey = `${dataSourceId}_${optionsHash}`;
+      const isMultiAuth = !!sourceOptions['multiple_auth_enabled'];
+      const enhancedCacheKey = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_${optionsHash}`
+        : `${dataSourceId}_${optionsHash}`;
+      const cacheKeyPrefix = isMultiAuth && userId
+        ? `${dataSourceId}_${userId}_`
+        : `${dataSourceId}_`;
       const cachedConnection = await getCachedConnection(enhancedCacheKey, dataSourceUpdatedAt);
       if (cachedConnection) return cachedConnection;
 
       const connection = await this.buildConnection(sourceOptions);
-      cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection);
+      cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection, cacheKeyPrefix);
       return connection;
     }
 

--- a/plugins/packages/snowflake/lib/index.ts
+++ b/plugins/packages/snowflake/lib/index.ts
@@ -819,8 +819,11 @@ export default class Snowflake implements QueryService {
       if (connection && (await connection.isValidAsync())) {
         return connection;
       } else {
+        const cacheKeyPrefix = sourceOptions.multiple_auth_enabled && userId
+          ? `${dataSourceId}_${userId}_`
+          : `${dataSourceId}_`;
         connection = await this.buildConnection(sourceOptions, context, buildOptions);
-        cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection);
+        cacheConnectionWithConfiguration(dataSourceId, enhancedCacheKey, connection, cacheKeyPrefix);
         return connection;
       }
     } else {


### PR DESCRIPTION
Fixes #14452

### Summary
When multi-user authentication is enabled on a datasource, connection caching was shared across all users and eviction cleared connections for all users of that datasource.

### Root Cause
`cacheConnectionWithConfiguration` in `utils.helper.ts` did not accept an explicit eviction prefix, and DB plugins did not include `userId` in the connection cache key when `multiple_auth_enabled` was true.

### Fix
- Added optional `cacheKeyPrefix` parameter to `cacheConnectionWithConfiguration` in `utils.helper.ts`.
- Updated 7 database plugins (`postgresql`, `mysql`, `mssql`, `oracledb`, `mariadb`, `snowflake`, `bigquery`) to build user-scoped cache keys (`${dataSourceId}_${userId}_${optionsHash}`) when `multiple_auth_enabled` is true.
- Fixed TypeScript parameter types in `utils.helper.ts`.
