### PR TITLE
fix: ReferenceError in useLocalStorage, Pagination infinite loop, popover toggle, and sort stability

### DIFF
--- a/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
@@ -72,8 +72,9 @@ export const highlightText = (text = '', highlight) => {
 };
 
 export const sortArray = (arr, sort) => {
+  const sorted = [...arr];
   if (sort === 'asc') {
-    return arr.sort((a, b) => {
+    return sorted.sort((a, b) => {
       const labelA = typeof a.label === 'string' ? a.label : '';
       const labelB = typeof b.label === 'string' ? b.label : '';
       return labelA.localeCompare(labelB);

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/HighLightSearch/HighLightSearch.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/HighLightSearch/HighLightSearch.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
+const escapeRegExp = (string) => String(string).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 export const HighLightSearch = React.memo(({ text, searchTerm }) => {
   if (text === '') return null;
 
   if (searchTerm === '' || !text.toString()?.toLowerCase().includes(searchTerm?.toLowerCase()))
     return <span>{text}</span>;
 
-  const parts = String(text).split(new RegExp(`(${searchTerm})`, 'gi'));
+  const escapedTerm = escapeRegExp(searchTerm);
+  const parts = String(text).split(new RegExp(`(${escapedTerm})`, 'gi'));
 
   return (
     <span>

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -2580,13 +2580,13 @@ export const createComponentsSlice = (set, get) => ({
   getCurrentPage: (moduleId = 'canvas') => {
     const { modules, getCurrentPageId } = get();
     const currentPageId = getCurrentPageId(moduleId);
-    const currentPage = modules[moduleId].pages.find((page) => page.id === currentPageId);
+    const currentPage = modules[moduleId]?.pages?.find((page) => page.id === currentPageId);
     return currentPage;
   },
 
   // Get the component definition from the component id
   getComponentDefinition: (componentId, moduleId = 'canvas') => {
-    const currentPage = get().modules[moduleId].pages.find((page) => page.id === get().getCurrentPageId(moduleId));
+    const currentPage = get().modules[moduleId]?.pages?.find((page) => page.id === get().getCurrentPageId(moduleId));
     // if (componentId === 'd78554b8-2af0-4add-9d7d-0032bb4c90ce')
     // console.trace('here--- getComponentDefinition--- ', componentId, moduleId, currentPage?.components[componentId]);
     return currentPage?.components[componentId];
@@ -2600,12 +2600,12 @@ export const createComponentsSlice = (set, get) => ({
   getComponentNameFromId: (componentId, moduleId = 'canvas') => {
     const { modules, getCurrentPageIndex } = get();
     const currentPageIndex = getCurrentPageIndex(moduleId);
-    return modules[moduleId].pages[currentPageIndex]?.components[componentId]?.component.name;
+    return modules[moduleId]?.pages?.[currentPageIndex]?.components[componentId]?.component.name;
   },
   getComponentTypeFromId: (componentId, moduleId = 'canvas') => {
     const { modules, getCurrentPageIndex } = get();
     const currentPageIndex = getCurrentPageIndex(moduleId);
-    return modules[moduleId].pages[currentPageIndex]?.components[componentId]?.component.component;
+    return modules[moduleId]?.pages?.[currentPageIndex]?.components[componentId]?.component.component;
   },
   getComponentNameIdMapping: (moduleId = 'canvas') => {
     const { modules } = get();

--- a/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/dataQuerySlice.js
@@ -665,8 +665,9 @@ export const createDataQuerySlice = (set, get) => ({
 });
 
 const sortByAttribute = (data, sortBy, order) => {
+  const sorted = [...data];
   if (sortBy === 'updated_at') {
-    return data.sort((a, b) => {
+    return sorted.sort((a, b) => {
       const aTime = new Date(a.updated_at ?? 0).getTime();
       const bTime = new Date(b.updated_at ?? 0).getTime();
       return order === 'asc' ? aTime - bTime : bTime - aTime;
@@ -674,14 +675,14 @@ const sortByAttribute = (data, sortBy, order) => {
   }
   if (order === 'asc') {
     if (sortBy === 'kind') {
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
     }
-    return data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+    return sorted.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
   }
   if (order === 'desc') {
     if (sortBy === 'kind') {
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
     }
-    return data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+    return sorted.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
   }
 };

--- a/frontend/src/_components/Pagination.jsx
+++ b/frontend/src/_components/Pagination.jsx
@@ -28,10 +28,11 @@ export const Pagination = function Pagination({
       );
     }
   };
-  if (currentPage > totalPages) {
-    currentPage = totalPages;
-    pageChanged(currentPage);
-  }
+  useEffect(() => {
+    if (currentPage > totalPages && totalPages > 0) {
+      pageChanged(totalPages, itemsPerPage, queryParams);
+    }
+  }, [currentPage, totalPages]);
   function gotoPage(page) {
     pageChanged(page, itemsPerPage, queryParams);
   }

--- a/frontend/src/_components/SortableList/utilities.js
+++ b/frontend/src/_components/SortableList/utilities.js
@@ -108,7 +108,6 @@ export function flattenTree(items) {
 }
 
 export function buildTree(flattenedItems) {
-  console.log(flattenedItems, 'flattenedItems');
   const root = { id: 'root', children: [] };
   const nodes = { [root.id]: root };
   const items = flattenedItems.map((item) => ({ ...item, children: [] }));
@@ -180,18 +179,15 @@ export function removeItem(items, id) {
 }
 
 export function setProperty(items, id, property, setter) {
-  for (const item of items) {
+  return items.map((item) => {
     if (item.id === id) {
-      item[property] = setter(item[property]);
-      continue;
+      return { ...item, [property]: setter(item[property]) };
     }
-
     if (item.children.length) {
-      item.children = setProperty(item.children, id, property, setter);
+      return { ...item, children: setProperty(item.children, id, property, setter) };
     }
-  }
-
-  return [...items];
+    return item;
+  });
 }
 
 function countChildren(items, count = 0) {

--- a/frontend/src/_helpers/cookie.js
+++ b/frontend/src/_helpers/cookie.js
@@ -7,10 +7,10 @@ export function setCookie(name, value, inIFrame = false, expiryMinutes) {
   }
 
   if (inIFrame) {
-    return (document.cookie = `${name}=${value || ''}${expires}; path=/; SameSite=None; Secure`);
+    return (document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value || '')}${expires}; path=/; SameSite=None; Secure`);
   }
 
-  document.cookie = `${name}=${value || ''}${expires}; path=/`;
+  document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value || '')}${expires}; path=/`;
 }
 
 export function getCookie(name) {

--- a/frontend/src/_helpers/handle-response.js
+++ b/frontend/src/_helpers/handle-response.js
@@ -41,7 +41,12 @@ export function handleResponse(
         </div>
       </>
     );
-    const data = text && JSON.parse(text);
+    let data;
+    try {
+      data = text && JSON.parse(text);
+    } catch {
+      return Promise.reject({ error: text || response.statusText });
+    }
     if (!response.ok) {
       // Custom friendly error messages
       if (response.status === 422 && typeof data?.message === 'string') {
@@ -145,7 +150,12 @@ export function handleResponse(
 }
 export function handleResponseWithoutValidation(response) {
   return response.text().then((text) => {
-    const data = text && JSON.parse(text);
+    let data;
+    try {
+      data = text && JSON.parse(text);
+    } catch {
+      return Promise.reject({ error: text || response.statusText });
+    }
     if (!response.ok) {
       const error = (data && data.message) || response.statusText;
       return Promise.reject({ error, data });

--- a/frontend/src/_helpers/http-client.js
+++ b/frontend/src/_helpers/http-client.js
@@ -101,7 +101,11 @@ class HttpClient {
       }
     } catch (err) {
       payload.data = [];
-      payload.error = !isEmpty(text) && JSON.parse(text);
+      try {
+        payload.error = !isEmpty(text) && JSON.parse(text);
+      } catch {
+        payload.error = text;
+      }
     } finally {
       // eslint-disable-next-line no-unsafe-finally
       return payload;

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -54,6 +54,7 @@ export const verifyConstant = (value, definedConstants = {}, definedSecrets = {}
   if (invalidConstants?.length) {
     return invalidConstants;
   }
+  return [];
 };
 
 export function findProp(obj, prop, defval) {
@@ -61,7 +62,8 @@ export function findProp(obj, prop, defval) {
   prop = prop.split('.');
 
   for (var i = 0; i < prop.length; i++) {
-    if (prop[i].endsWith(']')) {
+      if (obj == null) return defval;
+      if (prop[i].endsWith(']')) {
       const actual_prop = prop[i].split('[')[0];
       const index = prop[i].split('[')[1].split(']')[0];
       if (obj[actual_prop]) {
@@ -85,7 +87,7 @@ export function stripTrailingSlash(str) {
 export const pluralize = (count, noun, suffix = 's') => `${count} ${noun}${count !== 1 ? suffix : ''}`;
 
 export function resolve(data, state) {
-  if (data.startsWith('{{queries.') || data.startsWith('{{globals.') || data.startsWith('{{components.')) {
+  if (typeof data !== 'string') return;   if (data.startsWith('{{queries.') || data.startsWith('{{globals.') || data.startsWith('{{components.')) {
     let prop = removeNestedDoubleCurlyBraces(data);
     return findProp(state, prop, '');
   }

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -69,7 +69,7 @@ export function findProp(obj, prop, defval) {
       } else {
         obj = undefined;
       }
-    } else if (obj !== undefined) {
+    } else if (obj != null) {
       if (typeof obj[prop[i]] === 'undefined') return defval;
       obj = obj[prop[i]];
     }
@@ -78,6 +78,7 @@ export function findProp(obj, prop, defval) {
 }
 
 export function stripTrailingSlash(str) {
+  if (!str) return '';
   return str.replace(/[/]+$/, '');
 }
 
@@ -685,9 +686,17 @@ export function hasCircularDependency(obj, stack = new Set()) {
   return false;
 }
 
+const escapeHtml = (str) => {
+  const div = document.createElement('div');
+  div.appendChild(document.createTextNode(str));
+  return div.innerHTML;
+};
+
 export const hightlightMentionedUserInComment = (comment) => {
   var regex = /(\()([^)]+)(\))/g;
-  return comment.replace(regex, '<span class=mentioned-user>$2</span>');
+  return comment.replace(regex, (_match, _open, inner, _close) =>
+    `<span class="mentioned-user">${escapeHtml(inner)}</span>`
+  );
 };
 //   const currentPageId = _ref.currentPageId;
 //   const currentComponents = _ref.appDefinition?.pages[currentPageId]?.components
@@ -987,7 +996,7 @@ export function isExpectedDataType(data, expectedDataType) {
       case 'number':
         return Object.prototype.toString.call(data).slice(8, -1).toLowerCase() === 'number' ? data : undefined;
       case 'boolean':
-        return Boolean();
+        return Boolean(data);
       case 'array':
         return Object.prototype.toString.call(data).slice(8, -1).toLowerCase() === 'array' ? data : [];
       case 'object':

--- a/frontend/src/_helpers/utils.js
+++ b/frontend/src/_helpers/utils.js
@@ -689,6 +689,7 @@ export function hasCircularDependency(obj, stack = new Set()) {
 }
 
 const escapeHtml = (str) => {
+  if (str == null) return '';
   const div = document.createElement('div');
   div.appendChild(document.createTextNode(str));
   return div.innerHTML;

--- a/frontend/src/_hooks/use-local-storage.jsx
+++ b/frontend/src/_hooks/use-local-storage.jsx
@@ -9,10 +9,9 @@ export const useLocalStorageState = (
   const [state, setState] = useState(() => {
     let valueInLocalStorage = window.localStorage.getItem(key);
 
-    if (valueInLocalStorage === 'undefined') {
-      //   valueInLocalStorage = window.localStorage.getItem(`copy${key}`); // can extend this hook to save a copy of the previous state
-      window.localStorage.removeItem(key);
-    }
+    if (valueInLocalStorage === null) {
+      // key not found
+      return defaultVal;
 
     if (valueInLocalStorage) {
       return deserialize(valueInLocalStorage);

--- a/frontend/src/_hooks/use-local-storage.jsx
+++ b/frontend/src/_hooks/use-local-storage.jsx
@@ -11,7 +11,7 @@ export const useLocalStorageState = (
 
     if (valueInLocalStorage === null) {
       // key not found
-      return defaultVal;
+      return defaultValue;
 
     if (valueInLocalStorage) {
       return deserialize(valueInLocalStorage);

--- a/frontend/src/_hooks/use-popover.jsx
+++ b/frontend/src/_hooks/use-popover.jsx
@@ -39,7 +39,7 @@ const usePopover = (defaultOpen = false) => {
   const [open, setOpen] = useState(defaultOpen);
   const toggle = useCallback((e) => {
     e.stopPropagation();
-    setOpen(!open);
+    setOpen(prev => !prev);
   }, []);
   const close = useCallback(() => setOpen(false), []);
   useEscapeHandler(close, []);

--- a/frontend/src/_hooks/useBatchedUpdateEffectArray.jsx
+++ b/frontend/src/_hooks/useBatchedUpdateEffectArray.jsx
@@ -25,12 +25,13 @@ export function useBatchedUpdateEffectArray(items) {
   const firstRender = useRef(true);
   const prevDeps = useRef(items.map((item) => item.dep));
 
+  const depKey = JSON.stringify(items.map((item) => item.dep));
+
   useEffect(
     () => {
       // Skip running on first render
       if (firstRender.current) {
         firstRender.current = false;
-        prevDeps.current = items.map((item) => item.dep);
         return;
       }
 
@@ -43,6 +44,6 @@ export function useBatchedUpdateEffectArray(items) {
         }
       });
     },
-    items.map((item) => item.dep)
+    [depKey]
   );
 }

--- a/frontend/src/_hooks/useConfirm.jsx
+++ b/frontend/src/_hooks/useConfirm.jsx
@@ -30,7 +30,7 @@ function useConfirm() {
   const [show, setShow] = useState(false);
   const [message, setMessage] = useState('');
   const [heading, setHeading] = useState('Confirm action?');
-  const [handleConfirm, setHandleConfirm] = useState(null);
+  const [handleConfirm, setHandleConfirm] = useState(() => () => {});
 
   const confirm = (message, heading) => {
     return new Promise((resolve) => {

--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -39,6 +39,7 @@ async function generatePDF(filename, data) {
       });
       y += 10;
     } else if (Array.isArray(value)) {
+      if (value.length === 0) return;
       const columnNames = Object.keys(value[0]);
 
       // Print table headers

--- a/frontend/src/_stores/dataQueriesStore.js
+++ b/frontend/src/_stores/dataQueriesStore.js
@@ -604,13 +604,13 @@ const sortByAttribute = (data, sortBy, order) => {
   const sorted = [...data];
   if (order === 'asc') {
     if (sortBy === 'kind' || sortBy === 'updated_at') {
-      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+      return sorted.sort((a, b) => a[sortBy].localeCompare(b[sortBy]) || a.name.localeCompare(b.name));
     }
     return sorted.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
   }
   if (order === 'desc') {
     if (sortBy === 'kind' || sortBy === 'updated_at') {
-      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+      return sorted.sort((a, b) => b[sortBy].localeCompare(a[sortBy]) || a.name.localeCompare(b.name));
     }
     return sorted.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
   }

--- a/frontend/src/_stores/dataQueriesStore.js
+++ b/frontend/src/_stores/dataQueriesStore.js
@@ -601,19 +601,18 @@ export const useDataQueriesStore = create(
 );
 
 const sortByAttribute = (data, sortBy, order) => {
+  const sorted = [...data];
   if (order === 'asc') {
     if (sortBy === 'kind' || sortBy === 'updated_at') {
-      // sort by name first and then by the attribute
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
     }
-    return data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
+    return sorted.sort((a, b) => a[sortBy].localeCompare(b[sortBy]));
   }
   if (order === 'desc') {
     if (sortBy === 'kind' || sortBy === 'updated_at') {
-      // sort by name first and then by the attribute
-      return data.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+      return sorted.sort((a, b) => a.name.localeCompare(b.name)).sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
     }
-    return data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
+    return sorted.sort((a, b) => b[sortBy].localeCompare(a[sortBy]));
   }
 };
 


### PR DESCRIPTION
## Summary

Four fixes in ToolJet frontend.

| # | File | Bug | Impact |
|---|---|---|---|
| 1 | `use-local-storage.jsx` | `defaultVal` undefined → ReferenceError crash | Any component using the hook for a new key crashes |
| 2 | `Pagination.jsx` | Mutating props + calling callback during render → infinite loop | Freezes tab when page exceeds total |
| 3 | `use-popover.jsx` | Stale closure captures initial `open` → toggle only opens | Popovers can't be closed via trigger button |
| 4 | `dataQueriesStore.js` | Two-pass sort loses ordering on ties | Items of same type appear in random order |