### PR TITLE
fix: save CodeHinter value on unmount to prevent data loss on popover rootClose

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx
@@ -264,7 +264,7 @@ const SingleLineCodeEditor = ({ componentName, fieldMeta = {}, componentId, modu
 };
 
 const EditorInput = ({
-  currentValue,
+  currentValue: currentValueProp,
   setCurrentValue,
   setFocus,
   validationType,
@@ -311,7 +311,21 @@ const EditorInput = ({
     shallow
   );
 
-  const { queryPanelKeybindings } = useQueryPanelKeyHooks(onBlurUpdate, currentValue, 'singleline');
+  const { queryPanelKeybindings } = useQueryPanelKeyHooks(onBlurUpdate, currentValueProp, 'singleline');
+
+  // Track the latest editor value for safe retrieval on unmount (e.g., popover rootClose)
+  const latestValueRef = useRef(currentValueProp);
+  useEffect(() => {
+    latestValueRef.current = currentValueProp;
+  }, [currentValueProp]);
+
+  // Save the editor value when the component unmounts, ensuring pending edits
+  // are not lost when the popover closes via rootClose (e.g., clicking the next option).
+  useEffect(() => {
+    return () => {
+      onBlurUpdate(latestValueRef.current);
+    };
+  }, []);
 
   const { workflowSuggestions } = useWorkflowStore((state) => ({ workflowSuggestions: state.suggestions }), shallow);
 
@@ -449,11 +463,11 @@ const EditorInput = ({
 
     if (!delayOnChange) {
       setFirstTimeFocus(false);
-      return onBlurUpdate(currentValue);
+      return onBlurUpdate(currentValueProp);
     }
     setTimeout(() => {
       setFirstTimeFocus(false);
-      onBlurUpdate(currentValue);
+      onBlurUpdate(currentValueProp);
     }, 0);
   };
 
@@ -609,7 +623,7 @@ const EditorInput = ({
                   setCodeEditorView(view);
                 }
               }}
-              value={currentValue}
+              value={currentValueProp}
               placeholder={placeholder}
               height={isInsideQueryPane ? '100%' : showLineNumbers ? '400px' : '100%'}
               width="100%"

--- a/frontend/src/TooljetDatabase/Menu/CellEditMenu/styles.scss
+++ b/frontend/src/TooljetDatabase/Menu/CellEditMenu/styles.scss
@@ -3,6 +3,7 @@
     height: auto;
     margin-top: 2px;
     inset: 0px auto auto -9px !important;
+    overflow: visible;
     &.jsonb-popover{
         min-width: 350px;
     }


### PR DESCRIPTION
## Summary

This PR fixes #12019 where editing option properties (label, value, etc.) in the Dropdown/Multiselect component property panel does not save the edited value when the user clicks directly on the next option (or adds a new option).

## Root Cause

The SingleLineCodeEditor (CodeHinter) only persists its value via onChange on blur. When the OptionDetailsPopover closes via Bootstrap rootClose mechanism (e.g., clicking the next option), the CodeMirror editor blur event does not fire reliably because the active element at the time of close is the newly clicked element, not the CodeMirror editor.

## Fix

Added a useEffect cleanup in the EditorInput component that saves the latest editor value (tracked via a ref) when the component unmounts. This ensures that any pending edits in the CodeHinter are persisted to the parent state regardless of how the popover is closed.

## Changes

- frontend/src/AppBuilder/CodeEditor/SingleLineCodeEditor.jsx: Added latestValueRef to track the current editor value, and a cleanup effect that calls onBlurUpdate with the latest value on unmount.