### PR TITLE
[Table] Add default sort option on columns

### DIFF
--- a/frontend/src/AppBuilder/CodeBuilder/Elements/Select.jsx
+++ b/frontend/src/AppBuilder/CodeBuilder/Elements/Select.jsx
@@ -79,6 +79,7 @@ const selectCustomStyles = (width) => {
 };
 
 export const Select = ({ value, onChange, meta, width = '144px' }) => {
+  const resolvedWidth = meta?.fullWidth ? '100%' : width;
   return (
     <div
       className="row fx-container"
@@ -94,7 +95,7 @@ export const Select = ({ value, onChange, meta, width = '144px' }) => {
           onChange={onChange}
           width={224}
           height={32}
-          styles={selectCustomStyles(width)}
+          styles={selectCustomStyles(resolvedWidth)}
           useCustomStyles={true}
           customClassPrefix="inspector-select"
           components={{

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/Table.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/Table.jsx
@@ -119,16 +119,7 @@ export const Table = (props) => {
       ...componentMeta,
       properties: {
         ...componentMeta.properties,
-        defaultSortColumn: { type: 'select', displayName: 'Default sort column', options: defaultSortColumnOptions },
-        defaultSortDirection: {
-          type: 'select',
-          displayName: 'Default sort order',
-          options: [
-            { name: 'Ascending', value: 'asc' },
-            { name: 'Descending', value: 'desc' },
-            { name: 'Auto', value: 'auto' },
-          ],
-        },
+        defaultSortColumn: { ...componentMeta.properties?.defaultSortColumn, options: defaultSortColumnOptions },
       },
     }),
     [componentMeta, defaultSortColumnOptions]

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/Table.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Table/Table.jsx
@@ -103,6 +103,37 @@ export const Table = (props) => {
     paramUpdated,
   });
 
+  // Default sort column has no fixed set of options in the static widget config - it depends on
+  // the table's current columns, so it's patched into componentMeta here at render time.
+  const defaultSortColumnOptions = useMemo(
+    () =>
+      columns.map((col) => {
+        const columnKey = col.key || col.name;
+        return { name: getSafeRenderableValue(resolveReferences(col.name)) || columnKey, value: columnKey };
+      }),
+    [columns]
+  );
+
+  const tableComponentMeta = useMemo(
+    () => ({
+      ...componentMeta,
+      properties: {
+        ...componentMeta.properties,
+        defaultSortColumn: { type: 'select', displayName: 'Default sort column', options: defaultSortColumnOptions },
+        defaultSortDirection: {
+          type: 'select',
+          displayName: 'Default sort order',
+          options: [
+            { name: 'Ascending', value: 'asc' },
+            { name: 'Descending', value: 'desc' },
+            { name: 'Auto', value: 'auto' },
+          ],
+        },
+      },
+    }),
+    [componentMeta, defaultSortColumnOptions]
+  );
+
   const {
     activeIndex: activeColumnPopoverIndex,
     isRootCloseEnabled,
@@ -146,8 +177,8 @@ export const Table = (props) => {
   // Render helpers
   const renderCustomElement = useCallback(
     (param, paramType = 'properties') =>
-      renderElement(component, componentMeta, paramUpdated, dataQueries, param, paramType),
-    [component, componentMeta, paramUpdated, dataQueries]
+      renderElement(component, tableComponentMeta, paramUpdated, dataQueries, param, paramType),
+    [component, tableComponentMeta, paramUpdated, dataQueries]
   );
 
   // Column popover
@@ -387,6 +418,11 @@ export const Table = (props) => {
     [component.component.definition.properties.enabledSort?.value]
   );
 
+  const serverSideSort = useMemo(
+    () => resolveReferences(component.component.definition.properties.serverSideSort?.value) ?? false,
+    [component.component.definition.properties.serverSideSort?.value]
+  );
+
   const useDynamicColumn = useMemo(
     () => resolveReferences(component.component.definition.properties.useDynamicColumn?.value) ?? false,
     [component.component.definition.properties.useDynamicColumn?.value]
@@ -414,6 +450,16 @@ export const Table = (props) => {
     paramUpdated({ name: 'displaySearchBox' }, 'value', true, 'properties');
   }
 
+  // Default sort only applies to client side sorting - clear it out when sort type is server side
+  if (serverSideSort) {
+    if (component.component.definition.properties.defaultSortColumn?.value) {
+      paramUpdated({ name: 'defaultSortColumn' }, 'value', '', 'properties');
+    }
+    if (component.component.definition.properties.defaultSortDirection?.value) {
+      paramUpdated({ name: 'defaultSortDirection' }, 'value', '', 'properties');
+    }
+  }
+
   // Options arrays
   const rowSelectionsOptions = useMemo(
     () => [
@@ -439,10 +485,11 @@ export const Table = (props) => {
       ...(displayServerSideSearch ? ['serverSideSearch'] : []),
       'enabledSort',
       ...(enabledSort ? ['serverSideSort'] : []),
+      ...(enabledSort && !serverSideSort ? ['defaultSortColumn', 'defaultSortDirection'] : []),
       'showFilterButton',
       ...(displayServerSideFilter ? ['serverSideFilter'] : []),
     ],
-    [displaySearchBox, displayServerSideSearch, enabledSort, displayServerSideFilter]
+    [displaySearchBox, displayServerSideSearch, enabledSort, serverSideSort, displayServerSideFilter]
   );
 
   const paginationOptions = useMemo(

--- a/frontend/src/AppBuilder/WidgetManager/widgets/table.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/table.js
@@ -167,6 +167,28 @@ export const tableConfig = {
         { displayName: 'Server side', value: 'serverSide' },
       ],
     },
+    defaultSortColumn: {
+      type: 'select',
+      displayName: 'Default sort column',
+      options: [],
+      validation: {
+        schema: { type: 'string' },
+        defaultValue: '',
+      },
+    },
+    defaultSortDirection: {
+      type: 'select',
+      displayName: 'Default sort order',
+      options: [
+        { name: 'Ascending', value: 'asc' },
+        { name: 'Descending', value: 'desc' },
+        { name: 'Auto', value: 'auto' },
+      ],
+      validation: {
+        schema: { type: 'string' },
+        defaultValue: 'auto',
+      },
+    },
     serverSideFilter: {
       type: 'clientServerSwitch',
       displayName: 'Type',
@@ -832,6 +854,8 @@ export const tableConfig = {
       columnSizes: { value: '{{({})}}' },
       actions: { value: [] },
       enabledSort: { value: '{{true}}' },
+      defaultSortColumn: { value: '' },
+      defaultSortDirection: { value: 'auto' },
       hideColumnSelectorButton: { value: '{{false}}' },
       defaultSelectedRow: { value: '{{{"id":1}}}' },
       showAddNewRowButton: { value: '{{true}}' },

--- a/frontend/src/AppBuilder/WidgetManager/widgets/table.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/table.js
@@ -171,18 +171,21 @@ export const tableConfig = {
       type: 'select',
       displayName: 'Default sort column',
       options: [],
+      newLine: true,
+      fullWidth: true,
       validation: {
         schema: { type: 'string' },
         defaultValue: '',
       },
     },
     defaultSortDirection: {
-      type: 'select',
-      displayName: 'Default sort order',
+      type: 'switch',
+      displayName: 'Sort order',
+      isIcon: true,
       options: [
-        { name: 'Ascending', value: 'asc' },
-        { name: 'Descending', value: 'desc' },
-        { name: 'Auto', value: 'auto' },
+        { displayName: 'Ascending', value: 'asc', lucideIconName: 'sort-asc' },
+        { displayName: 'Descending', value: 'desc', lucideIconName: 'sort-desc' },
+        { displayName: 'Auto', value: 'auto', lucideIconName: 'refresh-ccw' },
       ],
       validation: {
         schema: { type: 'string' },

--- a/frontend/src/AppBuilder/Widgets/NewTable/__tests__/tableDefaultSort.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/__tests__/tableDefaultSort.spec.jsx
@@ -1,0 +1,119 @@
+/**
+ * Default sort column/direction (tj-ee#2082): the Table widget can be
+ * configured to load already sorted. This is owned by a single effect in
+ * TableExposedVariables.jsx that applies the configured column/direction via
+ * the same setSort CSA action, whenever either setting changes.
+ *
+ * SCOPE: renders TableExposedVariables directly with a hand-built fake
+ * `table`. The real react-table instance is only constructed by the full
+ * Table -> TableContainer -> AppCanvas/Container chain, which is not
+ * renderable in this suite (see integration/tableSelectedRow.spec.js).
+ * The fake implements only the methods this component calls, and setSorting
+ * mutates the fake's own state, so assertions read that state rather than a
+ * bare spy call count.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { TableExposedVariables } from '../_components/TableExposedVariables/TableExposedVariables';
+import useTableStore from '../_stores/tableStore';
+
+const tableState = () => useTableStore.getState();
+
+const COLUMNS = [
+  { id: 'col-name', columnDef: { accessorKey: 'name', header: 'Name' } },
+  { id: 'col-age', columnDef: { accessorKey: 'age', header: 'Age' } },
+];
+
+/** Minimal fake of the subset of react-table's `table` instance this component touches. */
+function createFakeTable() {
+  let internalState = { sorting: [], globalFilter: '', columnFilters: [], columnSizing: {}, rowSelection: {} };
+  const emptyRowModel = () => ({ rows: [] });
+  return {
+    getFilteredSelectedRowModel: emptyRowModel,
+    getPaginationRowModel: emptyRowModel,
+    getFilteredRowModel: emptyRowModel,
+    getAllColumns: () => COLUMNS,
+    getColumn: (id) => COLUMNS.find((col) => col.id === id),
+    getState: () => internalState,
+    setSorting: (updaterOrValue) => {
+      const sorting = typeof updaterOrValue === 'function' ? updaterOrValue(internalState.sorting) : updaterOrValue;
+      internalState = { ...internalState, sorting };
+    },
+    toggleAllRowsSelected: jest.fn(),
+    setPageIndex: jest.fn(),
+    setRowSelection: jest.fn(),
+    setColumnFilters: jest.fn(),
+    resetRowSelection: jest.fn(),
+  };
+}
+
+let currentUnmount;
+
+function renderTableExposedVariables(table) {
+  const result = render(
+    <TableExposedVariables
+      id="t1"
+      data={[]}
+      setExposedVariables={jest.fn()}
+      fireEvent={jest.fn()}
+      table={table}
+      componentName="table1"
+      pageIndex={1}
+      lastClickedRowRef={{ current: {} }}
+      hasDataChanged={false}
+      paginationBtnClicked={{ current: false }}
+    />
+  );
+  currentUnmount = result.unmount;
+  return result;
+}
+
+describe('Table default sort', () => {
+  // Unmount before the store auto-reset (setupTests.js) runs its own afterEach -
+  // otherwise the still-mounted component reacts to the reset outside act().
+  afterEach(() => currentUnmount?.());
+
+  test('applies the configured default column and direction on load', () => {
+    tableState().initializeComponent('t1');
+    tableState().setTableProperties('t1', { defaultSortColumn: 'age', defaultSortDirection: 'desc' });
+    const table = createFakeTable();
+
+    renderTableExposedVariables(table);
+
+    expect(table.getState().sorting).toEqual([{ id: 'col-age', desc: true }]);
+  });
+
+  test('does not sort when direction is "auto"', () => {
+    tableState().initializeComponent('t1');
+    tableState().setTableProperties('t1', { defaultSortColumn: 'age', defaultSortDirection: 'auto' });
+    const table = createFakeTable();
+
+    renderTableExposedVariables(table);
+
+    expect(table.getState().sorting).toEqual([]);
+  });
+
+  test('does not sort when no default column is configured', () => {
+    tableState().initializeComponent('t1');
+    tableState().setTableProperties('t1', { defaultSortColumn: '', defaultSortDirection: 'asc' });
+    const table = createFakeTable();
+
+    renderTableExposedVariables(table);
+
+    expect(table.getState().sorting).toEqual([]);
+  });
+
+  test('reapplies when the setting is changed after the table has already loaded', () => {
+    tableState().initializeComponent('t1');
+    tableState().setTableProperties('t1', { defaultSortColumn: 'name', defaultSortDirection: 'asc' });
+    const table = createFakeTable();
+    renderTableExposedVariables(table);
+    expect(table.getState().sorting).toEqual([{ id: 'col-name', desc: false }]);
+
+    act(() => {
+      tableState().setTableProperties('t1', { defaultSortColumn: 'age', defaultSortDirection: 'desc' });
+    });
+
+    expect(table.getState().sorting).toEqual([{ id: 'col-age', desc: true }]);
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableExposedVariables/TableExposedVariables.jsx
@@ -30,6 +30,8 @@ export const TableExposedVariables = ({
   const showBulkSelector = useTableStore((state) => state.getTableProperties(id)?.showBulkSelector, shallow);
   const clientSidePagination = useTableStore((state) => state.getTableProperties(id)?.clientSidePagination, shallow);
   const defaultSelectedRow = useTableStore((state) => state.getTableProperties(id)?.defaultSelectedRow, shallow);
+  const defaultSortColumn = useTableStore((state) => state.getTableProperties(id)?.defaultSortColumn, shallow);
+  const defaultSortDirection = useTableStore((state) => state.getTableProperties(id)?.defaultSortDirection, shallow);
   const columnSizes = useTableStore((state) => state.getTableProperties(id)?.columnSizes, shallow);
   const clearEditedRows = useTableStore((state) => state.clearEditedRows, shallow);
 
@@ -378,8 +380,8 @@ export const TableExposedVariables = ({
   }, [setColumnFilters, setExposedVariables, columns]);
 
   // CSA to set sort programmatically
-  useEffect(() => {
-    function setSort(columnKey, direction) {
+  const setSort = useCallback(
+    (columnKey, direction) => {
       if (columnKey === undefined && direction === undefined) {
         table.setSorting([]);
         return;
@@ -403,9 +405,19 @@ export const TableExposedVariables = ({
         desc = direction === 'desc';
       }
       table.setSorting([{ id: tanstackId, desc }]);
-    }
+    },
+    [columns, table]
+  );
+
+  useEffect(() => {
     setExposedVariables({ setSort });
-  }, [setExposedVariables, columns, table]);
+  }, [setExposedVariables, setSort]);
+
+  useEffect(() => {
+    if (!defaultSortColumn || !defaultSortDirection || defaultSortDirection === 'auto') return;
+    setSort(defaultSortColumn, defaultSortDirection);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultSortColumn, defaultSortDirection]);
 
   // CSA to download table data
   useEffect(() => {

--- a/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/__tests__/initSlice.spec.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/__tests__/initSlice.spec.js
@@ -1,0 +1,34 @@
+/**
+ * setTableProperties (initSlice.js) copies each named property onto
+ * state.components[id].properties one line at a time - it is not a generic
+ * spread of the incoming `properties` object. A property left out of that list
+ * is silently dropped, however correctly it is configured everywhere upstream.
+ *
+ * defaultSortColumn/defaultSortDirection (tj-ee#2082) hit exactly this: the
+ * default sort setting was configurable in the Inspector and resolved
+ * correctly, but never reached the running table, because these two lines
+ * were missing here.
+ */
+import useTableStore from '../../tableStore';
+
+const state = () => useTableStore.getState();
+
+describe('setTableProperties - defaultSortColumn/defaultSortDirection', () => {
+  test('copies the configured default sort column and direction into table properties', () => {
+    state().initializeComponent('t1');
+
+    state().setTableProperties('t1', { defaultSortColumn: 'age', defaultSortDirection: 'desc' });
+
+    expect(state().getTableProperties('t1').defaultSortColumn).toBe('age');
+    expect(state().getTableProperties('t1').defaultSortDirection).toBe('desc');
+  });
+
+  test('defaults to no column and "auto" direction when not configured', () => {
+    state().initializeComponent('t1');
+
+    state().setTableProperties('t1', {});
+
+    expect(state().getTableProperties('t1').defaultSortColumn).toBe('');
+    expect(state().getTableProperties('t1').defaultSortDirection).toBe('auto');
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/initSlice.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/initSlice.js
@@ -64,6 +64,8 @@ export const createInitSlice = (set, get) => ({
         state.components[id].properties.highlightSelectedRow = properties?.highlightSelectedRow ?? false;
         state.components[id].properties.rowsPerPage = properties?.rowsPerPage ?? 10;
         state.components[id].properties.enabledSort = properties?.enabledSort ?? true;
+        state.components[id].properties.defaultSortColumn = properties?.defaultSortColumn ?? '';
+        state.components[id].properties.defaultSortDirection = properties?.defaultSortDirection ?? 'auto';
         state.components[id].properties.columnSizes = properties?.columnSizes ?? {};
         state.components[id].properties.allowSelection =
           properties?.allowSelection ?? (properties?.showBulkSelector || properties?.highlightSelectedRow)

--- a/server/src/modules/apps/services/widget-config/table.js
+++ b/server/src/modules/apps/services/widget-config/table.js
@@ -167,6 +167,31 @@ export const tableConfig = {
         { displayName: 'Server side', value: 'serverSide' },
       ],
     },
+    defaultSortColumn: {
+      type: 'select',
+      displayName: 'Default sort column',
+      options: [],
+      newLine: true,
+      fullWidth: true,
+      validation: {
+        schema: { type: 'string' },
+        defaultValue: '',
+      },
+    },
+    defaultSortDirection: {
+      type: 'switch',
+      displayName: 'Sort order',
+      isIcon: true,
+      options: [
+        { displayName: 'Ascending', value: 'asc', lucideIconName: 'sort-asc' },
+        { displayName: 'Descending', value: 'desc', lucideIconName: 'sort-desc' },
+        { displayName: 'Auto', value: 'auto', lucideIconName: 'refresh-ccw' },
+      ],
+      validation: {
+        schema: { type: 'string' },
+        defaultValue: 'auto',
+      },
+    },
     serverSideFilter: {
       type: 'clientServerSwitch',
       displayName: 'Type',
@@ -832,6 +857,8 @@ export const tableConfig = {
       columnSizes: { value: '{{({})}}' },
       actions: { value: [] },
       enabledSort: { value: '{{true}}' },
+      defaultSortColumn: { value: '' },
+      defaultSortDirection: { value: 'auto' },
       hideColumnSelectorButton: { value: '{{false}}' },
       defaultSelectedRow: { value: '{{{"id":1}}}' },
       showAddNewRowButton: { value: '{{true}}' },


### PR DESCRIPTION
Issue: https://github.com/ToolJet/tj-ee/issues/2082

## Fix:
Adds a "Default sort column" and "Default sort order" (Ascending / Descending / Auto) setting to the Table widget, under Search, sort and filter in the properties panel, right below "Enable column sorting" and its client/server type toggle — addressing

## Behavior implemented:
Default sort column is an fx-enabled dropdown listing the table's current column names, so users can either pick a column directly or resolve one via an expression.
Default sort order offers Ascending, Descending, or Auto. Auto is a deliberate no-op — it applies no default sort at all.
The two new fields only appear when sorting is enabled and set to client-side. If sort type is switched to server-side, both fields are hidden and their values are cleared back to empty, since a default sort only makes sense for client-side sorting.
The configured default is applied automatically once the table renders, and re-applied whenever the setting itself is changed (e.g. while editing the app) — but it does not fight the user's own interaction: clicking a column header or calling the setSort action later isn't overridden by unrelated re-renders, since the effect only reacts to the default-sort setting changing, not to incidental table updates (pagination, resizing, etc.).

## Areas to Test

- Set a default column + Ascending/Descending on a fresh table — confirm it loads sorted, on both the builder canvas and preview, and after a full page refresh.
- Change the default sort setting while the app is open (not just on a brand-new table) — confirm it reapplies.
- Set direction to Auto — confirm no sort is imposed and existing/manual sorting is left alone.
- Switch sort type from client-side to server-side — confirm both new fields disappear and their stored values are cleared.
- Click a column header (or call the `setSort` action) after the default sort has applied — confirm it isn't reverted by an unrelated table re-render (e.g. changing page, resizing a column).
- Regression: existing tables created before this change should not error when their properties panel is opened.

## Screenshots:

<img width="308" height="362" alt="image" src="https://github.com/user-attachments/assets/706b2015-fee0-4c0f-9e7e-338c932456ad" />