### PR TITLE
5337: uuid changed to unique event identifier for debounce to work

### DIFF
--- a/frontend/src/AppBuilder/_stores/utils.js
+++ b/frontend/src/AppBuilder/_stores/utils.js
@@ -14,7 +14,8 @@ export function debounce(func) {
 
   return (...args) => {
     const event = args[0] || {};
-    const eventId = uuidv4();
+    const moduleId = args[3] || 'canvas';
+    const eventId = moduleId + '-' + (event?.id || uuidv4());
 
     const debounceTime = event?.event?.debounce || event?.debounce;
     if (debounceTime === undefined) {


### PR DESCRIPTION
# tj-ee-5337: Event Debounce Fix

Issue: https://github.com/ToolJet/tj-ee/issues/5337

## Issue Description

The "Debounce" option on component event handlers does not actually debounce. Rapid repeated triggers of the same event (e.g. fast typing on an `onChange`, repeated clicks) each independently execute after the configured delay, instead of only the last trigger firing — i.e. it behaves as a fixed delay applied per-call, not a debounce.

## Root Cause

The debounce wrapper (`frontend/src/AppBuilder/_stores/utils.js`, wrapping `executeAction` in `eventsSlice.js`) generated a brand-new `uuidv4()` as the timer-map key on every invocation instead of a stable key tied to the event being executed. Since the key was never reused, `timers.get(eventId)` always missed, making `clearTimeout()` a no-op — the previous pending timer was never cancelled. Every trigger scheduled its own independent `setTimeout`, so bursts of triggers all fired instead of collapsing into one trailing execution.

## Fix

Replaced the random UUID key with a stable key derived from `${moduleId}-${event.id}`, where `event.id` is the event handler's own persisted id (uniquely identifies a single configured handler row) and `moduleId` scopes it to canvas/page/module instance. This makes the key stable across repeated invocations of the same handler, so `clearTimeout` now correctly cancels a pending timer before scheduling a new one, restoring proper trailing-edge debounce behavior — and keeps timers isolated per instance when the same handler definition is reused across multiple Module instances.

## Areas to Test

- Rapid repeated firing of a debounced event (e.g. fast typing in a Text Input's `onChange` with debounce set) — only the final trigger should execute, not one per keystroke/click.
- Debounce on components directly on canvas.
- Debounce on components on a page (multi-page apps).
- Debounce on components inside a reusable Module — especially with **multiple instances of the same Module** on canvas at once, confirming one instance's debounce timer doesn't get cancelled/affected by another instance firing the same event.
- Regression: events with no debounce configured still execute immediately as before.
- Regression: multiple independent actions on the same trigger (e.g. two actions on `onClick`), each with its own debounce value, don't interfere with each other's timers.