### PR TITLE
fix: add padding-right to password input to prevent eye icon overlap (#17283)

### DIFF
--- a/frontend/src/components/ui/Input/Input.jsx
+++ b/frontend/src/components/ui/Input/Input.jsx
@@ -42,6 +42,7 @@ const Input = React.forwardRef(
             className={cn(
               inputVariants({ size }),
               `tw-peer tw-flex tw-text-[12px]/[18px] tw-w-full tw-rounded-[8px] tw-border-[1px] tw-border-solid tw-bg-background-surface-layer-01 tw-py-[7px] tw-text-text-default focus-visible:tw-ring-[1px] focus-visible:tw-ring-offset-[1px] focus-visible:tw-ring-border-accent-strong focus-visible:tw-ring-offset-border-accent-strong focus-visible:tw-border-transparent disabled:tw-cursor-not-allowed ${props.styles}`,
+              isPasswordField && 'tw-pr-[40px]',
               className
             )}
             ref={ref}


### PR DESCRIPTION
Fixes #17283

The eye icon in password inputs is positioned absolutely (`right: 8px`)
but the input had no padding-right reserved for it, so long masked
values (like API keys) run underneath the icon.

Added `tw-pr-[40px]` to the input's className for password fields
specifically, to clear the icon.

however, I wasn't able to get the app run locally to visually test this
end to end (ran into environment/setup issues). If someone could
test it and give feedback, I'd really appreciate it and will fix
anything that's off.