### PR TITLE
Fix: module editor loses state parity with App Builder on version switch

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
@@ -7,6 +7,10 @@ import {
 } from '@/_services';
 import useStore from '@/AppBuilder/_stores/store';
 import toast from 'react-hot-toast';
+import queryString from 'query-string';
+import { camelCase, isEmpty, mapKeys } from 'lodash';
+import { deepCamelCase } from '@/_helpers/appUtils';
+import { baseTheme } from '../utils';
 import {
   getEnvironmentAccessFromPermissions,
   hasEnvironmentAccess,
@@ -505,6 +509,58 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
           get().setResolvedConstants(orgConstants, moduleId);
           get().setSecrets(orgSecrets, moduleId);
         }
+
+        // Theme/JS-libraries/preloaded-script and page settings are stored per-version too —
+        // without this, a switch to a version with different global/page settings keeps
+        // showing the previous version's.
+        const globalSettings = mapKeys(
+          data.editing_version?.globalSettings || data.editing_version?.global_settings || data.globalSettings,
+          (value, key) => camelCase(key)
+        );
+        if (!globalSettings?.theme) {
+          globalSettings.theme = baseTheme;
+        }
+        get().setGlobalSettings(globalSettings);
+        get().setPageSettings(
+          get().computePageSettings(
+            deepCamelCase(data.editing_version?.pageSettings ?? data.editing_version?.page_settings)
+          ),
+          moduleId
+        );
+
+        // theme/urlparams/mode/currentUser essentially never change value within a session
+        // (same browser tab, same user, same dark-mode preference) — refreshed here anyway
+        // for full parity with the reference effect.
+        const exposedTheme =
+          get().globalSettings?.appMode && get().globalSettings.appMode !== 'auto'
+            ? get().globalSettings.appMode
+            : localStorage.getItem('darkMode') === 'true'
+            ? 'dark'
+            : 'light';
+        get().setResolvedGlobals('theme', { name: exposedTheme }, moduleId);
+        get().setResolvedGlobals(
+          'urlparams',
+          JSON.parse(JSON.stringify(queryString.parse(window.location?.search))),
+          moduleId
+        );
+        get().setResolvedGlobals('mode', { value: get().getCurrentMode(moduleId) }, moduleId);
+        const rawSession = authenticationService.currentSessionValue;
+        const sessionGroups = rawSession?.group_permissions
+          ? ['all_users', ...rawSession.group_permissions.map((group) => group.name), rawSession?.role?.name]
+          : ['all_users', rawSession?.role?.name];
+        get().setResolvedGlobals(
+          'currentUser',
+          {
+            ...get().user,
+            groups: sessionGroups,
+            role: rawSession?.role?.name,
+            ssoUserInfo: rawSession?.current_user?.sso_user_info,
+            ...(rawSession?.current_user?.metadata && !isEmpty(rawSession.current_user.metadata)
+              ? { metadata: rawSession.current_user.metadata }
+              : {}),
+          },
+          moduleId
+        );
       }
 
       // Pages/components are cloned with new ids for every version (see server's
@@ -528,6 +584,8 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
           // Event handlers are cloned with new ids per version too — without this, click/
           // onPageLoad actions stay wired to the previous version's event definitions.
           get().eventsSlice.updateEventsField('events', data.events || [], moduleId);
+          // "Go to app" link targets — stale otherwise.
+          get().setLinkedApps(data.linkedApps ?? {}, moduleId);
 
           // Queries are cloned with new ids per version too (mirrors pages above), but
           // getAppVersionData doesn't return them — without this refetch, queryNameIdMapping/
@@ -544,6 +602,9 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
             moduleId
           );
           get().setQueryMapping(moduleId);
+          if (dataQueries?.length > 0) {
+            get().queryPanel.setSelectedQuery(dataQueries[0]?.id, moduleId);
+          }
         }
 
         get().initDependencyGraph(moduleId);

--- a/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
@@ -428,6 +428,14 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
         get().resetUndoRedoStack();
         get().queryPanel.setSelectedQuery(null, moduleId);
         get().queryPanel.setPreviewData(null);
