### PR TITLE
Fix: align Bull Board queue registration with cloud edition guard

### DIFF
--- a/server/src/modules/app-history/module.ts
+++ b/server/src/modules/app-history/module.ts
@@ -4,6 +4,8 @@ import { getImportPath, TOOLJET_EDITIONS } from '@modules/app/constants';
 import { VersionRepository } from '@modules/versions/repository';
 import { AppsRepository } from '@modules/apps/repository';
 import { BullModule } from '@nestjs/bullmq';
+import { BullBoardModule } from '@bull-board/nestjs';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { FeatureAbilityFactory } from './ability';
 import { NameResolverRepository } from '@modules/app-history/repositories/name-resolver.repository';
 import { AppHistoryRepository } from '@modules/app-history/repository';
@@ -62,6 +64,16 @@ export class AppHistoryModule extends SubModule {
           },
         })
       );
+
+      // Bull Board's forRoot is not registered on cloud
+      if (edition !== TOOLJET_EDITIONS.Cloud) {
+        imports.push(
+          BullBoardModule.forFeature({
+            name: 'app-history',
+            adapter: BullMQAdapter,
+          })
+        );
+      }
     }
 
     // Register queue processor only when WORKER=true and edition is EE/Cloud

--- a/server/src/modules/git-sync-webhooks/module.ts
+++ b/server/src/modules/git-sync-webhooks/module.ts
@@ -4,6 +4,8 @@ import { ThrottlerModule } from '@nestjs/throttler';
 import { SubModule } from '@modules/app/sub-module';
 import { TOOLJET_EDITIONS } from '@modules/app/constants';
 import { BullModule } from '@nestjs/bullmq';
+import { BullBoardModule } from '@bull-board/nestjs';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { getTooljetEdition } from '@helpers/utils.helper';
 import { WorkspaceBranchesModule } from '@modules/workspace-branches/module';
 import { WebhookSkipFlagModule } from '@modules/git-sync-webhooks/webhook-skip-flag.module';
@@ -55,6 +57,16 @@ export class GitSyncWebhookModule extends SubModule {
         await WebhookSkipFlagModule.register(configs),
         await NotificationsModule.register(configs)
       );
+
+      // Bull Board's forRoot is not registered on cloud
+      if (edition !== TOOLJET_EDITIONS.Cloud) {
+        imports.push(
+          BullBoardModule.forFeature({
+            name: 'git-sync-webhooks',
+            adapter: BullMQAdapter,
+          })
+        );
+      }
 
       // EE-only services — no CE stubs needed since the entire block is edition-gated
       const { WebhookSignatureService } = await this.getProviders(configs, 'git-sync-webhooks', [

--- a/server/src/modules/workspace-branches/module.ts
+++ b/server/src/modules/workspace-branches/module.ts
@@ -15,6 +15,8 @@ import { WebhookSkipFlagModule } from '@modules/git-sync-webhooks/webhook-skip-f
 import { GitSyncConfigsModule } from '@modules/git-sync-configs/module';
 import { NotificationsModule } from '@modules/notifications/module';
 import { BackgroundProcessorModule } from '@modules/background-processor/module';
+import { getTooljetEdition } from '@helpers/utils.helper';
+import { TOOLJET_EDITIONS } from '@modules/app/constants';
 
 export class WorkspaceBranchesModule extends SubModule {
   static async register(configs?: { IS_GET_CONTEXT: boolean }, isMainImport?: boolean): Promise<DynamicModule> {
@@ -49,10 +51,14 @@ export class WorkspaceBranchesModule extends SubModule {
         BullModule.registerQueue({
           name: GIT_SYNC_QUEUE,
         }),
-        BullBoardModule.forFeature({
-          name: GIT_SYNC_QUEUE,
-          adapter: BullMQAdapter,
-        }),
+        ...(getTooljetEdition() !== TOOLJET_EDITIONS.Cloud
+          ? [
+              BullBoardModule.forFeature({
+                name: GIT_SYNC_QUEUE,
+                adapter: BullMQAdapter,
+              }),
+            ]
+          : []),
         await AppsModule.register(configs),
         await GitSyncModule.register(configs),
         await AppGitModule.register(configs),


### PR DESCRIPTION
## 📝 What this does
Fixes cloud edition failing to boot (and `db:migrate` crashing at `PopulateSSOConfigs`) with `Nest can't resolve dependencies of the BullBoardFeatureModule ... "bull_board_instance"`. The git-sync queue was pinned to the Bull Board dashboard in every edition, but the dashboard itself is never created on cloud. Also pins the two queues that were missing from the dashboard entirely, so self-hosted `/jobs` now shows all background queues.

## 🔀 Changes
- Gated the git-sync queue's Bull Board `forFeature` registration behind the same non-cloud edition check that guards `forRoot`
- Pinned `git-sync-webhooks` and `app-history` queues to Bull Board with the same non-cloud guard — previously invisible on `/jobs` everywhere
- Queue registrations themselves are untouched — background jobs still run on the same editions as before

## 🧪 How to test
- [x] Set `TOOLJET_EDITION=cloud` and run `npm run db:migrate` on a fresh database — completes without the `bull_board_instance` error
- [x] Run with `TOOLJET_EDITION=ee` — `/jobs` dashboard lists git-sync, git-sync-webhooks, app-history, and workflow queues

🤖 Generated with [Claude Code](https://claude.com/claude-code)