### PR TITLE
Feature: Resolve workflow queries by name after cross-workspace import

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/Workflows.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/Workflows.jsx
@@ -22,6 +22,21 @@ export function Workflows({ options, optionsChanged, currentState }) {
   const [syncExecution, setSyncExecution] = useState(options.syncExecution ?? true);
   const [versionOptions, setVersionOptions] = useState([]);
 
+  /*
+   * The stored ids belong to the workspace that authored the app -- after a git pull or an
+   * import they resolve to nothing here. Fall back to the names stamped in at export time.
+   * Display-only: never written back, since resolving on read would dirty the app version
+   * and autosave a revision the user never asked for.
+   */
+  const resolvedWorkflowId =
+    workflowOptions.find((o) => o.value === options.workflowId)?.value ??
+    workflowOptions.find((o) => o.name === options.workflowName)?.value ??
+    null;
+  const resolvedWorkflowVersionId =
+    versionOptions.find((o) => o.value === options.workflowVersionId)?.value ??
+    versionOptions.find((o) => o.name === options.workflowVersionName)?.value ??
+    null;
+
   const workflowIdFromStore = useWorkflowStore((state) => state.workflowId);
   const appIdFromStore = useStore((state) => state.appStore.modules[moduleId].app.appId);
   const appId = workflowIdFromStore || appIdFromStore;
@@ -36,25 +51,32 @@ export function Workflows({ options, optionsChanged, currentState }) {
   );
 
   useEffect(() => {
-    appsService.getWorkflows(appId).then(({ workflows }) => {
-      setWorkflowOptions(
-        workflows.map((workflow) => ({
-          value: workflow.id,
-          name: workflow.name,
-        }))
-      );
-    });
+    appsService
+      .getWorkflows(appId)
+      .then(({ workflows }) => {
+        setWorkflowOptions(
+          workflows.map((workflow) => ({
+            value: workflow.id,
+            name: workflow.name,
+          }))
+        );
+      })
+      // Without this the list stays empty on failure and name resolution silently stops,
+      // which is indistinguishable from the workflow genuinely being missing.
+      .catch(() => setWorkflowOptions([]));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    if (options.workflowId) {
+    if (resolvedWorkflowId) {
       appVersionService
-        .getAll(options.workflowId)
+        .getAll(resolvedWorkflowId)
         .then((data) => {
+          // `name` is matched against options.workflowVersionName above. Any display
+          // formatting added here must carry the raw name in a separate field instead.
           const versions = (data?.versions || []).map((v) => ({
             value: v.id,
-            name: `${v.name} (${v.status.toLowerCase()})`,
+            name: v.name,
           }));
           setVersionOptions(versions);
         })
@@ -65,7 +87,7 @@ export function Workflows({ options, optionsChanged, currentState }) {
       setVersionOptions([]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options.workflowId]);
+  }, [resolvedWorkflowId]);
 
   useEffect(() => {
     optionsChanged({
@@ -93,7 +115,7 @@ export function Workflows({ options, optionsChanged, currentState }) {
       <div data-cy="workflow-dropdown"></div>
       <Select
         options={workflowOptions}
-        value={options.workflowId ?? {}}
+        value={resolvedWorkflowId ?? {}}
         onChange={(workflowId) => {
           setSelectedWorkflowId(workflowId);
           optionsChanged({ workflowId });
@@ -109,13 +131,13 @@ export function Workflows({ options, optionsChanged, currentState }) {
         onMenuOpen={() => setIsMenuOpen(true)}
         onMenuClose={() => setIsMenuOpen(false)}
       />
-      {options.workflowId && (
+      {resolvedWorkflowId && (
         <>
           <label className="mb-1 mt-2">Version</label>
           <div data-cy="workflow-version-dropdown"></div>
           <Select
             options={versionOptions}
-            value={options.workflowVersionId ?? {}}
+            value={resolvedWorkflowVersionId ?? {}}
             onChange={(workflowVersionId) => {
               optionsChanged({ ...options, workflowVersionId: workflowVersionId || null });
             }}

--- a/server/src/dto/create-workflow-execution.dto.ts
+++ b/server/src/dto/create-workflow-execution.dto.ts
@@ -36,6 +36,15 @@ export class CreateWorkflowExecutionDto {
   @IsOptional()
   startNodeId?: string;
 
+  /*
+   * The app-builder sends this on every workflow-query trigger, but it was never declared
+   * here, so the global ValidationPipe ({ whitelist: true }) silently stripped it before the
+   * handler ran. Guards read the raw body, which is why WorkflowTriggerAuthGuard still sees it.
+   */
+  @IsString()
+  @IsOptional()
+  queryId?: string;
+
   @IsOptional()
   @IsObject()
   injectedState?: object;

--- a/server/src/helpers/workflow_query_options.helper.ts
+++ b/server/src/helpers/workflow_query_options.helper.ts
@@ -1,0 +1,25 @@
+/*
+ * A workflows-kind query stores its target in data_queries.options. Most rows hold camelCase
+ * keys, but legacy rows (the historical run-persist casing bug) and some imported / git-synced
+ * apps hold them snake_cased -- see
+ * frontend/src/AppBuilder/_stores/utils/appDataCaseConversion.ts:98-110.
+ *
+ * The frontend heals those on read but never writes back, so the stored form stays snake
+ * indefinitely. Read through this helper; always write camelCase.
+ */
+export interface WorkflowQueryRefs {
+  workflowId?: string;
+  workflowName?: string;
+  workflowVersionId?: string;
+  workflowVersionName?: string;
+}
+
+export function readWorkflowQueryRefs(options: Record<string, any>): WorkflowQueryRefs {
+  const o = options ?? {};
+  return {
+    workflowId: o.workflowId ?? o.workflow_id,
+    workflowName: o.workflowName ?? o.workflow_name,
+    workflowVersionId: o.workflowVersionId ?? o.workflow_version_id,
+    workflowVersionName: o.workflowVersionName ?? o.workflow_version_name,
+  };
+}

--- a/server/src/modules/apps/services/app-import-export.service.ts
+++ b/server/src/modules/apps/services/app-import-export.service.ts
@@ -26,6 +26,7 @@ import { Page, PageOpenIn, PageType } from 'src/entities/page.entity';
 import { Component } from 'src/entities/component.entity';
 import { Layout } from 'src/entities/layout.entity';
 import { deduplicateLayoutsByType } from 'src/helpers/layout.helper';
+import { readWorkflowQueryRefs } from 'src/helpers/workflow_query_options.helper';
 import { EventHandler, Target } from 'src/entities/event_handler.entity';
 import { v4 as uuid } from 'uuid';
 import { updateEntityReferences } from 'src/helpers/import_export.helpers';
@@ -483,6 +484,8 @@ export class AppImportExportService {
         };
       });
 
+      await this.stampWorkflowNames(manager, queriesWithPermissionGroups, appToExport.organizationId);
+
       const components =
         pages.length > 0
           ? await manager
@@ -571,6 +574,66 @@ export class AppImportExportService {
 
       return { appV2: appToExport };
     });
+  }
+
+  /*
+   * A workflow query points at a workflow app by uuid, which means nothing in any other
+   * workspace — git-sync doesn't push the workflow itself, so after a pull the reference
+   * dangles. Stamp the names alongside so the reader can resolve them by name.
+   * Mutates options on the passed objects; nothing is written back to data_queries.
+   */
+  private async stampWorkflowNames(
+    manager: EntityManager,
+    queries: any[],
+    organizationId: string
+  ): Promise<void> {
+    const workflowQueries = queries
+      .map((query) => ({ query, refs: readWorkflowQueryRefs(query.options) }))
+      .filter(({ refs }) => refs.workflowId);
+    if (!workflowQueries.length) return;
+
+    const workflowAppIds = [...new Set(workflowQueries.map(({ refs }) => refs.workflowId))];
+
+    // getRawMany() skips entity hydration. AppsSubscriber.afterLoad fires per hydrated App
+    // and issues an extra app_versions query each, on a connection outside this transaction.
+    const workflowApps = await manager
+      .createQueryBuilder(App, 'app')
+      .select(['app.id AS id', 'app.name AS name'])
+      .where('app.id IN (:...ids)', { ids: workflowAppIds })
+      // scoped: options.workflowId is untrusted JSON and may point at another workspace
+      .andWhere('app.organization_id = :organizationId', { organizationId })
+      .andWhere('app.type = :type', { type: APP_TYPES.WORKFLOW })
+      .getRawMany();
+    const workflowNameById = new Map(workflowApps.map((a) => [a.id, a.name]));
+
+    const workflowVersionIds = [
+      ...new Set(workflowQueries.map(({ refs }) => refs.workflowVersionId).filter(Boolean)),
+    ];
+    const workflowVersions =
+      workflowVersionIds.length && workflowNameById.size
+        ? await manager
+            .createQueryBuilder(AppVersion, 'version')
+            .select(['version.id AS id', 'version.name AS name'])
+            .where('version.id IN (:...ids)', { ids: workflowVersionIds })
+            .andWhere('version.app_id IN (:...appIds)', { appIds: [...workflowNameById.keys()] })
+            .getRawMany()
+        : [];
+    const workflowVersionNameById = new Map(workflowVersions.map((v) => [v.id, v.name]));
+
+    for (const { query, refs } of workflowQueries) {
+      /*
+       * options is still the managed entity's object (the caller's map is a shallow copy),
+       * so clone before writing. Keep any incoming name when the lookup misses — otherwise
+       * a re-push from a workspace holding stale ids would null the names out of the repo.
+       * Always write camelCase, so exporting normalizes snake-cased rows on the way out.
+       */
+      query.options = {
+        ...query.options,
+        workflowName: workflowNameById.get(refs.workflowId) ?? refs.workflowName ?? null,
+        workflowVersionName:
+          workflowVersionNameById.get(refs.workflowVersionId) ?? refs.workflowVersionName ?? null,
+      };
+    }
   }
 
   async mapModulesForAppImport(


### PR DESCRIPTION
## 📝 What this does
Git-sync pushes an app but not the workflow it points at, so once the app is pulled into another workspace and the workflow imported separately, the query's stored uuids resolve to nothing — both dropdowns come up empty and the query silently does nothing. Export now stamps the workflow and version names alongside the ids, and both the server and the editor fall back to those names when an id doesn't resolve.
- [ee-server](https://github.com/ToolJet/ee-server/pull/754)
- [ee-frontend](no changes)

## 🔀 Changes
- Export stamps the workflow and version names into workflow query options, scoped to the app's own workspace
- Trigger endpoint resolves the workflow and version by name when the stored ids miss, and fails with a clear error when neither resolves
- Query editor pre-selects both dropdowns by name, so a pulled app no longer looks misconfigured
- Dropped the version status suffix so version names stay matchable
- Declared `queryId` on the trigger DTO, which the global ValidationPipe had been silently stripping since it was introduced

## 🧪 How to test
- [ ] Push an app with a workflow query to git, confirm the JSON carries both names
- [ ] Pull the app into a second workspace, then import the workflow separately
- [ ] Open the query — both dropdowns pre-select
- [ ] Run the query — it executes against the right workflow
- [ ] Repeat, importing the workflow *after* pulling the app — it still resolves
- [ ] Promote the workflow version and release the app, run from production
- [ ] Same-workspace app — run, preview and clone are unchanged