### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Documentation is available at https://docs.tooljet.com.
 ## Self-hosted
 You can use ToolJet Cloud for a fully managed solution. If you want to self-host ToolJet, we have guides on deploying ToolJet on Kubernetes, AWS EC2, Docker, and more.
 
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/tooljet)
+
+One-click managed ToolJet, with no infrastructure to run: storage, backups, email and a free subdomain included. A share of every subscription goes back to ToolJet.
+
 | Provider  | Documentation |
 | :------------- | :------------- |
 | Digital Ocean | [Link](https://docs.tooljet.com/docs/setup/digitalocean)  |


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added ToolJet to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Self-hosted (links to https://zenith.hosting/host/tooljet).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting