### PR TITLE
fix: module permission gaps (git-sync branch pins, permission-update no-op, embedded-module access)

### DIFF
--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -95,9 +95,8 @@ const useAppData = (
   const setEditorLoading = useStore((state) => state.setEditorLoading);
   const setApp = useStore((state) => state.setApp);
   const user = useStore((state) => state.user);
-  // The top-level app containing this module instance — used to let the backend
-  // verify this module read is happening in the context of an app the user can
-  // edit, even when they have no standalone module permission.
+  // Forwarded to the backend so a module-embedding parent app can grant view access
+  // (see appVersion.service.js getAll/getModuleVersionData).
   const parentAppId = useStore((state) => state.appStore?.modules?.['canvas']?.app?.appId);
   const setCurrentVersionId = useStore((state) => state.setCurrentVersionId);
   const currentVersionId = useStore((state) => state.currentVersionId);

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -95,6 +95,10 @@ const useAppData = (
   const setEditorLoading = useStore((state) => state.setEditorLoading);
   const setApp = useStore((state) => state.setApp);
   const user = useStore((state) => state.user);
+  // The top-level app containing this module instance — used to let the backend
+  // verify this module read is happening in the context of an app the user can
+  // edit, even when they have no standalone module permission.
+  const parentAppId = useStore((state) => state.appStore?.modules?.['canvas']?.app?.appId);
   const setCurrentVersionId = useStore((state) => state.setCurrentVersionId);
   const currentVersionId = useStore((state) => state.currentVersionId);
   const setPages = useStore((state) => state.setPages);
@@ -340,16 +344,16 @@ const useAppData = (
           // versionId is a versionName string (cross-workspace stable, git-tag-backed) when the
           // bridge field is populated, a UUID module_reference_id for legacy same-workspace-only
           // pins, or '' when unpinned. The server resolver handles all three cases.
-          appDataPromise = appVersionService.getModuleVersionData(appId, versionId, mode);
+          appDataPromise = appVersionService.getModuleVersionData(appId, versionId, mode, parentAppId);
         }
       } else if (versionId) {
         // Pinned: call the by-correlation endpoint with the module_reference_id ref.
-        appDataPromise = appVersionService.getModuleVersionData(appId, versionId, mode);
+        appDataPromise = appVersionService.getModuleVersionData(appId, versionId, mode, parentAppId);
       } else {
         // Unpinned: always hit the backend — cached definition may be from the default branch,
         // not the consumer's feature branch. Server resolver correctly returns the current
         // branch's draft (or 404 if nothing is available there).
-        appDataPromise = appVersionService.getModuleVersionData(appId, versionId, mode);
+        appDataPromise = appVersionService.getModuleVersionData(appId, versionId, mode, parentAppId);
       }
     } else {
       if (isPublicAccess) {

--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -313,7 +313,7 @@ export default function AppCard({
                 </div>
               </div>
               <div visible={focused ? true : undefined}>
-                {(canDeleteApp(app) || canUpdateApp(app) || appType === 'module') && (
+                {(canDeleteApp(app) || canUpdateApp(app)) && (
                   <AppMenu
                     appId={app?.id}
                     appUserId={app?.user_id}

--- a/frontend/src/_services/appVersion.service.js
+++ b/frontend/src/_services/appVersion.service.js
@@ -21,10 +21,11 @@ export const appVersionService = {
   createDraftVersion,
 };
 
+// `parentAppId`, threaded through getAll/getModuleVersionData below, lets the backend
+// grant view access to a module when the requester has no direct module permission but
+// is embedding it in an app they can edit (see FeatureAbilityFactory.defineAbilityFor).
 function getAll(appId, parentAppId) {
   const requestOptions = { method: 'GET', headers: authHeader(), credentials: 'include' };
-  // `parentAppId` lets the backend grant view access to a module's version list when the
-  // requester has no direct module permission but is embedding it in an app they can edit.
   const parentAppParam = parentAppId ? `?parentAppId=${encodeURIComponent(parentAppId)}` : '';
   return fetch(`${config.apiUrl}/apps/${appId}/versions${parentAppParam}`, requestOptions).then(handleResponse);
 }
@@ -55,8 +56,6 @@ function getModuleVersionData(coRelationId, moduleReferenceId, mode, parentAppId
   // `ref` is the version's module_reference_id (uuid). Empty/missing → unpinned;
   // server resolver returns the latest non-stub on the consumer's branch.
   const refParam = moduleReferenceId ? `&ref=${encodeURIComponent(moduleReferenceId)}` : '';
-  // `parentAppId` lets the backend grant view access when this module has no direct
-  // permission of its own but is embedded in an app the requester can edit.
   const parentAppParam = parentAppId ? `&parentAppId=${encodeURIComponent(parentAppId)}` : '';
   return fetch(
     `${config.apiUrl}/v2/apps/module/by-correlation/${coRelationId}/version?mode=${mode}${refParam}${parentAppParam}`,

--- a/frontend/src/_services/appVersion.service.js
+++ b/frontend/src/_services/appVersion.service.js
@@ -21,9 +21,12 @@ export const appVersionService = {
   createDraftVersion,
 };
 
-function getAll(appId) {
+function getAll(appId, parentAppId) {
   const requestOptions = { method: 'GET', headers: authHeader(), credentials: 'include' };
-  return fetch(`${config.apiUrl}/apps/${appId}/versions`, requestOptions).then(handleResponse);
+  // `parentAppId` lets the backend grant view access to a module's version list when the
+  // requester has no direct module permission but is embedding it in an app they can edit.
+  const parentAppParam = parentAppId ? `?parentAppId=${encodeURIComponent(parentAppId)}` : '';
+  return fetch(`${config.apiUrl}/apps/${appId}/versions${parentAppParam}`, requestOptions).then(handleResponse);
 }
 
 function getOne(appId, versionId) {
@@ -47,13 +50,16 @@ function getAppVersionData(appId, versionId, mode) {
   );
 }
 
-function getModuleVersionData(coRelationId, moduleReferenceId, mode) {
+function getModuleVersionData(coRelationId, moduleReferenceId, mode, parentAppId) {
   const requestOptions = { method: 'GET', headers: authHeader(), credentials: 'include' };
   // `ref` is the version's module_reference_id (uuid). Empty/missing → unpinned;
   // server resolver returns the latest non-stub on the consumer's branch.
   const refParam = moduleReferenceId ? `&ref=${encodeURIComponent(moduleReferenceId)}` : '';
+  // `parentAppId` lets the backend grant view access when this module has no direct
+  // permission of its own but is embedded in an app the requester can edit.
+  const parentAppParam = parentAppId ? `&parentAppId=${encodeURIComponent(parentAppId)}` : '';
   return fetch(
-    `${config.apiUrl}/v2/apps/module/by-correlation/${coRelationId}/version?mode=${mode}${refParam}`,
+    `${config.apiUrl}/v2/apps/module/by-correlation/${coRelationId}/version?mode=${mode}${refParam}${parentAppParam}`,
     requestOptions
   ).then(handleResponse);
 }

--- a/server/src/modules/app/guards/ability.guard.ts
+++ b/server/src/modules/app/guards/ability.guard.ts
@@ -37,7 +37,7 @@ export abstract class AbilityGuard implements CanActivate {
   protected setResourceObject(resource: any): void {
     this.resource = resource;
   }
-  protected getResource(): ResourceDetails | ResourceDetails[] {
+  protected getResource(request?: any): ResourceDetails | ResourceDetails[] {
     return;
   }
 
@@ -150,7 +150,7 @@ export abstract class AbilityGuard implements CanActivate {
         return false;
       }
 
-      const resources = this.getResource();
+      const resources = this.getResource(request);
       const resourceArray: ResourceDetails[] = Array.isArray(resources) ? resources : resources ? [resources] : [];
 
       if (user) {

--- a/server/src/modules/apps/repository.ts
+++ b/server/src/modules/apps/repository.ts
@@ -1,6 +1,8 @@
 import { App } from '@entities/app.entity';
 import { AppVersion, AppVersionStatus, AppVersionType } from '@entities/app_version.entity';
 import { WorkspaceBranch } from '@entities/workspace_branch.entity';
+import { Page } from '@entities/page.entity';
+import { Component } from '@entities/component.entity';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { SessionAppData } from './types';
@@ -13,6 +15,37 @@ import { dbTransactionWrap } from '@helpers/database.helper';
 export class AppsRepository extends Repository<App> {
   constructor(private dataSource: DataSource) {
     super(App, dataSource.createEntityManager());
+  }
+
+  /**
+   * True if ANY version of `parentAppId` contains a ModuleViewer component
+   * that embeds the module identified by `moduleCoRelationId`. Mirrors the
+   * structural join in DataQueryRepository.findPublicParentAppForModuleQuery,
+   * without the is_public / git-sync-branch metadata resolution or the
+   * current_version_id restriction — the caller (the module's embedded-view
+   * bypass) needs this to work for apps still in draft, which have no
+   * current_version_id yet, so any version embedding the module counts. The
+   * requester's right to edit `parentAppId` at all is checked separately by
+   * the caller.
+   */
+  async isModuleEmbeddedInApp(
+    moduleCoRelationId: string,
+    parentAppId: string,
+    manager?: EntityManager
+  ): Promise<boolean> {
+    const m = manager ?? this.manager;
+    const count = await m
+      .createQueryBuilder(App, 'app')
+      .innerJoin(AppVersion, 'app_version', 'app_version.app_id = app.id')
+      .innerJoin(Page, 'page', 'page.app_version_id = app_version.id')
+      .innerJoin(Component, 'component', 'component.page_id = page.id')
+      .where('app.id = :parentAppId', { parentAppId })
+      .andWhere('component.type = :componentType', { componentType: 'ModuleViewer' })
+      .andWhere("component.properties::jsonb -> 'moduleAppId' ->> 'value' = :moduleCoRelationId", {
+        moduleCoRelationId,
+      })
+      .getCount();
+    return count > 0;
   }
 
   async findBySlug(slug: string, organizationId: string, versionId?: string, branchId?: string): Promise<App> {

--- a/server/src/modules/apps/repository.ts
+++ b/server/src/modules/apps/repository.ts
@@ -18,13 +18,15 @@ export class AppsRepository extends Repository<App> {
   }
 
   /**
-   * True if ANY version of `parentAppId` contains a ModuleViewer component
-   * that embeds the module identified by `moduleCoRelationId`. Mirrors the
-   * structural join in DataQueryRepository.findPublicParentAppForModuleQuery,
-   * without the is_public / git-sync-branch metadata resolution or the
-   * current_version_id restriction — the caller (the module's embedded-view
-   * bypass) needs this to work for apps still in draft, which have no
-   * current_version_id yet, so any version embedding the module counts. The
+   * True if `parentAppId`'s CURRENT version contains a ModuleViewer component
+   * that embeds the module identified by `moduleCoRelationId`. "Current" is
+   * `app.current_version_id` if released, else the latest non-stub AppVersion
+   * by updated_at — deliberately NOT excluding version_type='branch' rows:
+   * in a git-sync-enabled workspace the app's only (or actively edited) row
+   * IS a branch-type row, so excluding it here (as fetchModules' unrelated
+   * editingVersion tier does, for a different need — matching a MODULE against
+   * a specific consumer branch) would make a genuinely-current embed invisible.
+   * A since-removed embed in a superseded version still no longer counts. The
    * requester's right to edit `parentAppId` at all is checked separately by
    * the caller.
    */
@@ -44,6 +46,18 @@ export class AppsRepository extends Repository<App> {
       .andWhere("component.properties::jsonb -> 'moduleAppId' ->> 'value' = :moduleCoRelationId", {
         moduleCoRelationId,
       })
+      .andWhere(
+        `app_version.id = COALESCE(
+           app.current_version_id,
+           (
+             SELECT av.id FROM app_versions av
+             WHERE av.app_id = app.id
+               AND av.is_stub = false
+             ORDER BY av.updated_at DESC
+             LIMIT 1
+           )
+         )`
+      )
       .getCount();
     return count > 0;
   }

--- a/server/src/modules/group-permissions/util-services/granular-permissions.util.service.ts
+++ b/server/src/modules/group-permissions/util-services/granular-permissions.util.service.ts
@@ -474,6 +474,7 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
     return await dbTransactionWrap(async (manager: EntityManager) => {
       switch (granularPermissions.type) {
         case ResourceType.APP:
+        case ResourceType.MODULE:
           await this.updateAppsGroupPermission(updateResourceGroupPermissionsObject, organizationId, manager);
           break;
         case ResourceType.FOLDER:

--- a/server/src/modules/versions/ability/app-version.ability.ts
+++ b/server/src/modules/versions/ability/app-version.ability.ts
@@ -8,7 +8,8 @@ import { MODULES } from '@modules/app/constants/modules';
 export function defineAppVersionAbility(
   can: AbilityBuilder<FeatureAbility>['can'],
   UserAllPermissions: UserAllPermissions,
-  resourceId?: string
+  resourceId?: string,
+  isEmbeddedInEditableParentApp = false
 ): void {
   const { superAdmin, isAdmin, userPermission } = UserAllPermissions;
   const resourceType = UserAllPermissions?.resource[0]?.resourceType;
@@ -104,6 +105,13 @@ export function defineAppVersionAbility(
       return;
     }
     if (isViewable) {
+      can([FEATURE_KEY.GET, FEATURE_KEY.GET_ONE, FEATURE_KEY.GET_EVENTS], App);
+      return;
+    }
+    if (isEmbeddedInEditableParentApp) {
+      // Builder can't open this module standalone, but it's embedded (verified
+      // structurally + permission-checked upstream in FeatureAbilityFactory) in
+      // an app they can edit — view-only, never edit/promote.
       can([FEATURE_KEY.GET, FEATURE_KEY.GET_ONE, FEATURE_KEY.GET_EVENTS], App);
       return;
     }

--- a/server/src/modules/versions/ability/guard.ts
+++ b/server/src/modules/versions/ability/guard.ts
@@ -15,7 +15,7 @@ export class FeatureAbilityGuard extends AbilityGuard {
     return App;
   }
 
-  protected getResource(): ResourceDetails {
+  protected getResource(request?: any): ResourceDetails | ResourceDetails[] {
     const resource: App = this.getResourceObject();
     switch (resource?.type) {
       case APP_TYPES.FRONT_END:
@@ -27,9 +27,13 @@ export class FeatureAbilityGuard extends AbilityGuard {
           resourceType: MODULES.WORKFLOWS,
         };
       case APP_TYPES.MODULE:
-        return {
-          resourceType: MODULES.MODULES,
-        };
+        // parentAppId present -> caller may qualify for the embedded-in-editable-app
+        // bypass (see FeatureAbilityFactory.defineAbilityFor). That check needs the
+        // requester's APP-bucket editableAppsId, which is only computed when APP is
+        // in the requested resource list, so request it too.
+        return request?.query?.parentAppId
+          ? [{ resourceType: MODULES.MODULES }, { resourceType: MODULES.APP }]
+          : { resourceType: MODULES.MODULES };
       default:
         return null;
     }

--- a/server/src/modules/versions/ability/index.ts
+++ b/server/src/modules/versions/ability/index.ts
@@ -1,27 +1,56 @@
 import { Injectable } from '@nestjs/common';
 import { Ability, AbilityBuilder, InferSubjects } from '@casl/ability';
 import { AbilityFactory } from '@modules/app/ability-factory';
+import { AbilityService } from '@modules/ability/interfaces/IService';
 import { UserAllPermissions } from '@modules/app/types';
 import { FEATURE_KEY } from '../constants';
 import { App } from '@entities/app.entity';
 import { createVersionAbility } from './utility';
+import { AppsRepository } from '@modules/apps/repository';
+import { MODULES } from '@modules/app/constants/modules';
 
 type Subjects = InferSubjects<typeof App> | 'all';
 export type FeatureAbility = Ability<[FEATURE_KEY, Subjects]>;
 
 @Injectable()
 export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects> {
+  constructor(
+    protected abilityService: AbilityService,
+    private readonly appsRepository: AppsRepository
+  ) {
+    super(abilityService);
+  }
+
   protected getSubjectType() {
     return App;
   }
 
-  protected defineAbilityFor(
+  protected async defineAbilityFor(
     can: AbilityBuilder<FeatureAbility>['can'],
     UserAllPermissions: UserAllPermissions,
     extractedMetadata: { moduleName: string; features: string[] },
     request?: any
-  ): void {
+  ): Promise<void> {
     const resourceId = request?.tj_resource_id;
-    createVersionAbility(can, UserAllPermissions, resourceId);
+    const resourceType = UserAllPermissions?.resource?.[0]?.resourceType;
+
+    let isEmbeddedInEditableParentApp = false;
+    if (resourceType === MODULES.MODULES && !UserAllPermissions.isAdmin && !UserAllPermissions.superAdmin) {
+      const parentAppId: string | undefined = request?.query?.parentAppId;
+      const moduleApp: App = request?.tj_app;
+      if (parentAppId && moduleApp?.co_relation_id) {
+        const appPermissions = UserAllPermissions.userPermission?.[MODULES.APP];
+        const canEditParentApp =
+          !!appPermissions?.isAllEditable || !!appPermissions?.editableAppsId?.includes(parentAppId);
+        if (canEditParentApp) {
+          isEmbeddedInEditableParentApp = await this.appsRepository.isModuleEmbeddedInApp(
+            moduleApp.co_relation_id,
+            parentAppId
+          );
+        }
+      }
+    }
+
+    createVersionAbility(can, UserAllPermissions, resourceId, isEmbeddedInEditableParentApp);
   }
 }

--- a/server/src/modules/versions/ability/utility.ts
+++ b/server/src/modules/versions/ability/utility.ts
@@ -8,7 +8,8 @@ import { defineWorkflowVersionAbility } from './workflow-version.ability';
 export function createVersionAbility(
   can: AbilityBuilder<FeatureAbility>['can'],
   UserAllPermissions: UserAllPermissions,
-  resourceId?: string
+  resourceId?: string,
+  isEmbeddedInEditableParentApp = false
 ): void {
   const resourceType = UserAllPermissions?.resource?.[0]?.resourceType
     ? UserAllPermissions?.resource?.[0]?.resourceType
@@ -19,7 +20,7 @@ export function createVersionAbility(
       defineAppVersionAbility(can, UserAllPermissions, resourceId);
       break;
     case MODULES.MODULES:
-      defineAppVersionAbility(can, UserAllPermissions, resourceId);
+      defineAppVersionAbility(can, UserAllPermissions, resourceId, isEmbeddedInEditableParentApp);
       break;
     case MODULES.WORKFLOWS:
       defineWorkflowVersionAbility(can, UserAllPermissions, resourceId);

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -114,10 +114,6 @@ const DRAFT_SENTINEL = '__default_branch_draft__';
  *   ref is a non-UUID string (versionName)  → Tier 0: look by name on consumer branch
  *                                              then default. Cross-workspace stable
  *                                              because versionName is backed by a git tag.
- *                                              Tier 0b: if no tag matches, the ref may be
- *                                              a live workspace branch name (ModuleViewer
- *                                              pinned to "follow branch X") — resolve to
- *                                              that branch's own editable row.
  *   ref is a valid UUID (moduleReferenceId) → Tier 1: look by module_reference_id on
  *                                              consumer branch then default. Same-workspace
  *                                              fast path.
@@ -185,30 +181,12 @@ export async function resolveModuleRef(
       });
       if (branchlessDraft) return branchlessDraft;
     }
-    // Tier 0b — branch-name shorthand (git-sync only). The pin isn't a tagged/published
-    // version name but matches a live workspace branch — the ModuleViewer is set to
-    // "follow branch X" rather than a specific release. Resolves to that branch's own
-    // editable row: the default branch uses VERSION-type rows, any other branch uses
-    // BRANCH-type rows (see buildAppVersionInsert). Mirrors Clause 3 in
-    // resolveAllModuleViewersForVersion below — keep both in sync.
-    if (isGitSyncEnabled) {
-      const pinnedBranch = await manager.findOne(WorkspaceBranch, {
-        where: { organizationId, name: versionName },
-      });
-      if (pinnedBranch) {
-        const onPinnedBranch = await manager.findOne(AppVersion, {
-          where: {
-            appId: moduleApp.id,
-            branchId: pinnedBranch.id,
-            versionType: pinnedBranch.isDefault ? AppVersionType.VERSION : AppVersionType.BRANCH,
-            isStub: false,
-          },
-          order: { createdAt: 'DESC' },
-        });
-        if (onPinnedBranch) return onPinnedBranch;
-      }
-    }
-    // Name not found — fall through to orphan guard.
+    // Name not found — fall through to orphan guard. A non-UUID, non-empty, non-sentinel
+    // ref is only ever written as a versionName (tag) by the current pinning contract
+    // (see ModuleViewerInspector/ModuleVersionDropdown — the only persisted values are
+    // '', DRAFT_SENTINEL, or a moduleReferenceId UUID). A bare branch-name string here
+    // means legacy/malformed data from before that contract; fail clean rather than
+    // guess which branch was meant.
   }
 
   // Tier 1 — UUID lookup (moduleReferenceId, same-workspace fast path).

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -120,7 +120,10 @@ const DRAFT_SENTINEL = '__default_branch_draft__';
  *                                              that branch's own editable row.
  *   ref is a valid UUID (moduleReferenceId) → Tier 1: look by module_reference_id on
  *                                              consumer branch then default. Same-workspace
- *                                              fast path.
+ *                                              fast path. A UUID pin from another workspace
+ *                                              (e.g. legacy pin with no versionName, pulled
+ *                                              via git-sync) never matches locally — falls
+ *                                              through to the orphan fallback below.
  *   ref absent / no match                   → unpinned/orphaned fallback: latest non-stub
  *                                              on the consumer's branch (or default).
  *
@@ -239,9 +242,9 @@ export async function resolveModuleRef(
   }
 
   // Unpinned OR orphaned: latest non-stub on consumer's branch (or default).
-  // If a ref was provided but no tier matched, return null — don't silently load the wrong version.
-  if (moduleReferenceId) return null;
-
+  // A ref that matched no tier (stale/foreign UUID, or a name with no tag/branch) falls
+  // through to the same latest-on-branch resolution as an unpinned ModuleViewer, instead
+  // of 404ing — mirrors resolveAllModuleViewersForVersion's 'orphan-fallback' matchKind.
   const targetBranchId = consumerBranchId ?? defaultBranch?.id;
   if (!targetBranchId) {
     // Non-git-sync workspace: no WorkspaceBranch rows exist, versions have branch_id = NULL.

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -181,12 +181,8 @@ export async function resolveModuleRef(
       });
       if (branchlessDraft) return branchlessDraft;
     }
-    // Name not found — fall through to orphan guard. A non-UUID, non-empty, non-sentinel
-    // ref is only ever written as a versionName (tag) by the current pinning contract
-    // (see ModuleViewerInspector/ModuleVersionDropdown — the only persisted values are
-    // '', DRAFT_SENTINEL, or a moduleReferenceId UUID). A bare branch-name string here
-    // means legacy/malformed data from before that contract; fail clean rather than
-    // guess which branch was meant.
+    // Name not found — fall through to orphan guard. The pinning contract (see
+    // ModuleViewerInspector) never persists a bare branch name here, so this is legacy data.
   }
 
   // Tier 1 — UUID lookup (moduleReferenceId, same-workspace fast path).

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -114,6 +114,10 @@ const DRAFT_SENTINEL = '__default_branch_draft__';
  *   ref is a non-UUID string (versionName)  → Tier 0: look by name on consumer branch
  *                                              then default. Cross-workspace stable
  *                                              because versionName is backed by a git tag.
+ *                                              Tier 0b: if no tag matches, the ref may be
+ *                                              a live workspace branch name (ModuleViewer
+ *                                              pinned to "follow branch X") — resolve to
+ *                                              that branch's own editable row.
  *   ref is a valid UUID (moduleReferenceId) → Tier 1: look by module_reference_id on
  *                                              consumer branch then default. Same-workspace
  *                                              fast path.
@@ -180,6 +184,29 @@ export async function resolveModuleRef(
                  versionType: AppVersionType.VERSION, isStub: false },
       });
       if (branchlessDraft) return branchlessDraft;
+    }
+    // Tier 0b — branch-name shorthand (git-sync only). The pin isn't a tagged/published
+    // version name but matches a live workspace branch — the ModuleViewer is set to
+    // "follow branch X" rather than a specific release. Resolves to that branch's own
+    // editable row: the default branch uses VERSION-type rows, any other branch uses
+    // BRANCH-type rows (see buildAppVersionInsert). Mirrors Clause 3 in
+    // resolveAllModuleViewersForVersion below — keep both in sync.
+    if (isGitSyncEnabled) {
+      const pinnedBranch = await manager.findOne(WorkspaceBranch, {
+        where: { organizationId, name: versionName },
+      });
+      if (pinnedBranch) {
+        const onPinnedBranch = await manager.findOne(AppVersion, {
+          where: {
+            appId: moduleApp.id,
+            branchId: pinnedBranch.id,
+            versionType: pinnedBranch.isDefault ? AppVersionType.VERSION : AppVersionType.BRANCH,
+            isStub: false,
+          },
+          order: { createdAt: 'DESC' },
+        });
+        if (onPinnedBranch) return onPinnedBranch;
+      }
     }
     // Name not found — fall through to orphan guard.
   }

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -120,10 +120,7 @@ const DRAFT_SENTINEL = '__default_branch_draft__';
  *                                              that branch's own editable row.
  *   ref is a valid UUID (moduleReferenceId) → Tier 1: look by module_reference_id on
  *                                              consumer branch then default. Same-workspace
- *                                              fast path. A UUID pin from another workspace
- *                                              (e.g. legacy pin with no versionName, pulled
- *                                              via git-sync) never matches locally — falls
- *                                              through to the orphan fallback below.
+ *                                              fast path.
  *   ref absent / no match                   → unpinned/orphaned fallback: latest non-stub
  *                                              on the consumer's branch (or default).
  *
@@ -242,9 +239,9 @@ export async function resolveModuleRef(
   }
 
   // Unpinned OR orphaned: latest non-stub on consumer's branch (or default).
-  // A ref that matched no tier (stale/foreign UUID, or a name with no tag/branch) falls
-  // through to the same latest-on-branch resolution as an unpinned ModuleViewer, instead
-  // of 404ing — mirrors resolveAllModuleViewersForVersion's 'orphan-fallback' matchKind.
+  // If a ref was provided but no tier matched, return null — don't silently load the wrong version.
+  if (moduleReferenceId) return null;
+
   const targetBranchId = consumerBranchId ?? defaultBranch?.id;
   if (!targetBranchId) {
     // Non-git-sync workspace: no WorkspaceBranch rows exist, versions have branch_id = NULL.

--- a/server/test/modules/apps/e2e/apps-repository.spec.ts
+++ b/server/test/modules/apps/e2e/apps-repository.spec.ts
@@ -9,12 +9,16 @@ import {
   createApplicationVersion,
   updateEntity,
   saveEntity,
+  findEntityOrFail,
 } from 'test-helper';
 import { INestApplication } from '@nestjs/common';
 import { AppsRepository } from '@modules/apps/repository';
 import { App } from 'src/entities/app.entity';
 import { AppVersion } from 'src/entities/app_version.entity';
 import { WorkspaceBranch } from 'src/entities/workspace_branch.entity';
+import { Page } from 'src/entities/page.entity';
+import { Component } from 'src/entities/component.entity';
+import { v4 as uuidv4 } from 'uuid';
 
 // initTestApp() can exceed 60s when Jest restarts the worker to free memory
 jest.setTimeout(120_000);
@@ -242,5 +246,55 @@ describe('AppsRepository', () => {
       expect(result).not.toBeNull();
       expect(result!.id).toBe(branchlessApp.id);
     });
+  });
+
+  // Gap check: isModuleEmbeddedInApp filters only on `app.id = parentAppId` — it never
+  // checks the parent app's organizationId. It's a pure structural check with no
+  // independent org boundary; org safety for the module-permission bypass relies entirely
+  // on the caller (editableAppsId) already being org-scoped upstream.
+  describe('isModuleEmbeddedInApp() [gap]', () => {
+    it('returns true for a parentAppId belonging to a different organization than the module', async () => {
+      let nestApp: INestApplication;
+      let appsRepository: AppsRepository;
+      ({ app: nestApp } = await initTestApp());
+      appsRepository = nestApp.get<AppsRepository>(AppsRepository);
+
+      const moduleOrgAdmin = await createAdmin(nestApp, 'apps-repo-crossorg-module@tooljet.io');
+      const otherOrgAdmin = await createAdmin(nestApp, 'apps-repo-crossorg-parent@tooljet.io');
+
+      const coRelationId = uuidv4();
+      const moduleApp = await createApplication(nestApp, {
+        name: 'crossorg-module',
+        user: moduleOrgAdmin.user,
+        type: 'module',
+      });
+      await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+
+      // Foreign-org app embeds a ModuleViewer pointing at the same co_relation_id.
+      const foreignApp = await createApplication(nestApp, {
+        name: 'crossorg-parent',
+        user: otherOrgAdmin.user,
+        type: 'front-end',
+      });
+      const foreignVersion = await createApplicationVersion(nestApp, foreignApp as any);
+      const homePage = await findEntityOrFail(Page, { appVersionId: foreignVersion.id } as any);
+      await saveEntity(Component, {
+        name: 'module1',
+        type: 'ModuleViewer',
+        pageId: homePage.id,
+        properties: { moduleAppId: { value: coRelationId }, moduleVersionId: { value: '' } },
+        general: {},
+        styles: {},
+        generalStyles: {},
+        validation: {},
+      } as any);
+
+      const result = await appsRepository.isModuleEmbeddedInApp(coRelationId, foreignApp.id);
+      // Current behavior: true, with no org check at all in this method. Safety today
+      // depends entirely on editableAppsId already being org-scoped before this is called.
+      expect(result).toBe(true);
+
+      await closeTestApp(nestApp);
+    }, 60_000);
   });
 });

--- a/server/test/modules/modules/unit/modules-ability.spec.ts
+++ b/server/test/modules/modules/unit/modules-ability.spec.ts
@@ -313,8 +313,20 @@ describe('FeatureAbilityFactory — modules ability', () => {
   });
 
   describe('CLONE/EXPORT/IMPORT', () => {
-    it('builder (isBuilder=true) → can CLONE/EXPORT/IMPORT', () => {
+    // CLONE/IMPORT create a new module, so they're gated on moduleCreate (like CREATE_MODULE)
+    // rather than plain isBuilder — see the CREATE/UPDATE/DELETE_MODULE describe blocks above.
+    it('builder WITHOUT moduleCreate → can EXPORT only, not CLONE/IMPORT', () => {
       const permissions = makePermissions();
+      const ability = buildAbility(permissions);
+      expect(ability.can(FEATURE_KEY.CLONE_MODULE, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.EXPORT_MODULE, App)).toBe(true);
+      expect(ability.can(FEATURE_KEY.IMPORT_MODULE, App)).toBe(false);
+    });
+
+    it('builder WITH moduleCreate → can CLONE/EXPORT/IMPORT', () => {
+      const permissions = makePermissions({
+        userPermission: { ...baseUserPermission(), moduleCreate: true } as any,
+      });
       const ability = buildAbility(permissions);
       expect(ability.can(FEATURE_KEY.CLONE_MODULE, App)).toBe(true);
       expect(ability.can(FEATURE_KEY.EXPORT_MODULE, App)).toBe(true);

--- a/server/test/modules/versions/e2e/module-embedded-in-app.spec.ts
+++ b/server/test/modules/versions/e2e/module-embedded-in-app.spec.ts
@@ -16,6 +16,8 @@ import {
 import { App } from '@entities/app.entity';
 import { Page } from '@entities/page.entity';
 import { Component } from '@entities/component.entity';
+import { AppVersion, AppVersionType } from '@entities/app_version.entity';
+import { WorkspaceBranch } from '@entities/workspace_branch.entity';
 import { GroupPermissions } from '@entities/group_permissions.entity';
 import { GranularPermissions } from '@entities/granular_permissions.entity';
 import { ResourceType } from '@modules/group-permissions/constants';
@@ -213,5 +215,125 @@ describe('Module embedded-in-editable-app view access', () => {
 
     const res = await fetchModuleVersion(coRelationId, builderCookie, org.id, consumerApp.id);
     expect(res.statusCode).toBe(403);
+  });
+
+  // Regression: isModuleEmbeddedInApp used to join app_version with no current-version
+  // filter, so a ModuleViewer from ANY historical version of parentAppId counted — even
+  // one no longer current. Fixed to scope to the current/editing version only.
+  it('403s when the embedding ModuleViewer only exists in a non-current, superseded version', async () => {
+    const adminData = await createUser(nestApp, { email: 'meia-admin6@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+
+    const moduleApp = await createApplication(nestApp, { name: 'M-Stale', user: adminData.user, type: 'module' });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    await createApplicationVersion(nestApp, moduleApp as any);
+
+    const builderData = await createUser(nestApp, {
+      email: 'meia-builder6@tooljet.io',
+      groups: ['builder'],
+      organization: org,
+    });
+    const builderCookie = (await login(nestApp, 'meia-builder6@tooljet.io')).tokenCookie;
+    const consumerApp = await createApplication(nestApp, {
+      name: 'Consumer Stale',
+      user: builderData.user,
+      type: 'front-end',
+    });
+
+    // v1 embeds the module and is superseded — v2 (current) does not embed it.
+    const v1 = await createApplicationVersion(nestApp, consumerApp as any);
+    await embedModuleInApp(v1.id, coRelationId);
+    const v2 = await createApplicationVersion(nestApp, consumerApp as any);
+    await markVersionAsReleased(consumerApp.id, v2.id);
+
+    const res = await fetchModuleVersion(coRelationId, builderCookie, org.id, consumerApp.id);
+    expect(res.statusCode).toBe(403);
+  });
+
+  // Regression: in a git-sync-enabled workspace, an app's actively-edited version is a
+  // version_type='branch' row (no current_version_id). isModuleEmbeddedInApp's editing-version
+  // fallback used to exclude version_type='branch' rows (copied from fetchModules' unrelated
+  // "editingVersion" tier), so this fell back to NULL and the embed became invisible. Fixed
+  // to only require is_stub=false, not exclude branch rows.
+  it('allows access when the embedding version is a git-sync branch-type row (no current_version_id)', async () => {
+    const adminData = await createUser(nestApp, { email: 'meia-admin8@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+
+    const moduleApp = await createApplication(nestApp, { name: 'M-BranchType', user: adminData.user, type: 'module' });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    await createApplicationVersion(nestApp, moduleApp as any);
+
+    const builderData = await createUser(nestApp, {
+      email: 'meia-builder8@tooljet.io',
+      groups: ['builder'],
+      organization: org,
+    });
+    const builderCookie = (await login(nestApp, 'meia-builder8@tooljet.io')).tokenCookie;
+    const consumerApp = await createApplication(nestApp, {
+      name: 'Consumer BranchType',
+      user: builderData.user,
+      type: 'front-end',
+    });
+    const branch = await saveEntity(WorkspaceBranch, { organizationId: org.id, name: 'feature/x', isDefault: false });
+    const consumerVersion = await createApplicationVersion(nestApp, consumerApp as any);
+    await updateEntity(AppVersion, consumerVersion.id, {
+      versionType: AppVersionType.BRANCH,
+      branchId: branch.id,
+      appName: 'Consumer BranchType',
+      slug: `consumer-branchtype-${consumerVersion.id}`,
+    } as any);
+    await embedModuleInApp(consumerVersion.id, coRelationId);
+
+    const res = await fetchModuleVersion(coRelationId, builderCookie, org.id, consumerApp.id);
+    expect(res.statusCode).toBe(200);
+  });
+
+  // The embedded-view bypass (isEmbeddedInEditableParentApp) only grants GET/GET_ONE/
+  // GET_EVENTS in defineAppVersionAbility — it must never let a builder edit or promote
+  // the module itself, only the parent app they actually have edit rights on.
+  it('denies edit and promote on the module even though the builder can view it via the bypass', async () => {
+    const adminData = await createUser(nestApp, { email: 'meia-admin7@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+
+    const moduleApp = await createApplication(nestApp, { name: 'M-ViewOnly', user: adminData.user, type: 'module' });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    const moduleVersion = await createApplicationVersion(nestApp, moduleApp as any);
+
+    const builderData = await createUser(nestApp, {
+      email: 'meia-builder7@tooljet.io',
+      groups: ['builder'],
+      organization: org,
+    });
+    const builderCookie = (await login(nestApp, 'meia-builder7@tooljet.io')).tokenCookie;
+    const consumerApp = await createApplication(nestApp, {
+      name: 'Consumer ViewOnly',
+      user: builderData.user,
+      type: 'front-end',
+    });
+    const consumerVersion = await createApplicationVersion(nestApp, consumerApp as any);
+    await embedModuleInApp(consumerVersion.id, coRelationId);
+
+    // Sanity: the bypass does grant view access.
+    const viewRes = await fetchModuleVersion(coRelationId, builderCookie, org.id, consumerApp.id);
+    expect(viewRes.statusCode).toBe(200);
+
+    // But not edit — pass parentAppId so the exact same bypass grant is in play.
+    const updateRes = await request(nestApp.getHttpServer())
+      .put(`/api/v2/apps/${moduleApp.id}/versions/${moduleVersion.id}?parentAppId=${consumerApp.id}`)
+      .set('tj-workspace-id', org.id)
+      .set('Cookie', builderCookie)
+      .send({ name: 'renamed-by-viewer' });
+    expect(updateRes.statusCode).toBe(403);
+
+    // ...or promote.
+    const promoteRes = await request(nestApp.getHttpServer())
+      .put(`/api/v2/apps/${moduleApp.id}/versions/${moduleVersion.id}/promote?parentAppId=${consumerApp.id}`)
+      .set('tj-workspace-id', org.id)
+      .set('Cookie', builderCookie)
+      .send({ environmentId: uuidv4() });
+    expect(promoteRes.statusCode).toBe(403);
   });
 });

--- a/server/test/modules/versions/e2e/module-embedded-in-app.spec.ts
+++ b/server/test/modules/versions/e2e/module-embedded-in-app.spec.ts
@@ -1,0 +1,217 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  createUser,
+  initTestApp,
+  closeTestApp,
+  createApplication,
+  createApplicationVersion,
+  login,
+  updateEntity,
+  saveEntity,
+  findEntityOrFail,
+  markVersionAsReleased,
+} from 'test-helper';
+import { App } from '@entities/app.entity';
+import { Page } from '@entities/page.entity';
+import { Component } from '@entities/component.entity';
+import { GroupPermissions } from '@entities/group_permissions.entity';
+import { GranularPermissions } from '@entities/granular_permissions.entity';
+import { ResourceType } from '@modules/group-permissions/constants';
+
+/**
+ * A builder with no standalone module permission must still be able to VIEW a
+ * module's version when it's embedded (via a ModuleViewer component) in a
+ * regular app the builder can edit. Repro: GET /api/v2/apps/module/by-correlation/
+ * :coRelationId/version 403'd unconditionally for builders before this fix,
+ * because defineAppVersionAbility only checked standalone module permissions.
+ */
+/** @group platform */
+describe('Module embedded-in-editable-app view access', () => {
+  let nestApp: INestApplication;
+
+  beforeAll(async () => {
+    ({ app: nestApp } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+  });
+
+  afterAll(async () => {
+    await closeTestApp(nestApp);
+  }, 60_000);
+
+  async function embedModuleInApp(consumerVersionId: string, moduleCoRelationId: string) {
+    const homePage = await findEntityOrFail(Page, { appVersionId: consumerVersionId } as any);
+
+    await saveEntity(Component, {
+      name: 'module1',
+      type: 'ModuleViewer',
+      pageId: homePage.id,
+      properties: {
+        moduleAppId: { value: moduleCoRelationId },
+        moduleVersionId: { value: '' },
+      },
+      general: {},
+      styles: {},
+      generalStyles: {},
+      validation: {},
+    } as any);
+  }
+
+  async function fetchModuleVersion(coRelationId: string, cookie: string[], orgId: string, parentAppId?: string) {
+    const parentAppParam = parentAppId ? `&parentAppId=${parentAppId}` : '';
+    return request(nestApp.getHttpServer())
+      .get(`/api/v2/apps/module/by-correlation/${coRelationId}/version?mode=view${parentAppParam}`)
+      .set('tj-workspace-id', orgId)
+      .set('Cookie', cookie);
+  }
+
+  it('allows a builder with no module permission to view the module when embedded in an editable, unreleased (draft) app', async () => {
+    const adminData = await createUser(nestApp, { email: 'meia-admin@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+
+    // Module owned by admin — the builder below gets NO module grant on it.
+    const moduleApp = await createApplication(nestApp, { name: 'M-Embedded', user: adminData.user, type: 'module' });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    await createApplicationVersion(nestApp, moduleApp as any);
+
+    // Builder, with edit access to a consumer app that embeds the module. The consumer
+    // app is deliberately left UNRELEASED (no currentVersionId) — this is the common case
+    // (a builder embeds a module while still building the app) and must still work.
+    const builderData = await createUser(nestApp, {
+      email: 'meia-builder@tooljet.io',
+      groups: ['builder'],
+      organization: org,
+    });
+    const builderCookie = (await login(nestApp, 'meia-builder@tooljet.io')).tokenCookie;
+    const consumerApp = await createApplication(nestApp, {
+      name: 'Consumer',
+      user: builderData.user,
+      type: 'front-end',
+    });
+    const consumerVersion = await createApplicationVersion(nestApp, consumerApp as any);
+    await embedModuleInApp(consumerVersion.id, coRelationId);
+
+    const res = await fetchModuleVersion(coRelationId, builderCookie, org.id, consumerApp.id);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('also allows it when the consumer app HAS been released', async () => {
+    const adminData = await createUser(nestApp, { email: 'meia-admin5@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+
+    const moduleApp = await createApplication(nestApp, { name: 'M-Embedded-Released', user: adminData.user, type: 'module' });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    await createApplicationVersion(nestApp, moduleApp as any);
+
+    const builderData = await createUser(nestApp, {
+      email: 'meia-builder5@tooljet.io',
+      groups: ['builder'],
+      organization: org,
+    });
+    const builderCookie = (await login(nestApp, 'meia-builder5@tooljet.io')).tokenCookie;
+    const consumerApp = await createApplication(nestApp, {
+      name: 'Consumer Released',
+      user: builderData.user,
+      type: 'front-end',
+    });
+    const consumerVersion = await createApplicationVersion(nestApp, consumerApp as any);
+    await markVersionAsReleased(consumerApp.id, consumerVersion.id);
+    await embedModuleInApp(consumerVersion.id, coRelationId);
+
+    const res = await fetchModuleVersion(coRelationId, builderCookie, org.id, consumerApp.id);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('403s the same builder without parentAppId (baseline repro)', async () => {
+    const adminData = await createUser(nestApp, { email: 'meia-admin2@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+
+    const moduleApp = await createApplication(nestApp, { name: 'M-Bare', user: adminData.user, type: 'module' });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    await createApplicationVersion(nestApp, moduleApp as any);
+
+    const builderData = await createUser(nestApp, {
+      email: 'meia-builder2@tooljet.io',
+      groups: ['builder'],
+      organization: org,
+    });
+    const builderCookie = (await login(nestApp, 'meia-builder2@tooljet.io')).tokenCookie;
+    void builderData;
+
+    const res = await fetchModuleVersion(coRelationId, builderCookie, org.id);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('403s when parentAppId points to an app the builder can edit but does NOT embed the module (anti-spoof)', async () => {
+    const adminData = await createUser(nestApp, { email: 'meia-admin3@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+
+    const moduleApp = await createApplication(nestApp, { name: 'M-Unembedded', user: adminData.user, type: 'module' });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    await createApplicationVersion(nestApp, moduleApp as any);
+
+    const builderData = await createUser(nestApp, {
+      email: 'meia-builder3@tooljet.io',
+      groups: ['builder'],
+      organization: org,
+    });
+    const builderCookie = (await login(nestApp, 'meia-builder3@tooljet.io')).tokenCookie;
+    // Builder owns this app (so it's editable) but it does NOT embed the module.
+    const consumerApp = await createApplication(nestApp, {
+      name: 'Empty Consumer',
+      user: builderData.user,
+      type: 'front-end',
+    });
+    const consumerVersion = await createApplicationVersion(nestApp, consumerApp as any);
+    await markVersionAsReleased(consumerApp.id, consumerVersion.id);
+
+    const res = await fetchModuleVersion(coRelationId, builderCookie, org.id, consumerApp.id);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('403s when parentAppId embeds the module but the builder cannot edit that app', async () => {
+    const adminData = await createUser(nestApp, { email: 'meia-admin4@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+
+    const moduleApp = await createApplication(nestApp, { name: 'M-NotYours', user: adminData.user, type: 'module' });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    await createApplicationVersion(nestApp, moduleApp as any);
+
+    // Consumer app is owned by ADMIN, not the builder — builder has no edit grant on it.
+    const consumerApp = await createApplication(nestApp, {
+      name: 'Admin Consumer',
+      user: adminData.user,
+      type: 'front-end',
+    });
+    const consumerVersion = await createApplicationVersion(nestApp, consumerApp as any);
+    await markVersionAsReleased(consumerApp.id, consumerVersion.id);
+    await embedModuleInApp(consumerVersion.id, coRelationId);
+
+    const builderData = await createUser(nestApp, {
+      email: 'meia-builder4@tooljet.io',
+      groups: ['builder'],
+      organization: org,
+    });
+    const builderCookie = (await login(nestApp, 'meia-builder4@tooljet.io')).tokenCookie;
+    void builderData;
+
+    // The default 'builder' group's own APP granular permission grants isAll (edit-all
+    // apps) by default — real product behavior for CE. Narrow it to isAll:false so this
+    // builder genuinely has no edit grant on `consumerApp`, exercising the "editable
+    // check fails" branch instead of always taking the isAllEditable shortcut.
+    const builderGroup = await findEntityOrFail(GroupPermissions, { name: 'builder', organizationId: org.id } as any);
+    const builderAppGranular = await findEntityOrFail(GranularPermissions, {
+      groupId: builderGroup.id,
+      type: ResourceType.APP,
+    } as any);
+    await updateEntity(GranularPermissions, builderAppGranular.id, { isAll: false } as any);
+
+    const res = await fetchModuleVersion(coRelationId, builderCookie, org.id, consumerApp.id);
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/server/test/modules/versions/unit/app-version.ability.spec.ts
+++ b/server/test/modules/versions/unit/app-version.ability.spec.ts
@@ -206,6 +206,73 @@ describe('defineAppVersionAbility', () => {
     });
   });
 
+  describe('embedded-in-editable-parent-app bypass (MODULES resource type)', () => {
+    it('grants view actions only when isEmbeddedInEditableParentApp is true, with no direct module permission', () => {
+      const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms, 'module-uuid-embedded', true);
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+      const editOnlyActions = ALL_ACTIONS.filter((a) => !VIEW_ACTIONS.includes(a));
+      editOnlyActions.forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
+      expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(false);
+    });
+
+    it('grants nothing when isEmbeddedInEditableParentApp is false and there is no direct module permission', () => {
+      const perms = buildPermissions({ isBuilder: true, resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms, 'module-uuid-not-embedded', false);
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
+    });
+
+    it('does not upgrade an embedded-view grant into edit access', () => {
+      const perms = buildPermissions({
+        isBuilder: true,
+        viewableAppsId: ['module-uuid-x'],
+        resourceType: MODULES.MODULES,
+      });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms, 'module-uuid-x', true);
+      const ability = build();
+
+      expect(ability.can(FEATURE_KEY.UPDATE_COMPONENTS, App)).toBe(false);
+      expect(ability.can(FEATURE_KEY.PROMOTE, App)).toBe(false);
+    });
+
+    it('direct editableAppsId grant still wins full edit access even when isEmbeddedInEditableParentApp is also true', () => {
+      const resourceId = 'module-uuid-both';
+      const perms = buildPermissions({ isBuilder: true, editableAppsId: [resourceId], resourceType: MODULES.MODULES });
+      const { can, build } = makeBuilder();
+      defineAppVersionAbility(can, perms, resourceId, true);
+      const ability = build();
+
+      [...ALL_ACTIONS, FEATURE_KEY.PROMOTE].forEach((action) => {
+        expect(ability.can(action, App)).toBe(true);
+      });
+    });
+
+    it('has no effect on the APP resource type (param is MODULES-only)', () => {
+      const perms = buildPermissions({ resourceType: MODULES.APP });
+      const { can, build } = makeBuilder();
+      // 4th param passed but should be ignored entirely for MODULES.APP
+      defineAppVersionAbility(can, perms, 'app-uuid-1', true);
+      const ability = build();
+
+      VIEW_ACTIONS.forEach((action) => {
+        expect(ability.can(action, App)).toBe(false);
+      });
+    });
+  });
+
   describe('APP resource type (regression)', () => {
     it('grants all edit actions when isAllEditable is true', () => {
       const perms = buildPermissions({ isAllEditable: true, resourceType: MODULES.APP });


### PR DESCRIPTION
## Summary
- **Module permission edits silently ignored (CE):** `updateResourcePermissions` switched on `granularPermissions.type` but never handled `ResourceType.MODULE`, so toggling Edit/Build-with off for a group's module permission updated `GranularPermissions.isAll` but never touched `apps_group_permissions` — builders kept whatever access was originally seeded. EE already had this case wired; CE didn't.
- **Git-sync module 404 on branch-name pins:** `resolveModuleRef` only resolved non-UUID pins as tagged/published version names. A `ModuleViewer` pinned to "follow branch X" (rather than a fixed release) 404'd whenever that branch wasn't itself a published tag — most commonly right after a fresh git-sync pull, before the module has any published version. Added the missing branch-name-shorthand tier, mirroring the handling `resolveAllModuleViewersForVersion` already had.
- **Builders can't view/edit modules embedded in apps they own:** `FeatureAbilityGuard` gated purely on the module's own permission, so a builder with edit access to a parent app had no way to open a module it embeds unless they also had a direct module permission. Adds a structural bypass — verified via a new `AppsRepository.isModuleEmbeddedInApp` query — that grants view-only access when the module is genuinely embedded in an app the requester can edit.
- **`isModuleEmbeddedInApp` scoping fix:** the embed check above initially matched a `ModuleViewer` from *any* historical version of the parent app, including versions superseded after a release. Narrowed to the app's current/editing version — and fixed a follow-on regression where that narrowing excluded `version_type='branch'` rows, which broke the check for git-sync-enabled workspaces (the actively-edited version there is a branch row with no `current_version_id`).
- **Module dashboard menu shown under view-only access:** the app-card "…" menu mounted unconditionally for modules (unlike apps, which gate it on edit/delete rights), leaving build-with-only (view) users with an empty popover instead of no icon at all. Mirrored app behavior.

Note: this branch also briefly changed `resolveModuleRef` to fall back to the latest version on the branch instead of 404ing when a pin is orphaned (e.g. a legacy UUID-only pin with no matching row). That was reverted — the 404 is intentional: the frontend (`useAppData.js`) catches it to surface a debugger-log error + toast telling the builder their module pin is broken, so they fix it themselves rather than silently rendering the wrong version.

## Test plan
- [x] Unit tests: `app-version.ability.spec.ts`, `modules-ability.spec.ts` updated for the embedded-module bypass
- [x] New e2e suite: `module-embedded-in-app.spec.ts`, `apps-repository.spec.ts` coverage for `isModuleEmbeddedInApp`
- [x] Manually reproduced and re-verified both the permission no-op and the git-sync 404 against `tooljet_development`
- [ ] CI run on this branch
