### PR TITLE
Fix: module public-viewer bugs and folder-permission gaps

### DIFF
--- a/cypress-tests/cypress/constants/texts/manageGroups.js
+++ b/cypress-tests/cypress/constants/texts/manageGroups.js
@@ -25,7 +25,7 @@ export const groupsText = {
   resourcesFolders: "Folder",
   createLabel: "Create",
   folderCreateLabel: "Create",
-  folderCreateHelperText: "Create new folders in this workspace",
+  folderCreateHelperText: "Create new app folders in this workspace",
   folderDeleteHelperText: "Delete any folders in this workspace",
   deleteLabel: "Delete",
   deleteMessage: "This permission will be permanently deleted. Do you want to continue?",

--- a/frontend/src/AppBuilder/Viewer/PreviewSettings.jsx
+++ b/frontend/src/AppBuilder/Viewer/PreviewSettings.jsx
@@ -46,7 +46,7 @@ const PreviewSettings = ({ isMobileLayout, showHeader, darkMode }) => {
         <span className="preview-settings-text" data-cy="preview-settings-text">
           Preview settings
         </span>
-        {editingVersion && appType !== 'module' && (
+        {editingVersion && (
           <Suspense
             fallback={
               <div className="d-flex justify-content-center" style={{ width: '304px' }}>
@@ -107,17 +107,15 @@ const PreviewSettings = ({ isMobileLayout, showHeader, darkMode }) => {
           </Offcanvas.Header>
           {previewNavbar && (
             <Offcanvas.Body>
-              {appType !== 'module' && (
-                <Suspense fallback={null}>
-                  <span style={{ marginTop: '4px' }}>
-                    <AppEnvironments darkMode={darkMode} />
-                  </span>
-                  <hr className="m-0" />
-                  <span>
-                    <AppVersionsManager darkMode={darkMode} />
-                  </span>
-                </Suspense>
-              )}
+              <Suspense fallback={null}>
+                <span style={{ marginTop: '4px' }}>
+                  <AppEnvironments darkMode={darkMode} />
+                </span>
+                <hr className="m-0" />
+                <span>
+                  <AppVersionsManager darkMode={darkMode} />
+                </span>
+              </Suspense>
 
               <div
                 className={classNames('d-flex px-2 pb-2 align-items-center width-100', {

--- a/frontend/src/AppBuilder/Viewer/Viewer.jsx
+++ b/frontend/src/AppBuilder/Viewer/Viewer.jsx
@@ -23,6 +23,7 @@ export const Viewer = ({
   moduleId = 'canvas',
   switchDarkMode,
   environmentId,
+  environmentName,
   versionId,
   moduleMode = false,
   isHydrating = false,
@@ -36,7 +37,7 @@ export const Viewer = ({
     moduleId,
     darkMode,
     'view',
-    { environmentId, versionId, componentName },
+    { environmentId, environmentName, versionId, componentName },
     moduleMode,
     false,
     appSlug
@@ -197,8 +198,8 @@ export const Viewer = ({
                                 isPagesSidebarHidden || currentLayout === 'mobile'
                                   ? 'auto'
                                   : position === 'top'
-                                    ? '0px'
-                                    : '256px',
+                                  ? '0px'
+                                  : '256px',
                             }}
                           >
                             <div

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -41,7 +41,7 @@ const useAppData = (
   moduleId,
   darkMode,
   mode = 'edit',
-  { environmentId, versionId, componentName } = {},
+  { environmentId, environmentName, versionId, componentName } = {},
   moduleMode = false,
   isModuleEditor = false,
   appSlug
@@ -377,8 +377,8 @@ const useAppData = (
           if (moduleMode) {
             // A module's own is_public is always false, so PublicAppEnvironmentGuard 401s
             // on the module's slug. ModuleViewer already resolved the parent's environment
-            // into environmentId — reuse it instead of re-resolving.
-            editorEnvironment = { id: environmentId };
+            // id/name — reuse them instead of re-resolving.
+            editorEnvironment = { id: environmentId, name: environmentName };
           } else {
             try {
               const queryParams = { slug: slug };

--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -399,7 +399,7 @@ export default function AppCard({
                     </ToolTip>
                   ) : (
                     <div visible={focused ? true : undefined}>
-                      {(canDeleteApp(app) || canUpdateApp(app) || appType === 'module') && !isGitLicenseLocked && (
+                      {(canDeleteApp(app) || canUpdateApp(app)) && !isGitLicenseLocked && (
                         <AppMenu
                           appId={app?.id}
                           appUserId={app?.user_id}
@@ -448,7 +448,7 @@ export default function AppCard({
               )}
             </div>
             <div className="appcard-buttons-wrap">
-              {(canUpdate || appType === 'module') && (
+              {canUpdate && (
                 <div>
                   <ToolTip message={`Open in ${appType !== 'workflow' ? 'app builder' : 'workflow editor'}`}>
                     <Link
@@ -474,9 +474,16 @@ export default function AppCard({
                 <div>
                   <ToolTip message="Open in app builder">
                     <Link
-                      to={getPrivateRoute('editor', {
-                        slug: isValidSlug(app.slug) ? app.slug : app.id,
-                      })}
+                      // reloadDocument forces a hard navigation, discarding the in-memory active-branch
+                      // cache — carry the branch in the URL itself (same fix as handleEditClick) so the
+                      // module resolves on the branch its current version actually lives on, not just
+                      // the default branch.
+                      to={appendBranchName(
+                        getPrivateRoute('editor', {
+                          slug: isValidSlug(app.slug) ? app.slug : app.id,
+                        }),
+                        wsCurrentBranch?.name
+                      )}
                       reloadDocument
                     >
                       <button

--- a/frontend/src/HomePage/AppMenu.jsx
+++ b/frontend/src/HomePage/AppMenu.jsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { authenticationService } from '@/_services';
 import { useWorkspaceBranchesStore } from '@/_stores/workspaceBranchesStore';
 import { getFolderGroupPermissions } from './helper';
+import { canEditModule } from '@/modules/Modules/helpers/modulePermissions';
 
 export const AppMenu = function AppMenu({
   appId,
@@ -44,11 +45,15 @@ export const AppMenu = function AppMenu({
   // ─── App-level edit access ────────────────────────────────────────────────────
   // Backend resolves folder-derived permissions into editable_apps_id/editable_workflows_id,
   // so canEditApp already covers apps/workflows in folders owned by or explicitly shared
-  // with the user. Workflows have their own permission surface, separate from apps.
+  // with the user. Workflows and modules each have their own permission surface, separate
+  // from apps — modules delegate to canEditModule so this stays in sync with HomePage's
+  // canUserPerform and the module editor's own read-only gate.
   const canEditApp =
     appType === 'workflow'
       ? currentSession?.workflow_group_permissions?.is_all_editable ||
         currentSession?.workflow_group_permissions?.editable_workflows_id?.includes(appId)
+      : appType === 'module'
+      ? canEditModule(currentSession, appId, appUserId)
       : currentSession?.app_group_permissions?.is_all_editable ||
         currentSession?.app_group_permissions?.editable_apps_id?.includes(appId);
 

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -38,6 +38,7 @@ import { LicenseTooltip } from '@/LicenseTooltip';
 import ModalBase from '@/_ui/Modal';
 import FolderFilter from './FolderFilter';
 import { useLicenseStore } from '@/_stores/licenseStore';
+import { getFolderGroupPermissions, appTypeToDisplayNameMapping, getFolderPermissionField } from './helper';
 import { shallow } from 'zustand/shallow';
 import { fetchAndSetWindowTitle, pageTitles } from '@white-label/whiteLabelling';
 import HeaderSkeleton from '@/_ui/FolderSkeleton/HeaderSkeleton';
@@ -67,8 +68,6 @@ import { subscribeLiveNotifications } from '@/_stores/notificationsStore';
 import { WorkspaceSwitchBranchModal } from '@/_ui/WorkspaceBranchDropdown/SwitchBranchModal';
 import { PullConflictModal } from '@/_ui/WorkspaceBranchDropdown/WorkspacePullConflictModal';
 import { TriangleAlert } from 'lucide-react';
-
-import { appTypeToDisplayNameMapping, getFolderPermissionField } from './helper';
 
 const MAX_APPS_PER_PAGE = 9; // Keep in sync with server pagination limit
 class HomePageComponent extends React.Component {
@@ -2326,11 +2325,9 @@ class HomePageComponent extends React.Component {
                         const currentSession = authenticationService.currentSessionValue;
                         if (currentSession?.super_admin || currentSession?.admin) return true;
 
-                        // Builders have admin-level access to module folders
-                        if (this.props.appType === 'module' && currentSession?.role?.name === 'builder') return true;
-
-                        // Check if user has edit permissions for the folder
-                        const folderPermissions = currentSession?.user_permissions?.folder;
+                        // Check if user has edit permissions for the folder — resolved per
+                        // appType (front-end/module/workflow each have their own granular bucket).
+                        const folderPermissions = getFolderGroupPermissions(currentSession, this.props.appType);
                         if (folderPermissions?.is_all_editable) return true;
                         if (folderPermissions?.editable_folders_id?.includes(folder.id)) return true;
 

--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
@@ -699,7 +699,7 @@ class BaseManageGroupPermissionResources extends React.Component {
             class={`tj-text-xxsm ${disableNonPromoteReleasePermissions && 'check-label-disable'}`}
             data-cy="folder-create-helper-text"
           >
-            Create new folders in this workspace
+            Create new app folders in this workspace
           </span>
         </label>
         <label className="form-check form-check-inline">
@@ -1483,7 +1483,7 @@ class BaseManageGroupPermissionResources extends React.Component {
                                   <div data-cy="resource-folders">
                                     {this.props.t(
                                       'header.organization.menus.manageGroups.permissionResources.folder',
-                                      'Folder'
+                                      'App folder'
                                     )}
                                   </div>
                                   <div className="text-muted">

--- a/server/src/modules/app-git/ability/guard.ts
+++ b/server/src/modules/app-git/ability/guard.ts
@@ -3,12 +3,16 @@ import { FeatureAbilityFactory } from '.';
 import { AbilityGuard } from '@modules/app/guards/ability.guard';
 import { ResourceDetails } from '@modules/app/types';
 import { MODULES } from '@modules/app/constants/modules';
+import { APP_TYPES } from '@modules/apps/constants';
 import { App } from '@entities/app.entity';
 
 @Injectable()
 export class FeatureAbilityGuard extends AbilityGuard {
-  protected getResource(): ResourceDetails | ResourceDetails[] {
-    return [{ resourceType: MODULES.APP_GIT }, { resourceType: MODULES.APP }];
+  protected getResource(request?: any): ResourceDetails | ResourceDetails[] {
+    // Modules resolve via their own MODULES.MODULES bucket (granular module permissions),
+    // not the front-end app bucket — same mapping the ability factory reads.
+    const appResource = request?.tj_app?.type === APP_TYPES.MODULE ? MODULES.MODULES : MODULES.APP;
+    return [{ resourceType: MODULES.APP_GIT }, { resourceType: appResource }];
   }
 
   protected getAbilityFactory() {

--- a/server/src/modules/app-git/ability/index.ts
+++ b/server/src/modules/app-git/ability/index.ts
@@ -24,11 +24,14 @@ export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects>
   ): void {
     const appId = request?.tj_resource_id;
     const appType = request?.tj_app?.type;
+    const isModule = appType === APP_TYPES.MODULE;
     const { superAdmin, isAdmin, userPermission } = UserAllPermissions;
 
-    const userAppGitPermissions = userPermission?.[MODULES.APP];
+    // Modules resolve via their own MODULES.MODULES bucket (granular module permissions),
+    // not the front-end app bucket.
+    const userAppGitPermissions = userPermission?.[isModule ? MODULES.MODULES : MODULES.APP];
     const isAllAppsEditable = !!userAppGitPermissions?.isAllEditable;
-    const isAllAppsCreatable = !!userPermission?.appCreate;
+    const isAllAppsCreatable = !!(isModule ? userPermission?.moduleCreate : userPermission?.appCreate);
 
     // Used for public endpoint to get the app configs
     can(FEATURE_KEY.GIT_FETCH_APP_CONFIGS, App);
@@ -37,7 +40,7 @@ export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects>
     can(FEATURE_KEY.CREATE_BRANCH, App);
     can(FEATURE_KEY.FETCH_PULL_REQUESTS, App);
     // Grant feature-level access based on resource actions
-    if (isAdmin || superAdmin || (appType === APP_TYPES.MODULE && UserAllPermissions.isBuilder)) {
+    if (isAdmin || superAdmin) {
       // Admin or Super Admin gets full access to all features
       can(FEATURE_KEY.GIT_CREATE_APP, App);
       can(FEATURE_KEY.GIT_UPDATE_APP, App);

--- a/server/src/modules/apps/service.ts
+++ b/server/src/modules/apps/service.ts
@@ -323,7 +323,9 @@ export class AppsService implements IAppsService {
 
   validateReleasedApp(ability: AppAbility, app: App): { id: string; slug: string } {
     if (!app.currentVersionId) {
-      const editPermission = ability.can(FEATURE_KEY.UPDATE, App, app.id);
+      // ability is undefined for unauthenticated visitors on a public app - the guard
+      // lets them through without computing one. No ability means no edit permission.
+      const editPermission = ability?.can(FEATURE_KEY.UPDATE, App, app.id) ?? false;
       const errorResponse = {
         statusCode: HttpStatus.NOT_IMPLEMENTED,
         error: 'App is not released yet',

--- a/server/src/modules/custom-styles/module.ts
+++ b/server/src/modules/custom-styles/module.ts
@@ -1,5 +1,6 @@
 import { DynamicModule } from '@nestjs/common';
 import { OrganizationsModule } from '@modules/organizations/module';
+import { AppsModule } from '@modules/apps/module';
 import { FeatureAbilityFactory } from './ability';
 import { OrganizationRepository } from '@modules/organizations/repository';
 import { AppsRepository } from '@modules/apps/repository';
@@ -17,7 +18,10 @@ export class CustomStylesModule extends SubModule {
     ]);
     return this.cacheModule(cacheKey, {
       module: CustomStylesModule,
-      imports: [await OrganizationsModule.register(configs)],
+      // AppsModule provides AppsUtilService, which AppAuthGuard (used on the :slug route
+      // below) needs but this module never wired up — the guard's unauthenticated fallback
+      // path crashed with "Cannot read properties of undefined" instead of a clean 401.
+      imports: [await OrganizationsModule.register(configs), await AppsModule.register(configs)],
       providers: [CustomStylesService, FeatureAbilityFactory, OrganizationRepository, AppsRepository],
       controllers: isMainImport ? [CustomStylesController] : [],
       exports: [],

--- a/server/src/modules/data-queries/ability/app/data-query-app.ability.ts
+++ b/server/src/modules/data-queries/ability/app/data-query-app.ability.ts
@@ -12,18 +12,21 @@ export function defineDataQueryAppAbility(
   app: App
 ): void {
   const appId = app?.id;
-  const { superAdmin, isAdmin, userPermission, isBuilder, isEndUser } = UserAllPermissions;
-  const resourcePermissions = userPermission?.[MODULES.APP];
+  const { superAdmin, isAdmin, userPermission, isEndUser } = UserAllPermissions;
+  const isModule = app?.type === APP_TYPES.MODULE;
+  // Modules resolve via their own MODULES.MODULES bucket (granular module permissions),
+  // not the front-end app bucket — same mapping the guard used to fetch it.
+  const resourcePermissions = userPermission?.[isModule ? MODULES.MODULES : MODULES.APP];
   const isAllEditable = !!resourcePermissions?.isAllEditable;
-  const isCanCreate = userPermission.appCreate;
-  const isCanDelete = userPermission.appDelete;
+  const isCanCreate = isModule ? userPermission.moduleCreate : userPermission.appCreate;
+  const isCanDelete = isModule ? userPermission.moduleDelete : userPermission.appDelete;
   const isAllViewable = !!resourcePermissions?.isAllViewable;
 
   if (app?.isPublic) {
     can([FEATURE_KEY.RUN_VIEWER], App);
   }
 
-  if (isAdmin || superAdmin || (app?.type === APP_TYPES.MODULE && isBuilder)) {
+  if (isAdmin || superAdmin) {
     can(
       [
         FEATURE_KEY.CREATE,

--- a/server/src/modules/data-queries/repository.ts
+++ b/server/src/modules/data-queries/repository.ts
@@ -45,10 +45,9 @@ export class DataQueryRepository extends Repository<DataQuery> {
         .innerJoin(DataQuery, 'data_query', 'data_query.id = :dataQueryId', { dataQueryId })
         .innerJoin(AppVersion, 'module_version', 'module_version.id = data_query.app_version_id')
         .innerJoin(App, 'module_app', 'module_app.id = module_version.app_id')
-        // Metadata join: resolve is_public independently of which version is deployed.
-        // For git-sync apps apps.is_public is null; the canonical flag lives on the most
-        // recently updated version on the default branch (mirrors resolveMetadataVersion).
-        // For non-git-sync apps wb and av_meta will both be null, falling through to app.is_public.
+        // Metadata join: same row selection as AppsRepository.resolveMetadataVersion —
+        // without the is_stub filter/is_synced ordering, a stub row can outrank the
+        // canonical one on updated_at and read is_public as null, 401-ing a genuinely public app.
         .leftJoin(
           'organization_git_sync_branches',
           'wb',
@@ -59,15 +58,17 @@ export class DataQueryRepository extends Repository<DataQuery> {
           'av_meta',
           `av_meta.app_id = app.id
          AND av_meta.branch_id = wb.id
+         AND av_meta.is_stub = false
          AND av_meta.id = (
            SELECT av2.id FROM app_versions av2
-           WHERE av2.app_id = app.id AND av2.branch_id = wb.id
-           ORDER BY av2.updated_at DESC LIMIT 1
+           WHERE av2.app_id = app.id AND av2.branch_id = wb.id AND av2.is_stub = false
+           ORDER BY av2.is_synced DESC, av2.updated_at DESC LIMIT 1
          )`
         )
         .where('component.type = :componentType', { componentType: 'ModuleViewer' })
-        // Priority: git-sync metadata version → app row → structural version (non-git-sync fallback).
-        .andWhere('COALESCE(av_meta.is_public, app.is_public, app_version.is_public) = true')
+        // apps.is_public is never written (AppsUtilService.update), so app_version.is_public
+        // is the only real fallback if av_meta doesn't match.
+        .andWhere('COALESCE(av_meta.is_public, app_version.is_public) = true')
         .andWhere('module_version.app_id = :moduleAppId', { moduleAppId })
         .andWhere('module_version.app_id != app.id')
         .andWhere('app.organization_id = module_app.organization_id')

--- a/server/src/modules/folder-apps/ability/guard.ts
+++ b/server/src/modules/folder-apps/ability/guard.ts
@@ -8,7 +8,6 @@ import { Folder } from '@entities/folder.entity';
 import { App } from '@entities/app.entity';
 import { ResourceDetails } from '@modules/app/types';
 import { MODULES } from '@modules/app/constants/modules';
-import { APP_TYPES } from '@modules/apps/constants';
 import { cloneDeep } from 'lodash';
 import { FEATURE_KEY } from '../constants';
 import { LicenseTermsService } from '@modules/licensing/interfaces/IService';
@@ -74,13 +73,11 @@ export class FeatureAbilityGuard extends AbilityGuard {
         });
         request.tj_allow_owner_folder_app_create = folderOwnedByUser && !!app && app.userId === request.user.id;
         request.tj_allow_owner_folder_app_delete = folderOwnedByUser && !!app;
-        request.tj_app_is_module = app?.type === APP_TYPES.MODULE;
         request.tj_folder_app_type_mismatch = !!(folder?.type && app?.type && folder.type !== app.type);
       } else {
         // Bulk path (app_ids): folder ownership is sufficient — the frontend already
         // gates on canModifyApp before surfacing the "Add to folder" option.
         request.tj_allow_owner_folder_app_create = folderOwnedByUser;
-        request.tj_app_is_module = folder?.type === APP_TYPES.MODULE;
       }
     }
 

--- a/server/src/modules/folder-apps/ability/index.ts
+++ b/server/src/modules/folder-apps/ability/index.ts
@@ -11,7 +11,8 @@ export type FeatureAbility = Ability<[FEATURE_KEY, Subjects]>;
 
 // Folder-flavor → the UserPermissions bucket holding its resolved folder access.
 // Add an entry here (not another ternary arm) when a new folder-owning resource type is introduced.
-const FOLDER_RESOURCE_TYPE_BY_APP_TYPE: Partial<Record<APP_TYPES, MODULES>> = {
+// Exported so FolderAppsService.getFolders resolves the same bucket the ability check uses.
+export const FOLDER_RESOURCE_TYPE_BY_APP_TYPE: Partial<Record<APP_TYPES, MODULES>> = {
   [APP_TYPES.WORKFLOW]: MODULES.WORKFLOW_FOLDER,
   [APP_TYPES.MODULE]: MODULES.MODULE_FOLDER,
 };
@@ -50,10 +51,6 @@ export class FeatureAbilityFactory extends AbilityFactory<FEATURE_KEY, Subjects>
 
       if (ownerCanDeleteFolderApp) {
         can(FEATURE_KEY.DELETE_FOLDER_APP, FolderApp);
-      }
-
-      if (request?.tj_app_is_module && userPermission.isBuilder) {
-        can([FEATURE_KEY.CREATE_FOLDER_APP, FEATURE_KEY.DELETE_FOLDER_APP], FolderApp);
       }
 
       if (folderPermissions) {

--- a/server/src/modules/folder-apps/service.ts
+++ b/server/src/modules/folder-apps/service.ts
@@ -15,6 +15,7 @@ import { APP_TYPES } from '@modules/apps/constants';
 import { UserFolderPermissions } from '@modules/ability/types';
 import { GitSyncConfigsUtilService } from '@modules/git-sync-configs/util.service';
 import { skipAppEditingVersionHydration } from '@modules/apps/subscribers/apps.subscriber';
+import { FOLDER_RESOURCE_TYPE_BY_APP_TYPE } from './ability';
 @Injectable()
 export class FolderAppsService implements IFolderAppsService {
   constructor(
@@ -128,18 +129,15 @@ export class FolderAppsService implements IFolderAppsService {
         branchId = options.defaultBranch?.id;
       }
       const resourceType = this.getResourceTypefromAppType(type as APP_TYPES);
+      // Module/workflow folders are gated by their own MODULE_FOLDER/WORKFLOW_FOLDER bucket,
+      // not the generic front-end FOLDER bucket — same mapping the ability guard uses.
+      const folderResourceType = FOLDER_RESOURCE_TYPE_BY_APP_TYPE[type as APP_TYPES] ?? MODULES.FOLDER;
       const userPermissions = await this.abilityService.resourceActionsPermission(user, {
-        resources: [{ resource: resourceType }, { resource: MODULES.FOLDER }],
+        resources: [{ resource: resourceType }, { resource: folderResourceType }],
         organizationId: user.organizationId,
       });
       const userAppPermissions = userPermissions?.[resourceType] ?? userPermissions?.[MODULES.APP];
-      const userFolderPermissions = userPermissions?.[MODULES.FOLDER];
-
-      const isModuleBuilderAccess =
-        type === APP_TYPES.MODULE && (userPermissions?.isBuilder || userPermissions?.isAdmin);
-      const effectiveAppPermissions = isModuleBuilderAccess
-        ? { ...userAppPermissions, isAllEditable: true }
-        : userAppPermissions;
+      const userFolderPermissions = userPermissions?.[folderResourceType];
 
       const folders = await this.foldersUtilService.allFolders(user, manager, type);
       if (folders.length === 0) {
@@ -149,7 +147,7 @@ export class FolderAppsService implements IFolderAppsService {
       const folderIds = folders.map((f) => f.id);
       const folderApps = await this.folderAppsUtilService.findFolderAppsForFolders(
         folderIds,
-        effectiveAppPermissions,
+        userAppPermissions,
         manager,
         type as APP_TYPES,
         searchKey,
@@ -170,7 +168,7 @@ export class FolderAppsService implements IFolderAppsService {
       const visibleFolders = this.filterFoldersByPermissions(
         folders,
         user,
-        isModuleBuilderAccess || userPermissions?.isAdmin,
+        userPermissions?.isAdmin,
         userFolderPermissions
       );
 

--- a/server/src/modules/folder-apps/util.service.ts
+++ b/server/src/modules/folder-apps/util.service.ts
@@ -12,6 +12,19 @@ import { AbilityService } from '@modules/ability/interfaces/IService';
 import { APP_TYPES } from '@modules/apps/constants';
 import { AppVersionType } from '@entities/app_version.entity';
 
+// Permission resource that gates each app type's visibility. Mirrors
+// getResourceTypefromAppType in folder-apps/service.ts — keep both in sync.
+export function getPermissionResourceForAppType(type: APP_TYPES): MODULES {
+  switch (type) {
+    case APP_TYPES.WORKFLOW:
+      return MODULES.WORKFLOWS;
+    case APP_TYPES.MODULE:
+      return MODULES.MODULES;
+    default:
+      return MODULES.APP;
+  }
+}
+
 export function applyAppPermissionFilter(
   query: SelectQueryBuilder<FolderApp>,
   userAppPermissions: UserAppsPermissions
@@ -216,17 +229,16 @@ export class FolderAppsUtilService implements IFolderAppsUtilService {
 
     const folderApps = await folderAppsQuery.getMany();
 
+    // Modules resolve via their own MODULES.MODULES bucket (folder-level module grants
+    // live there, not under MODULES.APP) — same mapping as getResourceTypefromAppType
+    // in folder-apps/service.ts. Requesting MODULES.APP unconditionally left module
+    // folder-only permissions unresolved, hiding modules the "all modules" list showed.
+    const resourceType = getPermissionResourceForAppType(type);
     const userPermission = await this.abilityService.resourceActionsPermission(user, {
-      resources: [{ resource: MODULES.APP }],
+      resources: [{ resource: resourceType }],
       organizationId: user.organizationId,
     });
-    const userAppPermissions = userPermission?.[MODULES.APP];
-
-    // Builders have admin-level access to modules — skip app-level permission filtering.
-    const isModuleBuilderAccess = type === APP_TYPES.MODULE && (userPermission?.isBuilder || userPermission?.isAdmin);
-    const effectiveAppPermissions = isModuleBuilderAccess
-      ? { ...userAppPermissions, isAllEditable: true }
-      : userAppPermissions;
+    const userAppPermissions = userPermission?.[resourceType];
 
     const folderAppIds = folderApps.map((folderApp) => folderApp.appId);
     if (folderAppIds.length == 0) {
@@ -237,7 +249,7 @@ export class FolderAppsUtilService implements IFolderAppsUtilService {
     }
 
     const viewableAppsInFolder = this.getBaseAppsQuery(manager, searchKey, branchId);
-    this.addViewableFrontendFilter(viewableAppsInFolder, folderAppIds, effectiveAppPermissions);
+    this.addViewableFrontendFilter(viewableAppsInFolder, folderAppIds, userAppPermissions);
 
     // Branch presence is already enforced by the INNER JOIN in getBaseAppsQuery
     // (appVersions.branchId = :branchId). No secondary filter needed.

--- a/server/src/modules/group-permissions/util-services/granular-permissions.util.service.ts
+++ b/server/src/modules/group-permissions/util-services/granular-permissions.util.service.ts
@@ -406,6 +406,14 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
     moduleFolderGroupPermissions.canEditApps = false;
     moduleFolderGroupPermissions.canViewApps = false;
 
+    // Workflow folders follow the plain FOLDER visibility rule (all roles), unlike module folders.
+    const workflowFolderGranularPermission = new GranularPermissions();
+    const workflowFolderGroupPermissions = new FoldersGroupPermissions();
+    workflowFolderGranularPermission.foldersGroupPermissions = workflowFolderGroupPermissions;
+    workflowFolderGranularPermission.name = DEFAULT_GRANULAR_PERMISSIONS_NAME[ResourceType.WORKFLOW_FOLDER];
+    workflowFolderGranularPermission.isAll = true;
+    workflowFolderGranularPermission.type = ResourceType.WORKFLOW_FOLDER;
+
     switch (role) {
       case USER_ROLE.ADMIN:
         appGranularPermission.name = DEFAULT_GRANULAR_PERMISSIONS_NAME[ResourceType.APP];
@@ -424,7 +432,15 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
         folderGroupPermissions.canEditApps = false;
         folderGroupPermissions.canViewApps = false;
 
-        return [appGranularPermission, folderGranularPermission, moduleFolderGranularPermission];
+        workflowFolderGroupPermissions.canEditApps = false;
+        workflowFolderGroupPermissions.canViewApps = false;
+
+        return [
+          appGranularPermission,
+          folderGranularPermission,
+          moduleFolderGranularPermission,
+          workflowFolderGranularPermission,
+        ];
 
       case USER_ROLE.BUILDER:
         appGranularPermission.name = DEFAULT_GRANULAR_PERMISSIONS_NAME[ResourceType.APP];
@@ -446,7 +462,16 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
         folderGroupPermissions.canEditApps = false;
         folderGroupPermissions.canViewApps = false;
 
-        return [appGranularPermission, folderGranularPermission, moduleFolderGranularPermission];
+        workflowFolderGroupPermissions.canEditFolder = true;
+        workflowFolderGroupPermissions.canEditApps = false;
+        workflowFolderGroupPermissions.canViewApps = false;
+
+        return [
+          appGranularPermission,
+          folderGranularPermission,
+          moduleFolderGranularPermission,
+          workflowFolderGranularPermission,
+        ];
 
       case USER_ROLE.END_USER:
         appGranularPermission.name = DEFAULT_GRANULAR_PERMISSIONS_NAME[ResourceType.APP];
@@ -465,7 +490,11 @@ export class GranularPermissionsUtilService implements IGranularPermissionsUtilS
         folderGroupPermissions.canEditApps = false;
         folderGroupPermissions.canViewApps = true;
 
-        return [appGranularPermission, folderGranularPermission];
+        workflowFolderGroupPermissions.canEditFolder = false;
+        workflowFolderGroupPermissions.canEditApps = false;
+        workflowFolderGroupPermissions.canViewApps = true;
+
+        return [appGranularPermission, folderGranularPermission, workflowFolderGranularPermission];
 
       default:
         return [];

--- a/server/src/modules/group-permissions/util.service.ts
+++ b/server/src/modules/group-permissions/util.service.ts
@@ -74,7 +74,10 @@ export class GroupPermissionsUtilService implements IGroupPermissionsUtilService
       if (granularPerm.type === ResourceType.APP || granularPerm.type === ResourceType.WORKFLOWS) {
         if (granularPerm.appsGroupPermissions?.canEdit) return true;
       }
-      if (granularPerm.type === ResourceType.FOLDER) {
+      // Workflow folders follow the same edit-tier rule as plain FOLDER — view-only stays
+      // end-user-safe. Module folders are stricter (see checkIfBuilderLevelResourcesPermissions:
+      // modules aren't end-user-visible at all, so ANY module-folder grant counts there instead).
+      if (granularPerm.type === ResourceType.FOLDER || granularPerm.type === ResourceType.WORKFLOW_FOLDER) {
         const fp = granularPerm.foldersGroupPermissions;
         if (fp?.canEditFolder || fp?.canEditApps) return true;
       }

--- a/server/src/modules/roles/util.service.ts
+++ b/server/src/modules/roles/util.service.ts
@@ -196,8 +196,11 @@ export class RolesUtilService implements IRolesUtilService {
         (permissions) => permissions.type === ResourceType.DATA_SOURCE
       ).length;
       // Modules are never assignable to end-users, regardless of canView/canEdit - any module permission makes the group builder-level.
+      // Same rule for module folders — end-users can't see modules at all, so even a
+      // view-only module-folder grant makes the group builder-level (unlike plain/workflow
+      // folders, where view-only stays end-user-safe — see checkIfGroupHasBuilderGranularPermissions).
       const hasModulePermissions = allPermission.filter(
-        (permissions) => permissions.type === ResourceType.MODULE
+        (permissions) => permissions.type === ResourceType.MODULE || permissions.type === ResourceType.MODULE_FOLDER
       ).length;
       return isBuilderLevelAppsPermission || isBuilderLevelDataSourcePermissions || hasModulePermissions;
     }, manager);

--- a/server/test/modules/app-git/unit/ability.spec.ts
+++ b/server/test/modules/app-git/unit/ability.spec.ts
@@ -1,0 +1,89 @@
+import { AbilityBuilder, Ability } from '@casl/ability';
+import { App } from 'src/entities/app.entity';
+import { FEATURE_KEY } from 'src/modules/app-git/constants';
+import { MODULES } from 'src/modules/app/constants/modules';
+import { APP_TYPES } from 'src/modules/apps/constants';
+import { UserAllPermissions } from 'src/modules/app/types';
+import { AppGitAbility, FeatureAbilityFactory } from 'src/modules/app-git/ability';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the stale "any builder gets full git-sync access to
+// every module app" bypass (`appType === MODULE && isBuilder`) that predated
+// the module granular permission model and was removed alongside the
+// folder-apps fixes.
+// ---------------------------------------------------------------------------
+
+function buildAbility(permissions: Partial<UserAllPermissions>, request?: Record<string, unknown>): AppGitAbility {
+  const { can, build } = new AbilityBuilder<AppGitAbility>(Ability as any);
+  const factory = new FeatureAbilityFactory({ resourceActionsPermission: jest.fn() } as any);
+  (factory as any).defineAbilityFor(can, permissions as UserAllPermissions, { moduleName: '', features: [] }, request);
+  return build();
+}
+
+function baseUserPermission() {
+  return {
+    appCreate: false,
+    appDelete: false,
+    moduleCreate: false,
+    moduleDelete: false,
+    isAdmin: false,
+    isBuilder: true,
+    isEndUser: false,
+    isSuperAdmin: false,
+  };
+}
+
+function makePermissions(overrides: Partial<UserAllPermissions> = {}): UserAllPermissions {
+  return {
+    superAdmin: false,
+    isAdmin: false,
+    isBuilder: true,
+    isEndUser: false,
+    user: { id: 'user-1' } as any,
+    resource: [{ resourceType: MODULES.MODULES }],
+    userPermission: baseUserPermission() as any,
+    ...overrides,
+  };
+}
+
+function moduleAppInstance(id: string): App {
+  const a = new App();
+  (a as any).id = id;
+  (a as any).type = APP_TYPES.MODULE;
+  return a;
+}
+
+describe('FeatureAbilityFactory — app-git ability (module apps)', () => {
+  it('builder with NO module git-sync permissions cannot GIT_UPDATE_APP on a module', () => {
+    const permissions = makePermissions();
+    const ability = buildAbility(permissions, { tj_app: moduleAppInstance('mod-1'), tj_resource_id: 'mod-1' });
+    expect(ability.can(FEATURE_KEY.GIT_UPDATE_APP, App)).toBe(false);
+    expect(ability.can(FEATURE_KEY.GIT_SYNC_APP, App)).toBe(false);
+  });
+
+  it('builder with NO module create permission cannot GIT_CREATE_APP on a module', () => {
+    const permissions = makePermissions();
+    const ability = buildAbility(permissions, { tj_app: moduleAppInstance('mod-1'), tj_resource_id: 'mod-1' });
+    expect(ability.can(FEATURE_KEY.GIT_CREATE_APP, App)).toBe(false);
+  });
+
+  it('builder WITH MODULES.isAllEditable=true CAN GIT_UPDATE_APP on a module', () => {
+    const permissions = makePermissions({
+      userPermission: {
+        ...baseUserPermission(),
+        [MODULES.MODULES]: { isAllEditable: true, editableAppsId: [] },
+      } as any,
+    });
+    const ability = buildAbility(permissions, { tj_app: moduleAppInstance('mod-1'), tj_resource_id: 'mod-1' });
+    expect(ability.can(FEATURE_KEY.GIT_UPDATE_APP, App)).toBe(true);
+  });
+
+  it('admin can always GIT_UPDATE_APP on a module regardless of granular permissions', () => {
+    const permissions = makePermissions({
+      isAdmin: true,
+      userPermission: { ...baseUserPermission(), isAdmin: true } as any,
+    });
+    const ability = buildAbility(permissions, { tj_app: moduleAppInstance('mod-1'), tj_resource_id: 'mod-1' });
+    expect(ability.can(FEATURE_KEY.GIT_UPDATE_APP, App)).toBe(true);
+  });
+});

--- a/server/test/modules/custom-styles/e2e/custom-styles.spec.ts
+++ b/server/test/modules/custom-styles/e2e/custom-styles.spec.ts
@@ -1,0 +1,34 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { initTestApp, closeTestApp, createUser, createApplication, createApplicationVersion } from 'test-helper';
+
+/**
+ * GET /api/custom-styles/:slug — regression test for a DI wiring gap in CustomStylesModule
+ * (it never imported AppsModule, so AppAuthGuard's injected AppsUtilService was undefined).
+ * That crashed with a 500 ("Cannot read properties of undefined (reading
+ * 'getAppOrganizationDetails')") instead of a clean 401 whenever an unauthenticated request
+ * hit a non-public app — i.e. any public-viewer request on an app that isn't (yet) public.
+ */
+describe('CustomStylesController', () => {
+  describe('EE (plan: enterprise)', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      ({ app } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+    });
+
+    afterAll(async () => {
+      await closeTestApp(app);
+    }, 60_000);
+
+    it('returns 401, not 500, for an unauthenticated request against a non-public app', async () => {
+      const { user } = await createUser(app, { email: 'custom-styles-guard@tooljet.io' });
+      const application = await createApplication(app, { name: 'private-app', isPublic: false, user } as any);
+      const version = await createApplicationVersion(app, application as any);
+
+      const response = await request(app.getHttpServer()).get(`/api/custom-styles/${version.slug}`);
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+});

--- a/server/test/modules/data-queries/unit/data-query-app-ability.spec.ts
+++ b/server/test/modules/data-queries/unit/data-query-app-ability.spec.ts
@@ -1,0 +1,102 @@
+import { AbilityBuilder, Ability } from '@casl/ability';
+import { App } from 'src/entities/app.entity';
+import { FEATURE_KEY } from 'src/modules/data-queries/constants';
+import { MODULES } from 'src/modules/app/constants/modules';
+import { APP_TYPES } from 'src/modules/apps/constants';
+import { UserAllPermissions } from 'src/modules/app/types';
+import { defineDataQueryAppAbility } from 'src/modules/data-queries/ability/app/data-query-app.ability';
+import { FeatureAbility } from 'src/modules/data-queries/ability/app';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for two bugs in defineDataQueryAppAbility:
+//  1. `app?.type === MODULE && isBuilder` unconditionally granted full data-query
+//     CRUD on every module's queries — stale bypass predating module granular
+//     permissions.
+//  2. Permissions were always read from MODULES.APP even for module-type apps,
+//     instead of resolving MODULES.MODULES (the bucket module granular
+//     permissions actually populate).
+// ---------------------------------------------------------------------------
+
+function buildAbility(permissions: Partial<UserAllPermissions>, app: App): FeatureAbility {
+  const { can, build } = new AbilityBuilder<FeatureAbility>(Ability as any);
+  defineDataQueryAppAbility(can as any, permissions as UserAllPermissions, app);
+  return build();
+}
+
+function baseUserPermission() {
+  return {
+    appCreate: false,
+    appDelete: false,
+    moduleCreate: false,
+    moduleDelete: false,
+    isAdmin: false,
+    isBuilder: true,
+    isEndUser: false,
+    isSuperAdmin: false,
+  };
+}
+
+function makePermissions(overrides: Partial<UserAllPermissions> = {}): UserAllPermissions {
+  return {
+    superAdmin: false,
+    isAdmin: false,
+    isBuilder: true,
+    isEndUser: false,
+    user: { id: 'user-1' } as any,
+    resource: [{ resourceType: MODULES.MODULES }],
+    userPermission: baseUserPermission() as any,
+    ...overrides,
+  };
+}
+
+function moduleAppInstance(id: string): App {
+  const a = new App();
+  (a as any).id = id;
+  (a as any).type = APP_TYPES.MODULE;
+  return a;
+}
+
+describe('defineDataQueryAppAbility — module apps', () => {
+  it('builder with NO module data-source permissions cannot CREATE/UPDATE/DELETE queries on a module', () => {
+    const ability = buildAbility(makePermissions(), moduleAppInstance('mod-1'));
+    expect(ability.can(FEATURE_KEY.CREATE, App)).toBe(false);
+    expect(ability.can(FEATURE_KEY.UPDATE, App)).toBe(false);
+    expect(ability.can(FEATURE_KEY.DELETE, App)).toBe(false);
+  });
+
+  it('builder with moduleCreate=true CAN CREATE queries on a module (moduleCreate, not appCreate, gates it)', () => {
+    const permissions = makePermissions({
+      userPermission: { ...baseUserPermission(), moduleCreate: true } as any,
+    });
+    const ability = buildAbility(permissions, moduleAppInstance('mod-1'));
+    expect(ability.can(FEATURE_KEY.CREATE, App)).toBe(true);
+  });
+
+  it('builder with appCreate=true (front-end bucket) does NOT get module query access', () => {
+    const permissions = makePermissions({
+      userPermission: { ...baseUserPermission(), appCreate: true } as any,
+    });
+    const ability = buildAbility(permissions, moduleAppInstance('mod-1'));
+    expect(ability.can(FEATURE_KEY.CREATE, App)).toBe(false);
+  });
+
+  it('builder with MODULES.isAllEditable=true CAN edit queries on a module', () => {
+    const permissions = makePermissions({
+      userPermission: {
+        ...baseUserPermission(),
+        [MODULES.MODULES]: { isAllEditable: true, editableAppsId: [], isAllViewable: false, viewableAppsId: [] },
+      } as any,
+    });
+    const ability = buildAbility(permissions, moduleAppInstance('mod-1'));
+    expect(ability.can(FEATURE_KEY.UPDATE, App)).toBe(true);
+  });
+
+  it('admin can always CRUD queries on a module regardless of granular permissions', () => {
+    const permissions = makePermissions({
+      isAdmin: true,
+      userPermission: { ...baseUserPermission(), isAdmin: true } as any,
+    });
+    const ability = buildAbility(permissions, moduleAppInstance('mod-1'));
+    expect(ability.can(FEATURE_KEY.DELETE, App)).toBe(true);
+  });
+});

--- a/server/test/modules/data-queries/unit/find-public-parent-app-for-module-query.spec.ts
+++ b/server/test/modules/data-queries/unit/find-public-parent-app-for-module-query.spec.ts
@@ -1,0 +1,141 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  initTestApp,
+  closeTestApp,
+  resetDB,
+  createUser,
+  createApplication,
+  createApplicationVersion,
+  createDataSource,
+  createDataQuery,
+  updateEntity,
+  saveEntity,
+} from 'test-helper';
+import { DataQueryRepository } from '@modules/data-queries/repository';
+import { App } from '@entities/app.entity';
+import { AppVersion } from '@entities/app_version.entity';
+import { Component } from '@entities/component.entity';
+
+/**
+ * DataQueryRepository.findPublicParentAppForModuleQuery — regression test for the guard's
+ * module -> public-parent-app fallback (QueryAuthGuard), which 401s a module's query even
+ * when the parent app embedding it is genuinely public.
+ *
+ * Root cause: the parent app's is_public flag lives on an app_versions row, not on apps
+ * (apps.is_public is never written — see AppsUtilService.update). Resolving which row is
+ * canonical must match AppsRepository.resolveMetadataVersion elsewhere in the codebase:
+ * the non-stub row on the default branch, is_synced DESC then updated_at DESC. Without the
+ * is_stub filter, a stub row touched more recently can outrank the real one and read
+ * is_public as false/null, causing the guard to reject a public app's module query.
+ */
+describe('DataQueryRepository.findPublicParentAppForModuleQuery', () => {
+  let nestApp: INestApplication;
+  let repository: DataQueryRepository;
+
+  beforeAll(async () => {
+    ({ app: nestApp } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+    repository = nestApp.get<DataQueryRepository>(DataQueryRepository);
+  });
+
+  beforeEach(async () => {
+    await resetDB();
+  });
+
+  afterAll(async () => {
+    await closeTestApp(nestApp);
+  }, 60_000);
+
+  /** Wires a parent app (embedding a ModuleViewer) + module app + module query, mirroring
+   * the real component/data-query graph the join traverses. Both apps must share `user` —
+   * createApplication() creates its own anonymous org/user when none is passed, which
+   * collides with the previous call's default org name. */
+  async function setUpParentAndModule(
+    user: Parameters<typeof createApplication>[1]['user'],
+    {
+      canonicalVersionIsPublic,
+      addLaterTouchedStub,
+    }: { canonicalVersionIsPublic: boolean; addLaterTouchedStub: boolean }
+  ) {
+    const parentApp = await createApplication(nestApp, {
+      name: 'parent',
+      isPublic: canonicalVersionIsPublic,
+      user,
+    } as any);
+    const canonicalVersion = await createApplicationVersion(nestApp, parentApp as App & { organizationId: string });
+    await updateEntity(AppVersion, canonicalVersion.id, {
+      isPublic: canonicalVersionIsPublic,
+      isSynced: true,
+      isStub: false,
+      updatedAt: new Date(Date.now() - 60_000),
+    });
+
+    if (addLaterTouchedStub) {
+      // A stub row on the same branch, touched after the canonical row, with the opposite
+      // is_public — reproduces the exact ordering conflict the fix guards against.
+      await saveEntity(AppVersion, {
+        appId: parentApp.id,
+        name: `stub-${Date.now()}`,
+        branchId: canonicalVersion.branchId,
+        appName: parentApp.name,
+        slug: `stub-${Date.now()}`,
+        isStub: true,
+        isSynced: false,
+        isPublic: !canonicalVersionIsPublic,
+        updatedAt: new Date(),
+        definition: null,
+        globalSettings: {},
+        pageSettings: {},
+        showViewerNavigation: true,
+        currentEnvironmentId: canonicalVersion.currentEnvironmentId,
+      } as any);
+    }
+
+    await updateEntity(App, parentApp.id, { currentVersionId: canonicalVersion.id });
+
+    const moduleApp = await createApplication(nestApp, { name: 'module', type: 'module', user } as any);
+    await updateEntity(App, moduleApp.id, { co_relation_id: moduleApp.id });
+    const moduleVersion = await createApplicationVersion(nestApp, moduleApp as App & { organizationId: string });
+
+    await saveEntity(Component, {
+      pageId: canonicalVersion.homePageId,
+      name: 'module1',
+      type: 'ModuleViewer',
+      properties: { moduleAppId: { value: moduleApp.id }, moduleVersionId: { value: '' } },
+      styles: {},
+      validation: {},
+    } as any);
+
+    const dataSource = await createDataSource(nestApp, {
+      appVersion: moduleVersion,
+      name: 'ds',
+      kind: 'restapi',
+    } as any);
+    const dataQuery = await createDataQuery(nestApp, { dataSource, appVersion: moduleVersion, options: {} } as any);
+
+    return { moduleApp, dataQuery };
+  }
+
+  it('finds the public parent app when the canonical version row is public, ignoring a later-touched stub row', async () => {
+    const { user } = await createUser(nestApp, { email: 'module-guard-canonical-public@tooljet.io' });
+    const { moduleApp, dataQuery } = await setUpParentAndModule(user, {
+      canonicalVersionIsPublic: true,
+      addLaterTouchedStub: true,
+    });
+
+    const result = await repository.findPublicParentAppForModuleQuery(moduleApp.id, dataQuery.id);
+
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null when the canonical version row is not public, even with a later-touched public stub row', async () => {
+    const { user } = await createUser(nestApp, { email: 'module-guard-canonical-private@tooljet.io' });
+    const { moduleApp, dataQuery } = await setUpParentAndModule(user, {
+      canonicalVersionIsPublic: false,
+      addLaterTouchedStub: true,
+    });
+
+    const result = await repository.findPublicParentAppForModuleQuery(moduleApp.id, dataQuery.id);
+
+    expect(result).toBeNull();
+  });
+});

--- a/server/test/modules/folder-apps/unit/ability.spec.ts
+++ b/server/test/modules/folder-apps/unit/ability.spec.ts
@@ -1,0 +1,107 @@
+import { AbilityBuilder, Ability } from '@casl/ability';
+import { FolderApp } from 'src/entities/folder_app.entity';
+import { FEATURE_KEY } from 'src/modules/folder-apps/constants';
+import { MODULES } from 'src/modules/app/constants/modules';
+import { APP_TYPES } from 'src/modules/apps/constants';
+import { UserAllPermissions } from 'src/modules/app/types';
+import { FeatureAbility, FeatureAbilityFactory } from 'src/modules/folder-apps/ability';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the stale "any builder gets full module-folder-app
+// access" bypass (`tj_app_is_module && userPermission.isBuilder`) that predated
+// the MODULE_FOLDER granular permission model and was removed alongside the
+// getFolders() fix in server/src/modules/folder-apps/service.ts.
+// ---------------------------------------------------------------------------
+
+function buildAbility(permissions: Partial<UserAllPermissions>, request?: Record<string, unknown>): FeatureAbility {
+  const { can, build } = new AbilityBuilder<FeatureAbility>(Ability as any);
+  const factory = new FeatureAbilityFactory({ resourceActionsPermission: jest.fn() } as any);
+  (factory as any).defineAbilityFor(can, permissions as UserAllPermissions, { moduleName: '', features: [] }, request);
+  return build();
+}
+
+function baseUserPermission() {
+  return {
+    appCreate: false,
+    appDelete: false,
+    appRelease: false,
+    appPromote: false,
+    workflowCreate: false,
+    workflowDelete: false,
+    moduleCreate: false,
+    moduleDelete: false,
+    dataSourceCreate: false,
+    dataSourceDelete: false,
+    folderCreate: false,
+    folderDelete: false,
+    workflowFolderCreate: false,
+    workflowFolderDelete: false,
+    moduleFolderCreate: false,
+    moduleFolderDelete: false,
+    orgConstantCRUD: false,
+    orgVariableCRUD: false,
+    isAdmin: false,
+    isBuilder: true,
+    isEndUser: false,
+    isSuperAdmin: false,
+  };
+}
+
+function makePermissions(overrides: Partial<UserAllPermissions> = {}): UserAllPermissions {
+  return {
+    superAdmin: false,
+    isAdmin: false,
+    isBuilder: true,
+    isEndUser: false,
+    user: { id: 'user-1' } as any,
+    resource: [{ resourceType: MODULES.MODULE_FOLDER }],
+    userPermission: baseUserPermission() as any,
+    ...overrides,
+  };
+}
+
+describe('FeatureAbilityFactory — folder-apps ability (module folders)', () => {
+  it('builder with NO module-folder granular permissions cannot CREATE_FOLDER_APP on a module folder', () => {
+    const permissions = makePermissions();
+    const ability = buildAbility(permissions, { tj_folder_type: APP_TYPES.MODULE, tj_resource_id: 'folder-1' });
+    expect(ability.can(FEATURE_KEY.CREATE_FOLDER_APP, FolderApp)).toBe(false);
+  });
+
+  it('builder with NO module-folder granular permissions cannot DELETE_FOLDER_APP on a module folder', () => {
+    const permissions = makePermissions();
+    const ability = buildAbility(permissions, { tj_folder_type: APP_TYPES.MODULE, tj_resource_id: 'folder-1' });
+    expect(ability.can(FEATURE_KEY.DELETE_FOLDER_APP, FolderApp)).toBe(false);
+  });
+
+  it('builder WITH MODULE_FOLDER.isAllEditable=true CAN manage module folder apps', () => {
+    const permissions = makePermissions({
+      userPermission: {
+        ...baseUserPermission(),
+        [MODULES.MODULE_FOLDER]: {
+          isAllEditable: true,
+          editableFoldersId: [],
+          isAllViewable: false,
+          viewableFoldersId: [],
+          isAllEditApps: false,
+          editAppsInFoldersId: [],
+        },
+      } as any,
+    });
+    const ability = buildAbility(permissions, { tj_folder_type: APP_TYPES.MODULE, tj_resource_id: 'folder-1' });
+    expect(ability.can(FEATURE_KEY.CREATE_FOLDER_APP, FolderApp)).toBe(true);
+  });
+
+  it('admin can always manage module folder apps regardless of granular permissions', () => {
+    const permissions = makePermissions({
+      isAdmin: true,
+      userPermission: { ...baseUserPermission(), isAdmin: true } as any,
+    });
+    const ability = buildAbility(permissions, { tj_folder_type: APP_TYPES.MODULE, tj_resource_id: 'folder-1' });
+    expect(ability.can(FEATURE_KEY.CREATE_FOLDER_APP, FolderApp)).toBe(true);
+  });
+
+  it('GET_FOLDERS is always allowed (unfiltered read of the folder list itself)', () => {
+    const ability = buildAbility(makePermissions());
+    expect(ability.can(FEATURE_KEY.GET_FOLDERS, FolderApp)).toBe(true);
+  });
+});

--- a/server/test/modules/folder-apps/unit/get-folders.spec.ts
+++ b/server/test/modules/folder-apps/unit/get-folders.spec.ts
@@ -1,0 +1,134 @@
+import { FolderAppsService } from 'src/modules/folder-apps/service';
+import { MODULES } from 'src/modules/app/constants/modules';
+import { APP_TYPES } from 'src/modules/apps/constants';
+import { User } from 'src/entities/user.entity';
+import { Folder } from 'src/entities/folder.entity';
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the reported bug: a builder with ZERO module and
+// module-folder granular permissions could still see every module folder
+// (e.g. "mf1") in the folders tab.
+//
+// Root causes fixed in FolderAppsService.getFolders():
+//  1. Folder-permission lookup was hardcoded to MODULES.FOLDER instead of
+//     resolving MODULES.MODULE_FOLDER for module-type folders.
+//  2. A stale `isModuleBuilderAccess` bypass forced isAllEditable=true on the
+//     module app-permission object for ANY builder, unconditionally.
+// ---------------------------------------------------------------------------
+
+jest.mock('@helpers/database.helper', () => ({
+  getConnectionInstance: () => ({ manager: {} }),
+  dbTransactionWrap: (fn: any) => fn({}),
+}));
+
+function makeFolder(id: string, createdBy = 'other-user'): Folder {
+  const folder = new Folder();
+  (folder as any).id = id;
+  (folder as any).createdBy = createdBy;
+  return folder;
+}
+
+describe('FolderAppsService.getFolders — module folder permission gating', () => {
+  const user = { id: 'builder-1', organizationId: 'org-1', roleGroup: undefined } as User;
+
+  function buildService(userPermissions: any, folderApps: any[] = []) {
+    const resourceActionsPermission = jest.fn().mockResolvedValue(userPermissions);
+    const allFolders = jest.fn().mockResolvedValue([makeFolder('mf1')]);
+    const findFolderAppsForFolders = jest.fn().mockResolvedValue(folderApps);
+    const getDetails = jest.fn().mockResolvedValue({
+      isEnabled: false,
+      isMultiBranchingEnabled: false,
+      options: { defaultBranch: { id: 'branch-1' } },
+    });
+
+    const service = new FolderAppsService(
+      { resourceActionsPermission } as any,
+      { allFolders } as any,
+      { findFolderAppsForFolders } as any,
+      { getDetails } as any
+    );
+
+    return { service, resourceActionsPermission, allFolders, findFolderAppsForFolders };
+  }
+
+  it('requests MODULE_FOLDER permissions (not the generic FOLDER bucket) for type=module', async () => {
+    const { service, resourceActionsPermission } = buildService({
+      isAdmin: false,
+      isBuilder: true,
+      [MODULES.MODULES]: { isAllEditable: false, editableAppsId: [], isAllViewable: false, viewableAppsId: [] },
+      [MODULES.MODULE_FOLDER]: {
+        isAllEditable: false,
+        editableFoldersId: [],
+        isAllViewable: false,
+        viewableFoldersId: [],
+        isAllEditApps: false,
+        editAppsInFoldersId: [],
+      },
+    });
+
+    await service.getFolders(user, { type: APP_TYPES.MODULE });
+
+    const requestedResources = resourceActionsPermission.mock.calls[0][1].resources.map((r: any) => r.resource);
+    expect(requestedResources).toContain(MODULES.MODULE_FOLDER);
+    expect(requestedResources).not.toContain(MODULES.FOLDER);
+  });
+
+  it('does NOT force isAllEditable on the module app-permission object for a plain builder', async () => {
+    const { service, findFolderAppsForFolders } = buildService({
+      isAdmin: false,
+      isBuilder: true,
+      [MODULES.MODULES]: { isAllEditable: false, editableAppsId: [], isAllViewable: false, viewableAppsId: [] },
+      [MODULES.MODULE_FOLDER]: {
+        isAllEditable: false,
+        editableFoldersId: [],
+        isAllViewable: false,
+        viewableFoldersId: [],
+        isAllEditApps: false,
+        editAppsInFoldersId: [],
+      },
+    });
+
+    await service.getFolders(user, { type: APP_TYPES.MODULE });
+
+    const passedAppPermissions = findFolderAppsForFolders.mock.calls[0][1];
+    expect(passedAppPermissions.isAllEditable).toBe(false);
+  });
+
+  it('builder with zero module/module-folder permissions sees NO module folders', async () => {
+    // findFolderAppsForFolders reflects real DB filtering: with no editable/viewable
+    // module app permissions, it returns no rows, so the folder ends up empty.
+    const { service } = buildService(
+      {
+        isAdmin: false,
+        isBuilder: true,
+        [MODULES.MODULES]: { isAllEditable: false, editableAppsId: [], isAllViewable: false, viewableAppsId: [] },
+        [MODULES.MODULE_FOLDER]: {
+          isAllEditable: false,
+          editableFoldersId: [],
+          isAllViewable: false,
+          viewableFoldersId: [],
+          isAllEditApps: false,
+          editAppsInFoldersId: [],
+        },
+      },
+      []
+    );
+
+    const result = await service.getFolders(user, { type: APP_TYPES.MODULE });
+
+    expect(result.folders).toHaveLength(0);
+  });
+
+  it('admin still sees the module folder regardless of granular permissions', async () => {
+    const { service } = buildService({
+      isAdmin: true,
+      isBuilder: false,
+      [MODULES.MODULES]: { isAllEditable: false, editableAppsId: [], isAllViewable: false, viewableAppsId: [] },
+      [MODULES.MODULE_FOLDER]: undefined,
+    });
+
+    const result = await service.getFolders(user, { type: APP_TYPES.MODULE });
+
+    expect(result.folders).toHaveLength(1);
+  });
+});

--- a/server/test/modules/git-sync-configs/unit/service.spec.ts
+++ b/server/test/modules/git-sync-configs/unit/service.spec.ts
@@ -256,6 +256,40 @@ describe('GitSyncConfigsService.getOrgGitStatusById — env config', () => {
 
     expect(result.git_type).toBe(GITConnectionType.GITHUB_HTTPS);
     expect(result.is_git_sync_configured).toBe(true);
+    expect(result.repo_url).toBe(HTTPS_CONFIG.GITHUB_URL);
+    expect(result.default_git_branch).toBe(HTTPS_CONFIG.GITHUB_BRANCH);
+  });
+
+  // Regression coverage for the actual bug report: a workspace configured via the UI first (leaving
+  // a real gitHttps row in the DB), then switched to env-var config, correctly shows the env repo on
+  // the config page (getOrgGitByOrgId) but getOrgGitStatusById — which feeds the "Connected to repo"
+  // label plus the "View in Git Repo"/"Create PR" links in the pull/push modal — used to read
+  // orgGit.gitHttps directly and report the stale, never-deleted UI-configured repo instead.
+  it('reports the env repo, not the stale UI-configured repo, once switched to env config', async () => {
+    const orgGit = {
+      id: 'org-git-id',
+      organizationId: WORKSPACE_ID,
+      useEnvConfig: true,
+      envGitProvider: null,
+      isBranchingEnabled: true,
+      // Leftover row from when this workspace was configured through the UI — superseded by env
+      // config, never deleted. If the fix regresses, this is the URL getOrgGitStatusById returns.
+      gitHttps: {
+        isEnabled: true,
+        isFinalized: true,
+        httpsUrl: 'https://github.com/old-org/ui-configured-repo.git',
+        githubBranch: 'ui-branch',
+      },
+      gitLab: null,
+    };
+    const { service, registry } = makeService(orgGit);
+    await registry.initialize();
+
+    const result = await service.getOrgGitStatusById(WORKSPACE_ID, WORKSPACE_ID);
+
+    expect(result.repo_url).toBe(HTTPS_CONFIG.GITHUB_URL);
+    expect(result.default_git_branch).toBe(HTTPS_CONFIG.GITHUB_BRANCH);
+    expect(result.repo_url).not.toBe('https://github.com/old-org/ui-configured-repo.git');
   });
 });
 

--- a/server/test/modules/group-permissions/unit/check-if-group-has-builder-granular-permissions.spec.ts
+++ b/server/test/modules/group-permissions/unit/check-if-group-has-builder-granular-permissions.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for GroupPermissionsUtilService.checkIfGroupHasBuilderGranularPermissions.
+ *
+ * This predicate (alongside RolesUtilService.checkIfBuilderLevelResourcesPermissions) gates
+ * whether end-users can be added to a group (addUsersToGroup). It previously only inspected
+ * ResourceType.APP/WORKFLOWS (canEdit) and ResourceType.FOLDER (canEditFolder/canEditApps) —
+ * a group whose ONLY granular permission was a WORKFLOW_FOLDER edit-tier grant was never
+ * flagged as builder-level, silently letting end-users into it. This suite locks in the fix.
+ *
+ * Module folders are covered separately in RolesUtilService.checkIfBuilderLevelResourcesPermissions
+ * (any MODULE_FOLDER grant, even view-only, is disqualifying — modules aren't end-user-visible
+ * at all) — this file only covers the edit-tier WORKFLOW_FOLDER rule (view-only stays safe,
+ * matching plain FOLDER).
+ */
+
+import { GroupPermissionsUtilService } from '../../../../src/modules/group-permissions/util.service';
+import { ResourceType } from '../../../../src/modules/group-permissions/constants';
+
+function makeFolderPermission(
+  type: ResourceType,
+  fp: { canEditFolder?: boolean; canEditApps?: boolean; canViewApps?: boolean }
+) {
+  return { type, foldersGroupPermissions: fp } as any;
+}
+
+function makeService(getAllGranularPermissions: jest.Mock): GroupPermissionsUtilService {
+  const groupPermissionsRepository = { getAllGranularPermissions } as any;
+  return new GroupPermissionsUtilService(
+    groupPermissionsRepository,
+    null as any,
+    null as any,
+    null as any,
+    null as any,
+    null as any,
+    null as any,
+    null as any
+  );
+}
+
+describe('GroupPermissionsUtilService.checkIfGroupHasBuilderGranularPermissions', () => {
+  const groupId = 'group-uuid-1';
+  const organizationId = 'org-uuid-1';
+
+  it('returns false for a group with WORKFLOW_FOLDER view-only permission', async () => {
+    const service = makeService(
+      jest.fn().mockResolvedValue([makeFolderPermission(ResourceType.WORKFLOW_FOLDER, { canViewApps: true })])
+    );
+
+    await expect(service.checkIfGroupHasBuilderGranularPermissions(groupId, organizationId)).resolves.toBe(false);
+  });
+
+  it('returns true for a group with WORKFLOW_FOLDER canEditFolder permission — the fix', async () => {
+    const service = makeService(
+      jest.fn().mockResolvedValue([makeFolderPermission(ResourceType.WORKFLOW_FOLDER, { canEditFolder: true })])
+    );
+
+    await expect(service.checkIfGroupHasBuilderGranularPermissions(groupId, organizationId)).resolves.toBe(true);
+  });
+
+  it('returns true for a group with WORKFLOW_FOLDER canEditApps permission — the fix', async () => {
+    const service = makeService(
+      jest.fn().mockResolvedValue([makeFolderPermission(ResourceType.WORKFLOW_FOLDER, { canEditApps: true })])
+    );
+
+    await expect(service.checkIfGroupHasBuilderGranularPermissions(groupId, organizationId)).resolves.toBe(true);
+  });
+
+  it('returns true for a group with plain FOLDER canEditFolder permission — existing behaviour', async () => {
+    const service = makeService(
+      jest.fn().mockResolvedValue([makeFolderPermission(ResourceType.FOLDER, { canEditFolder: true })])
+    );
+
+    await expect(service.checkIfGroupHasBuilderGranularPermissions(groupId, organizationId)).resolves.toBe(true);
+  });
+
+  it('returns false for a group with no granular permissions', async () => {
+    const service = makeService(jest.fn().mockResolvedValue([]));
+
+    await expect(service.checkIfGroupHasBuilderGranularPermissions(groupId, organizationId)).resolves.toBe(false);
+  });
+});

--- a/server/test/modules/modules/e2e/module-granular-permissions.spec.ts
+++ b/server/test/modules/modules/e2e/module-granular-permissions.spec.ts
@@ -138,6 +138,8 @@ describe('ModuleGranularPermissions (H1)', () => {
       });
       expect(buildRes.statusCode).toBe(201);
 
+      console.log('Module permissions assigned.', { editRes: editRes.body, buildRes: buildRes.body });
+
       // --- assertions: dashboard reflects grants + ownership ----------------
       const visible = await listModuleNames(org.id, viewerCookie);
       expect(new Set(visible)).toEqual(new Set(['M-Edit', 'M-Build', 'M-Owned']));

--- a/server/test/modules/roles/unit/check-builder-level-resources-permissions.spec.ts
+++ b/server/test/modules/roles/unit/check-builder-level-resources-permissions.spec.ts
@@ -89,4 +89,26 @@ describe('RolesUtilService.checkIfBuilderLevelResourcesPermissions', () => {
 
     await expect(service.checkIfBuilderLevelResourcesPermissions(groupId, organizationId)).resolves.toBeTruthy();
   });
+
+  // Modules aren't end-user-visible at all, so a MODULE_FOLDER grant is just as disqualifying
+  // as a MODULE grant — even a view-only ("Build-with") one. Mirrors the MODULE cases above.
+  it('returns truthy for a group with module-folder Build-with (view-only) permission', async () => {
+    const service = makeService(
+      jest
+        .fn()
+        .mockResolvedValue([{ type: ResourceType.MODULE_FOLDER, foldersGroupPermissions: { canViewApps: true } }])
+    );
+
+    await expect(service.checkIfBuilderLevelResourcesPermissions(groupId, organizationId)).resolves.toBeTruthy();
+  });
+
+  it('returns truthy for a group with module-folder Edit permission', async () => {
+    const service = makeService(
+      jest
+        .fn()
+        .mockResolvedValue([{ type: ResourceType.MODULE_FOLDER, foldersGroupPermissions: { canEditFolder: true } }])
+    );
+
+    await expect(service.checkIfBuilderLevelResourcesPermissions(groupId, organizationId)).resolves.toBeTruthy();
+  });
 });


### PR DESCRIPTION
## 📝 What this does
Fixes three bugs that surface when a module is embedded in a public/released app and viewed by an unauthenticated or production viewer, plus a set of related module/workflow-folder permission gaps found while chasing those down — a stale builder bypass that let any builder see/manage module folders regardless of granular permissions, a "View" card link that 404'd on non-default branches, and an end-user group-assignment gate that missed module/workflow folder resource types. Also merges in the already-open workflow-folder basic-plan stub fix (#17429) since both land on this same base.
- [ee-server](https://github.com/ToolJet/ee-server/pull/755)
- [ee-frontend](https://github.com/ToolJet/ee-frontend/pull/585)

## 🔀 Changes
- Fixed a module's own globals.environment.name resolving undefined outside the App Builder, module REST queries 401ing under a genuinely public parent app, and GET /custom-styles/:slug 500ing instead of 401ing for unauthenticated requests
- Removed stale "any builder gets full module access" bypasses across folder-apps, app-git, and data-query ability checks, and fixed folder-permission resolution to use MODULE_FOLDER/WORKFLOW_FOLDER instead of the generic FOLDER bucket
- Fixed the module "View" card link 404ing when its current version lives on a non-default branch, by carrying branch context the same way "Edit" already does
- Closed a gap letting end-users be added to custom groups with builder-tier module-folder or workflow-folder granular permissions
- Merged in the workflow-folder basic-plan granular-permissions stub fix (#17429) and relabeled "folders" to "app folders" in group permission resource labels

## 🧪 How to test
- [ ] Embed a module in an app with `{{globals.environment.name}}` bound somewhere, release it, view as a public/unauthenticated visitor — correct env name, no error
- [ ] Add a REST API query inside a module embedded in a genuinely public app, run it unauthenticated — succeeds instead of 401ing
- [ ] Hit `GET /api/custom-styles/:slug` unauthenticated for a non-public app — returns 401, not 500
- [ ] As a builder with zero module/module-folder permissions, confirm module folders no longer appear in the Folders tab
- [ ] Grant a builder View-only access to a module via module-folder permissions; open it from the card's View button while on a non-default branch — confirms it loads instead of 404ing
- [ ] Try adding an end-user to a custom group with module-folder or workflow-folder builder-tier permissions — confirm it's rejected
- [ ] On a Basic/Starter plan org, confirm "Workflow folders" appears in the granular permissions list for Admin/Builder/End User