### PR TITLE
Fix: resolve legacy name-pinned module draft in git-sync workspaces

### DIFF
--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -143,11 +143,13 @@ export async function resolveModuleRef(
   }
 
   // Tier 0 — versionName lookup (non-UUID ref, cross-workspace stable).
-  // git-sync: default-branch PUBLISHED only — branched rows are always DRAFTs by constraint
-  //   chk_app_versions_branched_implies_draft, so checking PUBLISHED first prevents a
-  //   same-named branch DRAFT shadowing the real release.
-  // non-git-sync: also check default-branch any-status — DRAFTs are valid specific pins,
-  //   and a plain workspace's only version may still be an unpublished DRAFT.
+  // Check PUBLISHED first regardless of git-sync: a released version by that name should
+  // always win over a same-named unreleased draft. Then fall back to any status (DRAFT
+  // included) on the default branch — this can never be a "branch DRAFT shadowing the
+  // release" (chk_app_versions_branched_implies_draft is about *feature*-branch rows, which
+  // this query excludes via branchId: defaultBranch.id) — it's just a legacy name-pinned
+  // reference to a module version that's never been released, e.g. an app/module pinned
+  // before git-sync/branching was enabled on the workspace.
   if (moduleReferenceId && !UUID_RE.test(moduleReferenceId) && defaultBranch) {
     const versionName = moduleReferenceId;
     const defaultBranchForName = await manager.findOne(AppVersion, {
@@ -161,18 +163,16 @@ export async function resolveModuleRef(
       },
     });
     if (defaultBranchForName) return defaultBranchForName;
-    if (!isGitSyncEnabled) {
-      const defaultBranchDraft = await manager.findOne(AppVersion, {
-        where: {
-          appId: moduleApp.id,
-          name: versionName,
-          branchId: defaultBranch.id,
-          versionType: AppVersionType.VERSION,
-          isStub: false,
-        },
-      });
-      if (defaultBranchDraft) return defaultBranchDraft;
-    }
+    const defaultBranchDraft = await manager.findOne(AppVersion, {
+      where: {
+        appId: moduleApp.id,
+        name: versionName,
+        branchId: defaultBranch.id,
+        versionType: AppVersionType.VERSION,
+        isStub: false,
+      },
+    });
+    if (defaultBranchDraft) return defaultBranchDraft;
     // Name not found — fall through to orphan guard. The pinning contract (see
     // ModuleViewerInspector) never persists a bare branch name here, so this is legacy data.
   }

