### PR TITLE
Remove-license-checks-for-license-key-env-var

### DIFF
--- a/server/src/modules/licensing/configs/LicenseBase.ts
+++ b/server/src/modules/licensing/configs/LicenseBase.ts
@@ -694,10 +694,7 @@ export default class LicenseBase {
   }
 
   public get workspaceEnv(): boolean {
-    if (this.IsBasicPlan) {
-      return !!this.BASIC_PLAN_TERMS.features?.workspaceEnv;
-    }
-    return this._isEnvMapping;
+    return true;
   }
 
   public get appJsLibraries(): boolean {


### PR DESCRIPTION
Earlier workspace env toogle for license was for paid plan. This PR made it free.
ee frontend - https://github.com/ToolJet/ee-frontend/pull/549
ee server - https://github.com/ToolJet/ee-server/pull/708

PRD(4) - https://app.notion.com/p/Backlog-license-flags-Phase-4-3976a40b281080baa06ddefdfe565e6c
