### PR TITLE
Fix: match legacy NULL branch_id rows on default-branch fallback

### DIFF
--- a/server/src/modules/folder-apps/interfaces/IUtilService.ts
+++ b/server/src/modules/folder-apps/interfaces/IUtilService.ts
@@ -23,5 +23,10 @@ export interface IFolderAppsUtilService {
     type?: APP_TYPES,
     branchId?: string
   ): Promise<{ viewableApps: AppBase[]; totalCount: number }>;
-  bulkCreate(folderId: string, appIds: string[], branchId?: string): Promise<FolderApp[]>;
+  bulkCreate(
+    folderId: string,
+    appIds: string[],
+    branchId?: string,
+    matchNullAsDefaultBranch?: boolean
+  ): Promise<FolderApp[]>;
 }

--- a/server/src/modules/folder-apps/service.ts
+++ b/server/src/modules/folder-apps/service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { FolderApp } from '../../entities/folder_app.entity';
 import { App } from '../../entities/app.entity';
 import { dbTransactionWrap, getConnectionInstance } from '@helpers/database.helper';
-import { EntityManager, In, IsNull } from 'typeorm';
+import { EntityManager, Equal, In, IsNull, Or } from 'typeorm';
 import { decamelizeKeys } from 'humps';
 import { FoldersUtilService } from '@modules/folders/util.service';
 import { FolderAppsUtilService } from './util.service';
