### PR TITLE
fix: make TJDB cell edit Save/Cancel buttons visible in popover (Fixes #17106)

### DIFF
--- a/frontend/src/TooljetDatabase/Menu/CellEditMenu/styles.scss
+++ b/frontend/src/TooljetDatabase/Menu/CellEditMenu/styles.scss
@@ -3,6 +3,7 @@
     height: auto;
     margin-top: 2px;
     inset: 0px auto auto -9px !important;
+    overflow: visible;
     &.jsonb-popover{
         min-width: 350px;
     }


### PR DESCRIPTION
## Changes

Added `overflow: visible` to the `.tjdb-table-cell-edit-popover` CSS class to ensure the Save and Cancel buttons in the TJDB cell edit menu are visible.

## Root Cause

The popover for editing TJDB table cells was missing `overflow: visible`, which caused the Save/Cancel buttons in the `SaveChangesFooter` component to be clipped and not visible to users.

Fixes #17106