### PR TITLE
ci: wire git-sync e2e suite into CI against the live simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,16 @@ jobs:
       ENABLE_TOOLJET_DB: 'true'
       ENABLE_EXTERNAL_API: 'true'
       EXTERNAL_API_ACCESS_TOKEN: test-external-api-token
+      # git-sync e2e: real Gitea/GitHub-Enterprise-shaped simulator. Repo path is
+      # namespaced per run (must start with "run-ci/" per simulator owner) so
+      # concurrent CI runs don't collide on the same shared repo.
+      TEST_GIT_BASE_URL: ${{ secrets.GIT_SYNC_SIMULATOR_BASE_URL }}
+      TEST_GIT_REPO_PATH: run-ci/${{ github.run_id }}-${{ github.run_attempt }}
+      TOOLJET_GIT_ADMIN_USER: ${{ secrets.GIT_SYNC_SIMULATOR_ADMIN_USER }}
+      TOOLJET_GIT_ADMIN_PASSWORD: ${{ secrets.GIT_SYNC_SIMULATOR_ADMIN_PASSWORD }}
+      TOOLJET_GITHUB_APP_ID: ${{ secrets.GIT_SYNC_GITHUB_APP_ID }}
+      TOOLJET_GITHUB_INSTALLATION_ID: ${{ secrets.GIT_SYNC_GITHUB_INSTALLATION_ID }}
+      TOOLJET_GITHUB_APP_PRIVATE_KEY: ${{ secrets.GIT_SYNC_GITHUB_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v7
       - name: Checkout EE submodules
@@ -426,6 +436,16 @@ jobs:
       ENABLE_TOOLJET_DB: 'true'
       ENABLE_EXTERNAL_API: 'true'
       EXTERNAL_API_ACCESS_TOKEN: test-external-api-token
+      # git-sync e2e: real Gitea/GitHub-Enterprise-shaped simulator. Repo path is
+      # namespaced per run (must start with "run-ci/" per simulator owner) so
+      # concurrent CI runs don't collide on the same shared repo.
+      TEST_GIT_BASE_URL: ${{ secrets.GIT_SYNC_SIMULATOR_BASE_URL }}
+      TEST_GIT_REPO_PATH: run-ci/${{ github.run_id }}-${{ github.run_attempt }}
+      TOOLJET_GIT_ADMIN_USER: ${{ secrets.GIT_SYNC_SIMULATOR_ADMIN_USER }}
+      TOOLJET_GIT_ADMIN_PASSWORD: ${{ secrets.GIT_SYNC_SIMULATOR_ADMIN_PASSWORD }}
+      TOOLJET_GITHUB_APP_ID: ${{ secrets.GIT_SYNC_GITHUB_APP_ID }}
+      TOOLJET_GITHUB_INSTALLATION_ID: ${{ secrets.GIT_SYNC_GITHUB_INSTALLATION_ID }}
+      TOOLJET_GITHUB_APP_PRIVATE_KEY: ${{ secrets.GIT_SYNC_GITHUB_APP_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/server/test/jest-e2e.config.ts
+++ b/server/test/jest-e2e.config.ts
@@ -15,11 +15,11 @@ const config: Config.InitialOptions = {
   testRegex: 'test/modules/.*/e2e/.*spec\\.ts$',
   // Explicitly setting this key drops Jest's own default ('/node_modules/'), so it's
   // restored here — rootDir now covers server/node_modules too.
-  // QUARANTINE(git-sync): suites throw at import (require TEST_GIT_BASE_URL +
-  // a live git server) — describe.skip can't guard module-load failures. #17265
+  // QUARANTINE(git-sync-gitlab): suite throws at import (requires TEST_GIT_BASE_URL +
+  // a live GitLab-shaped simulator not yet wired into CI) — describe.skip can't guard
+  // module-load failures. #17265
   testPathIgnorePatterns: [
     '/node_modules/',
-    'modules/git-sync/e2e/git-sync\\.spec\\.ts$',
     'modules/git-sync/e2e/git-sync-gitlab\\.spec\\.ts$',
     'modules/workflows/e2e/workflow-lifecycle\\.e2e-spec\\.ts$',
   ],


### PR DESCRIPTION
## Summary

`test/modules/git-sync/e2e/git-sync.spec.ts` has been quarantined out of the e2e run (`jest-e2e.config.ts` `testPathIgnorePatterns`, #17265) because it throws at import time — its module-level `requireEnv()` calls hard-require `TEST_GIT_BASE_URL` and related vars that point at a real git-hosting simulator, none of which are set anywhere in `.github/workflows/`.

This PR:
- Removes `git-sync.spec.ts` from `testPathIgnorePatterns` in `server/test/jest-e2e.config.ts`. (`git-sync-gitlab.spec.ts` stays quarantined — separate simulator, out of scope here.)
- Adds the required env vars to the `test-server` and `test-changed` jobs in `ci.yml`, sourced from new repo secrets:
  - `TEST_GIT_BASE_URL` ← `secrets.GIT_SYNC_SIMULATOR_BASE_URL`
  - `TOOLJET_GIT_ADMIN_USER` / `TOOLJET_GIT_ADMIN_PASSWORD` ← `secrets.GIT_SYNC_SIMULATOR_ADMIN_USER` / `secrets.GIT_SYNC_SIMULATOR_ADMIN_PASSWORD`
  - `TOOLJET_GITHUB_APP_ID` / `TOOLJET_GITHUB_INSTALLATION_ID` / `TOOLJET_GITHUB_APP_PRIVATE_KEY` ← `secrets.GIT_SYNC_GITHUB_APP_ID` / `secrets.GIT_SYNC_GITHUB_INSTALLATION_ID` / `secrets.GIT_SYNC_GITHUB_APP_PRIVATE_KEY`
  - `TEST_GIT_REPO_PATH` — set inline (no secret needed) to `run-ci/${{ github.run_id }}-${{ github.run_attempt }}`, per the simulator owner's ask that per-run paths start with `run-ci/`. This namespaces every CI run to its own repo on the simulator so concurrent runs don't collide on shared state (the suite does a destructive reset-then-64-step build-up against whatever repo path it's given).

## Needs DevOps

This suite talks to a **real external git-hosting simulator** (custom Gitea/GitHub-Enterprise-shaped service, not a container spun up in CI). Before this can merge and actually pass, the following **repository secrets** need to be added:

| Secret | Value |
|---|---|
| `GIT_SYNC_SIMULATOR_BASE_URL` | Base URL of the simulator (e.g. `http://<host>:<port>`) |
| `GIT_SYNC_SIMULATOR_ADMIN_USER` | Basic-auth user for the simulator's `/admin/*` endpoints (reset/merge/files) |
| `GIT_SYNC_SIMULATOR_ADMIN_PASSWORD` | Basic-auth password for the same |
| `GIT_SYNC_GITHUB_APP_ID` | GitHub App ID the server authenticates as against the simulator |
| `GIT_SYNC_GITHUB_INSTALLATION_ID` | GitHub App installation ID |
| `GIT_SYNC_GITHUB_APP_PRIVATE_KEY` | GitHub App private key (PEM, `\n`-escaped is fine — the suite un-escapes it) |

## Known open item — repo cleanup on the simulator

The suite's simulator `/admin/*/reset` endpoint only wipes a repo's *contents*, it never deletes the repo itself, and nothing in the spec or this workflow deletes a run's `run-ci/<run_id>-<attempt>` repo afterward. Every CI run will create a new repo on the simulator that lives there permanently unless one of:
- the simulator has its own retention/GC for `run-ci/*` paths, or
- we add a cleanup step (calling a delete endpoint, if one exists) to the workflow.

Flagging this so whoever owns the simulator can confirm which applies — not blocking this PR, but will need addressing before this runs at real CI volume.

## Test plan
- [ ] DevOps adds the six secrets above
- [ ] Confirm `git-sync.spec.ts` runs (not skipped) in a CI run on this branch
- [ ] Confirm two concurrent CI runs don't collide (distinct `run-ci/<run_id>-<attempt>` repo paths)
- [ ] Confirm with simulator owner whether repo cleanup is needed