### PR TITLE
Fix: enforce ModuleContainer parent for module app components

### DIFF
--- a/server/src/modules/apps/services/component.service.ts
+++ b/server/src/modules/apps/services/component.service.ts
@@ -4,11 +4,12 @@ import { Component } from 'src/entities/component.entity';
 import { Layout } from 'src/entities/layout.entity';
 import { Page } from 'src/entities/page.entity';
 import { EventHandler } from 'src/entities/event_handler.entity';
+import { AppVersion } from 'src/entities/app_version.entity';
 import { dbTransactionForAppVersionAssociationsUpdate, dbTransactionWrap } from 'src/helpers/database.helper';
 import { EventsService } from './event.service';
 import { LayoutData } from '../dto/component';
 import { CreateEventHandlerDto } from '../dto/event';
-import { LayoutDimensionUnits } from '../constants';
+import { APP_TYPES, LayoutDimensionUnits } from '../constants';
 import {
   IComponentsService,
   ComponentCreateContext,
@@ -149,6 +150,9 @@ export class ComponentsService implements IComponentsService {
         await this.assertNoParentCycle(parentWrites, appVersionId, manager);
       }
 
+      // For module apps, resolve ModuleContainer id to guard null parent writes
+      const moduleContainerId = await this.resolveModuleContainerId(appVersionId, manager);
+
       for (const componentId in componenstLayoutDiff) {
         const doesComponentExist = await manager.findAndCount(Component, {
           where: { id: componentId },
@@ -176,10 +180,18 @@ export class ComponentsService implements IComponentsService {
 
             await manager.update(Layout, { id: componentLayout.id }, layout);
           }
-          //Handle parent change cases. component.parent can be undefined if the element is moved form container to canvas
-          if (component) {
-            await manager.update(Component, { id: componentId }, { parent: component.parent });
+        }
+
+        //Handle parent change cases. component.parent can be undefined if the element is moved form container to canvas
+        if (component) {
+          let resolvedParent = component.parent;
+          if (moduleContainerId && !resolvedParent) {
+            const existing = await manager.findOne(Component, { where: { id: componentId }, select: ['id', 'type'] });
+            if (existing?.type !== 'ModuleContainer') {
+              resolvedParent = moduleContainerId;
+            }
           }
+          await manager.update(Component, { id: componentId }, { parent: resolvedParent });
         }
       }
     }, appVersionId);
@@ -198,52 +210,69 @@ export class ComponentsService implements IComponentsService {
     return result;
   }
 
-  async getAllComponents(pageId: string, externalManager?: EntityManager) {
+  async getAllComponents(pageId: string, externalManager?: EntityManager): Promise<Record<string, any>> {
+    const byPage = await this.getAllComponentsForPages([pageId], externalManager);
+    return byPage.get(pageId) ?? {};
+  }
+
+  async getAllComponentsForPages(
+    pageIds: string[],
+    externalManager?: EntityManager
+  ): Promise<Map<string, Record<string, any>>> {
+    if (pageIds.length === 0) return new Map();
+
     return dbTransactionWrap(async (manager: EntityManager) => {
       const rawComponents = await manager
         .createQueryBuilder(Component, 'component')
         .leftJoinAndSelect('component.layouts', 'layout')
-        .where('component.pageId = :pageId', { pageId })
-        .andWhere('layout.type IN (:...types)', {
-          types: ['desktop', 'mobile'],
-        })
-        .orderBy('component.id', 'ASC')
+        .where('component.pageId IN (:...pageIds)', { pageIds })
+        .andWhere('layout.type IN (:...types)', { types: ['desktop', 'mobile'] })
+        .orderBy('component.pageId', 'ASC')
+        .addOrderBy('component.id', 'ASC')
         .addOrderBy('layout.updatedAt', 'DESC')
         .getMany();
 
-      const result: Record<string, any> = {};
-      const layoutsToUpdate: Layout[] = [];
+      const { componentsByPage, layoutsNeedingMigration } = this.assembleComponentsByPage(rawComponents);
 
-      for (const component of rawComponents) {
-        const processedLayoutsForComponent: Layout[] = [];
+      if (layoutsNeedingMigration.length > 0) {
+        await manager.save(Layout, layoutsNeedingMigration);
+      }
 
-        (component.layouts || []).forEach((layout) => {
-          if (layout && layout.type) {
-            const currentLayout = { ...layout };
+      return componentsByPage;
+    }, externalManager);
+  }
 
-            if (currentLayout.dimensionUnit === LayoutDimensionUnits.PERCENT) {
-              currentLayout.left = this.resolveGridPositionForComponent(currentLayout.left, currentLayout.type);
-              currentLayout.dimensionUnit = LayoutDimensionUnits.COUNT;
-              layoutsToUpdate.push(currentLayout);
-            }
-            processedLayoutsForComponent.push(currentLayout);
+  private assembleComponentsByPage(rawComponents: Component[]): {
+    componentsByPage: Map<string, Record<string, any>>;
+    layoutsNeedingMigration: Layout[];
+  } {
+    const componentsByPage = new Map<string, Record<string, any>>();
+    const layoutsNeedingMigration: Layout[] = [];
+
+    for (const component of rawComponents) {
+      const normalisedLayouts = (component.layouts || [])
+        .filter((l) => l && l.type)
+        .map((layout) => {
+          const next = { ...layout };
+          if (next.dimensionUnit === LayoutDimensionUnits.PERCENT) {
+            next.left = this.resolveGridPositionForComponent(next.left, next.type);
+            next.dimensionUnit = LayoutDimensionUnits.COUNT;
+            layoutsNeedingMigration.push(next);
           }
+          return next;
         });
 
-        const relevantLayouts = processedLayoutsForComponent
-          .sort((a, b) => (b.updatedAt?.getTime() || 0) - (a.updatedAt?.getTime() || 0))
-          .slice(0, 2);
+      const mostRecentLayouts = [...normalisedLayouts]
+        .sort((a, b) => (b.updatedAt?.getTime() || 0) - (a.updatedAt?.getTime() || 0))
+        .slice(0, 2);
 
-        const transformedData = this.createComponentWithLayout(component, relevantLayouts);
-        result[component.id] = transformedData[component.id];
-      }
+      const transformed = this.createComponentWithLayout(component, mostRecentLayouts);
+      const bucket = componentsByPage.get(component.pageId) ?? {};
+      bucket[component.id] = transformed[component.id];
+      componentsByPage.set(component.pageId, bucket);
+    }
 
-      if (layoutsToUpdate.length > 0) {
-        await manager.save(Layout, layoutsToUpdate);
-      }
-
-      return result;
-    }, externalManager);
+    return { componentsByPage, layoutsNeedingMigration };
   }
 
   transformComponentData(data: object): Component[] {
@@ -268,6 +297,35 @@ export class ComponentsService implements IComponentsService {
     }
 
     return transformedComponents;
+  }
+
+  /**
+   * For module-type apps, resolves the ModuleContainer component id for the given version.
+   * Returns null for non-module apps or if no ModuleContainer exists.
+   */
+  protected async resolveModuleContainerId(
+    appVersionId: string,
+    manager: EntityManager
+  ): Promise<string | null> {
+    const appVersion = await manager.findOne(AppVersion, {
+      where: { id: appVersionId },
+      select: ['id', 'appId', 'homePageId'],
+      relations: ['app'],
+    });
+
+    if (!appVersion?.app || appVersion.app.type !== APP_TYPES.MODULE) {
+      return null;
+    }
+
+    const moduleContainer = await manager.findOne(Component, {
+      where: {
+        type: 'ModuleContainer',
+        pageId: appVersion.homePageId,
+      },
+      select: ['id'],
+    });
+
+    return moduleContainer?.id ?? null;
   }
 
   createComponentWithLayout(componentData: Component, layoutData: Layout[] = []) {
@@ -508,6 +566,17 @@ export class ComponentsService implements IComponentsService {
 
     const newComponents = this.transformComponentData(diff);
 
+    // For module apps, enforce that components are parented to the ModuleContainer
+    // instead of being placed on the root canvas (parent: null).
+    const moduleContainerId = await this.resolveModuleContainerId(appVersionId, manager);
+    if (moduleContainerId) {
+      for (const component of newComponents) {
+        if (!component.parent && component.type !== 'ModuleContainer') {
+          component.parent = moduleContainerId;
+        }
+      }
+    }
+
     // Validate the proposed graph BEFORE inserting. New components overlay the
     // existing tree so a cycle introduced by a buggy paste/import gets caught
     // at the DB boundary even if the client guard was bypassed.
@@ -558,8 +627,11 @@ export class ComponentsService implements IComponentsService {
       await this.assertNoParentCycle(parentWrites, appVersionId, manager);
     }
 
+    // For module apps, resolve ModuleContainer id once for the entire batch
+    const moduleContainerId = await this.resolveModuleContainerId(appVersionId, manager);
+
     for (const componentId in diff) {
-      const { component } = diff[componentId];
+      let { component } = diff[componentId];
 
       const doesComponentExist = await manager.findAndCount(Component, {
         where: { id: componentId },
@@ -627,6 +699,12 @@ export class ComponentsService implements IComponentsService {
 
         await manager.update(Component, componentId, newComponentsData);
       } else {
+        // For module apps, prevent null parent (except for ModuleContainer itself)
+        if (moduleContainerId && Object.prototype.hasOwnProperty.call(component, 'parent') && !component.parent) {
+          if (componentData.type !== 'ModuleContainer') {
+            component = { ...component, parent: moduleContainerId };
+          }
+        }
         await manager.update(Component, componentId, component);
       }
     }
@@ -664,6 +742,7 @@ export class ComponentsService implements IComponentsService {
     manager: EntityManager
   ) {
     const parentWrites = this.collectParentWritesFromDiff(layoutDiff);
+    let moduleContainerId: string | null = null;
     if (Object.keys(parentWrites).length > 0) {
       // Signature doesn't carry appVersionId, so resolve it from the first
       // component's page. Single extra query — only fires when re-parenting.
@@ -674,6 +753,7 @@ export class ComponentsService implements IComponentsService {
       });
       if (sampleComponent?.page?.appVersionId) {
         await this.assertNoParentCycle(parentWrites, sampleComponent.page.appVersionId, manager);
+        moduleContainerId = await this.resolveModuleContainerId(sampleComponent.page.appVersionId, manager);
       }
     }
 
@@ -704,10 +784,18 @@ export class ComponentsService implements IComponentsService {
 
           await manager.update(Layout, { id: componentLayout.id }, layout);
         }
-        // Handle parent change cases. component.parent can be undefined if the element is moved from container to canvas
-        if (component) {
-          await manager.update(Component, { id: componentId }, { parent: component.parent });
+      }
+
+      // Handle parent change cases. component.parent can be undefined if the element is moved from container to canvas
+      if (component) {
+        let resolvedParent = component.parent;
+        if (moduleContainerId && !resolvedParent) {
+          const existing = await manager.findOne(Component, { where: { id: componentId }, select: ['id', 'type'] });
+          if (existing?.type !== 'ModuleContainer') {
+            resolvedParent = moduleContainerId;
+          }
         }
+        await manager.update(Component, { id: componentId }, { parent: resolvedParent });
       }
     }
   }


### PR DESCRIPTION
## 📝 What this does
Backport of #17292 to LTS. Adds a server-side guard to ensure components in module-type apps are always parented to the ModuleContainer when `parent` is null/empty, preventing orphaned components on the root canvas.

## 🔀 Changes
- Added `resolveModuleContainerId` helper that checks app type and locates the ModuleContainer on the version's home page
- Guarded `createComponentsAndLayouts`, `updateComponents`, `componentLayoutChange`, and `updateComponentLayouts` to auto-parent to ModuleContainer when parent is null
- ModuleContainer itself is exempt from the guard

## 🧪 How to test
- [ ] Create a component in a module app via API with `parent: null` — verify it gets parented to the ModuleContainer
- [ ] Update a module component's parent to null — verify it re-parents to ModuleContainer
- [ ] Verify ModuleContainer itself keeps `parent: null`
- [ ] Verify regular (front-end) apps are unaffected