### PR TITLE
Fix: Exposed selectedRow keeps the previously clicked row when Select row runs from a query event

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/TableData.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/TableData.jsx
@@ -130,7 +130,8 @@ export const TableData = ({
 
   // Handles row click for row selection
   const handleRowClick = (row, isCheckbox) => {
-    lastClickedRowRef.current = { row: row?.original, index: row.index };
+    lastClickedRowRef.current = { source: 'user', row: row?.original, index: row.index };
+
     if (!allowSelection) {
       setExposedVariables({
         selectedRow: row?.original ?? {},
@@ -139,9 +140,11 @@ export const TableData = ({
       fireEvent('onRowClicked');
       return;
     }
+
     if (disableRowDeselection && row.getIsSelected() && !isCheckbox) {
       return;
     }
+
     row.toggleSelected();
   };
 

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -254,9 +254,14 @@ export const TableExposedVariables = ({
   useEffect(() => {
     if (!hasDataChanged) return;
     resetRowSelection();
+
     function selectRow(key, value) {
       const index = data.findIndex((item) => item[key] == value);
       const item = index !== -1 ? data[index] : null;
+
+      // Keep the ref in sync before selecting, so the mirror effect cannot expose the stale row
+      lastClickedRowRef.current = item === null ? {} : { source: 'default', row: item, index };
+
       if (item) {
         setRowSelection({ [index]: true });
       }
@@ -265,6 +270,7 @@ export const TableExposedVariables = ({
         selectedRowId: item === null ? item : isNaN(index) ? String(index) : index,
       });
     }
+
     if (defaultSelectedRow) {
       lastClickedRowRef.current = {};
       const key = Object?.keys(defaultSelectedRow)[0] ?? '';
@@ -273,6 +279,8 @@ export const TableExposedVariables = ({
         selectRow(key, value);
       }
     } else {
+      // drop the previous click so the mirror effect cannot expose the stale row
+      lastClickedRowRef.current = {};
       setExposedVariables({
         selectedRow: {},
         selectedRowId: null,
@@ -291,7 +299,8 @@ export const TableExposedVariables = ({
   useEffect(() => {
     // onRowClicked event will be fired when a row is clicked
     // it should be triggered even when allowSelection is false which is handled in the handleRowClick()
-    if (allowSelection && Object.keys(lastClickedRow).length > 0) {
+    // Only actual user clicks fire the event
+    if (allowSelection && lastClickedRow?.source === 'user') {
       fireEvent('onRowClicked');
     }
   }, [lastClickedRow, fireEvent, allowSelection]);
@@ -300,10 +309,15 @@ export const TableExposedVariables = ({
     function selectRow(key, value) {
       const index = data.findIndex((item) => item[key] == value);
       const item = index !== -1 ? data[index] : null;
+
+      // Point lastClickedRowRef at the new row BEFORE changing the selection.
+      // setRowSelection can flush a synchronous re-render, and the effect that mirrors lastClickedRow into selectedRow/selectedRowId reads the ref during that render.
+      // Updating it first keeps both writers in agreement, so whichever lands last exposes the same row.
+      lastClickedRowRef.current = item === null ? {} : { source: 'csa', row: item, index };
+
       if (item) {
         setRowSelection({ [index]: true });
       }
-      lastClickedRowRef.current = {};
       setExposedVariables({
         selectedRow: item === null ? {} : item,
         selectedRowId: item === null ? item : isNaN(index) ? String(index) : index,
@@ -313,6 +327,10 @@ export const TableExposedVariables = ({
     function deselectRow(key, value) {
       const index = data.findIndex((item) => item[key] == value);
       const item = index !== -1 ? data[index] : null;
+
+      // Clear the ref first for the same reason as selectRow
+      lastClickedRowRef.current = {};
+
       if (item) {
         setRowSelection({ [index]: false });
       }

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -253,6 +253,10 @@ export const TableExposedVariables = ({
 
   useEffect(() => {
     if (!hasDataChanged) return;
+    // Drop the previous selection BEFORE resetRowSelection, not after.
+    // resetRowSelection can flush a synchronous re-render,
+    // and the effect that mirrors lastClickedRow into selectedRow reads the ref during that render
+    lastClickedRowRef.current = {};
     resetRowSelection();
 
     function selectRow(key, value) {
@@ -272,15 +276,12 @@ export const TableExposedVariables = ({
     }
 
     if (defaultSelectedRow) {
-      lastClickedRowRef.current = {};
       const key = Object?.keys(defaultSelectedRow)[0] ?? '';
       const value = defaultSelectedRow?.[key] ?? undefined;
       if (key && (value !== undefined || value !== null)) {
         selectRow(key, value);
       }
     } else {
-      // drop the previous click so the mirror effect cannot expose the stale row
-      lastClickedRowRef.current = {};
       setExposedVariables({
         selectedRow: {},
         selectedRowId: null,


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/5335

This pull request improves the reliability and clarity of row selection and event firing logic in the new table widget by synchronizing the `lastClickedRowRef` state and adding a `source` field to track how a row was selected. The changes ensure that event handlers and exposed variables always reflect the correct row, preventing bugs caused by stale or out-of-sync state.

**Row selection state management:**

* Added a `source` field to `lastClickedRowRef` to distinguish between user-initiated and programmatic row selections.
* Updated all selection and deselection code paths (`selectRow`, `deselectRow`, and default selection logic) to set or clear `lastClickedRowRef` before any state changes, preventing exposure of stale row data during synchronous re-renders [[1]](diffhunk://#diff-cf00b0ecbaef4363eaddae1bf0b02c4cb759e663d5af9ef14ef51cc198614b38R256-R268) [[2]](diffhunk://#diff-cf00b0ecbaef4363eaddae1bf0b02c4cb759e663d5af9ef14ef51cc198614b38R277-L269) [[3]](diffhunk://#diff-cf00b0ecbaef4363eaddae1bf0b02c4cb759e663d5af9ef14ef51cc198614b38R313-L306) [[4]](diffhunk://#diff-cf00b0ecbaef4363eaddae1bf0b02c4cb759e663d5af9ef14ef51cc198614b38R331-R334).

**Event firing improvements:**

* Modified the effect that fires the `onRowClicked` event so it only fires for actual user clicks, based on the new `source` field, avoiding false positives from programmatic selection.

**Minor logic cleanups:**

* Improved comments and removed redundant clearing of `lastClickedRowRef` for better maintainability [[1]](diffhunk://#diff-6e3b61fc62809192fe1681f67ac877755886ce4cfda015acf0836ed9bcb32cdaR143-R147) [[2]](diffhunk://#diff-cf00b0ecbaef4363eaddae1bf0b02c4cb759e663d5af9ef14ef51cc198614b38R277-L269).
