### PR TITLE
fix: QA bug batch (Button Group outline, Inspector label clipping)

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/ConfigHandle/ConfigHandle.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/ConfigHandle/ConfigHandle.jsx
@@ -5,7 +5,7 @@ import useStore from '@/AppBuilder/_stores/store';
 import useTransientStore from '@/AppBuilder/_stores/transientStore';
 import { findHighestLevelofSelection } from '../Grid/gridUtils';
 import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
-import { DROPPABLE_PARENTS } from '../appCanvasConstants';
+import { DROPPABLE_PARENTS, GRID_HEIGHT } from '../appCanvasConstants';
 import { Tooltip } from 'react-tooltip';
 import { ToolTip } from '@/_components/ToolTip';
 import { RIGHT_SIDE_BAR_TAB } from '@/AppBuilder/RightSideBar/rightSidebarConstants';
@@ -56,7 +56,9 @@ export const ConfigHandle = ({
   );
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const timeoutRef = useRef(null);
-  const position = widgetTop < 15 ? 'bottom' : 'top';
+  // Flip handle above the widget only once there's a full 3 grid rows of space above it —
+  // 1-2 rows isn't enough headroom in a child canvas (Tabs/Form/Modal etc.), handle ends up clipped.
+  const position = widgetTop < GRID_HEIGHT * 3 ? 'bottom' : 'top';
 
   const setComponentToInspect = useStore((state) => state.setComponentToInspect);
   const isModal = componentType === 'Modal' || componentType === 'ModalV2';

--- a/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/styles.scss
+++ b/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/styles.scss
@@ -108,6 +108,10 @@
 	font-size: 12px;
 	flex: 1;
 	min-width: 0px;
+
+	span {
+		white-space: nowrap;
+	}
 }
 
 

--- a/frontend/src/AppBuilder/Widgets/ButtonGroupV2/buttonGroupV2.scss
+++ b/frontend/src/AppBuilder/Widgets/ButtonGroupV2/buttonGroupV2.scss
@@ -20,6 +20,11 @@
                 font-weight: 500;
                 font-size: 14px;
                 line-height: 20px;
+
+                &:focus,
+                &:active {
+                    outline: none !important;
+                }
             }
         }
     }

--- a/frontend/src/AppBuilder/Widgets/ButtonGroupV2/buttonGroupV2.scss
+++ b/frontend/src/AppBuilder/Widgets/ButtonGroupV2/buttonGroupV2.scss
@@ -1,7 +1,9 @@
 .button-group-widget {
+    height: 100%;
     .button-group-content-wrapper {
         display: flex;
         width: 100%;
+        min-height: 100%;
 
         .button-group-content {
             height: max-content;


### PR DESCRIPTION
## Summary
Batch of 7 QA-reported component bugs. Findings/status for each below (full detail in `.scratch/qa-bugbatch-2026-07/`, not part of this diff).

**Fixed (4):**
- **#7** Button Group: weird black shadow on click in preview — was default browser `outline` on `:focus`/`:active`. Existing global reset (`theme.scss`) only targets `.btn`; ButtonGroupV2's native button lacks that class. Added scoped `outline: none !important` reset in `buttonGroupV2.scss`.
- **#8** Button Group: extra bottom padding, buttons clipped, handle overlapping content — repro needed the exact combo (empty label + alignment=top + layout=wrap). DevTools trace confirmed the content wrapper was scroll-clipping its own content (fixed px height didn't grow for wrapped multi-row buttons), and the root widget had no explicit height so it under-filled its actual grid cell. Fixed with `height: 100%` on the root and `min-height: 100%` on the content wrapper (`buttonGroupV2.scss` only). **Known limitation:** `min-height: 100%` floors but doesn't cap the wrapper — if the canvas height is dragged smaller than the content's actual height, the widget now grows past it instead of clipping. Pre-existing tradeoff, not a regression; flag if strict height-clamping is needed.
- **#13** Queries: name w/ caps + hyphen/plus breaks inspector open, UI cropped — actually the left-sidebar State/Data Inspector tree, not Query Manager. `Node.jsx` forces `whiteSpace="normal"` on `OverflowTooltip`, letting wide labels wrap to 2 lines inside a fixed-height row and clip. Forced `nowrap` on the label's inner spans so the existing ellipsis+tooltip handles overflow instead.
- **#16** Component name partially hidden after move to 3rd grid line — affects widgets inside a child canvas (Tabs/Form/Modal/etc). `ConfigHandle.jsx` flipped the handle from bottom to top once `widgetTop < 15`px, but grid rows are 10px — so a 2-grid-unit move already crossed that threshold without enough real headroom above, clipping the label. Changed threshold to `GRID_HEIGHT * 3` so the handle only moves to top once there's a full 3 grid rows of clearance.

**Needs info / blocked (3):**
- **#3** Button loader color not changing (High) — could not reproduce on either primary or outline variant, matched Jam steps. Found an unrelated dead code branch (`Button.jsx` checks against a stale default color) but it doesn't explain the reported symptom. Needs reporter to re-confirm repro.
- **#4** Button loading-off still looks disabled (Low) — reproduced a different path (Switch driving a "Set disable" action) but traced it to a static (unbound) Value field in that action config, not a widget bug. Original report is about the `loading` prop specifically — not yet retested via that exact path.
- **#9** Button Group missing "required" affordance when label empty (Low, UX) — reproduced, but treating as a design question, not a bug; pending input from UX (Jaseem) on intended affordance.

## Test plan
- [x] Button Group: click buttons in preview, confirm no outline/shadow flash
- [x] Button Group: empty label + alignment=top + layout=wrap, confirm no clipping/handle overlap; spot-checked row/column layouts and non-empty label for regressions
- [x] Inspector: create a query/component with a long all-caps name incl. `-`/`+`, confirm label stays single-line with ellipsis + hover tooltip, no clipping
- [x] Move a widget inside a child canvas (Tabs/Form/Modal) up by 1, 2, 3 grid rows — handle stays at bottom for 1-2, only flips to top at 3+
- [ ] Re-verify #3/#4 once reporters provide updated repro steps
- [ ] #9 pending UX decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)
