### PR TITLE
Refactor!: OTel semantic conventions and collector topology parity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,8 @@ PAT_EXPIRY=
 #ENABLE_OTEL=true
 # Browser error/web-vitals beacon (requires ENABLE_OTEL)
 #ENABLE_OTEL_FRONTEND=true
+# How often the browser flushes its beacon buffer. Default 30, clamped to 5-600.
+#OTEL_FRONTEND_FLUSH_INTERVAL_SECONDS=30
 #OTEL_EXPORTER_OTLP_TRACES=http://localhost:4318/v1/traces
 #OTEL_EXPORTER_OTLP_METRICS=http://localhost:4318/v1/metrics
 # Frontend error log records (Loki OTLP endpoint; requires ENABLE_OTEL_FRONTEND)

--- a/frontend/src/_services/frontend-metrics.service.js
+++ b/frontend/src/_services/frontend-metrics.service.js
@@ -3,8 +3,18 @@ import { onCLS, onFCP, onINP, onLCP, onTTFB } from 'web-vitals';
 import { authHeader } from '@/_helpers/auth-header';
 import { authenticationService } from '@/_services';
 
-const FLUSH_INTERVAL_MS = 30_000;
+const DEFAULT_FLUSH_INTERVAL_S = 30;
+const MIN_FLUSH_INTERVAL_S = 5;
+const MAX_FLUSH_INTERVAL_S = 600;
 const MAX_UNIQUE_ERRORS = 50;
+
+// OTEL_FRONTEND_FLUSH_INTERVAL_SECONDS, clamped. Too low floods ingest, too high loses a
+// tab's events to the buffer cap; a bad value falls back rather than breaking the timer.
+function getFlushIntervalMs() {
+  const raw = Number(window.public_config?.OTEL_FRONTEND_FLUSH_INTERVAL_SECONDS);
+  if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_FLUSH_INTERVAL_S * 1000;
+  return Math.min(Math.max(raw, MIN_FLUSH_INTERVAL_S), MAX_FLUSH_INTERVAL_S) * 1000;
+}
 
 let eventMap = new Map();
 let flushTimer = null;