+
+        // Global/Page "Variables" (exposedValues.variables/page.variables) otherwise carry
+        // over from the previous version instead of resetting to the new version's declared
+        // state, and ListView/Kanban's lazy-resolution bookkeeping keeps stale entries. Scoped
+        // to just those — constants/globals are already (re)populated by the explicit calls
+        // below/elsewhere in this action, so resetting them here too would just wipe fields
+        // (theme/urlparams/mode/currentUser) that nothing repopulates in this path.
+        get().resetExposedValues(moduleId, { resetConstants: false, resetGlobals: false });
       }
 
       get().setResolvedGlobals(

--- a/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
@@ -1,4 +1,10 @@
-import { appEnvironmentService, appVersionService, authenticationService } from '@/_services';
+import {
+  appEnvironmentService,
+  appVersionService,
+  authenticationService,
+  dataqueryService,
+  orgEnvironmentConstantService,
+} from '@/_services';
 import useStore from '@/AppBuilder/_stores/store';
 import toast from 'react-hot-toast';
 import {
@@ -6,6 +12,7 @@ import {
   hasEnvironmentAccess,
   getSafeEnvironment,
 } from '@/_helpers/environmentAccess';
+import { normalizeQueryTransformationOptions } from '@/AppBuilder/_hooks/useAppData';
 
 const initialState = {
   selectedVersion: null,
@@ -355,7 +362,7 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
     // only kicks in for `undefined`).
     moduleId = moduleId || 'canvas';
     try {
-      const data = await appVersionService.getAppVersionData(appId, versionId, get().currentMode);
+      const data = await appVersionService.getAppVersionData(appId, versionId, get().getCurrentMode(moduleId));
       const selectedVersion = {
         id: data.editing_version.id,
         name: data.editing_version.name,
@@ -407,11 +414,90 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
       }
 
       set((state) => ({ ...state, ...optionsToUpdate }));
+
+      // The App Builder's own version-switch effect (useAppData.js:880, skipped here via
+      // moduleMode) redoes all of the below unconditionally a moment after this action returns
+      // — so for the regular App Builder every one of these calls is pure redundant work (extra
+      // fetches, duplicate writes) that gets overwritten anyway. Restrict them to the module
+      // editor, which has no such follow-up effect and needs this action to be self-sufficient.
+      const isModuleApp = get().appStore?.modules?.canvas?.app?.appType === 'module';
+
+      if (isModuleApp) {
+        // Old version's undo/redo history and query-panel selection/preview no longer apply
+        // once the canvas has switched to a different version's (differently-id'd) state.
+        get().resetUndoRedoStack();
+        get().queryPanel.setSelectedQuery(null, moduleId);
+        get().queryPanel.setPreviewData(null);
+      }
+
       get().setResolvedGlobals(
         'environment',
         { id: appVersionEnvironment?.id, name: appVersionEnvironment?.name },
         moduleId
       );
+      // For branch-type versions, editing_version.name is the internal identifier — the
+      // human-readable name lives in display_name/displayName (server: versions/service.ts).
+      get().setResolvedGlobals(
+        'appVersion',
+        {
+          name: data.editing_version?.display_name || data.editing_version?.displayName || data.editing_version?.name,
+        },
+        moduleId
+      );
+
+      if (isModuleApp) {
+        // name/slug/isPublic/isMaintenanceOn are branch/version-scoped (see the app metadata
+        // storage model), so they can legitimately differ between versions — merge onto the
+        // existing app entry rather than replacing it. Unlike the App Builder's own switch
+        // path, this action never runs cleanUpStore, so a wholesale setApp() here would wipe
+        // fields (appId, co_relation_id, appType, ...) that this response doesn't carry.
+        get().setApp(
+          {
+            ...get().appStore?.modules?.[moduleId]?.app,
+            appName: data.branch_app_name || data.name,
+            slug: data.slug,
+            isPublic: data.isPublic,
+            isMaintenanceOn:
+              'is_maintenance_on' in data
+                ? data.is_maintenance_on
+                : 'isMaintenanceOn' in data
+                ? data.isMaintenanceOn
+                : false,
+            homePageId: data.editing_version?.homePageId || data.editing_version?.home_page_id,
+          },
+          moduleId
+        );
+
+        // A branch/version switch can land on a version with different active datasources.
+        get().fetchGlobalDataSources(
+          get().appStore?.modules?.[moduleId]?.app?.organizationId,
+          versionId,
+          appVersionEnvironment?.id
+        );
+
+        // Org constants/secrets are environment-scoped. Can't gate this on "did environment
+        // change" here: when this runs via environmentChangedAction's onSuccess (the
+        // dropdown's env-switch path), that action already wrote both selectedEnvironment and
+        // appVersionEnvironment to the new value before calling us — there's no pre-switch
+        // snapshot left to compare against. Always refetching is the simplest correct fix;
+        // it's one cheap, infrequent call, not a hot path.
+        if (appVersionEnvironment?.id) {
+          const { constants } = await orgEnvironmentConstantService.getConstantsFromEnvironment(
+            appVersionEnvironment.id
+          );
+          const orgConstants = {};
+          const orgSecrets = {};
+          constants.forEach((constant) => {
+            if (constant.type !== 'Secret') {
+              orgConstants[constant.name] = constant.value;
+            } else {
+              orgSecrets[constant.name] = constant.value;
+            }
+          });
+          get().setResolvedConstants(orgConstants, moduleId);
+          get().setSecrets(orgSecrets, moduleId);
+        }
+      }
 
       // Pages/components are cloned with new ids for every version (see server's
       // setupNewVersion), so the previously selected page id no longer exists on this
@@ -429,7 +515,42 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
         // values, not the raw page data — without rebuilding both here (mirroring the
         // mount-time load), the component tree stays blank until a reload recomputes them.
         get().setComponentNameIdMapping(moduleId);
+
+        if (isModuleApp) {
+          // Event handlers are cloned with new ids per version too — without this, click/
+          // onPageLoad actions stay wired to the previous version's event definitions.
+          get().eventsSlice.updateEventsField('events', data.events || [], moduleId);
+
+          // Queries are cloned with new ids per version too (mirrors pages above), but
+          // getAppVersionData doesn't return them — without this refetch, queryNameIdMapping/
+          // queryIdNameMapping keep pointing at the previous version's query ids, so canvas
+          // bindings referencing a query by name can't resolve and fall back to showing the
+          // stale id instead of the name. Must run before initDependencyGraph below, which
+          // reads the current queries list to register query dependencies.
+          const dataQueries =
+            (await dataqueryService.getAll(versionId, get().getCurrentMode(moduleId))).data_queries || [];
+          dataQueries.forEach((query) => normalizeQueryTransformationOptions(query));
+          get().dataQuery.setQueries(dataQueries, moduleId);
+          get().initialiseResolvedQuery(
+            dataQueries.map((query) => query.id),
+            moduleId
+          );
+          get().setQueryMapping(moduleId);
+        }
+
         get().initDependencyGraph(moduleId);
+
+        if (isModuleApp) {
+          // runOnPageLoad queries normally run via AppCanvas's Suspense-resolved ->
+          // isComponentLayoutReady(true) -> runOnLoadQueries cycle (useAppData.js), which
+          // fires on mount/remount. The App Builder still gets that for free: its
+          // version-switch effect (useAppData.js:880, skipped here via moduleMode)
+          // unmounts/remounts the canvas behind its loader, retriggering the cycle there —
+          // calling runOnLoadQueries here too would run every runOnPageLoad query twice. The
+          // module editor never unmounts on switch (no loader), so it's the only case where
+          // that cycle never fires and needs it explicitly.
+          get().dataQuery.runOnLoadQueries(moduleId);
+        }
       }
 
       onSuccess(data);


### PR DESCRIPTION
## Root cause

The standalone module editor and the regular App Builder are the same `Editor` component, but they diverge on version/environment switching:

- **App Builder** drives a switch through a `useEffect` in `useAppData.js` that fetches the full app-version payload, wipes the store (`cleanUpStore`), and repopulates everything — pages, queries, events, globals, app metadata, datasources, constants, settings — behind a loading spinner.
- **Module editor** deliberately skips that effect (`if (moduleMode) return;`, since re-enabling it raced against `changeEditorVersionAction`'s own updates) and relies solely on `changeEditorVersionAction` to refresh state in place, with no full reset and no loader — that's what keeps module version switches instant and flicker-free.

`changeEditorVersionAction` was only ever a partial reimplementation of what the App Builder's effect does — it handled pages/components, but nothing else. Every gap below is something the App Builder gets "for free" via its full refetch/remount that the module editor's leaner path never had.

## What's fixed

All of the following is gated on `isModuleApp`, so the regular App Builder's version switch is untouched — its own effect already does all of this via a full refetch/remount; adding it unconditionally would just double the work (or, for `runOnPageLoad` queries, double-run them).

- **Query dereferencing**: canvas bindings referencing a query by name resolved to the previous version's stale id instead of the new one (queries were never refetched on switch)
- **`runOnPageLoad` queries** never re-ran after a switch (no unmount/remount cycle to retrigger them) — required a manual Run
- **`globals.appVersion.name`** showed the version's internal id instead of its display name for branch-type versions
- **Undo/redo history** and **query-panel selection/preview** carried over from the previous version instead of resetting
- **App metadata** (name/slug/isPublic/isMaintenanceOn/homePageId) — branch/version-scoped fields stayed stale after switching to a different branch version
- **Datasources** and **environment-scoped org constants/secrets** weren't refetched for the new version/environment
- **Global/Page "Variables"** (`exposedValues.variables`/`page.variables`) carried over instead of resetting to the new version's declared state
- **Global/page settings** (theme, JS libraries, preloaded script, page settings) weren't reapplied
- **`globals.theme`/`urlparams`/`mode`/`currentUser`** stayed at whatever was resolved at mount
- **`linkedApps`** ("go to app" targets) stayed stale
- **Query panel** kept no selection after a switch instead of defaulting to the new version's first query
- Guards against a related crash (`Cannot read properties of undefined`) from stale dependency-graph entries referencing the previous version's components

## Test plan
- [x] Switch versions in the module editor — query names resolve, no stale ids
- [x] `runOnPageLoad` query auto-runs on switch (no manual Run needed)
- [x] `globals.appVersion.name` shows the version's display name, not a uuid
- [x] Switch to a branch/gitsync version — app name/slug/isPublic update
- [x] Global/Page Variables reset to the new version's declared state on switch
- [x] Global/page settings (theme, JS libraries, page settings) update on switch
- [x] `globals.urlparams`/`theme`/`mode`/`currentUser` resolve without error
- [x] "Go to app" actions still target the right app after a switch
- [x] Query panel defaults to the new version's first query after a switch
- [x] Repeated/rapid switching — no duplicate query runs, no console errors
- [x] Regular App Builder version switch unaffected (loader/refetch behavior, timing, and network calls unchanged)