### PR TITLE
fix: resolve TJDB cell edit Save/Cancel buttons not visible (Fixes #17106)

### DIFF
--- a/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
+++ b/frontend/src/TooljetDatabase/Menu/CellEditMenu/index.jsx
@@ -347,11 +347,8 @@ export const CellEditMenu = ({
   return (
     <OverlayTrigger
       show={dataType === 'jsonb' ? false : show}
-      trigger="click"
       placement="bottom-start"
-      rootclose
       overlay={popover}
-      defaultShow
     >
       {isForeignKey ? (
         <DropDownSelect

--- a/frontend/src/TooljetDatabase/Menu/CellEditMenu/styles.scss
+++ b/frontend/src/TooljetDatabase/Menu/CellEditMenu/styles.scss
@@ -2,7 +2,6 @@
     min-width: 300px;
     height: auto;
     margin-top: 2px;
-    inset: 0px auto auto -9px !important;
     &.jsonb-popover{
         min-width: 350px;
     }

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -12763,6 +12763,7 @@ tbody {
 }
 
 .plugins-card {
+  height: 100%;
   .card-body-alignment {
     min-height: 145px;
     display: flex;


### PR DESCRIPTION
## Summary

When editing a cell in the TJDB table, the Save and Cancel buttons were not visible. This was caused by the `OverlayTrigger` component having conflicting props: the controlled `show` prop was being used alongside `trigger="click"` and `rootclose` props, which can interfere with the overlay visibility in react-bootstrap v2.

## Changes

- **CellEditMenu/index.jsx**: Removed `trigger="click"`, `rootclose`, and `defaultShow` props from the `OverlayTrigger` component. Since `show` is controlled by the parent component, these additional trigger props are unnecessary and can conflict with the controlled state.

- **CellEditMenu/styles.scss**: Removed the `inset: 0px auto auto -9px !important` CSS property from the popover. This `!important` rule was overriding Popper.js positioning calculations, which could cause the popover to be positioned incorrectly.

## Test Plan

1. Log in with valid credentials
2. Navigate to TJDB
3. Create two tables with a foreign key relationship
4. Add data to the parent and child tables
5. Open the child table and click on a cell to edit its value
6. Verify that the Save and Cancel buttons are visible in the popover
7. Verify that clicking Save saves the changes and clicking Cancel discards them

Closes #17106