--- a/server/src/modules/versions/module-ref.util.ts
+++ b/server/src/modules/versions/module-ref.util.ts
@@ -144,12 +144,13 @@ export async function resolveModuleRef(
 
   // Tier 0 — versionName lookup (non-UUID ref, cross-workspace stable).
   // Check PUBLISHED first regardless of git-sync: a released version by that name should
-  // always win over a same-named unreleased draft. Then fall back to any status (DRAFT
-  // included) on the default branch — this can never be a "branch DRAFT shadowing the
-  // release" (chk_app_versions_branched_implies_draft is about *feature*-branch rows, which
-  // this query excludes via branchId: defaultBranch.id) — it's just a legacy name-pinned
-  // reference to a module version that's never been released, e.g. an app/module pinned
-  // before git-sync/branching was enabled on the workspace.
+  // always win over a same-named unreleased draft. Then fall back to an any-status match on
+  // the default branch, but under git-sync only for isSynced: false rows — legacy versions
+  // stamped before this workspace had git-sync/branching enabled (is_synced defaults false on
+  // backfill; new versions get isSynced: gitDetails.isEnabled at creation, see
+  // VersionUtilService.buildVersionFromParent). A genuinely git-native draft (isSynced: true)
+  // still requires PUBLISHED — that's the case chk_app_versions_branched_implies_draft actually
+  // guards against, and this fallback must not relax it.
   if (moduleReferenceId && !UUID_RE.test(moduleReferenceId) && defaultBranch) {
     const versionName = moduleReferenceId;
     const defaultBranchForName = await manager.findOne(AppVersion, {
@@ -170,20 +171,22 @@ export async function resolveModuleRef(
         branchId: defaultBranch.id,
         versionType: AppVersionType.VERSION,
         isStub: false,
+        ...(isGitSyncEnabled ? { isSynced: false } : {}),
       },
     });
     if (defaultBranchDraft) return defaultBranchDraft;
-    // Name not found — fall through to orphan guard. The pinning contract (see
+    // Name isn't found — fall through to orphan guard. The pinning contract (see
     // ModuleViewerInspector) never persists a bare branch name here, so this is legacy data.
   }
 
   // Tier 1 — UUID lookup (moduleReferenceId, same-workspace fast path).
   // git-sync: branched rows are always DRAFTs (chk_app_versions_branched_implies_draft) —
-  // a pin must only resolve to a default-branch PUBLISHED row.
+  // a pin must only resolve to a default-branch PUBLISHED row, unless the row predates
+  // git-sync on this workspace (isSynced: false) — same legacy-draft-pin case as Tier 0.
   // non-git-sync: default-branch lookup with no status filter is correct.
   if (moduleReferenceId && UUID_RE.test(moduleReferenceId) && defaultBranch) {
     if (isGitSyncEnabled) {
-      // git-sync: only default-branch PUBLISHED.
+      // git-sync: default-branch PUBLISHED first.
       const published = await manager.findOne(AppVersion, {
         where: {
           appId: moduleApp.id,
@@ -194,6 +197,17 @@ export async function resolveModuleRef(
         },
       });
       if (published) return published;
+      // Not published — only a legacy (isSynced: false) draft is allowed to match here.
+      const unsyncedDraft = await manager.findOne(AppVersion, {
+        where: {
+          appId: moduleApp.id,
+          moduleReferenceId,
+          branchId: defaultBranch.id,
+          isSynced: false,
+          isStub: false,
+        },
+      });
+      if (unsyncedDraft) return unsyncedDraft;
     } else {
       // Non-git-sync: default-branch (all rows land there, no status filter needed).
       const byMref = await manager.findOne(AppVersion, {

--- a/server/test/modules/versions/e2e/module-ref-resolution.spec.ts
+++ b/server/test/modules/versions/e2e/module-ref-resolution.spec.ts
@@ -176,21 +176,9 @@ describe('Module version resolution by pinned ref (git-sync-enabled workspace)',
     expect(res.body.editing_version.id).toBe(version.id);
   });
 
-  /**
-   * Regression coverage: a module app/pin created before branching was enabled on the
-   * workspace stores the pin as a plain version name (legacy format), not a
-   * module_reference_id UUID. If that version has never been published/released, it sits
-   * as a DRAFT on the default branch. Tier 0's any-status fallback used to be gated on
-   * `!isGitSyncEnabled`, so once the workspace turned git-sync/branching on, this legacy
-   * DRAFT pin 404'd even though nothing about the underlying data changed.
-   */
-  it('resolves a legacy name pin to a DRAFT-only version on the default branch', async () => {
-    const adminData = await createUser(nestApp, { email: 'mrr-gs-admin2@tooljet.io', groups: ['all_users', 'admin'] });
-    const org = adminData.organization;
-    const adminCookie = (await login(nestApp, 'mrr-gs-admin2@tooljet.io')).tokenCookie;
-
+  async function enableGitSync(orgId: string) {
     const orgGitSync = await saveEntity(OrganizationGitSync, {
-      organizationId: org.id,
+      organizationId: orgId,
       autoCommit: false,
       isBranchingEnabled: true,
     });
@@ -204,6 +192,24 @@ describe('Module version resolution by pinned ref (git-sync-enabled workspace)',
       isEnabled: true,
       isFinalized: true,
     } as any);
+  }
+
+  /**
+   * Regression coverage: a module app/pin created before branching was enabled on the
+   * workspace stores the pin as a plain version name (legacy format), not a
+   * module_reference_id UUID. If that version has never been published/released, it sits
+   * as a DRAFT on the default branch, with isSynced: false (stamped false by the
+   * NOT-NULL backfill migration — it predates git-sync on this workspace). Tier 0's
+   * any-status fallback used to be gated on `!isGitSyncEnabled`, so once the workspace
+   * turned git-sync/branching on, this legacy DRAFT pin 404'd even though nothing about
+   * the underlying data changed.
+   */
+  it('resolves a legacy (isSynced: false) name pin to a DRAFT-only version on the default branch', async () => {
+    const adminData = await createUser(nestApp, { email: 'mrr-gs-admin2@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+    const adminCookie = (await login(nestApp, 'mrr-gs-admin2@tooljet.io')).tokenCookie;
+
+    await enableGitSync(org.id);
 
     const moduleApp = await createApplication(nestApp, {
       name: 'M-GitSyncDraftName',
@@ -213,15 +219,47 @@ describe('Module version resolution by pinned ref (git-sync-enabled workspace)',
     const coRelationId = uuidv4();
     await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
     const version = await createApplicationVersion(nestApp, moduleApp as any);
-    // Left at DRAFT, pinned by name — never published/released, same as a module pinned
-    // before this workspace had branching/git-sync enabled.
+    // Left at DRAFT, pinned by name, isSynced forced false — never published/released,
+    // same as a module pinned before this workspace had branching/git-sync enabled.
     await updateEntity(AppVersion, version.id, {
       name: 'v3',
       status: AppVersionStatus.DRAFT,
+      isSynced: false,
     } as any);
 
     const res = await fetchModuleVersion(coRelationId, adminCookie, org.id, 'v3');
     expect(res.statusCode).toBe(200);
     expect(res.body.editing_version.id).toBe(version.id);
+  });
+
+  /**
+   * Guardrail: a genuinely git-native draft (isSynced: true — created through this
+   * workspace's own git-sync flow, not a legacy backfilled row) must NOT be resolvable
+   * by name unless it's PUBLISHED. The Tier 0 fallback added above must not relax this —
+   * it's scoped to isSynced: false rows only.
+   */
+  it('does NOT resolve a synced (isSynced: true) name-pinned DRAFT — still 404s', async () => {
+    const adminData = await createUser(nestApp, { email: 'mrr-gs-admin3@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+    const adminCookie = (await login(nestApp, 'mrr-gs-admin3@tooljet.io')).tokenCookie;
+
+    await enableGitSync(org.id);
+
+    const moduleApp = await createApplication(nestApp, {
+      name: 'M-GitSyncSyncedDraftName',
+      user: adminData.user,
+      type: 'module',
+    });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    const version = await createApplicationVersion(nestApp, moduleApp as any);
+    await updateEntity(AppVersion, version.id, {
+      name: 'v3',
+      status: AppVersionStatus.DRAFT,
+      isSynced: true,
+    } as any);
+
+    const res = await fetchModuleVersion(coRelationId, adminCookie, org.id, 'v3');
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/server/test/modules/versions/e2e/module-ref-resolution.spec.ts
+++ b/server/test/modules/versions/e2e/module-ref-resolution.spec.ts
@@ -175,4 +175,53 @@ describe('Module version resolution by pinned ref (git-sync-enabled workspace)',
     expect(res.statusCode).toBe(200);
     expect(res.body.editing_version.id).toBe(version.id);
   });
+
+  /**
+   * Regression coverage: a module app/pin created before branching was enabled on the
+   * workspace stores the pin as a plain version name (legacy format), not a
+   * module_reference_id UUID. If that version has never been published/released, it sits
+   * as a DRAFT on the default branch. Tier 0's any-status fallback used to be gated on
+   * `!isGitSyncEnabled`, so once the workspace turned git-sync/branching on, this legacy
+   * DRAFT pin 404'd even though nothing about the underlying data changed.
+   */
+  it('resolves a legacy name pin to a DRAFT-only version on the default branch', async () => {
+    const adminData = await createUser(nestApp, { email: 'mrr-gs-admin2@tooljet.io', groups: ['all_users', 'admin'] });
+    const org = adminData.organization;
+    const adminCookie = (await login(nestApp, 'mrr-gs-admin2@tooljet.io')).tokenCookie;
+
+    const orgGitSync = await saveEntity(OrganizationGitSync, {
+      organizationId: org.id,
+      autoCommit: false,
+      isBranchingEnabled: true,
+    });
+    await saveEntity(OrganizationGitHttps, {
+      configId: orgGitSync.id,
+      httpsUrl: 'https://github.com/tooljet-test/e2e-fixture',
+      githubBranch: 'main',
+      githubAppId: 'test-app-id',
+      githubInstallationId: 'test-installation-id',
+      githubPrivateKey: 'dummy-key-not-dereferenced-in-this-test',
+      isEnabled: true,
+      isFinalized: true,
+    } as any);
+
+    const moduleApp = await createApplication(nestApp, {
+      name: 'M-GitSyncDraftName',
+      user: adminData.user,
+      type: 'module',
+    });
+    const coRelationId = uuidv4();
+    await updateEntity(App, moduleApp.id, { co_relation_id: coRelationId } as any);
+    const version = await createApplicationVersion(nestApp, moduleApp as any);
+    // Left at DRAFT, pinned by name — never published/released, same as a module pinned
+    // before this workspace had branching/git-sync enabled.
+    await updateEntity(AppVersion, version.id, {
+      name: 'v3',
+      status: AppVersionStatus.DRAFT,
+    } as any);
+
+    const res = await fetchModuleVersion(coRelationId, adminCookie, org.id, 'v3');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.editing_version.id).toBe(version.id);
+  });
 });


### PR DESCRIPTION
## 📝 What this does
Fixes module resolution 404s for modules pinned by version name or UUID (legacy format, pre-dating git-sync/branching on the workspace) when that pinned version is still an unreleased draft on the default branch — without relaxing resolution for genuinely git-native drafts.

## 🔀 Changes
- Removed the git-sync-only gate blocking the default-branch draft fallback in the name-based (Tier 0) module version lookup
- Scoped that fallback (and an equivalent one added to the UUID-based Tier 1 lookup) to rows with `isSynced: false` — legacy versions that predate git-sync on the workspace — so actively synced drafts still require a PUBLISHED match
- Added regression coverage for a legacy name-pinned draft in a git-sync-enabled workspace, plus a guardrail test proving a genuinely synced draft still 404s by name

## 🧪 How to test
- [ ] In a git-sync/branching-enabled workspace, pin an app's ModuleViewer to a module version by name (not UUID) while that version is still a DRAFT that predates git-sync being enabled
- [ ] Open the app and confirm the module fetches successfully instead of 404ing with "Module version not found"
- [ ] Confirm published/saved module version pins still resolve as before
- [ ] Confirm a module version drafted *after* git-sync was enabled still does not resolve by name unless published