### PR TITLE
fix: ensure consistent plugin card height on Installed page (Fixes #17095)

### DIFF
--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -12763,6 +12763,7 @@ tbody {
 }
 
 .plugins-card {
+  height: 100%;
   .card-body-alignment {
     min-height: 145px;
     display: flex;


### PR DESCRIPTION
## Summary

When plugins are installed on the Marketplace Installed page, plugin cards can have inconsistent heights due to different content lengths. This causes an uneven UI layout, especially when cards with varying content appear in the same row.

## Changes

- **theme.scss**: Added `height: 100%` to the `.plugins-card` class. When combined with Bootstrap grid columns (`col-sm-6 col-lg-4`), this ensures all cards in the same row have equal height, creating a consistent and visually pleasing layout.

## Test Plan

1. Navigate to the Marketplace Installed plugins page
2. Verify that all plugin cards have consistent height within each row
3. Verify that the card content is still properly displayed
4. Test with different viewport sizes to ensure responsive behavior

Fixes #17095