### PR TITLE
fix: prevent eye icon from overlapping masked API key text in password input (#17283)

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -12084,6 +12084,11 @@ tbody {
 
 .tj-app-input-wrapper {
   display: flex;
+  position: relative;
+
+  input {
+    padding-right: 35px !important;
+  }
 
   .eye-icon {
     position: absolute;


### PR DESCRIPTION
## Summary

Fixes #17283

## Changes

- Added `position: relative` to `.tj-app-input-wrapper` so the absolute-positioned eye icon is positioned relative to the wrapper
- Added `padding-right: 35px` to the input inside `.tj-app-input-wrapper` to prevent text from being hidden behind the eye icon

## Before

The eye icon overlapped the masked API key text in the input field.

## After

The input has sufficient right padding so the eye icon doesn't overlap the text.