### PR TITLE
fix: findProp null guard, resolve type guard, verifyConstant return, cookie encoding

### DIFF
--- a/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
@@ -72,8 +72,9 @@ export const highlightText = (text = '', highlight) => {
 };
 
 export const sortArray = (arr, sort) => {
+  const sorted = [...arr];
   if (sort === 'asc') {
-    return arr.sort((a, b) => {
+    return sorted.sort((a, b) => {
       const labelA = typeof a.label === 'string' ? a.label : '';
       const labelB = typeof b.label === 'string' ? b.label : '';
       return labelA.localeCompare(labelB);

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/HighLightSearch/HighLightSearch.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/HighLightSearch/HighLightSearch.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
+const escapeRegExp = (string) => String(string).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 export const HighLightSearch = React.memo(({ text, searchTerm }) => {
   if (text === '') return null;
 
   if (searchTerm === '' || !text.toString()?.toLowerCase().includes(searchTerm?.toLowerCase()))
     return <span>{text}</span>;
 
-  const parts = String(text).split(new RegExp(`(${searchTerm})`, 'gi'));
+  const escapedTerm = escapeRegExp(searchTerm);
+  const parts = String(text).split(new RegExp(`(${escapedTerm})`, 'gi'));
 
   return (
     <span>

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -2580,13 +2580,13 @@ export const createComponentsSlice = (set, get) => ({
   getCurrentPage: (moduleId = 'canvas') => {
     const { modules, getCurrentPageId } = get();
     const currentPageId = getCurrentPageId(moduleId);
-    const currentPage = modules[moduleId].pages.find((page) => page.id === currentPageId);
+    const currentPage = modules[moduleId]?.pages?.find((page) => page.id === currentPageId);
     return currentPage;
   },
 
   // Get the component definition from the component id
   getComponentDefinition: (componentId, moduleId = 'canvas') => {
-    const currentPage = get().modules[moduleId].pages.find((page) => page.id === get().getCurrentPageId(moduleId));
+    const currentPage = get().modules[moduleId]?.pages?.find((page) => page.id === get().getCurrentPageId(moduleId));
     // if (componentId === 'd78554b8-2af0-4add-9d7d-0032bb4c90ce')
     // console.trace('here--- getComponentDefinition--- ', componentId, moduleId, currentPage?.components[componentId]);
     return currentPage?.components[componentId];
@@ -2600,12 +2600,12 @@ export const createComponentsSlice = (set, get) => ({
   getComponentNameFromId: (componentId, moduleId = 'canvas') => {
     const { modules, getCurrentPageIndex } = get();
     const currentPageIndex = getCurrentPageIndex(moduleId);
-    return modules[moduleId].pages[currentPageIndex]?.components[componentId]?.component.name;
+    return modules[moduleId]?.pages?.[currentPageIndex]?.components[componentId]?.component.name;
   },
   getComponentTypeFromId: (componentId, moduleId = 'canvas') => {
     const { modules, getCurrentPageIndex } = get();
     const currentPageIndex = getCurrentPageIndex(moduleId);
-    return modules[moduleId].pages[currentPageIndex]?.components[componentId]?.component.component;
+    return modules[moduleId]?.pages?.[currentPageIndex]?.components[componentId]?.component.component;
   },
   getComponentNameIdMapping: (moduleId = 'canvas') => {
     const { modules } = get();

--- a/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
@@ -665,8 +665,9 @@ export const createDataQuerySlice = (set, get) => ({
 });
 
 const sortByAttribute = (data, sortBy, order) => {
+  const sorted = [...data];
   if (sortBy === 'updated_at') {
-    return data.sort((a, b) => {
+    return sorted.sort((a, b) => {
       const aTime = new Date(a.updated_at ?? 0).getTime();
       const bTime = new Date(b.updated_at ?? 0).getTime();
       return order === 'asc' ? aTime - bTime : bTime - aTime;
@@ -674,14 +675,14 @@ const sortByAttribute = (data, sortBy, order) => {
   }
   if (order === 'asc') {
     if (sortBy === 'kind') {
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
     }
-    return data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+    return sorted.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
   }
   if (order === 'desc') {
     if (sortBy === 'kind') {
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
     }
-    return data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+    return sorted.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
   }
 };

--- a/frontend/src/_helpers/cookie.js
+++ b/frontend/src/_helpers/cookie.js
@@ -7,10 +7,10 @@ export function setCookie(name, value, inIFrame = false, expiryMinutes) {
   }
 
   if (inIFrame) {
-    return (document.cookie = `${name}=${value || ''}${expires}; path=/; SameSite=None; Secure`);
+    return (document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value || '')}${expires}; path=/; SameSite=None; Secure`);
   }
 
-  document.cookie = `${name}=${value || ''}${expires}; path=/`;
+  document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value || '')}${expires}; path=/`;
 }
 
 export function getCookie(name) {

--- a/frontend/src/_helpers/http-client.js
+++ b/frontend/src/_helpers/http-client.js
@@ -101,7 +101,11 @@ class HttpClient {
       }
     } catch (err) {
       payload.data = [];
-      payload.error = !isEmpty(text) && JSON.parse(text);
+      try {
+        payload.error = !isEmpty(text) && JSON.parse(text);
+      } catch {
+        payload.error = text;
+      }
     } finally {
       // eslint-disable-next-line no-unsafe-finally
       return payload;

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -54,6 +54,7 @@ export const verifyConstant = (value, definedConstants = {}, definedSecrets = {}
   if (invalidConstants?.length) {
     return invalidConstants;
   }
+  return [];
 };
 
 export function findProp(obj, prop, defval) {
@@ -61,7 +62,8 @@ export function findProp(obj, prop, defval) {
   prop = prop.split('.');
 
   for (var i = 0; i < prop.length; i++) {
-    if (prop[i].endsWith(']')) {
+      if (obj == null) return defval;
+      if (prop[i].endsWith(']')) {
       const actual_prop = prop[i].split('[')[0];
       const index = prop[i].split('[')[1].split(']')[0];
       if (obj[actual_prop]) {
@@ -85,7 +87,7 @@ export function stripTrailingSlash(str) {
 export const pluralize = (count, noun, suffix = 's') => `${count} ${noun}${count !== 1 ? suffix : ''}`;
 
 export function resolve(data, state) {
-  if (data.startsWith('{{queries.') || data.startsWith('{{globals.') || data.startsWith('{{components.')) {
+  if (typeof data !== 'string') return;   if (data.startsWith('{{queries.') || data.startsWith('{{globals.') || data.startsWith('{{components.')) {
     let prop = removeNestedDoubleCurlyBraces(data);
     return findProp(state, prop, '');
   }

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -69,7 +69,7 @@ export function findProp(obj, prop, defval) {
       } else {
         obj = undefined;
       }
-    } else if (obj !== undefined) {
+    } else if (obj != null) {
       if (typeof obj[prop[i]] === 'undefined') return defval;
       obj = obj[prop[i]];
     }
@@ -78,6 +78,7 @@ export function findProp(obj, prop, defval) {
 }
 
 export function stripTrailingSlash(str) {
+  if (!str) return '';
   return str.replace(/[/]+$/, '');
 }
 
@@ -685,9 +686,17 @@ export function hasCircularDependency(obj, stack = new Set()) {
   return false;
 }
 
+const escapeHtml = (str) => {
+  const div = document.createElement('div');
+  div.appendChild(document.createTextNode(str));
+  return div.innerHTML;
+};
+
 export const hightlightMentionedUserInComment = (comment) => {
   var regex = /(\()([^)]+)(\))/g;
-  return comment.replace(regex, '<span class=mentioned-user>$2</span>');
+  return comment.replace(regex, (_match, _open, inner, _close) =>
+    `<span class="mentioned-user">${escapeHtml(inner)}</span>`
+  );
 };
 //   const currentPageId = _ref.currentPageId;
 //   const currentComponents = _ref.appDefinition?.pages[currentPageId]?.components
@@ -987,7 +996,7 @@ export function isExpectedDataType(data, expectedDataType) {
       case 'number':
         return Object.prototype.toString.call(data).slice(8, -1).toLowerCase() === 'number' ? data : undefined;
       case 'boolean':
-        return Boolean();
+        return Boolean(data);
       case 'array':
         return Object.prototype.toString.call(data).slice(8, -1).toLowerCase() === 'array' ? data : [];
       case 'object':

--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -39,6 +39,7 @@ async function generatePDF(filename, data) {
       });
       y += 10;
     } else if (Array.isArray(value)) {
+      if (value.length === 0) return;
       const columnNames = Object.keys(value[0]);
 
       // Print table headers

--- a/frontend/src/_stores/dataQueriesStore.js
+++ b/frontend/src/_stores/dataQueriesStore.js
@@ -601,19 +601,18 @@ export const useDataQueriesStore = create(
 );
 
 const sortByAttribute = (data, sortBy, order) => {
+  const sorted = [...data];
   if (order === 'asc') {
     if (sortBy === 'kind' || sortBy === 'updated_at') {
-      // sort by name first and then by the attribute
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
     }
-    return data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+    return sorted.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
   }
   if (order === 'desc') {
     if (sortBy === 'kind' || sortBy === 'updated_at') {
-      // sort by name first and then by the attribute
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
     }
-    return data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+    return sorted.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
   }
 };
 


### PR DESCRIPTION
## Summary

Four bug fixes in ToolJet frontend utilities.

| # | File | Bug |
|---|---|---|
| 1 | `utils.js` | `findProp` bracket path access without null guard → TypeError |
| 2 | `utils.js` | `resolve()` crashes on non-string `data` (number/object/undefined) |
| 3 | `utils.js` | `verifyConstant` returns `undefined` instead of `[]` when no errors |
| 4 | `cookie.js` | Cookie values not `encodeURIComponent`'d → semicolons corrupt cookie header |