### PR TITLE
Fix: add missing workflow-folder entry to basic-plan granular permissions stub

### DIFF
--- a/server/src/modules/group-permissions/util-services/granular-permissions.util.service.ts
+++ b/server/src/modules/group-permissions/util-services/granular-permissions.util.service.ts
@@ -406,6 +406,14 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
     moduleFolderGroupPermissions.canEditApps = false;
     moduleFolderGroupPermissions.canViewApps = false;
 
+    // Workflow folders follow the plain FOLDER visibility rule (all roles), unlike module folders.
+    const workflowFolderGranularPermission = new GranularPermissions();
+    const workflowFolderGroupPermissions = new FoldersGroupPermissions();
+    workflowFolderGranularPermission.foldersGroupPermissions = workflowFolderGroupPermissions;
+    workflowFolderGranularPermission.name = DEFAULT_GRANULAR_PERMISSIONS_NAME[ResourceType.WORKFLOW_FOLDER];
+    workflowFolderGranularPermission.isAll = true;
+    workflowFolderGranularPermission.type = ResourceType.WORKFLOW_FOLDER;
+
     switch (role) {
       case USER_ROLE.ADMIN:
         appGranularPermission.name = DEFAULT_GRANULAR_PERMISSIONS_NAME[ResourceType.APP];
@@ -424,7 +432,15 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
         folderGroupPermissions.canEditApps = false;
         folderGroupPermissions.canViewApps = false;
 
-        return [appGranularPermission, folderGranularPermission, moduleFolderGranularPermission];
+        workflowFolderGroupPermissions.canEditApps = false;
+        workflowFolderGroupPermissions.canViewApps = false;
+
+        return [
+          appGranularPermission,
+          folderGranularPermission,
+          moduleFolderGranularPermission,
+          workflowFolderGranularPermission,
+        ];
 
       case USER_ROLE.BUILDER:
         appGranularPermission.name = DEFAULT_GRANULAR_PERMISSIONS_NAME[ResourceType.APP];
@@ -446,7 +462,16 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
         folderGroupPermissions.canEditApps = false;
         folderGroupPermissions.canViewApps = false;
 
-        return [appGranularPermission, folderGranularPermission, moduleFolderGranularPermission];
+        workflowFolderGroupPermissions.canEditFolder = true;
+        workflowFolderGroupPermissions.canEditApps = false;
+        workflowFolderGroupPermissions.canViewApps = false;
+
+        return [
+          appGranularPermission,
+          folderGranularPermission,
+          moduleFolderGranularPermission,
+          workflowFolderGranularPermission,
+        ];
 
       case USER_ROLE.END_USER:
         appGranularPermission.name = DEFAULT_GRANULAR_PERMISSIONS_NAME[ResourceType.APP];
@@ -465,7 +490,11 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
         folderGroupPermissions.canEditApps = false;
         folderGroupPermissions.canViewApps = true;
 
-        return [appGranularPermission, folderGranularPermission];
+        workflowFolderGroupPermissions.canEditFolder = false;
+        workflowFolderGroupPermissions.canEditApps = false;
+        workflowFolderGroupPermissions.canViewApps = true;
+
+        return [appGranularPermission, folderGranularPermission, workflowFolderGranularPermission];
 
       default:
         return [];


### PR DESCRIPTION
## 📝 What this does
On Basic/Starter plan orgs, the granular-permissions list falls back to a hand-built stub instead of querying the DB — and that stub never included a workflow-folder entry, so workflow folders silently disappeared from the group permissions list for every role.
- [ee-server](https://github.com/ToolJet/ee-server/pull/750)
- [ee-frontend](no changes)

## 🔀 Changes
- Added a workflow-folder granular-permission entry to the basic-plan stub (CE + EE), built the same way as the existing plain-folder entry
- Included it for Admin, Builder, and End User — workflow folders aren't restricted the way module folders are (which are Admin/Builder only)

## 🧪 How to test
- [ ] On a Basic or Starter plan org, open Workspace Settings → Groups → a default group's granular permissions
- [ ] Confirm "Workflow folders" now appears in the resource list for Admin, Builder, and End User groups