### PR TITLE
Fix: Listview dynamic height now working as expected when child Accordion is collapsed

### DIFF
--- a/frontend/src/AppBuilder/_stores/utils/dynamicHeightReflow.js
+++ b/frontend/src/AppBuilder/_stores/utils/dynamicHeightReflow.js
@@ -711,7 +711,12 @@ export const resolveContainerHeight = ({
     let flowHeight = 0;
     if (layoutEntry?.inFlow) {
       flowHeight = effectiveLayout.height ?? 0;
-      if (typeof calculateMoveableBoxHeightWithId === 'function') {
+      // Floor at the calc-bumped canonical ONLY for children that never wrote a temp height.
+      // A child that HAS a temp already reflects its real rendered height via its own reflow pass,
+      // including a legitimate shrink BELOW canonical (an Accordion collapsing to header-only).
+      // Flooring those at canonical would pin the container at the pre-collapse height and block the shrink from propagating.
+      const childHasTemp = temporaryLayouts?.[getDynamicLayoutKey(childId, childContext)]?.height != null;
+      if (!childHasTemp && typeof calculateMoveableBoxHeightWithId === 'function') {
         const childDefinition = getComponentDefinition?.(childId);
         const childStylesDefinition = childDefinition?.component?.definition?.styles;
         const bumpedHeight = calculateMoveableBoxHeightWithId(childId, currentLayout, childStylesDefinition);

--- a/frontend/src/AppBuilder/_stores/utils/dynamicHeightReflow.js
+++ b/frontend/src/AppBuilder/_stores/utils/dynamicHeightReflow.js
@@ -770,17 +770,20 @@ export const resolveContainerHeight = ({
 };
 
 // The changed widget's target height:
-//   - Container-like widget: delegate to `containerHeight` (already computed).
+//   - Container-like widget (incl. the Listview widget itself): delegate to the
+//     already-computed `containerHeight`. For the Listview widget this is the
+//     row-sum (resolveListviewHeightFromRows), which reflects the row heights the
+//     reflow just wrote. We must NOT fall back to the DOM `offsetHeight` for the
+//     Listview widget: the reflow runs inside a requestAnimationFrame before React
+//     re-renders the new row heights, so offsetHeight is one frame stale — which
+//     makes any sibling positioned below the listview lag by one operation.
 //   - Leaf widget: DOM `offsetHeight`, falling back to the last temp height,
 //     then canonical, then zero.
 //   - Hidden: return the existing stored height so the widget's last known
 //     size is preserved (needed for show-restore and for container height
 //     calculations that skip 0-flow children).
-// Note: Listview widget (no row context) is always treated as a container;
-// Listview in a row context is treated as a leaf from this function's POV.
 export const resolveWidgetMeasuredHeight = ({
   componentId,
-  componentType,
   currentLayout,
   currentPageComponents,
   temporaryLayouts,
@@ -791,7 +794,7 @@ export const resolveWidgetMeasuredHeight = ({
   calculateMoveableBoxHeightWithId,
   moduleId = 'canvas',
 }) => {
-  if (isContainer && (componentType !== 'Listview' || normalizeLayoutContext(contextIndices))) {
+  if (isContainer) {
     return containerHeight;
   }
 


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/5333

This pull request refines the logic for dynamic height calculation and widget reflow, particularly around how temporary heights and canonical heights are handled for container and leaf widgets. The main goal is to ensure more accurate and responsive layout updates, especially for widgets like Listview and Accordion that can change size dynamically.

Dynamic Height Calculation Improvements:

* In `resolveContainerHeight`, only floor the height at the canonical value for children that have never written a temporary height, allowing widgets like Accordions to shrink below their canonical height when collapsing. This prevents containers from being stuck at a pre-collapse height.

Listview and Container Widget Height Handling:

* Updated the logic and comments in `resolveWidgetMeasuredHeight` to clarify that Listview widgets (and other containers) should always use the already-computed container height, avoiding fallback to DOM `offsetHeight` which can be stale due to animation frame timing.
* Simplified the container check in `resolveWidgetMeasuredHeight` to remove special-casing for Listview, since the correct behavior is now handled by always using `containerHeight` for containers.