### PR TITLE
Fix: module import drops component parenting and container visibility

### DIFF
--- a/server/src/modules/apps/services/app-import-export.service.ts
+++ b/server/src/modules/apps/services/app-import-export.service.ts
@@ -975,7 +975,8 @@ export class AppImportExportService {
       tooljetVersion,
       moduleResourceMappings,
       importingDataQueryFolders,
-      importingDataQueryFolderMappings
+      importingDataQueryFolderMappings,
+      importedApp.type
     );
 
     const importedAppVersionIds = Object.values(appResourceMappings.appVersionMapping);
@@ -1212,7 +1213,8 @@ export class AppImportExportService {
     tooljetVersion: string | null,
     moduleResourceMappings?: any,
     importingDataQueryFolders: DataQueryFolder[] = [],
-    importingDataQueryFolderMappings: DataQueryFolderMapping[] = []
+    importingDataQueryFolderMappings: DataQueryFolderMapping[] = [],
+    appType?: string
   ): Promise<AppResourceMappings> {
     appResourceMappings = { ...appResourceMappings };
 
@@ -1417,6 +1419,14 @@ export class AppImportExportService {
           newComponentIdsMap[component.id] = uuid();
         }
 
+        // Modules require every non-container component to be parented under the
+        // ModuleContainer; the builder/incremental APIs enforce this (component.service.ts),
+        // but imported bundles can carry components with no parent at all. Fall back to the
+        // page's ModuleContainer so imported modules get the same guarantee.
+        const moduleContainerComponent =
+          appType === APP_TYPES.MODULE ? pageComponents.find((c) => c.type === 'ModuleContainer') : null;
+        const moduleContainerId = moduleContainerComponent ? newComponentIdsMap[moduleContainerComponent.id] : null;
+
         for (const component of pageComponents) {
           let skipComponent = false;
           const newComponent = new Component();
@@ -1466,6 +1476,15 @@ export class AppImportExportService {
               NewRevampedComponents,
               tooljetVersion
             );
+            // ModuleContainer's visibility isn't a schema-declared property (no UI control for
+            // it), so there's no resolve-time fallback if it's missing - unlike the builder/API
+            // create paths (util.service.ts, appCanvasUtils.js) which hardcode it at creation
+            // time. Imported bundles can carry a ModuleContainer with this stripped, which
+            // renders it at 0 height. Mirror the same hardcoded default here.
+            if (component.type === 'ModuleContainer' && !properties.visibility) {
+              properties.visibility = { value: '{{true}}' };
+            }
+
             newComponent.id = newComponentIdsMap[component.id];
             newComponent.name = component.name;
             newComponent.type = component.type;
@@ -1475,7 +1494,11 @@ export class AppImportExportService {
             newComponent.general = general;
             newComponent.displayPreferences = component.displayPreferences;
             newComponent.validation = validation;
-            newComponent.parent = component.parent ? parentId : null;
+            newComponent.parent = component.parent
+              ? parentId
+              : moduleContainerId && component.type !== 'ModuleContainer'
+                ? moduleContainerId
+                : null;
 
             if (component.type === 'ModuleViewer' && moduleResourceMappings) {
               // Replace module app ID


### PR DESCRIPTION
## 📝 What this does
Modules imported via `POST /api/v2/resources/import` (e.g. by third-party integrations building modules programmatically) could end up with components that aren't nested under the module's `ModuleContainer`, and a `ModuleContainer` missing its `visibility` property — both silently collapsing the module's render to nothing. The builder/incremental component APIs already guard against this (`component.service.ts`); the import path did not.

## 🔀 Changes
- Component import now falls back a component's missing `parent` to the page's `ModuleContainer` id, for module-type apps only
- `ModuleContainer` components missing the `visibility` property now default to visible on import, mirroring the same hardcoded default already used when a module is created via the UI/API (`util.service.ts`)
- Both fixes are additive fallbacks — only apply when the source value is missing, existing valid `parent`/`visibility` values are untouched

## 🧪 How to test
- [ ] Import a module bundle (`POST /api/v2/resources/import`) where some components have no `parent` and the `ModuleContainer` has no `visibility` property set
- [ ] Open the imported module in the builder and confirm all components render nested under the `ModuleContainer` and the container itself is visible
- [ ] Import a normal front-end app bundle and confirm behavior is unchanged (no `ModuleContainer` fallback applied)