### PR TITLE
Automated RDS SSL setup

### DIFF
--- a/deploy/ec2/ee/.env
+++ b/deploy/ec2/ee/.env
@@ -21,6 +21,10 @@ PGRST_JWT_SECRET=
 PGRST_DB_URI=
 PGRST_DB_PRE_CONFIG=postgrest.pre_config
 
+# PostgreSQL SSL Configuration
+PGSSLMODE=require
+NODE_EXTRA_CA_CERTS=/home/ubuntu/certs/global-bundle.pem
+
 #Redis
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/deploy/ec2/ee/setup_app
+++ b/deploy/ec2/ee/setup_app
@@ -130,6 +130,17 @@ fi
 
 export $(grep -v '^#' .env | xargs)
 
+# Create directory for RDS certificates
+mkdir -p /home/ubuntu/certs
+
+# Download the latest AWS RDS CA bundle
+if wget -q -O /home/ubuntu/certs/global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem; then
+  echo "RDS cert bundle downloaded successfully."
+else
+  echo "Error: Failed to download RDS cert bundle."
+  exit 1
+fi
+
 if psql -d postgresql://$PG_USER:$PG_PASS@$PG_HOST/postgres -c 'select now()' > /dev/null 2>&1
 then
   echo "Successfully pinged the database!";


### PR DESCRIPTION
### In .env 
```
PGSSLMODE=require
NODE_EXTRA_CA_CERTS=/home/ubuntu/certs/global-bundle.pem
```


### Added dir creation and global pem installation on setup_app 
```
mkdir -p /home/ubuntu/certs
if wget -q -O /home/ubuntu/certs/global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem; then
  echo "RDS cert bundle downloaded successfully."
else
  echo "Error: Failed to download RDS cert bundle."
  exit 1
fi
```