### PR TITLE
fix: utility bug fixes (regex escaping, null guards, sort mutation, JSON parse safety)

### DIFF
--- a/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
@@ -72,8 +72,9 @@ export const highlightText = (text = '', highlight) => {
 };
 
 export const sortArray = (arr, sort) => {
+  const sorted = [...arr];
   if (sort === 'asc') {
-    return arr.sort((a, b) => {
+    return sorted.sort((a, b) => {
       const labelA = typeof a.label === 'string' ? a.label : '';
       const labelB = typeof b.label === 'string' ? b.label : '';
       return labelA.localeCompare(labelB);

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/HighLightSearch/HighLightSearch.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/HighLightSearch/HighLightSearch.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
+const escapeRegExp = (string) => String(string).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 export const HighLightSearch = React.memo(({ text, searchTerm }) => {
   if (text === '') return null;
 
   if (searchTerm === '' || !text.toString()?.toLowerCase().includes(searchTerm?.toLowerCase()))
     return <span>{text}</span>;
 
-  const parts = String(text).split(new RegExp(`(${searchTerm})`, 'gi'));
+  const escapedTerm = escapeRegExp(searchTerm);
+  const parts = String(text).split(new RegExp(`(${escapedTerm})`, 'gi'));
 
   return (
     <span>

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -2580,13 +2580,13 @@ export const createComponentsSlice = (set, get) => ({
   getCurrentPage: (moduleId = 'canvas') => {
     const { modules, getCurrentPageId } = get();
     const currentPageId = getCurrentPageId(moduleId);
-    const currentPage = modules[moduleId].pages.find((page) => page.id === currentPageId);
+    const currentPage = modules[moduleId]?.pages?.find((page) => page.id === currentPageId);
     return currentPage;
   },
 
   // Get the component definition from the component id
   getComponentDefinition: (componentId, moduleId = 'canvas') => {
-    const currentPage = get().modules[moduleId].pages.find((page) => page.id === get().getCurrentPageId(moduleId));
+    const currentPage = get().modules[moduleId]?.pages?.find((page) => page.id === get().getCurrentPageId(moduleId));
     // if (componentId === 'd78554b8-2af0-4add-9d7d-0032bb4c90ce')
     // console.trace('here--- getComponentDefinition--- ', componentId, moduleId, currentPage?.components[componentId]);
     return currentPage?.components[componentId];
@@ -2600,12 +2600,12 @@ export const createComponentsSlice = (set, get) => ({
   getComponentNameFromId: (componentId, moduleId = 'canvas') => {
     const { modules, getCurrentPageIndex } = get();
     const currentPageIndex = getCurrentPageIndex(moduleId);
-    return modules[moduleId].pages[currentPageIndex]?.components[componentId]?.component.name;
+    return modules[moduleId]?.pages?.[currentPageIndex]?.components[componentId]?.component.name;
   },
   getComponentTypeFromId: (componentId, moduleId = 'canvas') => {
     const { modules, getCurrentPageIndex } = get();
     const currentPageIndex = getCurrentPageIndex(moduleId);
-    return modules[moduleId].pages[currentPageIndex]?.components[componentId]?.component.component;
+    return modules[moduleId]?.pages?.[currentPageIndex]?.components[componentId]?.component.component;
   },
   getComponentNameIdMapping: (moduleId = 'canvas') => {
     const { modules } = get();

--- a/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
@@ -665,8 +665,9 @@ export const createDataQuerySlice = (set, get) => ({
 });
 
 const sortByAttribute = (data, sortBy, order) => {
+  const sorted = [...data];
   if (sortBy === 'updated_at') {
-    return data.sort((a, b) => {
+    return sorted.sort((a, b) => {
       const aTime = new Date(a.updated_at ?? 0).getTime();
       const bTime = new Date(b.updated_at ?? 0).getTime();
       return order === 'asc' ? aTime - bTime : bTime - aTime;
@@ -674,14 +675,14 @@ const sortByAttribute = (data, sortBy, order) => {
   }
   if (order === 'asc') {
     if (sortBy === 'kind') {
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
     }
-    return data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+    return sorted.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
   }
   if (order === 'desc') {
     if (sortBy === 'kind') {
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
     }
-    return data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+    return sorted.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
   }
 };

--- a/frontend/src/_helpers/http-client.js
+++ b/frontend/src/_helpers/http-client.js
@@ -101,7 +101,11 @@ class HttpClient {
       }
     } catch (err) {
       payload.data = [];
-      payload.error = !isEmpty(text) && JSON.parse(text);
+      try {
+        payload.error = !isEmpty(text) && JSON.parse(text);
+      } catch {
+        payload.error = text;
+      }
     } finally {
       // eslint-disable-next-line no-unsafe-finally
       return payload;

--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -39,6 +39,7 @@ async function generatePDF(filename, data) {
       });
       y += 10;
     } else if (Array.isArray(value)) {
+      if (value.length === 0) return;
       const columnNames = Object.keys(value[0]);
 
       // Print table headers

--- a/frontend/src/_stores/dataQueriesStore.js
+++ b/frontend/src/_stores/dataQueriesStore.js
@@ -601,19 +601,18 @@ export const useDataQueriesStore = create(
 );
 
 const sortByAttribute = (data, sortBy, order) => {
+  const sorted = [...data];
   if (order === 'asc') {
     if (sortBy === 'kind' || sortBy === 'updated_at') {
-      // sort by name first and then by the attribute
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
     }
-    return data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+    return sorted.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
   }
   if (order === 'desc') {
     if (sortBy === 'kind' || sortBy === 'updated_at') {
-      // sort by name first and then by the attribute
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
     }
-    return data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+    return sorted.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
   }
 };
 


### PR DESCRIPTION
## Summary

Six utility bug fixes across the ToolJet frontend.

### 1. Regex crash in HighLightSearch (`HighLightSearch.jsx`)
User-supplied search terms containing regex metacharacters (`(`, `)`, `[`, `*`, etc.) caused uncaught `SyntaxError` when interpolated directly into `new RegExp()`. Fix: escape regex special characters using the same `escapeRegExp` pattern already used in `DropdownV2/utils.js`.

### 2. Double-fault in HTTP client (`http-client.js`)
When a request failed with non-JSON response (HTML error page, 502 gateway), `JSON.parse(text)` inside the catch block threw a second uncaught exception. Fix: wrap in try/catch, fall back to raw text.

### 3. Crash on empty array in PDF generation (`generate-file.js`)
`Object.keys(value[0])` throws `TypeError` when `value` is an empty array (valid query result). Fix: early return when array is empty.

### 4. TypeError on stale module ID (`componentsSlice.js`)
Four methods accessed `modules[moduleId].pages` without null guard. If moduleId was stale/invalid, accessing `.pages` on `undefined` threw TypeError. Fix: add optional chaining on module access.

### 5. Sort mutation corrupts Zustand state (`dataQueriesStore.js`, `dataQuerySlice.js`)
`sortByAttribute` called `data.sort()` in-place, mutating Zustand state arrays and preventing React from detecting changes. Fix: spread-copy before sorting.

### 6. Sort mutation in DropdownV2 (`utils.js`)
`sortArray` had the same in-place mutation, affecting dropdown, multiselect, and tag input widgets. Fix: spread-copy before sorting.

## Testing
- All changes are defensive guards — existing behavior preserved for valid inputs
- Regex escaping matches the existing pattern in `DropdownV2/utils.js:52-57`