### PR TITLE
Fix: auto-scroll tab header into view on programmatic tab switch

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Tabs/Tabs.jsx
+++ b/frontend/src/AppBuilder/Widgets/Tabs/Tabs.jsx
@@ -193,6 +193,19 @@ export const Tabs = function Tabs({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTab, parsedScrollToTopOnTabSwitch]);
 
+  // Auto-scroll the tab header into view when the active tab changes
+  useEffect(() => {
+    const tabsContainer = tabsRef.current;
+    if (!tabsContainer) return;
+    const raf = requestAnimationFrame(() => {
+      const activeItem = tabsContainer.querySelector('.nav-item.active');
+      if (activeItem) {
+        activeItem.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [currentTab]);
+
   useEffect(() => {
     const exposedVariables = {
       setTab: async function (id) {


### PR DESCRIPTION
## 📝 What this does
When the Tabs widget has enough tabs to overflow and require scroll arrows, switching the active tab programmatically via `setTab` (e.g., from a button event) changes the content but doesn't scroll the tab header into view. This adds auto-scrolling so the selected tab's header is always visible.

## Closes
[#5314](https://github.com/ToolJet/tj-ee/issues/5314)

## 🔀 Changes
- Added a `useEffect` that watches `currentTab` and scrolls the active `.nav-item` into view using `scrollIntoView({ behavior: 'smooth', inline: 'nearest' })`

## 🧪 How to test
- [ ] Add a Tabs widget with 6-8+ tabs so headers overflow and scroll arrows appear
- [ ] Add a Button, set its click event to run `components.tabs1.setTab('<last-tab-id>')`
- [ ] Preview the app, click the button — tab header should scroll into view smoothly
- [ ] Set active to last tab, then use button to switch to first tab — should scroll back
- [ ] Click tab headers directly — should still work normally with no double-scroll or jank