### PR TITLE
Fix: Preserve explicit false in useExposeState initialization so hidden widgets don't leave a phantom-visible wrapper

### DIFF
--- a/frontend/src/AppBuilder/_hooks/useExposeVariables.js
+++ b/frontend/src/AppBuilder/_hooks/useExposeVariables.js
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 
 export const useExposeState = (loadingState, visibleState, disabledState, setExposedVariables, setExposedVariable) => {
-  const [isDisabled, setDisable] = useState(disabledState || false);
-  const [isVisible, setVisibility] = useState(visibleState || true);
-  const [isLoading, setLoading] = useState(loadingState || false);
+  const [isDisabled, setDisable] = useState(disabledState ?? false);
+  const [isVisible, setVisibility] = useState(visibleState ?? true);
+  const [isLoading, setLoading] = useState(loadingState ?? false);
 
   const applyVisibility = (value) => {
     setVisibility(value);


### PR DESCRIPTION
This pull request makes a small improvement to the `useExposeState` hook by updating the initialization of its internal state variables. The change ensures that `null` or `undefined` values are handled correctly using the nullish coalescing operator (`??`) instead of the logical OR operator (`||`).

- Improved state initialization in `useExposeState` to use `??` for handling `null` and `undefined` values, ensuring more predictable default values.

- Updated the useExposeState hook to use the nullish coalescing operator (??) instead of logical OR (||) for initializing state variables. This change ensures that explicit false values for loadingState, visibleState, and disabledState are preserved, preventing unintended behavior in widget visibility management. This addresses a bug where widgets that should be hidden were incorrectly initialized as visible.