### PR TITLE
fix: validate expression whitespace and filter empty path segments in Inspector [Fixes #17240]

### DIFF
--- a/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/utils.js
+++ b/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/utils.js
@@ -108,7 +108,7 @@ export const copyToClipboard = (data, includeQuotes = true) => {
 export const formatPathForCopy = (path) => {
   const isArray = path.includes('.');
   if (isArray) {
-    const pathArray = path.split('.');
+    const pathArray = path.split('.').filter(Boolean);
     const newPath = pathArray.map((item) => {
       if (!isNaN(item) && item !== '') {
         return `[${item}]`;

--- a/frontend/src/_helpers/utility.js
+++ b/frontend/src/_helpers/utility.js
@@ -2,6 +2,17 @@ import { useResolveStore } from '@/_stores/resolverStore';
 import _ from 'lodash';
 
 export function validateMultilineCode(code, isMultiLine = false) {
+  // Check for whitespace immediately after a dot (e.g., constants. null_value)
+  // This is invalid JavaScript syntax and should be flagged as an error
+  if (/\.[\s]/.test(code)) {
+    return {
+      status: 'failed',
+      data: {
+        message: 'Invalid expression',
+        description: 'Whitespace is not allowed immediately after a dot (.)',
+      },
+    };
+  }
   return {
     status: 'success',
     data: {


### PR DESCRIPTION
## Changes

Two fixes for workspace constants expression handling:

1. **Expression validation**: Updated `validateMultilineCode` to detect invalid whitespace immediately after a dot (e.g., `{{constants. null_value}}`). This now correctly returns a validation error instead of silently resolving.

2. **Inspector copy path**: Added `.filter(Boolean)` to `formatPathForCopy` to remove empty path segments caused by trailing dots. This ensures the copied path is `constants.null_value` instead of `constants.null_value.`.

Fixes #17240