@@ -169,7 +179,7 @@ export function initFrontendMetrics() {
   initialized = true;
 
   if (window.__tjMetricsTimer) clearInterval(window.__tjMetricsTimer);
-  flushTimer = setInterval(flush, FLUSH_INTERVAL_MS);
+  flushTimer = setInterval(flush, getFlushIntervalMs());
   window.__tjMetricsTimer = flushTimer;
 
   // Register vitals before our own visibilitychange listener — the lib reports

--- a/server/src/modules/app/middlewares/otel.middleware.ts
+++ b/server/src/modules/app/middlewares/otel.middleware.ts
@@ -30,9 +30,6 @@ export class OtelMiddleware implements NestMiddleware {
     const route = req.route?.path || req.path || 'unknown_route';
     const method = req.method || 'UNKNOWN_METHOD';
 
-    // Span naming only. The api.hits / api.duration counters this used to feed were
-    // duplicates of http.server.request.duration from auto-instrumentation, and the
-    // res.json monkey-patch existed solely to time them.
     if (span && route.startsWith('/api/') && route !== '/api/health') {
       span.updateName(`${method} ${route}`);
       span.setAttribute('http.route', route);

--- a/server/src/modules/app/middlewares/otel.middleware.ts
+++ b/server/src/modules/app/middlewares/otel.middleware.ts
@@ -5,8 +5,6 @@ import { ConfigService } from '@nestjs/config';
 import { trace, context } from '@opentelemetry/api';
 import { NextFunction } from 'express';
 import { Request, Response } from 'express';
-import { recordApiDuration, recordApiHit } from '@otel/tracing';
-import { Logger } from 'nestjs-pino';
 import { getTooljetEdition } from '@helpers/utils.helper';
 import { TOOLJET_EDITIONS } from '@modules/app/constants';
 
@@ -14,8 +12,7 @@ import { TOOLJET_EDITIONS } from '@modules/app/constants';
 export class OtelMiddleware implements NestMiddleware {
   constructor(
     private readonly licenseTermsService: LicenseTermsService,
-    private readonly configService: ConfigService,
-    private readonly logger: Logger
+    private readonly configService: ConfigService
   ) {}
 
   async use(req: Request, res: Response, next: NextFunction) {
@@ -32,28 +29,14 @@ export class OtelMiddleware implements NestMiddleware {
     const span = trace.getSpan(context.active());
     const route = req.route?.path || req.path || 'unknown_route';
     const method = req.method || 'UNKNOWN_METHOD';
-    const startTime = Date.now();
 
+    // Span naming only. The api.hits / api.duration counters this used to feed were
+    // duplicates of http.server.request.duration from auto-instrumentation, and the
+    // res.json monkey-patch existed solely to time them.
     if (span && route.startsWith('/api/') && route !== '/api/health') {
       span.updateName(`${method} ${route}`);
       span.setAttribute('http.route', route);
       span.setAttribute('http.method', method);
-
-      recordApiHit({ route, method });
-
-      const originalJson = res.json.bind(res);
-      res.json = (body: any) => {
-        const statusCode = res.statusCode;
-        const duration = Date.now() - startTime;
-
-        span.setAttribute('http.status_code', statusCode);
-        recordApiDuration(duration, { route, method, status_code: statusCode });
-        this.logger.log(
-          `Setting up Otel logging : API ${method} ${route} completed with status ${statusCode} in ${duration}ms`
-        );
-
-        return originalJson(body);
-      };
     }
 
     next();

--- a/server/src/modules/configs/service.ts
+++ b/server/src/modules/configs/service.ts
@@ -49,6 +49,7 @@ export class ConfigService implements IConfigService {
       'SSO_HUBSPOT_PORTAL_ID',
       'SSO_HUBSPOT_FORM_ID',
       'ENABLE_OTEL_FRONTEND',
+      'OTEL_FRONTEND_FLUSH_INTERVAL_SECONDS',
     ];
   }
 

--- a/server/src/modules/data-queries/util.service.ts
+++ b/server/src/modules/data-queries/util.service.ts
@@ -377,7 +377,11 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
 
       return result;
     } catch (queryError) {
-      abortCtrl.cleanup();
+      // abortCtrl is only constructed once the data source and its options resolve.
+      // Anything that throws before that (permissions, getOptions, plugin load) used to
+      // hit a TypeError HERE, which replaced the real error and skipped setFailure —
+      // and then threw again in finally, so the query metric never emitted.
+      abortCtrl?.cleanup();
       queryStatus.setFailure({
         message: queryError?.message,
         description: queryError?.description,
@@ -386,7 +390,7 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
       });
       throw queryError;
     } finally {
-      abortCtrl.cleanup();
+      abortCtrl?.cleanup();
       if (user) {
         // Get metadata from queryStatus
         const queryMetadata = queryStatus.getMetaData();

--- a/server/src/modules/data-queries/util.service.ts
+++ b/server/src/modules/data-queries/util.service.ts
@@ -377,10 +377,7 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
 
       return result;
     } catch (queryError) {
-      // abortCtrl is only constructed once the data source and its options resolve.
-      // Anything that throws before that (permissions, getOptions, plugin load) used to
-      // hit a TypeError HERE, which replaced the real error and skipped setFailure —
-      // and then threw again in finally, so the query metric never emitted.
+      // Null if we threw before it was built. Unguarded, that TypeError masked the real error.
       abortCtrl?.cleanup();
       queryStatus.setFailure({
         message: queryError?.message,

--- a/server/src/modules/frontend-metrics/service.ts
+++ b/server/src/modules/frontend-metrics/service.ts
@@ -83,18 +83,14 @@ export class FrontendMetricsService {
         severityText: 'WARN',
         body: ev.detail.value,
         attributes: {
-          // Same translation the metric path uses, so logs and metrics cannot
-          // disagree about what a beacon key is called.
           ...translateBeaconAttrs(ev.attrs),
           [ATTR.EVENT_TYPE]: ev.type,
-          // Same value the metric counter is split by, so error.type reads the
-          // same on both signals
+          // Same value the metric counter splits on
           [ATTR.ERROR_TYPE]: ev.type,
           [ATTR.ORGANIZATION_ID]: context.organizationId,
           [ATTR.ORGANIZATION_NAME]: organizationName,
           [ATTR.USER_ID]: context.userId,
           [ATTR.ERROR_FINGERPRINT]: `${ev.type}:${ev.detail.value}`.slice(0, 80),
-          // exception.* stay log-record-only — the unbounded detail metrics can't carry
           [ATTR.EXCEPTION_TYPE]: ev.detail.type,
           [ATTR.EXCEPTION_MESSAGE]: ev.detail.value,
           [ATTR.EXCEPTION_STACKTRACE]: ev.detail.stacktrace ?? '',
@@ -108,8 +104,7 @@ export class FrontendMetricsService {
     if (!attrs || typeof attrs !== 'object' || Array.isArray(attrs)) return {};
     const result: Record<string, string | number | boolean> = {};
     for (const key of Object.keys(attrs as object)) {
-      // Bounded keyspace — an arbitrary client key is unbounded OTEL cardinality.
-      // Server-injected keys are absent from the map, so a client cannot pre-empt them.
+      // Arbitrary client key = unbounded cardinality
       if (!isAcceptedBeaconAttr(key)) continue;
       const val = (attrs as Record<string, unknown>)[key];
       if (typeof val === 'boolean' || typeof val === 'number') {

--- a/server/src/modules/frontend-metrics/service.ts
+++ b/server/src/modules/frontend-metrics/service.ts
@@ -5,7 +5,7 @@ import { recordFrontendMetricsBatch } from '@otel/frontend-metrics';
 import { getFrontendErrorLogger } from '@otel/logs';
 import { getWorkspaceNameLabel } from '@otel/org-plan-cache';
 import { getOrganizationNameCached } from '@otel/org-name-cache';
-import { ATTR, isAcceptedBeaconAttr } from '@otel/semconv';
+import { ATTR, isAcceptedBeaconAttr, translateBeaconAttrs } from '@otel/semconv';
 
 const MAX_EVENTS_PER_BATCH = 200;
 const MAX_ATTR_VALUE_LENGTH = 200;
@@ -83,13 +83,13 @@ export class FrontendMetricsService {
         severityText: 'WARN',
         body: ev.detail.value,
         attributes: {
+          // Same translation the metric path uses, so logs and metrics cannot
+          // disagree about what a beacon key is called.
+          ...translateBeaconAttrs(ev.attrs),
           [ATTR.EVENT_TYPE]: ev.type,
-          [ATTR.APP_CONTEXT]: ev.attrs['app.context'],
-          [ATTR.APP_NAME]: ev.attrs['app.name'],
-          [ATTR.ENVIRONMENT_NAME]: ev.attrs['app.environment'],
-          [ATTR.APP_VERSION]: ev.attrs['app.version'],
-          [ATTR.ERROR_TYPE]: ev.attrs['error.kind'],
-          [ATTR.WIDGET_TYPE]: ev.attrs['widget.type'],
+          // Same value the metric counter is split by, so error.type reads the
+          // same on both signals
+          [ATTR.ERROR_TYPE]: ev.type,
           [ATTR.ORGANIZATION_ID]: context.organizationId,
           [ATTR.ORGANIZATION_NAME]: organizationName,
           [ATTR.USER_ID]: context.userId,

--- a/server/src/modules/frontend-metrics/service.ts
+++ b/server/src/modules/frontend-metrics/service.ts
@@ -5,22 +5,10 @@ import { recordFrontendMetricsBatch } from '@otel/frontend-metrics';
 import { getFrontendErrorLogger } from '@otel/logs';
 import { getWorkspaceNameLabel } from '@otel/org-plan-cache';
 import { getOrganizationNameCached } from '@otel/org-name-cache';
+import { ATTR, isAcceptedBeaconAttr } from '@otel/semconv';
 
 const MAX_EVENTS_PER_BATCH = 200;
 const MAX_ATTR_VALUE_LENGTH = 200;
-
-// Bounded keyspace — prevents unbounded OTEL cardinality from arbitrary client keys.
-const ALLOWED_ATTR_KEYS = new Set([
-  'app.name',
-  'app.context',
-  'widget.type',
-  'vital.name',
-  'app.environment',
-  'app.version',
-  'error.kind',
-]);
-// Server injects these — strip from client payload so clients cannot pre-empt them.
-const RESERVED_ATTR_KEYS = new Set(['organization.id', 'user.id', 'organization.name', 'tooljet.version']);
 
 // Client dedup doesn't protect against N clients or attacker-chosen fingerprints;
 // cap verbose log emits per org. Metrics keep counting when capped.
@@ -95,21 +83,22 @@ export class FrontendMetricsService {
         severityText: 'WARN',
         body: ev.detail.value,
         attributes: {
-          'event.type': ev.type,
-          'app.context': ev.attrs['app.context'],
-          'app.name': ev.attrs['app.name'],
-          'app.environment': ev.attrs['app.environment'],
-          'app.version': ev.attrs['app.version'],
-          'error.kind': ev.attrs['error.kind'],
-          'widget.type': ev.attrs['widget.type'],
-          'organization.id': context.organizationId,
-          'organization.name': organizationName,
-          'user.id': context.userId,
-          'error.fingerprint': `${ev.type}:${ev.detail.value}`.slice(0, 80),
-          'exception.type': ev.detail.type,
-          'exception.message': ev.detail.value,
-          'exception.stacktrace': ev.detail.stacktrace ?? '',
-          'event.count': ev.count ?? 1,
+          [ATTR.EVENT_TYPE]: ev.type,
+          [ATTR.APP_CONTEXT]: ev.attrs['app.context'],
+          [ATTR.APP_NAME]: ev.attrs['app.name'],
+          [ATTR.ENVIRONMENT_NAME]: ev.attrs['app.environment'],
+          [ATTR.APP_VERSION]: ev.attrs['app.version'],
+          [ATTR.ERROR_TYPE]: ev.attrs['error.kind'],
+          [ATTR.WIDGET_TYPE]: ev.attrs['widget.type'],
+          [ATTR.ORGANIZATION_ID]: context.organizationId,
+          [ATTR.ORGANIZATION_NAME]: organizationName,
+          [ATTR.USER_ID]: context.userId,
+          [ATTR.ERROR_FINGERPRINT]: `${ev.type}:${ev.detail.value}`.slice(0, 80),
+          // exception.* stay log-record-only — the unbounded detail metrics can't carry
+          [ATTR.EXCEPTION_TYPE]: ev.detail.type,
+          [ATTR.EXCEPTION_MESSAGE]: ev.detail.value,
+          [ATTR.EXCEPTION_STACKTRACE]: ev.detail.stacktrace ?? '',
+          [ATTR.EVENT_COUNT]: ev.count ?? 1,
         },
       });
     }
@@ -119,8 +108,9 @@ export class FrontendMetricsService {
     if (!attrs || typeof attrs !== 'object' || Array.isArray(attrs)) return {};
     const result: Record<string, string | number | boolean> = {};
     for (const key of Object.keys(attrs as object)) {
-      if (RESERVED_ATTR_KEYS.has(key)) continue;
-      if (!ALLOWED_ATTR_KEYS.has(key)) continue;
+      // Bounded keyspace — an arbitrary client key is unbounded OTEL cardinality.
+      // Server-injected keys are absent from the map, so a client cannot pre-empt them.
+      if (!isAcceptedBeaconAttr(key)) continue;
       const val = (attrs as Record<string, unknown>)[key];
       if (typeof val === 'boolean' || typeof val === 'number') {
         result[key] = val;

--- a/server/src/modules/session/jwt/jwt.strategy.ts
+++ b/server/src/modules/session/jwt/jwt.strategy.ts
@@ -159,7 +159,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
             trackUserActivity({
               workspaceId: user.organizationId,
               userId: user.id,
-              sessionId: payload.sessionId,
               /* App-scoped requests only; PAT sessions carry the app id on the token itself */
               appId: extractAppIdFromPath(req.originalUrl || req.url) || payload.appId,
             });
@@ -224,7 +223,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         trackUserActivity({
           workspaceId: user.organizationId,
           userId: user.id,
-          sessionId: user.sessionId,
           appId: extractAppIdFromPath(req.originalUrl || req.url),
         });
       } catch (error) {

--- a/server/src/modules/session/service.ts
+++ b/server/src/modules/session/service.ts
@@ -21,7 +21,6 @@ import { fullName, generateOrgInviteURL, isSuperAdmin } from '@helpers/utils.hel
 import { decamelizeKeys } from 'humps';
 import { RequestContext } from '@modules/request-context/service';
 import { AUDIT_LOGS_REQUEST_CONTEXT_KEY } from '@modules/app/constants';
-import { decrementConcurrentUsers } from '@otel/tracing';
 
 @Injectable()
 export class SessionService {
@@ -37,18 +36,6 @@ export class SessionService {
     response.clearCookie('tj_auth_token', this.sessionUtilService.getClearCookieOptions());
     await dbTransactionWrap(async (manager: EntityManager) => {
       await manager.delete(UserSessions, { id: sessionId, userId: user.id });
-
-      // Decrement metrics
-      try {
-        if (user?.organizationId) {
-          decrementConcurrentUsers({
-            workspaceId: user.organizationId,
-            userId: user.id,
-          });
-        }
-      } catch (error) {
-        console.error('Error decrementing session metrics:', error);
-      }
 
       const auditLogData = {
         userId: user.id,

--- a/server/src/modules/session/util.service.ts
+++ b/server/src/modules/session/util.service.ts
@@ -26,7 +26,7 @@ import {
   UserAppsPermissions,
   UserDataSourcePermissions,
   UserFolderPermissions,
-  UserPermissions
+  UserPermissions,
 } from '@modules/ability/types';
 import { JwtService } from '@nestjs/jwt';
 import { RolesRepository } from '@modules/roles/repository';
@@ -34,7 +34,6 @@ import { EncryptionService } from '@modules/encryption/service';
 import { OnboardingStatus } from '@modules/onboarding/constants';
 import { RequestContext } from '@modules/request-context/service';
 import { SessionType } from '@modules/external-apis/constants';
-import { incrementConcurrentUsers } from '@otel/tracing';
 
 @Injectable()
 export class SessionUtilService {
@@ -150,19 +149,6 @@ export class SessionUtilService {
 
       const permissionData = await this.getPermissionDataToAuthorize(user, manager);
       const noActiveWorkspaces = await this.checkUserWorkspaceStatus(user.id, manager);
-
-      // Track concurrent users if a new session was created and organization is available
-      if (loggedInUser?.id !== user.id && !isPatLogin && organization?.id) {
-        try {
-          incrementConcurrentUsers({
-            workspaceId: organization.id as string,
-            userId: user.id,
-            userRole: permissionData.admin ? 'admin' : 'member',
-          });
-        } catch (error) {
-          console.error('Error incrementing concurrent users metric:', error);
-        }
-      }
 
       const responsePayload = {
         organizationId: organization?.id,

--- a/server/src/otel/audit-metrics.ts
+++ b/server/src/otel/audit-metrics.ts
@@ -1,397 +1,49 @@
 import { metrics } from '@opentelemetry/api';
-import { AuditLogFields } from '@modules/audit-logs/types';
+import type { Counter, Histogram, Meter } from '@opentelemetry/api';
 import { getWorkspaceLabel, getWorkspaceNameLabel } from './org-plan-cache';
+import { ATTR, BUCKETS_SECONDS, METRIC } from './semconv';
 
 /**
- * OTEL Metrics for Audit Logs
+ * Query execution metrics.
  *
- * This module provides OpenTelemetry metrics instrumentation for audit logs.
- * It tracks various app-based metrics by streaming audit log events to the OTEL collector.
+ * Emitted directly at the query execution site rather than off the audit
+ * pipeline, so they flow regardless of audit-log licensing and carry the full
+ * label set the app drilldown needs.
  *
- * Metrics are separated into two categories:
- * - Platform metrics: Platform-level operations (user management, org settings, etc.)
- * - App metrics: App-specific operations (query execution, app usage, etc.)
+ * The audit-log counter family that used to live here (audit.logs.*,
+ * user.sessions.total, app.usage/errors/lifecycle.*, datasource.lifecycle.*)
+ * was removed: no dashboard ever queried it, and every emit carried label
+ * cardinality for nothing.
  */
 
-// Meters for different metric categories
-let platformMeter: any;
-let appMeter: any;
+let appMeter: Meter;
+let queryExecutionsCounter: Counter;
+let queryDurationHistogram: Histogram;
 
-// Platform-level metrics
-let auditLogCounter: any;
-let auditLogActionCounter: any;
-let auditLogResourceCounter: any;
-let auditLogUserActivityGauge: any;
-let auditLogOrganizationActivityGauge: any;
-let userSessionsCounter: any;
-
-// App-level query metrics (with mode and environment tracking)
-let queryExecutionsCounter: any;
-let queryFailuresCounter: any;
-let queryDurationHistogram: any;
-
-// App-level metrics
-let appUsageCounter: any;
-let appActiveUsersGauge: any;
-let appSuccessRateGauge: any;
-let appErrorsCounter: any;
-
-// App lifecycle metrics
-let appCreationsCounter: any;
-let appUpdatesCounter: any;
-let appDeletionsCounter: any;
-let appReleasesCounter: any;
-
-// Data source lifecycle metrics
-let datasourceCreationsCounter: any;
-let datasourceUpdatesCounter: any;
-let datasourceDeletionsCounter: any;
-
-// Store recent activity for gauges (last 15 minutes)
-const ACTIVITY_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
-const userActivity = new Map<string, { count: number; lastUpdate: number }>();
-const organizationActivity = new Map<string, { count: number; lastUpdate: number }>();
-const appActiveUsers = new Map<string, Map<string, number>>(); // appId -> Map<userId, lastSeen>
-
-// Store app success/failure counts for success rate calculation
-// Key format: "appId:mode:environment" -> { success: number, failure: number, lastUpdate: number }
-const appSuccessTracking = new Map<string, { success: number; failure: number; lastUpdate: number }>();
-
-/**
- * Initialize audit log metrics
- * Should be called after OTEL SDK is started
- */
 export const initializeAuditLogMetrics = () => {
-  // Create separate meters for platform and app metrics
-  platformMeter = metrics.getMeter('tooljet-platform');
   appMeter = metrics.getMeter('tooljet-app');
 
-  // ============ Platform-level metrics ============
-
-  // Counter: Total audit log events
-  auditLogCounter = platformMeter.createCounter('audit.logs.total', {
-    description: 'Total number of audit log events',
+  // No authored `_total` — the Prometheus exporter appends it.
+  queryExecutionsCounter = appMeter.createCounter(METRIC.QUERY_EXECUTIONS, {
+    description: 'Query executions, labeled by app, workspace, mode and environment',
     unit: '1',
   });
 
-  // Counter: Audit log events by action type
-  auditLogActionCounter = platformMeter.createCounter('audit.logs.actions', {
-    description: 'Number of audit log events by action type',
-    unit: '1',
+  queryDurationHistogram = appMeter.createHistogram(METRIC.QUERY_DURATION, {
+    description: 'Query execution duration',
+    unit: 's',
+    advice: { explicitBucketBoundaries: [...BUCKETS_SECONDS.QUERY] },
   });
 
-  // Counter: Audit log events by resource type
-  auditLogResourceCounter = platformMeter.createCounter('audit.logs.resources', {
-    description: 'Number of audit log events by resource type',
-    unit: '1',
-  });
-
-  // Gauge: Active users by organization (based on recent audit logs)
-  auditLogUserActivityGauge = platformMeter.createObservableGauge('audit.logs.active_users', {
-    description: 'Number of active users by organization (based on audit log activity in last 15 minutes)',
-    unit: '1',
-  });
-
-  auditLogUserActivityGauge.addCallback((observableResult: any) => {
-    const now = Date.now();
-    const cutoffTime = now - ACTIVITY_WINDOW_MS;
-
-    // Clean up old entries and aggregate by organization
-    const orgUserCounts = new Map<string, Set<string>>();
-
-    for (const [key, value] of userActivity.entries()) {
-      if (value.lastUpdate < cutoffTime) {
-        userActivity.delete(key);
-      } else {
-        // key format: "orgId:userId"
-        const [orgId, userId] = key.split(':');
-        if (!orgUserCounts.has(orgId)) {
-          orgUserCounts.set(orgId, new Set());
-        }
-        orgUserCounts.get(orgId)!.add(userId);
-      }
-    }
-
-    // Report metrics for each organization
-    for (const [orgId, users] of orgUserCounts.entries()) {
-      observableResult.observe(users.size, {
-        organization_id: orgId,
-      });
-    }
-  });
-
-  // Gauge: Activity count by organization
-  auditLogOrganizationActivityGauge = platformMeter.createObservableGauge('audit.logs.organization_activity', {
-    description: 'Number of audit log events by organization in last 15 minutes',
-    unit: '1',
-  });
-
-  auditLogOrganizationActivityGauge.addCallback((observableResult: any) => {
-    const now = Date.now();
-    const cutoffTime = now - ACTIVITY_WINDOW_MS;
-
-    // Clean up old entries
-    for (const [orgId, activity] of organizationActivity.entries()) {
-      if (activity.lastUpdate < cutoffTime) {
-        organizationActivity.delete(orgId);
-      } else {
-        observableResult.observe(activity.count, {
-          organization_id: orgId,
-        });
-      }
-    }
-  });
-
-  // User Sessions Counter (platform-level)
-  userSessionsCounter = platformMeter.createCounter('user.sessions.total', {
-    description: 'Total user login/logout events',
-    unit: '1',
-  });
-
-  // ============ App-level metrics ============
-
-  // Query Execution Counter (with mode and environment labels)
-  queryExecutionsCounter = appMeter.createCounter('query.executions.total', {
-    description: 'Total number of query executions (labeled by mode and environment)',
-    unit: '1',
-  });
-
-  // Query Failures Counter (with mode and environment labels)
-  queryFailuresCounter = appMeter.createCounter('query.failures.total', {
-    description: 'Total number of failed queries (labeled by mode and environment)',
-    unit: '1',
-  });
-
-  // Query Duration Histogram (with mode and environment labels)
-  queryDurationHistogram = appMeter.createHistogram('query.duration', {
-    description: 'Query execution duration in milliseconds (labeled by mode and environment)',
-    unit: 'ms',
-  });
-
-  // App Usage Counter
-  appUsageCounter = appMeter.createCounter('app.usage.total', {
-    description: 'Total app interactions',
-    unit: '1',
-  });
-
-  // App Active Users Gauge
-  appActiveUsersGauge = appMeter.createObservableGauge('app.active_users', {
-    description: 'Number of active users per app (last 15 minutes)',
-    unit: '1',
-  });
-
-  appActiveUsersGauge.addCallback((observableResult: any) => {
-    const now = Date.now();
-    const cutoffTime = now - ACTIVITY_WINDOW_MS;
-
-    for (const [appId, users] of appActiveUsers.entries()) {
-      // Clean up inactive users
-      for (const [userId, lastSeen] of users.entries()) {
-        if (lastSeen < cutoffTime) {
-          users.delete(userId);
-        }
-      }
-
-      // Report active user count for this app
-      if (users.size > 0) {
-        observableResult.observe(users.size, {
-          app_id: appId,
-        });
-      } else {
-        // Remove empty app entries
-        appActiveUsers.delete(appId);
-      }
-    }
-  });
-
-  // App Success Rate Gauge (by mode and environment)
-  appSuccessRateGauge = appMeter.createObservableGauge('app.success_rate', {
-    description: 'Success rate of app queries (0-100%) by mode and environment in last 15 minutes',
-    unit: '%',
-  });
-
-  appSuccessRateGauge.addCallback((observableResult: any) => {
-    const now = Date.now();
-    const cutoffTime = now - ACTIVITY_WINDOW_MS;
-
-    for (const [key, stats] of appSuccessTracking.entries()) {
-      if (stats.lastUpdate < cutoffTime) {
-        appSuccessTracking.delete(key);
-      } else {
-        const [appId, mode, environment] = key.split(':');
-        const total = stats.success + stats.failure;
-        const successRate = total > 0 ? (stats.success / total) * 100 : 100;
-
-        observableResult.observe(successRate, {
-          app_id: appId,
-          mode: mode,
-          environment: environment,
-        });
-      }
-    }
-  });
-
-  // App Errors Counter (for released apps)
-  appErrorsCounter = appMeter.createCounter('app.errors.total', {
-    description: 'Total errors in apps by mode and environment',
-    unit: '1',
-  });
-
-  // App Lifecycle Counters
-  appCreationsCounter = appMeter.createCounter('app.creations.total', {
-    description: 'Total number of app creations',
-    unit: '1',
-  });
-
-  appUpdatesCounter = appMeter.createCounter('app.updates.total', {
-    description: 'Total number of app updates',
-    unit: '1',
-  });
-
-  appDeletionsCounter = appMeter.createCounter('app.deletions.total', {
-    description: 'Total number of app deletions',
-    unit: '1',
-  });
-
-  appReleasesCounter = appMeter.createCounter('app.releases.total', {
-    description: 'Total number of app releases',
-    unit: '1',
-  });
-
-  // Data Source Lifecycle Counters
-  datasourceCreationsCounter = appMeter.createCounter('datasource.creations.total', {
-    description: 'Total number of datasource creations',
-    unit: '1',
-  });
-
-  datasourceUpdatesCounter = appMeter.createCounter('datasource.updates.total', {
-    description: 'Total number of datasource updates',
-    unit: '1',
-  });
-
-  datasourceDeletionsCounter = appMeter.createCounter('datasource.deletions.total', {
-    description: 'Total number of datasource deletions',
-    unit: '1',
-  });
-
-  console.log('✅ Audit log metrics initialized with separate meters:');
-  console.log('   Platform metrics (tooljet-platform):');
-  console.log('     - audit.logs.total, audit.logs.actions, audit.logs.resources');
-  console.log('     - audit.logs.active_users, audit.logs.organization_activity');
-  console.log('     - user.sessions.total');
-  console.log('   App metrics (tooljet-app):');
-  console.log('     - query.executions.total (with mode/environment), query.failures.total, query.duration');
-  console.log('     - app.usage.total, app.active_users, app.success_rate, app.errors.total');
-  console.log('     - app.creations.total, app.updates.total, app.deletions.total, app.releases.total');
-  console.log('     - datasource.creations.total, datasource.updates.total, datasource.deletions.total');
-  console.log('');
-  console.log('⚙️  Configuration:');
-  console.log(`   OTEL_INCLUDE_QUERY_TEXT: ${process.env.OTEL_INCLUDE_QUERY_TEXT === 'true' ? 'enabled' : 'disabled (default)'}`);
-  if (process.env.OTEL_INCLUDE_QUERY_TEXT === 'true') {
-    console.log('   ⚠️  WARNING: query_text creates high cardinality metrics - use OTEL Collector to drop in production');
-  }
-};
-
-/**
- * Record an audit log event to OTEL metrics
- *
- * @param auditLogData - The audit log data to record
- */
-export const recordAuditLogMetric = (auditLogData: AuditLogFields,isOtelEnabled?: boolean) => {
-   if (!isOtelEnabled) {
-   return;
- }
-  if (!auditLogCounter) {
-    console.warn('Audit log metrics not initialized. Skipping metric recording.');
-    return;
-  }
-
-  try {
-    const {
-      userId,
-      organizationId,
-      resourceType,
-      actionType,
-      resourceName,
-      resourceId,
-      ipAddress,
-      metadata = {},
-    } = auditLogData;
-
-    // Prepare common attributes
-    const commonAttributes = {
-      organization_id: organizationId,
-      user_id: userId,
-      resource_type: resourceType,
-      action_type: actionType,
-    };
-
-    // Record total audit log counter
-    auditLogCounter.add(1, commonAttributes);
-
-    // Record action-specific counter
-    auditLogActionCounter.add(1, {
-      action_type: actionType,
-      resource_type: resourceType,
-      organization_id: organizationId,
-    });
-
-    // Record resource-specific counter
-    auditLogResourceCounter.add(1, {
-      resource_type: resourceType,
-      organization_id: organizationId,
-    });
-
-    // Update user activity gauge data
-    const userActivityKey = `${organizationId}:${userId}`;
-    userActivity.set(userActivityKey, {
-      count: (userActivity.get(userActivityKey)?.count || 0) + 1,
-      lastUpdate: Date.now(),
-    });
-
-    // Update organization activity gauge data
-    if (organizationActivity.has(organizationId)) {
-      const current = organizationActivity.get(organizationId)!;
-      organizationActivity.set(organizationId, {
-        count: current.count + 1,
-        lastUpdate: Date.now(),
-      });
-    } else {
-      organizationActivity.set(organizationId, {
-        count: 1,
-        lastUpdate: Date.now(),
-      });
-    }
-
-    // Query metrics are recorded directly at the execution site (recordQueryMetric),
-    // not from the audit pipeline — recording here too would double-count.
-
-    // Record app-specific metrics
-    if (resourceType === 'APP' || actionType.startsWith('APP_')) {
-      recordAppMetrics(auditLogData);
-    }
-
-    // Record user session metrics
-    if (actionType === 'USER_LOGIN' || actionType === 'USER_LOGOUT') {
-      recordUserSessionMetrics(auditLogData);
-    }
-
-    // Record app lifecycle metrics
-    if (actionType === 'APP_CREATE' || actionType === 'APP_UPDATE' || actionType === 'APP_DELETE' || actionType === 'APP_RELEASE') {
-      recordAppLifecycleMetrics(auditLogData);
-    }
-
-    // Record datasource lifecycle metrics
-    if (actionType === 'DATA_SOURCE_CREATE' || actionType === 'DATA_SOURCE_UPDATE' || actionType === 'DATA_SOURCE_DELETE') {
-      recordDataSourceLifecycleMetrics(auditLogData);
-    }
-
-    // Log for debugging (optional, can be removed in production)
-    if (process.env.OTEL_LOG_LEVEL === 'debug') {
-      console.log(`[OTEL Audit Metric] Recorded: ${actionType} on ${resourceType} by user ${userId}`);
-    }
-  } catch (error) {
-    console.error('Error recording audit log metric:', error);
+  if (process.env.OTEL_LOG_LEVEL === 'debug') {
+    console.log(`[OTEL] Query metrics initialized: ${METRIC.QUERY_EXECUTIONS}, ${METRIC.QUERY_DURATION}`);
+    console.log(
+      `[OTEL] OTEL_INCLUDE_QUERY_TEXT: ${
+        process.env.OTEL_INCLUDE_QUERY_TEXT === 'true'
+          ? 'enabled — query text becomes a label, high cardinality'
+          : 'disabled (default)'
+      }`
+    );
   }
 };
 
@@ -407,7 +59,7 @@ export interface QueryMetricPayload {
   appMode: string; // 'edit' | 'view'
   environment: string; // environment name
   status: 'success' | 'failure' | string;
-  duration?: number; // ms
+  duration?: number; // ms at the call site; recorded in seconds
   error?: string;
   errorType?: string;
   queryText?: string; // only labeled if OTEL_INCLUDE_QUERY_TEXT=true
@@ -416,15 +68,28 @@ export interface QueryMetricPayload {
 }
 
 /**
- * Record query metrics directly at the query execution site — no audit
- * pipeline dependency, so metrics flow regardless of audit log licensing.
+ * Categorize an error message into a low-cardinality error.type value.
  */
+function categorizeError(error: unknown): string {
+  if (!error) return 'unknown';
+
+  const errorStr = typeof error === 'string' ? error : (error as Error)?.message || String(error);
+  const lowerError = errorStr.toLowerCase();
+
+  if (lowerError.includes('timeout')) return 'timeout';
+  if (lowerError.includes('connection')) return 'connection_error';
+  if (lowerError.includes('syntax')) return 'syntax_error';
+  if (lowerError.includes('permission') || lowerError.includes('denied')) return 'permission_error';
+  if (lowerError.includes('not found')) return 'not_found';
+
+  return 'unknown_error';
+}
+
 export const recordQueryMetric = (payload: QueryMetricPayload) => {
   if (!queryExecutionsCounter) return;
 
   try {
     const {
-      userId,
       organizationId,
       organizationName = 'unknown',
       appId,
@@ -442,265 +107,39 @@ export const recordQueryMetric = (payload: QueryMetricPayload) => {
       versionName = 'unknown',
     } = payload;
 
-    const errorType = payload.errorType || categorizeError(error);
-    const isReleased = appMode === 'view' ? 'true' : 'false';
-    const qtLabel = process.env.OTEL_INCLUDE_QUERY_TEXT === 'true' ? queryText : '';
+    const failed = status === 'failure' || !!error;
 
     // App-level metric — free-tier orgs bucket on Cloud; id and name gate together
-    const labels = {
-      app_id: appId || 'unknown',
-      app_name: appName,
-      query_id: queryId,
-      query_name: queryName,
-      data_source_type: dataSourceType,
-      organization_id: getWorkspaceLabel(organizationId),
-      organization_name: getWorkspaceNameLabel(organizationId, organizationName),
-      status,
-      app_mode: appMode,
-      environment,
-      is_released: isReleased,
-      query_text: qtLabel,
-      query_type: queryType,
-      version_name: versionName,
+    const labels: Record<string, string> = {
+      [ATTR.APP_ID]: appId || 'unknown',
+      [ATTR.APP_NAME]: appName,
+      [ATTR.QUERY_ID]: queryId,
+      [ATTR.QUERY_NAME]: queryName,
+      [ATTR.QUERY_TYPE]: queryType,
+      [ATTR.DATA_SOURCE_TYPE]: dataSourceType,
+      [ATTR.ORGANIZATION_ID]: getWorkspaceLabel(organizationId),
+      [ATTR.ORGANIZATION_NAME]: getWorkspaceNameLabel(organizationId, organizationName),
+      [ATTR.APP_MODE]: appMode,
+      [ATTR.APP_RELEASED]: appMode === 'view' ? 'true' : 'false',
+      [ATTR.ENVIRONMENT_NAME]: environment,
+      [ATTR.APP_VERSION]: versionName,
+      [ATTR.QUERY_TEXT]: process.env.OTEL_INCLUDE_QUERY_TEXT === 'true' ? queryText : '',
     };
+
+    // error.type is set if and only if the query failed. Its absence is what
+    // marks success, which is why there is no separate `status` label and no
+    // separate failures counter to drift out of step with this one.
+    if (failed) {
+      labels[ATTR.ERROR_TYPE] = payload.errorType || categorizeError(error);
+    }
 
     queryExecutionsCounter.add(1, labels);
 
     if (typeof duration === 'number') {
-      queryDurationHistogram.record(duration, labels);
-    }
-
-    if (status === 'failure' || error) {
-      queryFailuresCounter?.add(1, {
-        ...labels,
-        error_type: errorType,
-      });
-
-      appErrorsCounter?.add(1, {
-        app_id: appId || 'unknown',
-        app_name: appName,
-        error_type: errorType,
-        app_mode: appMode,
-        environment,
-        organization_id: getWorkspaceLabel(organizationId),
-        organization_name: getWorkspaceNameLabel(organizationId, organizationName),
-      });
-    }
-
-    if (appId && appId !== 'unknown') {
-      trackAppActiveUser(appId, userId);
-      if (appMode !== 'unknown' && environment !== 'unknown') {
-        trackAppSuccess(appId, appMode, environment, status === 'success');
-      }
+      queryDurationHistogram.record(duration / 1000, labels);
     }
   } catch (err) {
     // Observability must never break query execution
     console.error('[OTEL] Error in recordQueryMetric:', err);
   }
-};
-
-/**
- * Record app usage metrics
- */
-function recordAppMetrics(auditLogData: AuditLogFields) {
-  if (!appUsageCounter) return;
-
-  const { resourceId, resourceName, actionType, organizationId, userId, metadata = {} } = auditLogData;
-
-  const appId = resourceId || metadata['appId'] || 'unknown';
-  const appName = resourceName || metadata['appName'] || 'unknown';
-
-  const labels = {
-    app_id: appId,
-    app_name: appName,
-    action_type: actionType,
-    // App-level metric — free-tier orgs bucket on Cloud
-    organization_id: getWorkspaceLabel(organizationId),
-  };
-
-  appUsageCounter.add(1, labels);
-
-  // Track active users for this app
-  if (appId !== 'unknown') {
-    trackAppActiveUser(appId, userId);
-  }
-}
-
-/**
- * Record user session metrics (login/logout)
- */
-function recordUserSessionMetrics(auditLogData: AuditLogFields) {
-  if (!userSessionsCounter) return;
-
-  const { actionType, resourceData = {}, organizationId } = auditLogData;
-
-  const eventType = actionType === 'USER_LOGIN' ? 'login' : 'logout';
-  const authMethod = resourceData['auth_method'] || 'unknown';
-
-  const labels = {
-    event_type: eventType,
-    auth_method: authMethod,
-    organization_id: organizationId,
-  };
-
-  userSessionsCounter.add(1, labels);
-}
-
-/**
- * Track active user for an app
- */
-function trackAppActiveUser(appId: string, userId: string) {
-  if (!appActiveUsers.has(appId)) {
-    appActiveUsers.set(appId, new Map());
-  }
-  appActiveUsers.get(appId)!.set(userId, Date.now());
-}
-
-/**
- * Track app success/failure for success rate calculation
- */
-function trackAppSuccess(appId: string, mode: string, environment: string, isSuccess: boolean) {
-  const key = `${appId}:${mode}:${environment}`;
-  const now = Date.now();
-
-  if (!appSuccessTracking.has(key)) {
-    appSuccessTracking.set(key, { success: 0, failure: 0, lastUpdate: now });
-  }
-
-  const stats = appSuccessTracking.get(key)!;
-  if (isSuccess) {
-    stats.success += 1;
-  } else {
-    stats.failure += 1;
-  }
-  stats.lastUpdate = now;
-}
-
-/**
- * Record app lifecycle metrics (create, update, delete, release)
- */
-function recordAppLifecycleMetrics(auditLogData: AuditLogFields) {
-  const { actionType, resourceId, resourceName, resourceData = {}, organizationId } = auditLogData;
-
-  const appSlug = resourceData['appSlug'] || resourceId || 'unknown';
-  const isPublic = resourceData['isPublic'] || false;
-
-  const labels = {
-    app_id: resourceId,
-    app_name: resourceName || 'unknown',
-    app_slug: appSlug,
-    is_public: String(isPublic),
-    // App-level metric — free-tier orgs bucket on Cloud
-    organization_id: getWorkspaceLabel(organizationId),
-  };
-
-  switch (actionType) {
-    case 'APP_CREATE':
-      if (appCreationsCounter) {
-        appCreationsCounter.add(1, labels);
-      }
-      break;
-    case 'APP_UPDATE':
-      if (appUpdatesCounter) {
-        const updatedFields = resourceData['updatedFields'] || [];
-        appUpdatesCounter.add(1, {
-          ...labels,
-          updated_fields: Array.isArray(updatedFields) ? updatedFields.join(',') : String(updatedFields),
-        });
-      }
-      break;
-    case 'APP_DELETE':
-      if (appDeletionsCounter) {
-        appDeletionsCounter.add(1, labels);
-      }
-      break;
-    case 'APP_RELEASE':
-      if (appReleasesCounter) {
-        const environmentName = resourceData['environmentName'] || 'unknown';
-        const releasedVersionName = resourceData['releasedVersionName'] || 'unknown';
-        appReleasesCounter.add(1, {
-          ...labels,
-          environment: environmentName,
-          version: releasedVersionName,
-        });
-      }
-      break;
-  }
-}
-
-/**
- * Record datasource lifecycle metrics (create, update, delete)
- */
-function recordDataSourceLifecycleMetrics(auditLogData: AuditLogFields) {
-  const { actionType, resourceId, resourceName, resourceData = {}, organizationId } = auditLogData;
-
-  const dataSourceKind = resourceData['dataSourceKind'] || 'unknown';
-  const dataSourceScope = resourceData['dataSourceScope'] || 'unknown';
-  const appId = resourceData['appId'] || null;
-  const environmentId = resourceData['environmentId'] || 'unknown';
-
-  const labels = {
-    datasource_id: resourceId,
-    datasource_name: resourceName || 'unknown',
-    datasource_kind: dataSourceKind,
-    datasource_scope: dataSourceScope,
-    // App-level metric — free-tier orgs bucket on Cloud
-    organization_id: getWorkspaceLabel(organizationId),
-    environment_id: environmentId,
-  };
-
-  // Add appId only if it's not null (for app-scoped datasources)
-  if (appId) {
-    labels['app_id'] = appId;
-  }
-
-  switch (actionType) {
-    case 'DATA_SOURCE_CREATE':
-      if (datasourceCreationsCounter) {
-        datasourceCreationsCounter.add(1, labels);
-      }
-      break;
-    case 'DATA_SOURCE_UPDATE':
-      if (datasourceUpdatesCounter) {
-        const updatedFields = resourceData['updatedFields'] || [];
-        datasourceUpdatesCounter.add(1, {
-          ...labels,
-          updated_fields: Array.isArray(updatedFields) ? updatedFields.join(',') : String(updatedFields),
-        });
-      }
-      break;
-    case 'DATA_SOURCE_DELETE':
-      if (datasourceDeletionsCounter) {
-        datasourceDeletionsCounter.add(1, labels);
-      }
-      break;
-  }
-}
-
-/**
- * Categorize error type from error message
- */
-function categorizeError(error: any): string {
-  if (!error) return 'unknown';
-
-  const errorStr = typeof error === 'string' ? error : error.message || String(error);
-  const lowerError = errorStr.toLowerCase();
-
-  if (lowerError.includes('timeout')) return 'timeout';
-  if (lowerError.includes('connection')) return 'connection_error';
-  if (lowerError.includes('syntax')) return 'syntax_error';
-  if (lowerError.includes('permission') || lowerError.includes('denied')) return 'permission_error';
-  if (lowerError.includes('not found')) return 'not_found';
-
-  return 'unknown_error';
-}
-
-/**
- * Clear activity data (useful for testing)
- */
-export const clearActivityData = () => {
-  userActivity.clear();
-  organizationActivity.clear();
-  appActiveUsers.clear();
-  appSuccessTracking.clear();
 };

--- a/server/src/otel/audit-metrics.ts
+++ b/server/src/otel/audit-metrics.ts
@@ -3,18 +3,7 @@ import type { Counter, Histogram, Meter } from '@opentelemetry/api';
 import { getWorkspaceLabel, getWorkspaceNameLabel } from './org-plan-cache';
 import { ATTR, BUCKETS_SECONDS, METRIC } from './semconv';
 
-/**
- * Query execution metrics.
- *
- * Emitted directly at the query execution site rather than off the audit
- * pipeline, so they flow regardless of audit-log licensing and carry the full
- * label set the app drilldown needs.
- *
- * The audit-log counter family that used to live here (audit.logs.*,
- * user.sessions.total, app.usage/errors/lifecycle.*, datasource.lifecycle.*)
- * was removed: no dashboard ever queried it, and every emit carried label
- * cardinality for nothing.
- */
+// Emitted at the query site, not off the audit pipeline — flows regardless of audit licensing.
 
 let appMeter: Meter;
 let queryExecutionsCounter: Counter;
@@ -67,9 +56,6 @@ export interface QueryMetricPayload {
   versionName?: string;
 }
 
-/**
- * Categorize an error message into a low-cardinality error.type value.
- */
 function categorizeError(error: unknown): string {
   if (!error) return 'unknown';
 
@@ -126,9 +112,7 @@ export const recordQueryMetric = (payload: QueryMetricPayload) => {
       [ATTR.QUERY_TEXT]: process.env.OTEL_INCLUDE_QUERY_TEXT === 'true' ? queryText : '',
     };
 
-    // error.type is set if and only if the query failed. Its absence is what
-    // marks success, which is why there is no separate `status` label and no
-    // separate failures counter to drift out of step with this one.
+    // Set only on failure — absence marks success, so no `status` label, no failures counter.
     if (failed) {
       labels[ATTR.ERROR_TYPE] = payload.errorType || categorizeError(error);
     }

--- a/server/src/otel/frontend-metrics.ts
+++ b/server/src/otel/frontend-metrics.ts
@@ -1,12 +1,12 @@
 import { metrics } from '@opentelemetry/api';
 import type { Counter, Histogram, Meter } from '@opentelemetry/api';
 import { getWorkspaceLabel } from './org-plan-cache';
+import { ATTR, BUCKETS_SECONDS, FRONTEND_ERROR_TYPE, METRIC, translateBeaconAttrs } from './semconv';
 
 let frontendMeter: Meter;
-let jsErrorCounter: Counter;
-let widgetErrorCounter: Counter;
-let webVitalsHistogram: Histogram;
-let clsHistogram: Histogram;
+let errorCounter: Counter;
+let webVitalDurationHistogram: Histogram;
+let webVitalScoreHistogram: Histogram;
 let appLoadDurationHistogram: Histogram;
 let appLoadFailureCounter: Counter;
 
@@ -17,42 +17,33 @@ export const initializeFrontendMetrics = () => {
 
   frontendMeter = metrics.getMeter('tooljet-frontend');
 
-  jsErrorCounter = frontendMeter.createCounter('tooljet.frontend.js.errors', {
-    description: 'JavaScript errors caught in the browser (error boundaries, window.onerror, unhandled rejections)',
+  // One counter split by error.type, not two counters that can drift apart.
+  errorCounter = frontendMeter.createCounter(METRIC.FRONTEND_ERRORS, {
+    description: 'Browser errors, split by error.type (js_error, widget_error)',
     unit: '1',
   });
 
-  widgetErrorCounter = frontendMeter.createCounter('tooljet.frontend.widget.errors', {
-    description: 'Widget render errors caught by widget error boundaries',
-    unit: '1',
-  });
-
-  // Durations and CLS are separate instruments — ms vs unitless score need different buckets
-  webVitalsHistogram = frontendMeter.createHistogram('tooljet.frontend.web_vitals.duration', {
+  // Durations and CLS are separate instruments — seconds vs unitless score need different buckets
+  webVitalDurationHistogram = frontendMeter.createHistogram(METRIC.FRONTEND_WEB_VITAL_DURATION, {
     description: 'Web vitals durations (lcp, fcp, ttfb, inp) reported by the browser',
-    unit: 'ms',
-    // Default buckets top out at 10s — real ToolJet lcp/fcp land past that, pinning every
-    // quantile to the ceiling. Boundaries straddle the web-vitals good/poor thresholds
-    // (inp 200/500, ttfb 800/1800, fcp 1800/3000, lcp 2500/4000) and are fewer than the default 15.
-    advice: { explicitBucketBoundaries: [100, 200, 500, 800, 1200, 1800, 2500, 4000, 6000, 10000, 20000, 40000] },
+    unit: 's',
+    advice: { explicitBucketBoundaries: [...BUCKETS_SECONDS.WEB_VITAL] },
   });
 
-  clsHistogram = frontendMeter.createHistogram('tooljet.frontend.cls', {
-    description: 'Cumulative Layout Shift score reported by the browser',
+  webVitalScoreHistogram = frontendMeter.createHistogram(METRIC.FRONTEND_WEB_VITAL_SCORE, {
+    description: 'Unitless web vital scores reported by the browser (cls)',
     unit: '1',
-    // Default buckets are ms-scale (5,10,25…) — CLS is a 0-1ish score, needs its own boundaries
-    advice: { explicitBucketBoundaries: [0.05, 0.1, 0.15, 0.25, 0.5, 0.75, 1, 2] },
+    advice: { explicitBucketBoundaries: [...BUCKETS_SECONDS.CLS_SCORE] },
   });
 
   // The end-user SLI: viewer mount -> app loaded.
-  appLoadDurationHistogram = frontendMeter.createHistogram('tooljet.frontend.app_load.duration', {
+  appLoadDurationHistogram = frontendMeter.createHistogram(METRIC.FRONTEND_APP_LOAD_DURATION, {
     description: 'Time from viewer mount to app loaded',
-    unit: 'ms',
-    // Same ceiling problem as web vitals: app loads routinely exceed the default 10s top bucket.
-    advice: { explicitBucketBoundaries: [250, 500, 1000, 2000, 3000, 5000, 8000, 12000, 20000, 30000, 60000] },
+    unit: 's',
+    advice: { explicitBucketBoundaries: [...BUCKETS_SECONDS.APP_LOAD] },
   });
 
-  appLoadFailureCounter = frontendMeter.createCounter('tooljet.frontend.app_load.failures', {
+  appLoadFailureCounter = frontendMeter.createCounter(METRIC.FRONTEND_APP_LOAD_FAILURES, {
     description: 'App load did not complete (error/timeout before loaded)',
     unit: '1',
   });
@@ -79,6 +70,12 @@ export interface FrontendMetricsBatch {
   events: FrontendMetricEvent[];
 }
 
+const MS_PER_SECOND = 1000;
+
+/** Beacon values are milliseconds; every duration metric is in seconds. */
+const isUsableDuration = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0;
+
 export const recordFrontendMetricsBatch = (
   batch: FrontendMetricsBatch,
   context: { userId?: string; organizationId?: string }
@@ -93,30 +90,37 @@ export const recordFrontendMetricsBatch = (
     try {
       // Platform-context events are platform health, never bucketed — only app-scoped metrics gate
       const isPlatformContext = event.attrs?.['app.context'] === 'platform';
+
+      // The browser sends its own key names and keeps sending them; translation happens
+      // here so a deployed frontend and a newer server never have to agree on labels.
+      // Unrecognised keys are dropped rather than passed through — client-controlled
+      // input becomes Prometheus label cardinality.
       const attrs: Record<string, string | number | boolean> = {
-        ...event.attrs,
-        'organization.id': isPlatformContext ? organizationId : getWorkspaceLabel(organizationId),
+        ...translateBeaconAttrs(event.attrs),
+        [ATTR.ORGANIZATION_ID]: isPlatformContext ? organizationId : getWorkspaceLabel(organizationId),
       };
+
       switch (event.type) {
         case 'js_error':
-          jsErrorCounter.add(event.count ?? 1, attrs);
+          errorCounter.add(event.count ?? 1, { ...attrs, [ATTR.ERROR_TYPE]: FRONTEND_ERROR_TYPE.JS });
           break;
         case 'widget_error':
-          widgetErrorCounter.add(event.count ?? 1, attrs);
+          errorCounter.add(event.count ?? 1, { ...attrs, [ATTR.ERROR_TYPE]: FRONTEND_ERROR_TYPE.WIDGET });
           break;
         case 'web_vital': {
-          if (typeof event.value !== 'number' || !Number.isFinite(event.value) || event.value < 0) break;
-          const { 'vital.name': vitalName, ...rest } = attrs;
+          if (!isUsableDuration(event.value)) break;
+          const { [ATTR.WEB_VITAL_NAME]: vitalName, ...withoutName } = attrs;
           if (vitalName === 'cls') {
-            clsHistogram.record(event.value, rest);
+            // CLS is a unitless score, not a duration — no ms->s conversion, no name label
+            webVitalScoreHistogram.record(event.value, withoutName);
           } else {
-            webVitalsHistogram.record(event.value, attrs);
+            webVitalDurationHistogram.record(event.value / MS_PER_SECOND, attrs);
           }
           break;
         }
         case 'app_load':
-          if (typeof event.value !== 'number' || !Number.isFinite(event.value) || event.value < 0) break;
-          appLoadDurationHistogram.record(event.value, attrs);
+          if (!isUsableDuration(event.value)) break;
+          appLoadDurationHistogram.record(event.value / MS_PER_SECOND, attrs);
           break;
         case 'app_load_failure':
           appLoadFailureCounter.add(event.count ?? 1, attrs);

--- a/server/src/otel/frontend-metrics.ts
+++ b/server/src/otel/frontend-metrics.ts
@@ -23,7 +23,7 @@ export const initializeFrontendMetrics = () => {
     unit: '1',
   });
 
-  // Durations and CLS are separate instruments — seconds vs unitless score need different buckets
+  // Separate instruments — seconds vs unitless score need different buckets
   webVitalDurationHistogram = frontendMeter.createHistogram(METRIC.FRONTEND_WEB_VITAL_DURATION, {
     description: 'Web vitals durations (lcp, fcp, ttfb, inp) reported by the browser',
     unit: 's',
@@ -72,7 +72,6 @@ export interface FrontendMetricsBatch {
 
 const MS_PER_SECOND = 1000;
 
-/** Beacon values are milliseconds; every duration metric is in seconds. */
 const isUsableDuration = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value) && value >= 0;
 
@@ -91,16 +90,11 @@ export const recordFrontendMetricsBatch = (
       // Platform-context events are platform health, never bucketed — only app-scoped metrics gate
       const isPlatformContext = event.attrs?.['app.context'] === 'platform';
 
-      // The browser sends its own key names and keeps sending them; translation happens
-      // here so a deployed frontend and a newer server never have to agree on labels.
-      // Unrecognised keys are dropped rather than passed through — client-controlled
-      // input becomes Prometheus label cardinality.
       const attrs: Record<string, string | number | boolean> = {
         ...translateBeaconAttrs(event.attrs),
         [ATTR.ORGANIZATION_ID]: isPlatformContext ? organizationId : getWorkspaceLabel(organizationId),
       };
-      // The beacon's own error kind is diagnostic detail for the log record, not a
-      // metric dimension — as a label it would multiply every error series by it.
+      // Log-record detail. As a label it would multiply every error series.
       delete attrs[ATTR.ERROR_KIND];
 
       switch (event.type) {
@@ -114,7 +108,7 @@ export const recordFrontendMetricsBatch = (
           if (!isUsableDuration(event.value)) break;
           const { [ATTR.WEB_VITAL_NAME]: vitalName, ...withoutName } = attrs;
           if (vitalName === 'cls') {
-            // CLS is a unitless score, not a duration — no ms->s conversion, no name label
+            // Unitless score — no ms->s, no name label
             webVitalScoreHistogram.record(event.value, withoutName);
           } else {
             webVitalDurationHistogram.record(event.value / MS_PER_SECOND, attrs);

--- a/server/src/otel/frontend-metrics.ts
+++ b/server/src/otel/frontend-metrics.ts
@@ -99,6 +99,9 @@ export const recordFrontendMetricsBatch = (
         ...translateBeaconAttrs(event.attrs),
         [ATTR.ORGANIZATION_ID]: isPlatformContext ? organizationId : getWorkspaceLabel(organizationId),
       };
+      // The beacon's own error kind is diagnostic detail for the log record, not a
+      // metric dimension — as a label it would multiply every error series by it.
+      delete attrs[ATTR.ERROR_KIND];
 
       switch (event.type) {
         case 'js_error':

--- a/server/src/otel/logs.ts
+++ b/server/src/otel/logs.ts
@@ -3,6 +3,7 @@ import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import { ATTR_DEPLOYMENT_ENVIRONMENT_NAME, deploymentEnvironmentName } from './semconv';
 
 // Module-local provider, deliberately NOT registered via logs.setGlobalLoggerProvider:
 // tracing.ts runs PinoInstrumentation, whose dormant log-sending bridge activates against
@@ -13,9 +14,12 @@ export const initializeOtelLogs = () => {
   if (provider || !process.env.OTEL_EXPORTER_OTLP_LOGS) return;
 
   provider = new LoggerProvider({
+    // Same three resource attributes tracing.ts sets, so logs and metrics agree
+    // on which service and deployment they came from.
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: process.env.SERVICE_NAME || 'tooljet',
       [ATTR_SERVICE_VERSION]: globalThis.TOOLJET_VERSION || process.env.SERVICE_VERSION || 'unknown',
+      [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: deploymentEnvironmentName(),
     }),
     processors: [
       // Bounded queue (default 2048); drops on overflow / exporter failure instead of retry-spamming
@@ -24,5 +28,4 @@ export const initializeOtelLogs = () => {
   });
 };
 
-export const getFrontendErrorLogger = (): Logger | undefined =>
-  provider?.getLogger('tooljet-frontend-errors');
+export const getFrontendErrorLogger = (): Logger | undefined => provider?.getLogger('tooljet-frontend-errors');

--- a/server/src/otel/logs.ts
+++ b/server/src/otel/logs.ts
@@ -14,8 +14,7 @@ export const initializeOtelLogs = () => {
   if (provider || !process.env.OTEL_EXPORTER_OTLP_LOGS) return;
 
   provider = new LoggerProvider({
-    // Same three resource attributes tracing.ts sets, so logs and metrics agree
-    // on which service and deployment they came from.
+    // Must match tracing.ts, else logs and metrics disagree on service identity
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: process.env.SERVICE_NAME || 'tooljet',
       [ATTR_SERVICE_VERSION]: globalThis.TOOLJET_VERSION || process.env.SERVICE_VERSION || 'unknown',

--- a/server/src/otel/semconv.ts
+++ b/server/src/otel/semconv.ts
@@ -27,8 +27,7 @@ export const BUCKETS_SECONDS = {
 export const ATTR_DEPLOYMENT_ENVIRONMENT_NAME = 'deployment.environment.name';
 
 // Where this server runs. NOT service.name, which must be identical across instances.
-export const deploymentEnvironmentName = (): string =>
-  process.env.DEPLOYMENT_ENVIRONMENT_NAME || process.env.NODE_ENV || 'development';
+export const deploymentEnvironmentName = (): string => process.env.NODE_ENV || 'development';
 
 export const ATTR = {
   // Set only on failure — absence marks success, so no parallel `status` label.

--- a/server/src/otel/semconv.ts
+++ b/server/src/otel/semconv.ts
@@ -1,0 +1,186 @@
+/**
+ * The single authority for every metric name and attribute key ToolJet emits.
+ *
+ * Rules applied (OpenTelemetry naming specification):
+ *  - lowercase, dot-delimited namespaces; snake_case inside a segment
+ *  - object properties read {object}.{property}
+ *  - application-specific names take our own `tooljet.` prefix. `app.*` is an
+ *    OCCUPIED semconv namespace meaning the client application (app.build_id,
+ *    app.crash.id, app.jank.*, app.widget.*) — reusing it as our prefix is
+ *    explicitly discouraged, hence `tooljet.app.*` for customer-built apps.
+ *  - metric namespaces are never pluralized; `_total` is the Prometheus
+ *    exporter's suffix to add, never ours to author
+ *  - durations are recorded in SECONDS
+ *
+ * Everything is authored dotted. The Prometheus exporter flattens dots, so
+ * `tooljet.query.executions` is queried as `tooljet_query_executions_total`.
+ */
+
+// ─── Metrics ────────────────────────────────────────────────────────────────
+
+export const METRIC = {
+  // Browser beacon
+  FRONTEND_ERRORS: 'tooljet.frontend.errors',
+  FRONTEND_WEB_VITAL_DURATION: 'tooljet.frontend.web_vital.duration',
+  FRONTEND_WEB_VITAL_SCORE: 'tooljet.frontend.web_vital.score',
+  FRONTEND_APP_LOAD_DURATION: 'tooljet.frontend.app_load.duration',
+  FRONTEND_APP_LOAD_FAILURES: 'tooljet.frontend.app_load.failures',
+
+  // Query execution
+  QUERY_EXECUTIONS: 'tooljet.query.executions',
+  QUERY_DURATION: 'tooljet.query.duration',
+
+  // Seats and activity
+  ORGANIZATION_SEATS: 'tooljet.organization.seats',
+  APP_ACTIVE_USERS: 'tooljet.app.active_users',
+} as const;
+
+/**
+ * Histogram boundaries, in seconds.
+ *
+ * The SDK defaults top out at 10s. Real ToolJet lcp/fcp and app loads exceed
+ * that, which pinned every quantile to the ceiling. These straddle the
+ * web-vitals good/poor thresholds (inp 0.2/0.5, ttfb 0.8/1.8, fcp 1.8/3,
+ * lcp 2.5/4) using fewer buckets than the default 15.
+ */
+export const BUCKETS_SECONDS = {
+  WEB_VITAL: [0.1, 0.2, 0.5, 0.8, 1.2, 1.8, 2.5, 4, 6, 10, 20, 40],
+  APP_LOAD: [0.25, 0.5, 1, 2, 3, 5, 8, 12, 20, 30, 60],
+  QUERY: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60],
+  // CLS is a unitless 0-1ish score, not a duration — kept here so every
+  // boundary set lives in one place.
+  CLS_SCORE: [0.05, 0.1, 0.15, 0.25, 0.5, 0.75, 1, 2],
+} as const;
+
+// ─── Resource attributes ────────────────────────────────────────────────────
+
+/**
+ * Semconv renamed `deployment.environment` to `deployment.environment.name`.
+ * The SDK still ships only the deprecated constant, so it is spelled here.
+ */
+export const ATTR_DEPLOYMENT_ENVIRONMENT_NAME = 'deployment.environment.name';
+
+/**
+ * Where this server runs — 'local', 'staging', 'production'.
+ *
+ * NOT service.name. service.name is the LOGICAL service and must be identical
+ * across every instance of it; putting a branch or deployment name there makes
+ * a feature branch look like a different service in every query. Several
+ * per-branch deployments sharing one Prometheus discriminate here instead
+ * (e.g. 'staging-refactor-optimisations').
+ *
+ * Falls back to NODE_ENV, which is why staging reported 'production'.
+ */
+export const deploymentEnvironmentName = (): string =>
+  process.env.DEPLOYMENT_ENVIRONMENT_NAME || process.env.NODE_ENV || 'development';
+
+// ─── Attributes ─────────────────────────────────────────────────────────────
+
+export const ATTR = {
+  /**
+   * Stable semconv. Low-cardinality error class, set ONLY when the operation
+   * failed — its absence is what marks success, so no parallel `status` label.
+   * `exception.type`/`.message`/`.stacktrace` are the log-record equivalents
+   * and never appear on metrics.
+   */
+  ERROR_TYPE: 'error.type',
+
+  // Customer-built apps
+  APP_ID: 'tooljet.app.id',
+  APP_NAME: 'tooljet.app.name',
+  APP_VERSION: 'tooljet.app.version',
+  /** Server-side truth: 'edit' | 'view'. Distinct from APP_CONTEXT. */
+  APP_MODE: 'tooljet.app.mode',
+  /** Browser-side truth: 'editor' | 'released_app' | 'platform'. */
+  APP_CONTEXT: 'tooljet.app.context',
+  APP_RELEASED: 'tooljet.app.released',
+
+  // Workspaces
+  ORGANIZATION_ID: 'tooljet.organization.id',
+  ORGANIZATION_NAME: 'tooljet.organization.name',
+
+  // Queries
+  QUERY_ID: 'tooljet.query.id',
+  QUERY_NAME: 'tooljet.query.name',
+  QUERY_TYPE: 'tooljet.query.type',
+  QUERY_TEXT: 'tooljet.query.text',
+  DATA_SOURCE_TYPE: 'tooljet.data_source.type',
+
+  // Multi-environment (development/staging/production inside a workspace) —
+  // NOT deployment.environment.name, which names where the server itself runs.
+  ENVIRONMENT_NAME: 'tooljet.environment.name',
+
+  USER_ROLE: 'tooljet.user.role',
+  WEB_VITAL_NAME: 'tooljet.web_vital.name',
+  /** Component kind that threw — 'table', 'button', … Bounded by the widget catalogue. */
+  WIDGET_TYPE: 'tooljet.widget.type',
+
+  // Log records only. Metrics use ERROR_TYPE; these carry the unbounded detail
+  // that would be cardinality suicide as a label.
+  EXCEPTION_TYPE: 'exception.type',
+  EXCEPTION_MESSAGE: 'exception.message',
+  EXCEPTION_STACKTRACE: 'exception.stacktrace',
+  EVENT_TYPE: 'event.type',
+  EVENT_COUNT: 'event.count',
+  ERROR_FINGERPRINT: 'error.fingerprint',
+  USER_ID: 'user.id',
+} as const;
+
+/**
+ * Values for ATTR.ERROR_TYPE on frontend error metrics.
+ */
+export const FRONTEND_ERROR_TYPE = {
+  JS: 'js_error',
+  WIDGET: 'widget_error',
+} as const;
+
+// ─── Beacon translation ─────────────────────────────────────────────────────
+
+/**
+ * The browser beacon sends its own key names and keeps sending them — a
+ * deployed frontend outlives any given server build, so the server translates
+ * at ingest rather than requiring the two to change in lockstep. This is also
+ * the only place that decides what a label is finally called.
+ *
+ * Keys absent from this map are dropped, not passed through: the beacon is
+ * client-controlled input, and an unbounded key would mint unbounded series.
+ */
+export const BEACON_ATTR_MAP: Readonly<Record<string, string>> = {
+  'app.name': ATTR.APP_NAME,
+  'app.context': ATTR.APP_CONTEXT,
+  'app.environment': ATTR.ENVIRONMENT_NAME,
+  'app.version': ATTR.APP_VERSION,
+  'error.kind': ATTR.ERROR_TYPE,
+  'vital.name': ATTR.WEB_VITAL_NAME,
+  'widget.type': ATTR.WIDGET_TYPE,
+};
+
+/**
+ * The keys the ingest endpoint accepts from a client payload. This IS the
+ * allowlist — server-injected keys (organization.id, user.id, …) are absent
+ * from the map, so a client that sends them is ignored by construction rather
+ * than by a second reserved-key list that could fall out of step.
+ */
+export const isAcceptedBeaconAttr = (key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(BEACON_ATTR_MAP, key);
+
+/** Longest label value we accept from the browser before truncating. */
+export const MAX_BEACON_LABEL_LENGTH = 120;
+
+/**
+ * Translate one beacon attribute bag into canonical keys, dropping anything
+ * unrecognised and clamping value length.
+ */
+export const translateBeaconAttrs = (
+  raw: Record<string, string | number | boolean> | undefined
+): Record<string, string | number | boolean> => {
+  const out: Record<string, string | number | boolean> = {};
+  if (!raw) return out;
+
+  for (const [key, value] of Object.entries(raw)) {
+    const canonical = BEACON_ATTR_MAP[key];
+    if (!canonical) continue;
+    out[canonical] = typeof value === 'string' ? value.slice(0, MAX_BEACON_LABEL_LENGTH) : value;
+  }
+  return out;
+};

--- a/server/src/otel/semconv.ts
+++ b/server/src/otel/semconv.ts
@@ -1,128 +1,66 @@
-/**
- * The single authority for every metric name and attribute key ToolJet emits.
- *
- * Rules applied (OpenTelemetry naming specification):
- *  - lowercase, dot-delimited namespaces; snake_case inside a segment
- *  - object properties read {object}.{property}
- *  - application-specific names take our own `tooljet.` prefix. `app.*` is an
- *    OCCUPIED semconv namespace meaning the client application (app.build_id,
- *    app.crash.id, app.jank.*, app.widget.*) — reusing it as our prefix is
- *    explicitly discouraged, hence `tooljet.app.*` for customer-built apps.
- *  - metric namespaces are never pluralized; `_total` is the Prometheus
- *    exporter's suffix to add, never ours to author
- *  - durations are recorded in SECONDS
- *
- * Everything is authored dotted. The Prometheus exporter flattens dots, so
- * `tooljet.query.executions` is queried as `tooljet_query_executions_total`.
- */
-
-// ─── Metrics ────────────────────────────────────────────────────────────────
+// Every metric name and attribute key we emit. Dotted; exporter flattens. Durations in seconds.
+// `app.*` is an occupied semconv namespace (the client app) — ours go under `tooljet.app.*`.
 
 export const METRIC = {
-  // Browser beacon
   FRONTEND_ERRORS: 'tooljet.frontend.errors',
   FRONTEND_WEB_VITAL_DURATION: 'tooljet.frontend.web_vital.duration',
   FRONTEND_WEB_VITAL_SCORE: 'tooljet.frontend.web_vital.score',
   FRONTEND_APP_LOAD_DURATION: 'tooljet.frontend.app_load.duration',
   FRONTEND_APP_LOAD_FAILURES: 'tooljet.frontend.app_load.failures',
 
-  // Query execution
   QUERY_EXECUTIONS: 'tooljet.query.executions',
   QUERY_DURATION: 'tooljet.query.duration',
 
-  // Seats and activity
   ORGANIZATION_SEATS: 'tooljet.organization.seats',
   APP_ACTIVE_USERS: 'tooljet.app.active_users',
 } as const;
 
-/**
- * Histogram boundaries, in seconds.
- *
- * The SDK defaults top out at 10s. Real ToolJet lcp/fcp and app loads exceed
- * that, which pinned every quantile to the ceiling. These straddle the
- * web-vitals good/poor thresholds (inp 0.2/0.5, ttfb 0.8/1.8, fcp 1.8/3,
- * lcp 2.5/4) using fewer buckets than the default 15.
- */
+// SDK defaults top out at 10s; real lcp/fcp and app loads overflow it and pin every quantile.
 export const BUCKETS_SECONDS = {
   WEB_VITAL: [0.1, 0.2, 0.5, 0.8, 1.2, 1.8, 2.5, 4, 6, 10, 20, 40],
   APP_LOAD: [0.25, 0.5, 1, 2, 3, 5, 8, 12, 20, 30, 60],
   QUERY: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60],
-  // CLS is a unitless 0-1ish score, not a duration — kept here so every
-  // boundary set lives in one place.
   CLS_SCORE: [0.05, 0.1, 0.15, 0.25, 0.5, 0.75, 1, 2],
 } as const;
 
-// ─── Resource attributes ────────────────────────────────────────────────────
-
-/**
- * Semconv renamed `deployment.environment` to `deployment.environment.name`.
- * The SDK still ships only the deprecated constant, so it is spelled here.
- */
+// SDK still ships only the deprecated `deployment.environment`.
 export const ATTR_DEPLOYMENT_ENVIRONMENT_NAME = 'deployment.environment.name';
 
-/**
- * Where this server runs — 'local', 'staging', 'production'.
- *
- * NOT service.name. service.name is the LOGICAL service and must be identical
- * across every instance of it; putting a branch or deployment name there makes
- * a feature branch look like a different service in every query. Several
- * per-branch deployments sharing one Prometheus discriminate here instead
- * (e.g. 'staging-refactor-optimisations').
- *
- * Falls back to NODE_ENV, which is why staging reported 'production'.
- */
+// Where this server runs. NOT service.name, which must be identical across instances.
 export const deploymentEnvironmentName = (): string =>
   process.env.DEPLOYMENT_ENVIRONMENT_NAME || process.env.NODE_ENV || 'development';
 
-// ─── Attributes ─────────────────────────────────────────────────────────────
-
 export const ATTR = {
-  /**
-   * Stable semconv. Low-cardinality error class, set ONLY when the operation
-   * failed — its absence is what marks success, so no parallel `status` label.
-   * `exception.type`/`.message`/`.stacktrace` are the log-record equivalents
-   * and never appear on metrics.
-   */
+  // Set only on failure — absence marks success, so no parallel `status` label.
   ERROR_TYPE: 'error.type',
 
-  // Customer-built apps
   APP_ID: 'tooljet.app.id',
   APP_NAME: 'tooljet.app.name',
   APP_VERSION: 'tooljet.app.version',
-  /** Server-side truth: 'edit' | 'view'. Distinct from APP_CONTEXT. */
+  // Server truth: 'edit' | 'view'. APP_CONTEXT is the browser's answer, different question.
   APP_MODE: 'tooljet.app.mode',
-  /** Browser-side truth: 'editor' | 'released_app' | 'platform'. */
   APP_CONTEXT: 'tooljet.app.context',
   APP_RELEASED: 'tooljet.app.released',
 
-  // Workspaces
   ORGANIZATION_ID: 'tooljet.organization.id',
   ORGANIZATION_NAME: 'tooljet.organization.name',
 
-  // Queries
   QUERY_ID: 'tooljet.query.id',
   QUERY_NAME: 'tooljet.query.name',
   QUERY_TYPE: 'tooljet.query.type',
   QUERY_TEXT: 'tooljet.query.text',
   DATA_SOURCE_TYPE: 'tooljet.data_source.type',
 
-  // Multi-environment (development/staging/production inside a workspace) —
-  // NOT deployment.environment.name, which names where the server itself runs.
+  // Workspace environment, not where the server runs.
   ENVIRONMENT_NAME: 'tooljet.environment.name',
 
   USER_ROLE: 'tooljet.user.role',
   WEB_VITAL_NAME: 'tooljet.web_vital.name',
-  /**
-   * The beacon's own error classification ('boundary', 'render', …). Kept
-   * distinct from ERROR_TYPE so one key never means two things: ERROR_TYPE is
-   * always the event class (js_error / widget_error) on both metrics and logs.
-   */
+  // Beacon classification. Separate key so ERROR_TYPE stays event class on both signals.
   ERROR_KIND: 'tooljet.error.kind',
-  /** Component kind that threw — 'table', 'button', … Bounded by the widget catalogue. */
   WIDGET_TYPE: 'tooljet.widget.type',
 
-  // Log records only. Metrics use ERROR_TYPE; these carry the unbounded detail
-  // that would be cardinality suicide as a label.
+  // Log records only — unbounded detail, never metric labels.
   EXCEPTION_TYPE: 'exception.type',
   EXCEPTION_MESSAGE: 'exception.message',
   EXCEPTION_STACKTRACE: 'exception.stacktrace',
@@ -132,25 +70,12 @@ export const ATTR = {
   USER_ID: 'user.id',
 } as const;
 
-/**
- * Values for ATTR.ERROR_TYPE on frontend error metrics.
- */
 export const FRONTEND_ERROR_TYPE = {
   JS: 'js_error',
   WIDGET: 'widget_error',
 } as const;
 
-// ─── Beacon translation ─────────────────────────────────────────────────────
-
-/**
- * The browser beacon sends its own key names and keeps sending them — a
- * deployed frontend outlives any given server build, so the server translates
- * at ingest rather than requiring the two to change in lockstep. This is also
- * the only place that decides what a label is finally called.
- *
- * Keys absent from this map are dropped, not passed through: the beacon is
- * client-controlled input, and an unbounded key would mint unbounded series.
- */
+// Beacon keys accepted, and what we call them. Absent key = dropped; client input is cardinality.
 export const BEACON_ATTR_MAP: Readonly<Record<string, string>> = {
   'app.name': ATTR.APP_NAME,
   'app.context': ATTR.APP_CONTEXT,
@@ -161,20 +86,11 @@ export const BEACON_ATTR_MAP: Readonly<Record<string, string>> = {
   'widget.type': ATTR.WIDGET_TYPE,
 };
 
-/**
- * The keys the ingest endpoint accepts from a client payload. This IS the
- * allowlist — server-injected keys (organization.id, user.id, …) are absent
- * from the map, so a client that sends them is ignored by construction rather
- * than by a second reserved-key list that could fall out of step.
- */
+// Server-injected keys are absent from the map, so a client cannot pre-empt them.
 export const isAcceptedBeaconAttr = (key: string): boolean =>
   Object.prototype.hasOwnProperty.call(BEACON_ATTR_MAP, key);
 
-/**
- * Rename one beacon attribute bag to canonical keys, dropping anything
- * unrecognised. Pure renaming — the ingest endpoint is the trust boundary and
- * has already clamped value length, so this does not clamp again.
- */
+// Rename only — ingest already clamped value length.
 export const translateBeaconAttrs = (
   raw: Record<string, string | number | boolean> | undefined
 ): Record<string, string | number | boolean> => {

--- a/server/src/otel/semconv.ts
+++ b/server/src/otel/semconv.ts
@@ -112,6 +112,12 @@ export const ATTR = {
 
   USER_ROLE: 'tooljet.user.role',
   WEB_VITAL_NAME: 'tooljet.web_vital.name',
+  /**
+   * The beacon's own error classification ('boundary', 'render', …). Kept
+   * distinct from ERROR_TYPE so one key never means two things: ERROR_TYPE is
+   * always the event class (js_error / widget_error) on both metrics and logs.
+   */
+  ERROR_KIND: 'tooljet.error.kind',
   /** Component kind that threw — 'table', 'button', … Bounded by the widget catalogue. */
   WIDGET_TYPE: 'tooljet.widget.type',
 
@@ -150,7 +156,7 @@ export const BEACON_ATTR_MAP: Readonly<Record<string, string>> = {
   'app.context': ATTR.APP_CONTEXT,
   'app.environment': ATTR.ENVIRONMENT_NAME,
   'app.version': ATTR.APP_VERSION,
-  'error.kind': ATTR.ERROR_TYPE,
+  'error.kind': ATTR.ERROR_KIND,
   'vital.name': ATTR.WEB_VITAL_NAME,
   'widget.type': ATTR.WIDGET_TYPE,
 };
@@ -164,12 +170,10 @@ export const BEACON_ATTR_MAP: Readonly<Record<string, string>> = {
 export const isAcceptedBeaconAttr = (key: string): boolean =>
   Object.prototype.hasOwnProperty.call(BEACON_ATTR_MAP, key);
 
-/** Longest label value we accept from the browser before truncating. */
-export const MAX_BEACON_LABEL_LENGTH = 120;
-
 /**
- * Translate one beacon attribute bag into canonical keys, dropping anything
- * unrecognised and clamping value length.
+ * Rename one beacon attribute bag to canonical keys, dropping anything
+ * unrecognised. Pure renaming — the ingest endpoint is the trust boundary and
+ * has already clamped value length, so this does not clamp again.
  */
 export const translateBeaconAttrs = (
   raw: Record<string, string | number | boolean> | undefined
@@ -179,8 +183,7 @@ export const translateBeaconAttrs = (
 
   for (const [key, value] of Object.entries(raw)) {
     const canonical = BEACON_ATTR_MAP[key];
-    if (!canonical) continue;
-    out[canonical] = typeof value === 'string' ? value.slice(0, MAX_BEACON_LABEL_LENGTH) : value;
+    if (canonical) out[canonical] = value;
   }
   return out;
 };

--- a/server/src/otel/tracing.ts
+++ b/server/src/otel/tracing.ts
@@ -6,6 +6,7 @@ import {
   DiagLogLevel,
   diag,
   metrics,
+  Meter,
   ObservableGauge,
   ObservableResult,
 } from '@opentelemetry/api';
@@ -22,13 +23,10 @@ import { PinoInstrumentation } from '@opentelemetry/instrumentation-pino';
 import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runtime-node';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
 import { PeriodicExportingMetricReader, AggregationTemporality } from '@opentelemetry/sdk-metrics';
-import {
-  ATTR_SERVICE_NAME,
-  ATTR_SERVICE_VERSION,
-  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
-} from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { getTooljetEdition } from '../helpers/utils.helper';
 import { TOOLJET_EDITIONS } from '../modules/app/constants';
+import { ATTR, ATTR_DEPLOYMENT_ENVIRONMENT_NAME, METRIC, deploymentEnvironmentName } from './semconv';
 
 // Set this up to see debug logs
 if (process.env.OTEL_LOG_LEVEL === 'debug') {
@@ -82,7 +80,7 @@ function createSDK(): NodeSDK {
   const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: process.env.SERVICE_NAME || 'tooljet',
     [ATTR_SERVICE_VERSION]: globalThis.TOOLJET_VERSION || process.env.SERVICE_VERSION || 'unknown',
-    [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: process.env.NODE_ENV || 'development',
+    [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: deploymentEnvironmentName(),
   });
 
   return new NodeSDK({
@@ -155,17 +153,9 @@ function createSDK(): NodeSDK {
 }
 
 // Custom metrics
-let meter: any;
-let apiHitCounter: any;
-let apiDurationHistogram: any;
-let concurrentUsersCounter: any;
-let concurrentUsersGauge: any;
+let meter: Meter;
 let appActiveUsersGauge: ObservableGauge;
-let workspaceSeatsGauge: ObservableGauge;
-
-// Track active users per workspace with last activity timestamp
-// Key format: "workspaceId:userId", Value: { lastSeen: timestamp, role: string }
-const activeUsersByWorkspace = new Map<string, { lastSeen: number; role?: string; sessionId?: string }>();
+let organizationSeatsGauge: ObservableGauge;
 
 // Track active users per app with last activity timestamp
 // Key format: "workspaceId:appId:userId", Value: { lastSeen: timestamp, role: string }
@@ -264,21 +254,7 @@ const cleanupInactiveUsers = () => {
     const cutoffTime = now - ACTIVE_USER_WINDOW_MS * 2; // Inactive for 2x the window
     let cleanedUsers = 0;
 
-    // Cleanup users: Collect entries to delete (don't modify during iteration)
-    const usersToDelete: string[] = [];
-    for (const [key, data] of activeUsersByWorkspace.entries()) {
-      if (data.lastSeen < cutoffTime) {
-        usersToDelete.push(key);
-      }
-    }
-
-    // Delete collected user entries
-    for (const key of usersToDelete) {
-      activeUsersByWorkspace.delete(key);
-      cleanedUsers++;
-    }
-
-    // Cleanup per-app users
+    // Cleanup per-app users: collect entries to delete (don't modify during iteration)
     const appUsersToDelete: string[] = [];
     for (const [key, data] of activeUsersByApp.entries()) {
       if (data.lastSeen < cutoffTime) {
@@ -297,7 +273,7 @@ const cleanupInactiveUsers = () => {
 
     // Log memory stats if debug enabled
     if (process.env.OTEL_LOG_LEVEL === 'debug') {
-      const totalUsers = activeUsersByWorkspace.size;
+      const totalUsers = activeUsersByApp.size;
       const memoryEstimateMB = ((totalUsers * 100) / (1024 * 1024)).toFixed(2);
       console.log(
         `[OTEL] Active tracking: ${totalUsers} users (~${memoryEstimateMB} MB), window: ${ACTIVITY_WINDOW_MINUTES}min`
@@ -414,79 +390,8 @@ const pollWorkspaceSeats = async (): Promise<void> => {
 const initializeCustomMetrics = () => {
   meter = metrics.getMeter('tooljet-custom-metrics');
 
-  // Counter for API hits
-  apiHitCounter = meter.createCounter('api.hits', {
-    description: 'Number of times an API endpoint is hit',
-    unit: '1',
-  });
-
-  // UpDownCounter for concurrent users (login/logout based)
-  concurrentUsersCounter = meter.createUpDownCounter('users.concurrent', {
-    description: 'Number of concurrent users by workspace (login/logout based)',
-    unit: '{users}',
-  });
-
-  // ObservableGauge for request-based concurrent users
-  concurrentUsersGauge = meter.createObservableGauge('users.concurrent.active', {
-    description: 'Number of concurrent users by workspace based on request activity in last 5 minutes',
-    unit: '{users}',
-  });
-
-  concurrentUsersGauge.addCallback((observableResult: any) => {
-    try {
-      const now = Date.now();
-      const cutoffTime = now - ACTIVE_USER_WINDOW_MS;
-
-      // Group active users by workspace
-      const usersByWorkspace = new Map<string, Set<string>>();
-      const entriesToDelete: string[] = [];
-
-      // First pass: collect inactive entries and group active ones (don't modify during iteration)
-      for (const [key, data] of activeUsersByWorkspace.entries()) {
-        if (data.lastSeen < cutoffTime) {
-          entriesToDelete.push(key);
-        } else {
-          const [workspaceId, userId] = key.split(':');
-          if (!usersByWorkspace.has(workspaceId)) {
-            usersByWorkspace.set(workspaceId, new Set());
-          }
-          usersByWorkspace.get(workspaceId)!.add(userId);
-        }
-      }
-
-      // Second pass: delete inactive entries
-      for (const key of entriesToDelete) {
-        activeUsersByWorkspace.delete(key);
-      }
-
-      // Report metrics for each workspace
-      for (const [workspaceId, users] of usersByWorkspace.entries()) {
-        // Report workspace-level aggregate
-        // No per-user observations — user.id as a label is one series per active user
-        // with nothing consuming it; workspace_total already carries the count
-        observableResult.observe(users.size, {
-          'workspace.id': workspaceId,
-          metric_type: 'workspace_total',
-        });
-      }
-
-      // Also report total active users across all workspaces
-      const totalUniqueUsers = new Set<string>();
-      for (const key of activeUsersByWorkspace.keys()) {
-        const userId = key.split(':')[1];
-        if (userId) totalUniqueUsers.add(userId);
-      }
-      observableResult.observe(totalUniqueUsers.size, {
-        'workspace.id': 'all',
-        metric_type: 'workspace_total',
-      });
-    } catch (error) {
-      console.error('[OTEL] Error in concurrentUsersGauge callback:', error);
-    }
-  });
-
   // ObservableGauge for per-app active users by role
-  appActiveUsersGauge = meter.createObservableGauge('tooljet.app.active_users', {
+  appActiveUsersGauge = meter.createObservableGauge(METRIC.APP_ACTIVE_USERS, {
     description: 'Number of active users per app by role based on app-scoped request activity in last 5 minutes',
     unit: '{users}',
   });
@@ -528,13 +433,16 @@ const initializeCustomMetrics = () => {
         observations.push({
           value: users.size,
           attrs: {
-            'organization.id': getWorkspaceLabel(workspaceId),
-            'organization.name': getWorkspaceNameLabel(workspaceId, namesByOrg.get(workspaceId) || UNKNOWN_ORG_NAME),
-            'app.id': appId,
+            [ATTR.ORGANIZATION_ID]: getWorkspaceLabel(workspaceId),
+            [ATTR.ORGANIZATION_NAME]: getWorkspaceNameLabel(
+              workspaceId,
+              namesByOrg.get(workspaceId) || UNKNOWN_ORG_NAME
+            ),
+            [ATTR.APP_ID]: appId,
             // Name rides alongside the id rather than replacing it: the id is what drilldown links
             // key on, the name is what a human reads. One name per id, so no extra series.
-            'app.name': namesByApp.get(appId) || UNKNOWN_APP_NAME,
-            role: role,
+            [ATTR.APP_NAME]: namesByApp.get(appId) || UNKNOWN_APP_NAME,
+            [ATTR.USER_ROLE]: role,
           },
         });
       }
@@ -548,20 +456,20 @@ const initializeCustomMetrics = () => {
   });
 
   // ObservableGauge for registered seats per workspace by role (DB-polled snapshot)
-  workspaceSeatsGauge = meter.createObservableGauge('tooljet.workspace.seats', {
+  organizationSeatsGauge = meter.createObservableGauge(METRIC.ORGANIZATION_SEATS, {
     description: 'Number of registered users per workspace by role',
     unit: '{users}',
   });
 
-  workspaceSeatsGauge.addCallback((observableResult: ObservableResult) => {
+  organizationSeatsGauge.addCallback((observableResult: ObservableResult) => {
     try {
       const observations: Observation[] = seatSnapshot.counts.map(
         ({ organizationId, organizationName, role, seats }) => ({
           value: seats,
           attrs: {
-            'organization.id': getWorkspaceLabel(organizationId),
-            'organization.name': getWorkspaceNameLabel(organizationId, organizationName),
-            role: role,
+            [ATTR.ORGANIZATION_ID]: getWorkspaceLabel(organizationId),
+            [ATTR.ORGANIZATION_NAME]: getWorkspaceNameLabel(organizationId, organizationName),
+            [ATTR.USER_ROLE]: role,
           },
         })
       );
@@ -570,30 +478,10 @@ const initializeCustomMetrics = () => {
         observableResult.observe(value, attrs);
       }
     } catch (error) {
-      console.error('[OTEL] Error in workspaceSeatsGauge callback:', error);
+      console.error('[OTEL] Error in organizationSeatsGauge callback:', error);
     }
   });
-
-  // Histogram for API duration
-  apiDurationHistogram = meter.createHistogram('api.duration', {
-    description: 'API request duration in milliseconds',
-    unit: 'ms',
-  });
 };
-
-export function recordApiHit(attrs: { route: string; method: string }) {
-  apiHitCounter.add(1, attrs);
-}
-export function recordApiDuration(
-  duration: number,
-  attrs: {
-    route: string;
-    method: string;
-    status_code: number | string;
-  }
-) {
-  apiDurationHistogram.record(duration, attrs);
-}
 
 process.on('SIGTERM', () => {
   // Clear cleanup interval
@@ -655,9 +543,7 @@ export const startOpenTelemetry = async (): Promise<void> => {
 
     if (process.env.OTEL_LOG_LEVEL === 'debug') {
       console.log('OpenTelemetry instrumentation initialized');
-      console.log(
-        'Custom metrics initialized: api.hits, api.duration, users.concurrent, users.concurrent.active'
-      );
+      console.log(`Custom metrics initialized: ${METRIC.APP_ACTIVE_USERS}, ${METRIC.ORGANIZATION_SEATS}`);
       console.log(`Active user tracking window: ${ACTIVITY_WINDOW_MINUTES} minutes`);
     }
   } catch (error) {
@@ -666,8 +552,6 @@ export const startOpenTelemetry = async (): Promise<void> => {
   }
 };
 
-// Export audit metrics function for use in services
-export { recordAuditLogMetric } from './audit-metrics';
 // Helper function to track user activity on each authenticated request
 export const trackUserActivity = (attributes: {
   workspaceId: string;
@@ -688,29 +572,8 @@ export const trackUserActivity = (attributes: {
     // Sanitize and limit lengths to prevent memory issues
     const workspaceId = String(attributes.workspaceId).slice(0, 100);
     const userId = String(attributes.userId).slice(0, 100);
-    const sessionId = attributes.sessionId ? String(attributes.sessionId).slice(0, 100) : undefined;
 
     const now = Date.now();
-
-    // Track unique users (workspaceId:userId)
-    const userKey = `${workspaceId}:${userId}`;
-
-    // Safety cap to prevent unbounded memory growth for users
-    if (activeUsersByWorkspace.size >= MAX_TRACKED_USERS && !activeUsersByWorkspace.has(userKey)) {
-      const oldestKey = activeUsersByWorkspace.keys().next().value;
-      if (oldestKey) {
-        activeUsersByWorkspace.delete(oldestKey);
-        if (process.env.OTEL_LOG_LEVEL === 'debug') {
-          console.warn('[OTEL] Max tracked users reached, removed oldest entry');
-        }
-      }
-    }
-
-    activeUsersByWorkspace.set(userKey, {
-      lastSeen: now,
-      role: attributes.userRole,
-      sessionId: sessionId,
-    });
 
     // Track per-app activity only for app-scoped requests
     if (attributes.appId) {
@@ -738,27 +601,6 @@ export const trackUserActivity = (attributes: {
       console.error('[OTEL] Error tracking user activity:', error);
     }
     // Don't throw - metric collection should never break the app
-  }
-};
-
-// Helper functions for user metrics tracking
-export const incrementConcurrentUsers = (attributes: { workspaceId?: string; userId?: string; userRole?: string }) => {
-  if (concurrentUsersCounter) {
-    const metricAttributes: any = {};
-    if (attributes.workspaceId) metricAttributes['workspace.id'] = attributes.workspaceId;
-    if (attributes.userRole) metricAttributes['user.role'] = attributes.userRole;
-
-    concurrentUsersCounter.add(1, metricAttributes);
-  }
-};
-
-export const decrementConcurrentUsers = (attributes: { workspaceId?: string; userId?: string; userRole?: string }) => {
-  if (concurrentUsersCounter) {
-    const metricAttributes: any = {};
-    if (attributes.workspaceId) metricAttributes['workspace.id'] = attributes.workspaceId;
-    if (attributes.userRole) metricAttributes['user.role'] = attributes.userRole;
-
-    concurrentUsersCounter.add(-1, metricAttributes);
   }
 };
 

--- a/server/src/otel/tracing.ts
+++ b/server/src/otel/tracing.ts
@@ -556,7 +556,6 @@ export const startOpenTelemetry = async (): Promise<void> => {
 export const trackUserActivity = (attributes: {
   workspaceId: string;
   userId: string;
-  sessionId?: string;
   userRole?: string;
   appId?: string;
 }) => {

--- a/server/test/modules/session/unit/session.service.spec.ts
+++ b/server/test/modules/session/unit/session.service.spec.ts
@@ -29,12 +29,10 @@ jest.mock('src/helpers/database.helper', () => ({
   dbTransactionWrap: jest.fn((cb: (manager: any) => Promise<any>) => cb(mockManager)),
 }));
 
-// Mock OpenTelemetry metrics (they reference global tracer state)
+// Mock @otel/tracing — importing it for real runs the SDK auto-start block
 jest.mock('@otel/tracing', () => ({
-  decrementActiveSessions: jest.fn(),
-  decrementConcurrentUsers: jest.fn(),
-  incrementActiveSessions: jest.fn(),
-  incrementConcurrentUsers: jest.fn(),
+  trackUserActivity: jest.fn(),
+  extractAppIdFromPath: jest.fn(),
 }));
 
 // Mock RequestContext (CLS-based, not available outside HTTP context)


### PR DESCRIPTION
## 📝 What this does
Stacked on #17448. Renames every metric and label we emit to follow OpenTelemetry semantic conventions, and deletes the families no dashboard has ever queried. The local observability stack gains a collector so it finally matches staging's shape — which is what let three of these defects hide in the first place.
- [ee-server](https://github.com/ToolJet/ee-server/pull/759)

> **Breaking.** Every existing series orphans at the deploy boundary and panels show a visible gap. That is inherent to a rename, not a regression.

## 🏗️ Architecture

### Why now
Two days of debugging why staging's frontend error panels were empty produced three findings with one root cause: local and staging had drifted into different architectures, so a defect could exist in one and be invisible in the other.

- **Frontend errors never reached Loki on staging.** Staging runs Loki 2.9.0, which has no OTLP ingest endpoint — that arrived in 3.0 — and its collector declares only `traces` and `metrics` pipelines. Local runs Loki 3.4.2 with no collector, pushing straight from the app, which is why identical code worked there and was silent in staging.
- **Every deploy orphaned every series.** Staging's collector set `resource_to_telemetry_conversion: enabled`, promoting *every* resource attribute to a metric label — including `process_pid`, which changes on restart.
- **Our names collided with an occupied namespace.** `app.*` is semconv's namespace for *the client application* (`app.build_id`, `app.crash.id`, `app.jank.*`, `app.widget.*`). We were using it for customer-built apps. The naming spec explicitly discourages reusing a semconv namespace as an application-specific prefix.

### Signal flow, both environments
```mermaid
flowchart LR
    APP[ToolJet server] -->|OTLP 4318| COL[otel-collector]
    COL -->|traces| TEMPO[(Tempo)]
    COL -->|metrics :8889| PROM[(Prometheus scrape)]
    COL -->|logs| LOKI[(Loki 3.x OTLP)]
    BEACON[Browser beacon] -->|client keys| INGEST[ingest translates to canonical]
    INGEST --> APP
```

### Design considerations
- **One authority for names.** `semconv.ts` holds every metric name and attribute key, so the next rename is a one-file edit rather than a grep across the OTel modules.
- **The beacon is deliberately unchanged.** A deployed frontend outlives any given server build, so the server translates client keys at ingest instead of requiring the two to change in lockstep. That also puts value validation where it belongs: unrecognised keys are now dropped rather than passed through, closing a path where a logged-in user could mint unbounded series by scripting `app.name`.
- **`error.type` replaces the parallel failure counter.** Semconv sets it if and only if the operation failed, so its absence marks success. That removes both `query.failures.total` and the `status` label — two counters that could silently drift become one.
- **The resource-attribute allowlist is explicit.** Six bounded attributes, one value per service, per build, per pod. Nothing that changes when a process restarts.
- **Deletions are not cleanup theatre.** `api.hits` and `api.duration` duplicated `http.server.request.duration` from auto-instrumentation; removing the latter also removed a `res.json` monkey-patch that existed only to time it. The audit-log family, `users.concurrent` and friends had no consumer at all.
- **`deployment.environment.name` needed a code change, not just config.** It was reading `NODE_ENV`, which is why staging reported itself as `production`.

### Two things found while verifying
`target_info` does not exist once `resource_to_telemetry_conversion` is off — the collector's `prometheus` exporter never emits it, and three dashboard variables read from it. They now read the same attributes off a metric the allowlist labels. `host.name` and `process.runtime.version` had to join that allowlist for the same reason.

## 🔀 Changes
- Renamed every metric and attribute to semconv; durations now record in seconds with rescaled histogram buckets
- Merged the two frontend error counters into one split by `error.type`, and folded query failures into the executions counter
- Deleted the metric families no dashboard queries: audit-log, app lifecycle, data source lifecycle, concurrent users, and the API hit/duration duplicates
- Moved beacon key translation and value validation to the ingest layer, leaving the browser unchanged
- Added a collector to the local stack with an explicit resource-attribute allowlist, so local and staging finally run the same topology

## 🧪 How to test
- [x] Every renamed family appears under its new name with the expected labels (verified against local Prometheus)
- [x] Deleted families are absent and no series carries `process_pid`
- [x] Durations land in the predicted buckets — 2600ms web vital in `le=4`, 3400ms app load in `le=5`, CLS unconverted
- [x] Success series carries no `error_type`; failure series carries the categorised value
- [x] Query panels resolve — failure %, p95 latency, top kinds, top failing queries
- [x] Browser errors reach Loki with `exception.*` intact and canonical label names
- [x] A hostile beacon payload has unmapped keys dropped and a spoofed `organization.id` overridden
- [ ] Staging: apply the manifest changes, confirm Loki 3.x accepts OTLP and Promtail v11 data stays queryable