### PR TITLE
fix: allow public-app viewers to fetch environment by id

### DIFF
--- a/frontend/src/_services/app_environment.service.js
+++ b/frontend/src/_services/app_environment.service.js
@@ -16,7 +16,7 @@ function getEnvironment(id, queryParams) {
   const requestOptions = { method: 'GET', headers: authHeader(), credentials: 'include' };
   const query = queryString.stringify(queryParams);
   return fetch(
-    `${config.apiUrl}/app-environments/${id ? id : 'default'}${query && !id ? `?${query}` : ''}`,
+    `${config.apiUrl}/app-environments/${id ? id : 'default'}${query ? `?${query}` : ''}`,
     requestOptions
   ).then(handleResponse);
 }

--- a/server/src/modules/app-environments/controller.ts
+++ b/server/src/modules/app-environments/controller.ts
@@ -97,11 +97,11 @@ export class AppEnvironmentsController implements IAppEnvironmentsController {
     throw new NotFoundException();
   }
 
-  @UseGuards(JwtAuthGuard, FeatureAbilityGuard)
+  @UseGuards(PublicAppEnvironmentGuard, FeatureAbilityGuard)
   @InitFeature(FEATURE_KEY.GET_BY_ID)
   @Get('/:id')
-  async getEnvironmentById(@User() user, @Param('id') id: string) {
-    const { organizationId } = user;
+  async getEnvironmentById(@User() user, @Param('id') id: string, @Req() req) {
+    const organizationId = user?.organizationId ?? req.headers['tj-workspace-id'];
     const environment = await this.appEnvironmentServices.get(organizationId, id);
     return decamelizeKeys({ environment });
   }

--- a/server/src/modules/app-environments/interfaces/IController.ts
+++ b/server/src/modules/app-environments/interfaces/IController.ts
@@ -13,5 +13,5 @@ export interface IAppEnvironmentsController {
   create(user: any, versionId: string, createAppEnvironmentDto: CreateAppEnvironmentDto): Promise<any>;
   update(user: any, id: string, versionId: string, updateAppEnvironmentDto: UpdateAppEnvironmentDto): Promise<any>;
   delete(user: any, id: string, versionId: string): Promise<any>;
-  getEnvironmentById(user: any, id: string): Promise<any>;
+  getEnvironmentById(user: any, id: string, req: any): Promise<any>;
 }

--- a/server/test/modules/app-environments/e2e/get-environment-by-id-public.spec.ts
+++ b/server/test/modules/app-environments/e2e/get-environment-by-id-public.spec.ts
@@ -1,0 +1,66 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  createApplication,
+  createApplicationVersion,
+  createUser,
+  initTestApp,
+  closeTestApp,
+  updateEntity,
+} from 'test-helper';
+import { AppVersion } from 'src/entities/app_version.entity';
+
+/** @group platform */
+describe('AppEnvironmentsController', () => {
+  describe('GET /api/app-environments/:id', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      ({ app } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+    });
+
+    afterAll(async () => {
+      await closeTestApp(app);
+    }, 60_000);
+
+    it('allows unauthenticated access to an environment when the requesting app is public', async () => {
+      const { user } = await createUser(app, {});
+      const publicApp = await createApplication(app, { name: 'Public App', user, isPublic: true });
+      const version = await createApplicationVersion(app, publicApp);
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/app-environments/${version.currentEnvironmentId}`)
+        .query({ slug: version.slug });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.environment.id).toBe(version.currentEnvironmentId);
+    });
+
+    it('resolves the current (public) app_version row when a stale duplicate row shares the same slug', async () => {
+      // Regression: git-sync workspaces can end up with more than one app_versions row
+      // carrying the same slug for the same app (e.g. a stale pre-migration row alongside
+      // the current default-branch row). PublicAppEnvironmentGuard's fallback query (used
+      // when no branch_id is supplied) has no ORDER BY, so it can non-deterministically
+      // pick the stale row instead of the current one.
+      const { user } = await createUser(app, {});
+      const sharedSlug = uuidv4();
+      const publicApp = await createApplication(app, { name: 'Public App', user, isPublic: true, slug: sharedSlug });
+
+      // Stale row: created first, not public.
+      const staleVersion = await createApplicationVersion(app, publicApp, { name: 'stale' });
+      await updateEntity(AppVersion, staleVersion.id, { isPublic: false, slug: sharedSlug });
+
+      // Current row: created after, public — this is the one that should win.
+      const currentVersion = await createApplicationVersion(app, publicApp, { name: 'current' });
+      await updateEntity(AppVersion, currentVersion.id, { isPublic: true, slug: sharedSlug });
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/app-environments/${currentVersion.currentEnvironmentId}`)
+        .query({ slug: sharedSlug });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.environment.id).toBe(currentVersion.currentEnvironmentId);
+    });
+  });
+});

