### PR TITLE
fix: truncate Intercom plugin description to keep card layout consistent (Fixes #17095)

### DIFF
--- a/marketplace/plugins/intercom/lib/manifest.json
+++ b/marketplace/plugins/intercom/lib/manifest.json
@@ -1,14 +1,21 @@
 {
   "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/manifest.schema.json",
   "title": "Intercom Datasource",
-  "description": "Integrate with Intercom API to manage contacts, support tickets, and conversations etc",
+  "description": "Integrate with Intercom API to manage contacts, support tickets,",
   "type": "api",
   "source": {
     "name": "Intercom",
     "kind": "intercom",
-    "exposedVariables": { "isLoading": false, "data": {}, "rawData": {} },
+    "exposedVariables": {
+      "isLoading": false,
+      "data": {},
+      "rawData": {}
+    },
     "options": {
-      "access_token": { "type": "string", "encrypted": true }
+      "access_token": {
+        "type": "string",
+        "encrypted": true
+      }
     },
     "customTesting": false
   },
@@ -21,5 +28,7 @@
       "description": "Enter your Intercom Access Token"
     }
   },
-  "required": ["access_token"]
+  "required": [
+    "access_token"
+  ]
 }


### PR DESCRIPTION
### Fixes #17095

## Changes

Truncated the Intercom plugin description from:
- `Integrate with Intercom API to manage contacts, support tickets, and conversations etc`
- to: `Integrate with Intercom API to manage contacts, support tickets,`

## Why

The long description caused the plugin card to have inconsistent dimensions on the Installed page. Other plugins display descriptions in 3 lines max. This change keeps the card layout consistent, as suggested by @srushti-chavanke in the issue comments.