### PR TITLE
fix: prevent eye icon from overlapping API key text in encrypted input fields

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -9,7 +9,6 @@
 @import "./typography.scss";
 @import "./designtheme.scss";
 @import "./dropdown-custom.scss";
-@import "./editor/react-select-search.scss";
 @import "./ui-operations.scss";
 @import "./license.scss";
 @import "react-loading-skeleton/dist/skeleton.css";
@@ -178,119 +177,6 @@
   /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
 }
 
-/* ibm-plex-mono-100 - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 100;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-100.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-100italic - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 100;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-100italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-200 - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 200;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-200.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-200italic - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 200;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-200italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-300 - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 300;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-300.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-300italic - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 300;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-300italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-regular - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 400;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-italic - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 400;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-500 - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 500;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-500.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-500italic - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 500;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-500italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-600 - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 600;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-600.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-600italic - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 600;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-600italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-700 - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 700;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-700.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-/* ibm-plex-mono-700italic - latin */
-@font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 700;
-  src: url('/assets/fonts/ibm-plex-mono-v20-latin/ibm-plex-mono-v20-latin-700italic.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
-}
-
 .transparent-scrollbar {
   &::-webkit-scrollbar {
     width: 6px;
@@ -325,6 +211,8 @@
 
 @layer utilities {
   .tw-transparent-scrollbar {
+    // scrollbar-color: transparent transparent;
+
     &::-webkit-scrollbar-thumb {
       background: transparent;
     }
@@ -335,21 +223,10 @@
   }
 
   .tw-show-scrollbar {
-    &::-webkit-scrollbar {
-      width: 10px;
-      height: 10px;
-    }
+    // scrollbar-color: var(--slate8);
 
     &::-webkit-scrollbar-thumb {
-      background: var(--interactive-hover);
-      background-clip: padding-box;
-      border: 2px solid transparent;
-      border-radius: 9999px;
-    }
-
-    &:hover::-webkit-scrollbar-thumb {
-      background: var(--interactive-selected);
-      background-clip: padding-box;
+      background: var(--slate8);
     }
 
     &::-webkit-scrollbar-track {
@@ -701,7 +578,6 @@ button {
     background-color: var(--surfaces-surface-01);
     background-clip: border-box;
     height: 100vh;
-    z-index: 1041;
 
     >div {
       background-color: var(--surfaces-surface-01);
@@ -1589,7 +1465,7 @@ button {
     /* IE and Edge */
     scrollbar-width: none;
     /* Firefox */
-    border-top: none !important;
+    border-top: 1px solid var(--slate5) !important;
   }
 
   &.module-editor-inspector {
@@ -3897,12 +3773,6 @@ input[type="text"] {
   }
 }
 
-.daterange-picker-widget.has-clear-btn {
-  .DateRangePickerInput {
-    padding-right: 32px;
-  }
-}
-
 .form-ele {
   .DateRangePicker_picker {
     top: 40px !important;
@@ -5173,21 +5043,20 @@ div#driver-page-overlay {
 
 .editor .editor-sidebar .inspector .inspector-edit-widget-name {
   padding: 4px 8px;
-  color: var(--text-default);
+  color: var(--slate12);
   border: 1px solid transparent !important;
   border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
-  background-color: transparent;
+  background-color: var(--base);
+
   &:hover {
-    background-color: var(--interactive-hover);
-    border: 1px solid var(--border-weak);
+    background-color: var(--slate4);
+    border: 1px solid var(--slate7);
   }
 
-  &:focus, &:active {
+  &:focus {
     border: 1px solid var(--indigo9) !important;
-    background-color: var(--indigo2) !important;
-    box-shadow: 0px 0px 0px 1px #c6d4f9 !important;
+    background-color: var(--indigo2);
+    box-shadow: 0px 0px 0px 1px #c6d4f9;
   }
 }
 
@@ -6381,72 +6250,25 @@ a.step-item-disabled {
   background: var(--completedAccent) !important;
 }
 
-// design (153:7287): 13px blue pill overlapping the bell's top-right (badge at x16,y2 of the 32px nav item)
 .notification-center-badge {
+  margin-top: 0px;
+  margin-left: 10px;
+  margin-bottom: 15px;
   position: absolute;
-  top: 2px;
-  // right-anchored so the 99+ pill grows leftward instead of clipping at the
-  // 48px sidebar's overflow-x: hidden edge
-  left: auto;
-  right: -2px;
-  margin: 0;
-  padding: 2px 4px;
-  height: 13px;
-  min-width: 13px;
-  background: #4368e3;
-  color: #f6f8fa;
-  border-radius: 8px;
-  font-family: 'Inter', 'IBM Plex Sans', sans-serif;
-  font-size: 10px;
-  font-weight: 400;
-  line-height: 9px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  right: 6px;
 }
 
-// panel container (68:3832): 420 wide, radius 10, 1px weak border, elevation-400 shadow
 .notification-center {
   max-height: 500px;
-  width: 420px;
   min-width: 420px;
   overflow: auto;
   margin-left: 11px !important;
-  padding: 0;
-  border: 1px solid var(--borders-weak, #e4e7eb) !important; // beat tabler's 0.667px dropdown border
-  border-radius: 10px;
-  box-shadow: 0 0 1px rgba(48, 50, 51, 0.05), 0 8px 16px rgba(48, 50, 51, 0.1);
 
-  // empty state (85:9355): 40px icon box + 12px medium title + 12px grey hint, centered
   .empty {
-    padding: 6px 32px !important;
-    margin: 0;
-    min-height: 304px; // fills the 320px list cap without scrolling
-    justify-content: center;
-    align-items: center;
-    gap: 2px;
+    padding: 0 !important;
 
     .empty-img {
-      padding: 10px;
-      margin: 0;
-      line-height: 0;
-    }
-
-    .empty-title {
-      margin: 0;
-      font-size: 12px;
-      font-weight: 500;
-      line-height: 18px;
-      letter-spacing: -0.24px;
-      color: var(--text-default, #1b1f24);
-    }
-
-    .empty-subtitle {
-      margin: 0;
-      font-size: 12px !important; // tabler .empty-subtitle bumps size
-      line-height: 18px;
-      letter-spacing: -0.24px;
-      color: var(--text-placeholder, #6a727c) !important;
+      font-size: 2.5em;
     }
   }
 
@@ -6454,25 +6276,7 @@ a.step-item-disabled {
     min-width: 400px;
     background: var(--surfaces-surface-01);
     color: var(--text-default);
-    border: none;
-    border-radius: 10px;
-    box-shadow: none;
-  }
-
-  // header (68:3833): 48px, py 8 px 16, 14/20 medium title
-  .card-header {
-    padding: 8px 16px;
-    min-height: 48px;
-    align-items: center;
-    border-bottom: 1px solid var(--borders-weak, #e4e7eb) !important;
-
-    .card-title {
-      margin: 0;
-      font-size: 14px;
-      font-weight: 500;
-      line-height: 20px;
-      color: var(--text-default, #1b1f24);
-    }
+    box-shadow: var(--elevation-400-box-shadow);
   }
 
   .card-footer {
@@ -6482,340 +6286,6 @@ a.step-item-disabled {
 
   .spinner {
     min-height: 100px;
-  }
-
-  // dark panel (Figma 282:4776) — --borders-weak has no dark token and --slate3
-  // stays light inside .dark-theme, so both need explicit dark values
-  &.dark-theme {
-    background: var(--surfaces-surface-01, #1e2226);
-    border-color: #2b3036 !important;
-
-    .card-header {
-      border-bottom-color: #2b3036 !important;
-    }
-
-    .notification-new-pill {
-      background: #3c434b;
-      color: #ffffff;
-    }
-
-    .notification-load-more {
-      border-top-color: #2b3036;
-    }
-  }
-}
-
-// notification row — Figma "Notif types and states": unread = right blue dot; read = grey
-// (#acb2b9) text, not opacity; hover greys the row and swaps the dot for open/× actions
-.notification-row {
-  display: flex;
-  gap: 6px;
-  align-items: flex-start;
-  padding: 8px 4px;
-  border-radius: 4px;
-  font-family: 'Inter', 'IBM Plex Sans', sans-serif; // design family/regular: Inter
-  transition: background 0.15s;
-  cursor: pointer;
-
-  .notification-row-icon {
-    width: 28px;
-    height: 28px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-  }
-
-  // read rows keep full color (Figma 70:7733) — the only differentiator is the missing dot
-  &:hover {
-    background: rgba(136, 144, 153, 0.12);
-
-    .notification-row-dot {
-      display: none;
-    }
-
-    .notification-row-actions {
-      display: flex;
-    }
-  }
-
-  &:active {
-    background: rgba(136, 144, 153, 0.18); // design pressed state
-  }
-
-  .notification-row-content {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 2px; // design: text column top-aligned with the 28px icon box, 2px between lines
-  }
-
-  .notification-row-title {
-    font-size: 12px;
-    font-weight: 500;
-    line-height: 18px;
-    letter-spacing: -0.24px;
-    color: var(--text-default, #1b1f24);
-  }
-
-  .notification-row-body {
-    font-size: 12px;
-    line-height: 18px;
-    letter-spacing: -0.24px;
-    color: var(--text-placeholder, #6a727c);
-
-    .notification-row-mono {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 12px;
-      color: var(--text-medium, #2d343b);
-      background: none;
-      padding: 0 2px;
-    }
-  }
-
-  .notification-row-time {
-    font-size: 12px;
-    line-height: 18px;
-    letter-spacing: -0.24px;
-    color: var(--text-placeholder, #6a727c);
-  }
-
-  .notification-row-side {
-    display: flex;
-    align-items: center;
-    align-self: flex-start; // dot rides the title line, not row center
-    height: 28px;
-    // constant width whether it holds the dot (8px) or the hover actions (2×28px) —
-    // otherwise the text column re-wraps on hover and the panel height jitters
-    min-width: 56px;
-    justify-content: flex-end;
-    flex-shrink: 0;
-  }
-
-  .notification-row-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: #4368e3;
-    margin-right: 10px; // optically centered in the 28px slot the × occupies on hover
-  }
-
-  .notification-row-actions {
-    display: none;
-  }
-
-  .notification-row-action {
-    width: 28px;
-    height: 28px;
-    border-radius: 6px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-placeholder, #6a727c);
-
-    &:hover {
-      background: rgba(136, 144, 153, 0.15);
-      color: var(--text-default);
-    }
-  }
-}
-
-// panel header: "N new" pill + icon actions (bell-check / brush-cleaning)
-.notification-new-pill {
-  margin-left: 10px; // design gap 10 between title and pill
-  padding: 0 8px;
-  border-radius: 6px;
-  background: var(--slate3, #f1f3f5);
-  color: var(--text-default, #1b1f24); // design slate/12 #11181c; nearest dark-mode-safe token
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 20px;
-}
-
-.notification-header-actions {
-  display: flex;
-  gap: 4px;
-}
-
-.notification-header-action {
-  width: 32px;
-  height: 32px;
-  background: none;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  color: var(--text-secondary, #6a727c);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  &:hover:not(:disabled) {
-    background: rgba(136, 144, 153, 0.12);
-    color: var(--text-default);
-  }
-
-  &:disabled {
-    color: var(--icon-default, #acb2b9); // design empty state: icons greyed, not translucent
-    cursor: default;
-  }
-}
-
-// cursor pagination — pinned footer bar below the scroll area (design 70:8193)
-.notification-load-more {
-  display: block;
-  width: 100%;
-  background: none;
-  border: none;
-  border-top: 1px solid var(--borders-weak, #e4e7eb);
-  padding: 10px 16px;
-  cursor: pointer;
-  color: var(--text-default, #1b1f24);
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 18px;
-  letter-spacing: -0.24px;
-  text-align: center;
-
-  &:hover:not(:disabled) {
-    background: var(--surfaces-surface-02, #f6f8fa);
-  }
-
-  &:disabled {
-    color: var(--text-placeholder);
-    cursor: default;
-  }
-}
-
-// "View details" action inside notification arrival toasts (standard react-hot-toast look)
-// design 70:6926: message + secondary-button action on one row
-.notification-toast-row {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.notification-toast-view {
-  padding: 4px 12px;
-  border: 1px solid var(--borders-default, #ccd1d5);
-  border-radius: 6px;
-  background: var(--surfaces-surface-01, #fff);
-  color: var(--text-default, #1b1f24);
-  font-size: inherit;
-  font-weight: 500;
-  cursor: pointer;
-  white-space: nowrap;
-
-  &:hover {
-    background: var(--interactive-overlays-fill-hover, #f6f8fa);
-  }
-}
-
-// cap the bell list to ~4 rows; scroll the rest (bell sits low, panel grows upward)
-.notification-center .notifications-card .list-group {
-  max-height: 320px;
-  overflow-y: auto;
-}
-
-// error detail modal (Figma 70:6766): icon+title header, lead + time, trace box, Copy trace footer
-.modal-dialog:has(.notification-error-modal) {
-  max-width: 712px; // design frame width, not bootstrap modal-lg 800px
-}
-
-.notification-error-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-bottom: 12px;
-  margin-bottom: 12px;
-  border-bottom: 1px solid var(--borders-weak, #e4e7eb);
-}
-
-.notification-error-title {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-default, #1b1f24);
-}
-
-.notification-error-close {
-  background: none;
-  border: none;
-  padding: 4px;
-  border-radius: 6px;
-  cursor: pointer;
-  color: var(--text-placeholder, #6a727c);
-  display: inline-flex;
-
-  &:hover {
-    color: var(--text-default);
-  }
-}
-
-.notification-error-lead {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-
-  .notification-error-message {
-    font-size: 13px;
-    color: var(--text-default, #1b1f24);
-  }
-
-  .notification-error-time {
-    font-size: 12px;
-    color: var(--text-placeholder, #6a727c);
-    flex-shrink: 0;
-  }
-}
-
-.notification-error-pre {
-  height: 280px;
-  overflow: auto;
-  white-space: pre;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 12px;
-  line-height: 1.6;
-  color: var(--text-placeholder, #6a727c);
-  background: var(--surfaces-surface-01, #ffffff);
-  border: 1px solid var(--borders-weak, #e4e7eb);
-  padding: 12px;
-  border-radius: 8px;
-  margin-top: 12px;
-  margin-bottom: 0;
-}
-
-.notification-error-footer {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 16px;
-
-  // design dev-inspect: 7px 12px, gap 6, radius 6, button/primary + elevation/100
-  .notification-copy-trace {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    padding: 7px 12px;
-    border-radius: 6px;
-    border: none;
-    background: #4368e3;
-    color: #fff;
-    font-size: 12px;
-    font-weight: 500;
-    line-height: 18px;
-    box-shadow: 0 0 1px 0 rgba(48, 50, 51, 0.05);
-    cursor: pointer;
-
-    &:hover {
-      background: #3a5cd0;
-    }
   }
 }
 
@@ -6843,7 +6313,29 @@ input.hide-input-arrows {
   width: 36px;
 }
 
+.custom-checkbox-tree {
+  overflow-y: auto;
+  color: #3e525b;
 
+  .react-checkbox-tree label:hover {
+    background: none !important;
+  }
+
+  .rct-icons-fa4 {
+
+    .rct-icon-expand-open,
+    .rct-icon-expand-close {
+      &::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1024 1024' focusable='false' data-icon='caret-down' width='12px' height='12px' fill='currentColor' aria-hidden='true'%3E%3Cpath d='M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z'%3E%3C/path%3E%3C/svg%3E") !important;
+      }
+    }
+
+    .rct-icon-expand-close {
+      transform: rotate(-90deg);
+      -webkit-transform: rotate(-90deg);
+    }
+  }
+}
 
 // sso enable/disable box
 .tick-cross-info {
@@ -8027,7 +7519,6 @@ tbody {
 .audit-log-nav-item,
 .notification-center-nav-item {
   border-radius: 4px;
-  position: relative; // anchor for the unread count pill
 }
 
 .settings-nav-item {
@@ -9858,22 +9349,8 @@ tbody {
 }
 
 .workspace-settings-table-wrap {
-  min-width: 936px;
+  min-width: 930px;
   margin: 0 auto;
-
-  ::-webkit-scrollbar {
-    display: block;
-    width: 4px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: var(--base);
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: var(--slate7);
-    border-radius: 6px;
-  }
 
   &:hover {
     .tj-user-table-wrapper {
@@ -10090,7 +9567,7 @@ tbody {
 }
 
 .workspace-page-header {
-  width: 936px;
+  width: 930px;
   margin: 0 auto !important;
 
   div:first-child {
@@ -12084,6 +11561,7 @@ tbody {
 
 .tj-app-input-wrapper {
   display: flex;
+  position: relative;
 
   .eye-icon {
     position: absolute;
@@ -12101,6 +11579,10 @@ tbody {
 
   .form-control {
     padding-right: 2.2rem;
+  }
+
+  input {
+    padding-right: 28px;
   }
 }
 
@@ -12799,18 +12281,6 @@ tbody {
 
 .marketplace-install {
   color: var(--indigo9);
-}
-
-.marketplace-search-holder {
-  width: 100%;
-  margin-top: 8px;
-  margin-bottom: 24px;
-}
-
-.marketplace-empty-state {
-  display: block;
-  text-align: center;
-  margin-top: 48px;
 }
 
 .popover {
@@ -14082,8 +13552,7 @@ tbody {
   }
 }
 
-#popover-basic-2,
-#table-column-popover-basic {
+#popover-basic-2 {
   .sketch-picker {
     left: 7px;
     width: 170px !important;
@@ -14419,8 +13888,7 @@ tbody {
   }
 }
 
-#popover-basic-2,
-#table-column-popover-basic {
+#popover-basic-2 {
   .sketch-picker {
     left: 7px;
     width: 170px !important;
@@ -14475,17 +13943,6 @@ tbody {
 
 .tooltip-inner {
   border-radius: 8px;
-}
-
-// Shared tooltip style for long (up to 100-char) app/module/workflow names:
-// wrap into a readable box instead of bootstrap's cramped default or a wide single line.
-.long-name-tooltip {
-  .tooltip-inner {
-    max-width: 210px;
-    white-space: normal;
-    word-break: break-word;
-    text-align: left;
-  }
 }
 
 #inspector-tabpane-properties {
@@ -14823,8 +14280,7 @@ tbody {
   }
 }
 
-#popover-basic-2,
-#table-column-popover-basic {
+#popover-basic-2 {
   .sketch-picker {
     left: 7px;
     width: 170px !important;
@@ -14944,6 +14400,131 @@ tbody {
   }
 }
 
+.git-sync-modal,
+.modal-base {
+
+  .create-commit-container,
+  .commit-info,
+  .pull-container,
+  .pushpull-container {
+    height: 260px !important;
+
+    .form-control {
+      font-weight: 400;
+      font-size: 12px;
+      line-height: 20px;
+      color: var(--slate12);
+    }
+
+    .form-group {
+      .tj-input-error-state {
+        border: 1px solid var(--tomato9) !important;
+      }
+
+      .tj-input-error {
+        color: var(--tomato10) !important;
+      }
+    }
+
+    .info-text {
+      color: var(--slate10);
+    }
+
+    .tj-input-error {
+      color: var(--tomato10);
+    }
+
+    .form-control.disabled {
+      background-color: var(--slate3) !important;
+      color: var(--slate9) !important;
+    }
+
+    .last-commit-info {
+      background: var(--slate3);
+
+      .message-info {
+        display: flex;
+        justify-content: space-between;
+      }
+
+      .author-info {
+        font-size: 10px;
+        color: var(--slate11);
+      }
+    }
+
+    .check-for-updates {
+      display: flex;
+      align-items: center;
+      color: var(--indigo9);
+
+      svg {
+        path {
+          fill: var(--indigo9);
+        }
+
+        rect {
+          fill: none;
+        }
+      }
+
+      .loader-container {
+        height: unset !important;
+
+        .primary-spin-loader {
+          width: 18px;
+          height: 18px;
+          margin-right: 5px;
+        }
+      }
+    }
+  }
+
+  .modal-footer {
+    border-top: 1px solid var(--slate5);
+    padding: 1rem;
+
+    .tj-btn-left-icon {
+      svg {
+        width: 20px;
+        height: 20px;
+
+        path {
+          fill: var(--indigo1);
+        }
+      }
+    }
+
+    .tj-large-btn {
+      font-weight: 500;
+      font-size: 14px;
+    }
+  }
+
+  .modal-body {
+    .loader-container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 180px;
+    }
+  }
+
+  .modal-base {
+    .tj-text-xxsm {
+      color: var(--slate11);
+    }
+  }
+
+  .modal-header {
+    border-bottom: 1px solid var(--slate5) !important;
+
+    .modal-title {
+      color: var(--slate12);
+    }
+  }
+}
+
 .custom-gap-7 {
   gap: 7px;
 }
@@ -14978,11 +14559,6 @@ tbody {
     overflow: hidden;
     white-space: nowrap;
     max-width: 95px;
-  }
-
-  .group-chip--overflow {
-    flex: 0 0 auto;
-    max-width: none;
   }
 
   .all-groups-list {
@@ -15103,11 +14679,6 @@ tbody {
     border-radius: 6px;
     background-color: var(--slate3);
     color: var(--slate11);
-  }
-
-  .group-chip--overflow {
-    flex: 0 0 auto;
-    max-width: none;
   }
 
   .all-groups-list {
@@ -15321,21 +14892,6 @@ textarea.tj-text-input-widget {
   &::placeholder {
     color: var(--text-placeholder) !important;
   }
-}
-
-.tj-input-clear-btn {
-  align-items: center;
-  background: transparent;
-  border: 0;
-  border-radius: 6px;
-  cursor: pointer;
-  display: inline-flex;
-  justify-content: center;
-  padding: 2px;
-}
-
-.tj-input-clear-btn:hover {
-  background-color: var(--interactive-overlays-fill-hover);
 }
 
 .icon-style-container {
@@ -15628,12 +15184,6 @@ textarea.tj-text-input-widget {
   @extend .widget-version-identifier;
 }
 
-.widget-version-beta-identifier {
-  background-color: var(--indigo9);
-  @extend .widget-version-identifier;
-  width: 36px;
-}
-
 .tjdb-display-time-pill {
   height: 12px;
   gap: 10px;
@@ -15671,8 +15221,7 @@ textarea.tj-text-input-widget {
   }
 }
 
-.ds-svg-container svg,
-.ds-svg-container img {
+.ds-svg-container svg {
   padding: 2px;
   object-fit: contain;
 }
@@ -15717,7 +15266,7 @@ textarea.tj-text-input-widget {
   display: flex;
   flex-direction: row;
   align-items: center;
-  background-color: var(--dropdown-menu-bg, var(--cc-surface1-surface)) !important;
+  background-color: var(--cc-surface1-surface) !important;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
 
@@ -16298,7 +15847,7 @@ section.ai-message-prompt-input-wrapper {
 
   div.input {
     color: var(--text-default, #1b1f24);
-    font-size: var(--font-size-large);
+    font-size: 12px;
     font-style: normal;
     font-weight: 400;
     line-height: 18px;
@@ -16800,9 +16349,17 @@ section.ai-message-prompt-input-wrapper {
   z-index: 1000;
   overflow-y: auto;
 
-  background-color: var(--background-surface-layer-01);
+  border-left: 1px solid var(--border-weak, #e4e7eb);
+  background-color: #fff;
   box-shadow: 0px 0px 1px 0px var(--dropshadow-100700-layer-1, rgba(48, 50, 51, 0.05)),
     0px 8px 16px 0px var(--dropshadow-100400-layer-2, rgba(48, 50, 51, 0.1));
+
+  .input-box-gradient {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    z-index: 1;
+  }
 
   .reactMarkdown {
     * {
@@ -16815,6 +16372,14 @@ section.ai-message-prompt-input-wrapper {
     align-self: flex-start;
     background-color: var(--text-placeholder, #6a727c);
     margin-top: 6px;
+  }
+
+  &.dark-theme {
+    background-color: #1f2936;
+
+    .header {
+      background-color: #1f2936;
+    }
   }
 
   button.dropdown-toggle {
@@ -16848,10 +16413,46 @@ section.ai-message-prompt-input-wrapper {
     }
   }
 
+  .header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+
+    background-color: #fff;
+    padding: 0.75rem 1.75rem;
+
+    border-bottom: 1px solid var(--border-weak, #e4e7eb);
+
+    section {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      button {
+        height: 28px;
+        width: 28px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: transparent;
+
+        &:hover {
+          background: var(--interactive-hover, rgba(136, 144, 153, 0.12));
+        }
+
+        // &:focus {
+        //     border: 1px solid var(--border-default, #CCD1D5);
+        //     background: var(--button-outline, #FFF);
+        //     box-shadow: 0px 0px 0px 2px var(--Interactive-focusActive, #4368E3);
+        // }
+      }
+    }
+  }
+
   .conversation-wrapper {
     overflow-y: auto;
     flex-grow: 1;
-    padding: 1.25rem 1.25rem 1rem;
+    padding: 1.25rem 1.75rem 1rem;
     z-index: 2;
     scroll-behavior: smooth;
 
@@ -17274,7 +16875,7 @@ section.ai-message-prompt-input-wrapper {
           white-space: pre-wrap;
           display: inline-block;
           border-radius: 8px;
-          background-color: var(--interactive-default);
+          background: #f5f6f7;
           padding: 0.75rem 1rem;
           justify-content: flex-end;
           align-items: center;
@@ -17282,6 +16883,10 @@ section.ai-message-prompt-input-wrapper {
           color: var(--text-default, #1b1f24);
 
           margin-left: auto;
+
+          &.dark-theme {
+            background-color: #1b1f24;
+          }
         }
       }
     }
@@ -17395,6 +17000,78 @@ section.ai-message-prompt-input-wrapper {
 
       &:hover {
         background: var(--interactive-hover, rgba(136, 144, 153, 0.12));
+      }
+    }
+  }
+}
+
+.ai-message-loading-state {
+  display: flex;
+  margin-top: 12px;
+  gap: 20px;
+
+  .logo {
+    height: 28px;
+    width: 28px;
+    border-radius: 24px;
+    background: var(--background-surface-layer-01, #ffffff);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid var(--border-weak, #e4e7eb);
+  }
+
+  .right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    span {
+      color: var(--text-placeholder, #6a727c);
+      text-align: center;
+      font-size: 11px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 16px;
+    }
+
+    div.dots {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+
+      .dot {
+        width: 8px;
+        height: 8px;
+        background-color: #ff5f6d;
+        opacity: 0.3;
+        border-radius: 50%;
+        animation: dot-blink 1.2s infinite;
+      }
+
+      .dot:nth-child(1) {
+        animation-delay: 0s;
+      }
+
+      .dot:nth-child(2) {
+        animation-delay: 0.3s;
+      }
+
+      .dot:nth-child(3) {
+        animation-delay: 0.6s;
+      }
+
+      @keyframes dot-blink {
+
+        0%,
+        80%,
+        100% {
+          opacity: 0;
+        }
+
+        40% {
+          opacity: 1;
+        }
       }
     }
   }
@@ -17584,12 +17261,26 @@ section.ai-message-prompt-input-wrapper {
   }
 
   &.dark-theme {
+    .copilot-loader-wrapper {
+      background-color: #858c9414;
+    }
+
     section.content {
       background-color: #858c9414;
 
       pre {
         color: #fff;
       }
+    }
+  }
+
+  .copilot-loader-wrapper {
+    border-radius: 6px;
+    background-color: #f6f7f7;
+    padding: 8px;
+
+    .ai-message-loading-state {
+      margin-top: 0;
     }
   }
 }
@@ -17789,7 +17480,7 @@ section.ai-message-prompt-input-wrapper {
 }
 
 .cm-tooltip {
-  z-index: 99999 !important;
+  z-index: 9999 !important;
 }
 
 .accordion-item {
@@ -18225,56 +17916,20 @@ section.ai-message-prompt-input-wrapper {
   }
 }
 
-.import-in-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 12px;
+.git-sync-modal {
+  width: 400px !important;
+  height: 484px !important;
+}
 
-  .branch-name-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 2px 8px;
-    border-radius: 4px;
-    background: var(--indigo3);
-    color: var(--indigo11);
-    font-size: 12px;
-    font-weight: 500;
+.dark-theme.git-sync-modal {
+  .modal-header {
+    border-bottom: 1px solid var(--slate5) !important;
   }
 }
 
-.import-from-helper-text {
-  margin-top: 4px;
-  color: var(--slate11);
-}
-
-.import-from-disabled-select {
-  .react-select__control--is-disabled {
-    background-color: rgba(204, 209, 213, 0.3) !important;
-    border-color: transparent !important;
-  }
-  .react-select__dropdown-indicator {
-    color: var(--slate8) !important;
-  }
-}
-
-.import-dependent-info-alert {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 10px 12px;
-  background: var(--indigo3);
-  border-radius: 6px;
-  color: var(--slate12);
-  font-size: 12px;
-  line-height: 18px;
-  margin-bottom: 12px;
-
-  svg {
-    flex-shrink: 0;
-    margin-top: 1px;
-  }
+.git-sync-modal .modal-header .modal-title .push-pull-tabs .tab-push.active,
+.git-sync-modal .modal-header .modal-title .push-pull-tabs .tab-pull.active {
+  border-bottom: 2px solid var(--indigo9) !important;
 }
 
 .custom_fc_frame {


### PR DESCRIPTION
### Problem
The eye icon in encrypted/password input fields (e.g., OpenAI API key) overlaps the masked text, making it partially unreadable.

### Root cause
1. The parent container `.tj-app-input-wrapper` is missing `position: relative`, so the absolute-positioned eye icon positions relative to the wrong ancestor.
2. The `<input>` element lacks `padding-right`, so the input text extends underneath the icon.

### Fix
1. Added `position: relative` to `.tj-app-input-wrapper` so the absolute-positioned icon is correctly scoped to the wrapper.
2. Added `input { padding-right: 28px; }` inside `.tj-app-input-wrapper` to ensure the text doesn't overlap with the icon.

Closes #17283