### PR TITLE
fix(ability): merge orgVariableCRUD from group grants

### DIFF
--- a/server/src/modules/ability/service.ts
+++ b/server/src/modules/ability/service.ts
@@ -70,7 +70,7 @@ export class AbilityService extends IAbilityService {
           folderDelete: acc.folderDelete || group.folderDelete,
           orgConstantCRUD: acc.orgConstantCRUD || group.orgConstantCRUD,
           tjdbCRUD: acc.tjdbCRUD || group.tjdbCRUD,
-          orgVariableCRUD: acc.orgVariableCRUD,
+          orgVariableCRUD: acc.orgVariableCRUD || group.orgVariableCRUD,
           workflowCreate: acc.workflowCreate || group.workflowCreate,
           workflowDelete: acc.workflowDelete || group.workflowDelete,
           moduleCreate: acc.moduleCreate || group.moduleCreate,


### PR DESCRIPTION
### What

`server/src/modules/ability/service.ts` — in `resourceActionsPermission`, the reduce over group permissions ORs every flag from each group (`acc.X || group.X`) except `orgVariableCRUD`, which read only `acc.orgVariableCRUD` and never merged the group's own value:

```ts
orgVariableCRUD: acc.orgVariableCRUD,
```

So the resolved `orgVariableCRUD` permission stayed at its default (`false`) regardless of what any group actually granted.

### Fix

Match the sibling flags so a group's grant is merged in:

```ts
orgVariableCRUD: acc.orgVariableCRUD || group.orgVariableCRUD,
```

Fixes #17392