@@ -25,8 +25,12 @@ export class FolderAppsService implements IFolderAppsService {
   ) {}
 
   async create(folderId: string, appId: string, branchId?: string, organizationId?: string): Promise<FolderApp> {
-    const resolvedBranchId = await this.resolveEffectiveBranchId(appId, branchId, organizationId);
-    return this.folderAppsUtilService.create(folderId, appId, resolvedBranchId);
+    const { branchId: resolvedBranchId, isDefaultFallback } = await this.resolveEffectiveBranchId(
+      appId,
+      branchId,
+      organizationId
+    );
+    return this.folderAppsUtilService.create(folderId, appId, resolvedBranchId, isDefaultFallback);
   }
 
   async bulkCreate(
@@ -35,51 +39,58 @@ export class FolderAppsService implements IFolderAppsService {
     branchId?: string,
     organizationId?: string
   ): Promise<FolderApp[]> {
-    const resolvedBranchId = await this.resolveEffectiveBranchIdForBulk(appIds, branchId, organizationId);
-    return this.folderAppsUtilService.bulkCreate(folderId, appIds, resolvedBranchId);
+    const { branchId: resolvedBranchId, isDefaultFallback } = await this.resolveEffectiveBranchIdForBulk(
+      appIds,
+      branchId,
+      organizationId
+    );
+    return this.folderAppsUtilService.bulkCreate(folderId, appIds, resolvedBranchId, isDefaultFallback);
   }
 
   async remove(folderId: string, appId: string, branchId?: string, organizationId?: string): Promise<void> {
-    const resolvedBranchId = await this.resolveEffectiveBranchId(appId, branchId, organizationId);
+    const { branchId: resolvedBranchId, isDefaultFallback } = await this.resolveEffectiveBranchId(
+      appId,
+      branchId,
+      organizationId
+    );
     return dbTransactionWrap(async (manager: EntityManager) => {
       const where = resolvedBranchId
-        ? { folderId, appId, branchId: resolvedBranchId }
+        ? { folderId, appId, branchId: isDefaultFallback ? Or(Equal(resolvedBranchId), IsNull()) : resolvedBranchId }
         : { folderId, appId, branchId: IsNull() };
       return await manager.delete(FolderApp, where);
     });
   }
 
-  // Resolves the effective branch_id for a write operation. When branchId is already provided it
-  // is returned as-is. When absent and the app is not a workflow (which always uses branch_id=NULL
-  // by convention), we resolve the org's default branch so that non-git-workspace writes land on
-  // the same branch_id as the read path — preventing duplicate rows keyed on (app_id, NULL) vs
-  // (app_id, defaultBranchId) that would stale-lock folder-based permissions.
+  // When branchId is absent (non-workflow apps), we resolve the org's default branch so writes
+  // land on the same branch_id as the read path. isDefaultFallback flags that resolution so
+  // callers also match pre-existing branch_id=NULL rows for this app — otherwise those legacy
+  // rows are invisible to the (app_id, defaultBranchId) lookup and get orphaned.
   private async resolveEffectiveBranchId(
     appId: string,
     branchId?: string,
     organizationId?: string
-  ): Promise<string | undefined> {
-    if (branchId || !organizationId || !appId) return branchId;
+  ): Promise<{ branchId?: string; isDefaultFallback: boolean }> {
+    if (branchId || !organizationId || !appId) return { branchId, isDefaultFallback: false };
     const manager = getConnectionInstance().manager;
     const app = await manager.findOne(App, { where: { id: appId }, select: ['type'] });
-    if (!app || app.type === APP_TYPES.WORKFLOW) return undefined;
+    if (!app || app.type === APP_TYPES.WORKFLOW) return { branchId: undefined, isDefaultFallback: false };
     const { options } = await this.gitSyncConfigsUtilService.getDetails(organizationId);
-    return options.defaultBranch?.id;
+    return { branchId: options.defaultBranch?.id, isDefaultFallback: !!options.defaultBranch?.id };
   }
 
   private async resolveEffectiveBranchIdForBulk(
     appIds: string[],
     branchId?: string,
     organizationId?: string
-  ): Promise<string | undefined> {
-    if (branchId || !organizationId || !appIds.length) return branchId;
+  ): Promise<{ branchId?: string; isDefaultFallback: boolean }> {
+    if (branchId || !organizationId || !appIds.length) return { branchId, isDefaultFallback: false };
     const manager = getConnectionInstance().manager;
     // Check first app's type — bulk operations come from a single-type list in practice (the
     // frontend always sends either all FRONT_END/MODULE apps or all workflows in one call).
     const app = await manager.findOne(App, { where: { id: In(appIds) }, select: ['type'] });
-    if (!app || app.type === APP_TYPES.WORKFLOW) return undefined;
+    if (!app || app.type === APP_TYPES.WORKFLOW) return { branchId: undefined, isDefaultFallback: false };
     const { options } = await this.gitSyncConfigsUtilService.getDetails(organizationId);
-    return options.defaultBranch?.id;
+    return { branchId: options.defaultBranch?.id, isDefaultFallback: !!options.defaultBranch?.id };
   }
 
   private getResourceTypefromAppType(type: APP_TYPES) {

--- a/server/src/modules/folder-apps/util.service.ts
+++ b/server/src/modules/folder-apps/util.service.ts
@@ -1,7 +1,7 @@
 import { Folder } from '@entities/folder.entity';
 import { User } from '@entities/user.entity';
 import { Injectable } from '@nestjs/common';
-import { EntityManager, In, IsNull, SelectQueryBuilder } from 'typeorm';
+import { EntityManager, Equal, In, IsNull, Or, SelectQueryBuilder } from 'typeorm';
 import { IFolderAppsUtilService } from './interfaces/IUtilService';
 import { AppBase } from '@entities/app_base.entity';
 import { dbTransactionWrap, getConnectionInstance } from '@helpers/database.helper';
@@ -272,9 +272,22 @@ export class FolderAppsUtilService implements IFolderAppsUtilService {
     };
   }
 
-  async bulkCreate(folderId: string, appIds: string[], branchId?: string): Promise<FolderApp[]> {
+  // matchNullAsDefaultBranch: branchId was resolved from the org's default branch rather than
+  // passed explicitly, so also match legacy branch_id=NULL rows for this app — they predate
+  // branch_id being mandatory and would otherwise look like a different row.
+  private buildBranchFilter(branchId?: string, matchNullAsDefaultBranch = false) {
+    if (!branchId) return { branchId: IsNull() };
+    return { branchId: matchNullAsDefaultBranch ? Or(Equal(branchId), IsNull()) : branchId };
+  }
+
+  async bulkCreate(
+    folderId: string,
+    appIds: string[],
+    branchId?: string,
+    matchNullAsDefaultBranch = false
+  ): Promise<FolderApp[]> {
     return dbTransactionWrap(async (manager: EntityManager) => {
-      const branchFilter = branchId ? { branchId } : { branchId: IsNull() };
+      const branchFilter = this.buildBranchFilter(branchId, matchNullAsDefaultBranch);
       const existing = await manager.find(FolderApp, { where: { appId: In(appIds), ...branchFilter } });
       const alreadyInFolder = new Set(existing.filter((fa) => fa.folderId === folderId).map((fa) => fa.appId));
       const toRemove = existing.filter((fa) => fa.folderId !== folderId);
@@ -293,9 +306,14 @@ export class FolderAppsUtilService implements IFolderAppsUtilService {
     });
   }
 
-  async create(folderId: string, appId: string, branchId?: string): Promise<FolderApp> {
+  async create(
+    folderId: string,
+    appId: string,
+    branchId?: string,
+    matchNullAsDefaultBranch = false
+  ): Promise<FolderApp> {
     return dbTransactionWrap(async (manager: EntityManager) => {
-      const branchFilter = branchId ? { branchId } : { branchId: IsNull() };
+      const branchFilter = this.buildBranchFilter(branchId, matchNullAsDefaultBranch);
       const existingFolderApp = await manager.findOne(FolderApp, {
         where: { appId, ...branchFilter },
       });

--- a/server/test/modules/modules/e2e/module-granular-permissions.spec.ts
+++ b/server/test/modules/modules/e2e/module-granular-permissions.spec.ts
@@ -1,6 +1,14 @@
 import * as request from 'supertest';
 import { INestApplication } from '@nestjs/common';
-import { createUser, initTestApp, closeTestApp, createApplication, login, findEntityOrFail } from 'test-helper';
+import {
+  createUser,
+  initTestApp,
+  closeTestApp,
+  createApplication,
+  createApplicationVersion,
+  login,
+  findEntityOrFail,
+} from 'test-helper';
 import { GroupPermissions } from 'src/entities/group_permissions.entity';
 
 /**
@@ -99,12 +107,19 @@ describe('ModuleGranularPermissions (H1)', () => {
       const viewerCookie = (await login(nestApp, 'mgp-viewer@tooljet.io')).tokenCookie;
 
       // --- modules (all owned by admin) -------------------------------------
+      // The dashboard query inner-joins app_versions on the org's default branch (modules are
+      // branch-scoped, same as front-end apps) — createApplication alone leaves an app with no
+      // version, so it never surfaces on the module dashboard. Give each one a version.
       const mEdit = await createApplication(nestApp, { name: 'M-Edit', user: adminData.user, type: 'module' });
+      await createApplicationVersion(nestApp, mEdit);
       const mBuild = await createApplication(nestApp, { name: 'M-Build', user: adminData.user, type: 'module' });
-      await createApplication(nestApp, { name: 'M-None', user: adminData.user, type: 'module' });
+      await createApplicationVersion(nestApp, mBuild);
+      const mNone = await createApplication(nestApp, { name: 'M-None', user: adminData.user, type: 'module' });
+      await createApplicationVersion(nestApp, mNone);
 
       // a module OWNED by the viewer, with no group grant
-      await createApplication(nestApp, { name: 'M-Owned', user: viewerData.user, type: 'module' });
+      const mOwned = await createApplication(nestApp, { name: 'M-Owned', user: viewerData.user, type: 'module' });
+      await createApplicationVersion(nestApp, mOwned);
 
       // --- assign module perms to the custom group --------------------------
       const teamId = await groupId('module-team', org.id);


### PR DESCRIPTION
## 📝 What this does
Folder-app writes (add/move/remove) resolve a NULL branch_id to the org's default branch now that every org always has one, but that broke moving/removing folder-app rows seeded before branch_id became mandatory — those rows stayed NULL and got orphaned instead of matched. This restores the fallback-matching behavior so legacy NULL rows and default-branch rows are treated as the same row.

## 🔀 Changes
- Matched legacy branch_id=NULL folder-app rows against the resolved default branch when no explicit branch_id was passed, so they're moved/deleted instead of orphaned
- Threaded an isDefaultFallback flag from FolderAppsService through to FolderAppsUtilService's create/bulkCreate to drive that matching
- Restored missing createApplicationVersion calls in the module-granular-permissions e2e spec so seeded module apps get a version row on the default branch and appear on the dashboard

## 🧪 How to test
- [ ] `task test:e2e-filter -- folder-apps`
- [ ] `task test:e2e-filter -- module-granular-permissions`