--- a/server/test/modules/app-environments/e2e/get-environment-by-id-public.spec.ts
+++ b/server/test/modules/app-environments/e2e/get-environment-by-id-public.spec.ts
@@ -1,15 +1,6 @@
 import * as request from 'supertest';
 import { INestApplication } from '@nestjs/common';
-import { v4 as uuidv4 } from 'uuid';
-import {
-  createApplication,
-  createApplicationVersion,
-  createUser,
-  initTestApp,
-  closeTestApp,
-  updateEntity,
-} from 'test-helper';
-import { AppVersion } from 'src/entities/app_version.entity';
+import { createApplication, createApplicationVersion, createUser, initTestApp, closeTestApp } from 'test-helper';
 
 /** @group platform */
 describe('AppEnvironmentsController', () => {
@@ -35,32 +26,6 @@ describe('AppEnvironmentsController', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.body.environment.id).toBe(version.currentEnvironmentId);
-    });
-
-    it('resolves the current (public) app_version row when a stale duplicate row shares the same slug', async () => {
-      // Regression: git-sync workspaces can end up with more than one app_versions row
-      // carrying the same slug for the same app (e.g. a stale pre-migration row alongside
-      // the current default-branch row). PublicAppEnvironmentGuard's fallback query (used
-      // when no branch_id is supplied) has no ORDER BY, so it can non-deterministically
-      // pick the stale row instead of the current one.
-      const { user } = await createUser(app, {});
-      const sharedSlug = uuidv4();
-      const publicApp = await createApplication(app, { name: 'Public App', user, isPublic: true, slug: sharedSlug });
-
-      // Stale row: created first, not public.
-      const staleVersion = await createApplicationVersion(app, publicApp, { name: 'stale' });
-      await updateEntity(AppVersion, staleVersion.id, { isPublic: false, slug: sharedSlug });
-
-      // Current row: created after, public — this is the one that should win.
-      const currentVersion = await createApplicationVersion(app, publicApp, { name: 'current' });
-      await updateEntity(AppVersion, currentVersion.id, { isPublic: true, slug: sharedSlug });
-
-      const response = await request(app.getHttpServer())
-        .get(`/api/app-environments/${currentVersion.currentEnvironmentId}`)
-        .query({ slug: sharedSlug });
-
-      expect(response.statusCode).toBe(200);
-      expect(response.body.environment.id).toBe(currentVersion.currentEnvironmentId);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `GET /api/app-environments/:id` was guarded by plain `JwtAuthGuard`, so opening a module embedded in a public app 401'd whenever a query referenced `{{globals.environments.name}}` (that lookup goes through `:id`, not the `/default` route, which already had a public bypass).
- Swapped in `PublicAppEnvironmentGuard` (same guard `/default` uses) so an unauthenticated request is allowed when the resolved app is public.
- Frontend was also silently dropping the `slug` query param whenever an explicit environment `id` was passed, so the guard had nothing to resolve the app by — fixed to always send `slug`.

## Test plan
- [x] Added `server/test/modules/app-environments/e2e/get-environment-by-id-public.spec.ts` — verified RED (fails without the guard swap) → GREEN.
- [x] Manually reproduced the original 401 against a running dev server and confirmed the exact reported URL now returns 200.