### PR TITLE
[App Theme] Expose themes in inspector and code suggestions #5319

### DIFF
--- a/frontend/src/AppBuilder/Header/CreateVersionModal.jsx
+++ b/frontend/src/AppBuilder/Header/CreateVersionModal.jsx
@@ -23,7 +23,6 @@ const CreateVersionModal = ({
   onVersionCreated,
 }) => {
   const { moduleId } = useModuleContext();
-  const setResolvedGlobals = useStore((state) => state.setResolvedGlobals, shallow);
   const [isCreatingVersion, setIsCreatingVersion] = useState(false);
   const [versionName, setVersionName] = useState('');
   const [versionDescription, setVersionDescription] = useState('');

--- a/frontend/src/AppBuilder/LeftSidebar/GlobalSettings/AppModeToggle.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/GlobalSettings/AppModeToggle.jsx
@@ -16,7 +16,7 @@ const AppModeToggle = ({ darkMode, isModuleEditor = false }) => {
   const { onAppModeChange, appMode } = useAppDarkMode();
   const { t } = useTranslation();
 
-  const setResolvedGlobals = useStore((state) => state.setResolvedGlobals);
+  const updateExposedTheme = useStore((state) => state.updateExposedTheme);
 
   return (
     <div className="canvas-settings-row">
@@ -34,7 +34,7 @@ const AppModeToggle = ({ darkMode, isModuleEditor = false }) => {
                 exposedTheme = darkMode ? 'dark' : 'light';
               }
               onAppModeChange({ appMode: value });
-              setResolvedGlobals('theme', { name: exposedTheme });
+              updateExposedTheme(exposedTheme);
             }}
             defaultValue={appMode}
           >

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -80,6 +80,7 @@ const useAppData = (
   const setSecrets = useStore((state) => state.setSecrets);
   const setQueryMapping = useStore((state) => state.setQueryMapping);
   const setResolvedGlobals = useStore((state) => state.setResolvedGlobals);
+  const updateExposedTheme = useStore((state) => state.updateExposedTheme);
   const setResolvedPageConstants = useStore((state) => state.setResolvedPageConstants);
   const updateFeatureAccess = useStore((state) => state.updateFeatureAccess);
   const computePageSettings = useStore((state) => state.computePageSettings);
@@ -264,8 +265,8 @@ const useAppData = (
   useEffect(() => {
     const exposedTheme =
       appMode && appMode !== 'auto' ? appMode : localStorage.getItem('darkMode') === 'true' ? 'dark' : 'light';
-    setResolvedGlobals('theme', { name: exposedTheme }, moduleId);
-  }, [appMode, darkMode, moduleId]);
+    updateExposedTheme(exposedTheme, moduleId);
+  }, [appMode, darkMode, moduleId, selectedTheme, themeAccess]);
 
   useEffect(() => {
     if (!currentSession) {
@@ -891,7 +892,7 @@ const useAppData = (
         try {
           const exposedTheme =
             appMode && appMode !== 'auto' ? appMode : localStorage.getItem('darkMode') === 'true' ? 'dark' : 'light';
-          setResolvedGlobals('theme', { name: exposedTheme });
+          updateExposedTheme(exposedTheme);
         } catch (error) {
           console.log('error', error);
         }

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -81,6 +81,7 @@ const useAppData = (
   const setQueryMapping = useStore((state) => state.setQueryMapping);
   const setResolvedGlobals = useStore((state) => state.setResolvedGlobals);
   const updateExposedTheme = useStore((state) => state.updateExposedTheme);
+  const getActiveTheme = useStore((state) => state.getActiveTheme);
   const setResolvedPageConstants = useStore((state) => state.setResolvedPageConstants);
   const updateFeatureAccess = useStore((state) => state.updateFeatureAccess);
   const computePageSettings = useStore((state) => state.computePageSettings);
@@ -263,9 +264,7 @@ const useAppData = (
   }, [moduleMode]);
 
   useEffect(() => {
-    const exposedTheme =
-      appMode && appMode !== 'auto' ? appMode : localStorage.getItem('darkMode') === 'true' ? 'dark' : 'light';
-    updateExposedTheme(exposedTheme, moduleId);
+    updateExposedTheme(undefined, moduleId);
   }, [appMode, darkMode, moduleId, selectedTheme, themeAccess]);
 
   useEffect(() => {
@@ -734,7 +733,7 @@ const useAppData = (
   useEffect(() => {
     const root = document.documentElement;
     const mode = appMode && appMode !== 'auto' ? appMode : darkMode ? 'dark' : 'light';
-    const themeObj = !themeAccess ? baseTheme?.definition : selectedTheme?.definition || {};
+    const themeObj = getActiveTheme().definition || {};
     Object.keys(themeObj).forEach((category) => {
       const categoryObj = themeObj[category];
       Object.keys(categoryObj).forEach((property) => {
@@ -890,9 +889,7 @@ const useAppData = (
         }
 
         try {
-          const exposedTheme =
-            appMode && appMode !== 'auto' ? appMode : localStorage.getItem('darkMode') === 'true' ? 'dark' : 'light';
-          updateExposedTheme(exposedTheme);
+          updateExposedTheme();
         } catch (error) {
           console.log('error', error);
         }

--- a/frontend/src/AppBuilder/_stores/__tests__/integration/themeExposure.spec.js
+++ b/frontend/src/AppBuilder/_stores/__tests__/integration/themeExposure.spec.js
@@ -1,0 +1,173 @@
+/**
+ * Theme exposure suite — how `globals.theme` (App Builder inspector, `{{ }}` bindings)
+ * gets its value, and which theme "counts" as active. (ToolJet/ToolJet#17479, tj-ee-5319)
+ *
+ * Crosses three slices — license (isLicenseValid/isFeatureAccessible), app
+ * (globalSettings.theme/appMode, getActiveTheme), and resolved (updateExposedTheme,
+ * setResolvedGlobals) — so this runs against the real composed store rather than any
+ * one slice in isolation; that is also what guarantees `getActiveTheme()` is the single
+ * source of truth `updateExposedTheme` and the CSS-variable effect both read from.
+ *
+ * Subjects under test:
+ *   - appSlice.js: getActiveTheme()
+ *   - resolvedSlice.js: updateExposedTheme(overrideMode, moduleId)
+ */
+import useStore from '@/AppBuilder/_stores/store';
+import { baseTheme } from '@/AppBuilder/_stores/utils';
+
+const state = () => useStore.getState();
+
+const licensedFeatureAccess = (overrides = {}) => ({
+  customThemes: true,
+  licenseStatus: { isLicenseValid: true, isExpired: false },
+  ...overrides,
+});
+
+const setLicense = (featureAccess) => {
+  useStore.setState((s) => {
+    s.license = { featureAccess };
+  });
+};
+
+const setSelectedTheme = (theme) => {
+  useStore.setState((s) => {
+    s.globalSettings.theme = theme;
+  });
+};
+
+const setAppMode = (appMode) => {
+  useStore.setState((s) => {
+    s.globalSettings.appMode = appMode;
+  });
+};
+
+const customTheme = (overrides = {}) => ({
+  id: 'theme-1',
+  name: 'Custom Brand',
+  definition: {
+    brand: { colors: { primary: { light: '#010101', dark: '#fefefe' } } },
+  },
+  ...overrides,
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('getActiveTheme', () => {
+  test('falls back to baseTheme when the org has no license/feature access', () => {
+    setSelectedTheme(customTheme());
+
+    expect(state().getActiveTheme()).toBe(baseTheme);
+  });
+
+  test('falls back to baseTheme when customThemes is licensed but the license itself is invalid', () => {
+    setLicense(licensedFeatureAccess({ licenseStatus: { isLicenseValid: false, isExpired: false } }));
+    setSelectedTheme(customTheme());
+
+    expect(state().getActiveTheme()).toBe(baseTheme);
+  });
+
+  test('uses the selected theme when licensed and the theme has a definition', () => {
+    setLicense(licensedFeatureAccess());
+    const theme = customTheme();
+    setSelectedTheme(theme);
+
+    expect(state().getActiveTheme()).toBe(theme);
+  });
+
+  test('falls back to baseTheme when licensed but the selected theme has no definition', () => {
+    setLicense(licensedFeatureAccess());
+    setSelectedTheme({ id: 'theme-2', name: 'Broken Theme' });
+
+    expect(state().getActiveTheme()).toBe(baseTheme);
+  });
+});
+
+describe('updateExposedTheme — mode derivation', () => {
+  test('defaults to light when nothing is set', () => {
+    state().updateExposedTheme();
+
+    expect(state().resolvedStore.modules.canvas.exposedValues.globals.theme.name).toBe('light');
+  });
+
+  test('falls back to localStorage darkMode when appMode is unset', () => {
+    localStorage.setItem('darkMode', 'true');
+
+    state().updateExposedTheme();
+
+    expect(state().resolvedStore.modules.canvas.exposedValues.globals.theme.name).toBe('dark');
+  });
+
+  test('globalSettings.appMode wins over localStorage when set to an explicit mode', () => {
+    setAppMode('dark');
+    localStorage.setItem('darkMode', 'false');
+
+    state().updateExposedTheme();
+
+    expect(state().resolvedStore.modules.canvas.exposedValues.globals.theme.name).toBe('dark');
+  });
+
+  test('"auto" appMode is not treated as an explicit mode — falls through to localStorage', () => {
+    setAppMode('auto');
+    localStorage.setItem('darkMode', 'true');
+
+    state().updateExposedTheme();
+
+    expect(state().resolvedStore.modules.canvas.exposedValues.globals.theme.name).toBe('dark');
+  });
+
+  test('an explicit overrideMode wins over appMode and localStorage', () => {
+    setAppMode('light');
+    localStorage.setItem('darkMode', 'false');
+
+    state().updateExposedTheme('dark');
+
+    expect(state().resolvedStore.modules.canvas.exposedValues.globals.theme.name).toBe('dark');
+  });
+});
+
+describe('updateExposedTheme — resolved globals.theme shape', () => {
+  test('unlicensed org resolves baseTheme colors for the current mode', () => {
+    state().updateExposedTheme('dark');
+
+    const theme = state().resolvedStore.modules.canvas.exposedValues.globals.theme;
+
+    expect(theme.themeName).toBe('ToolJet');
+    expect(theme.brand.colors.primary).toBe(baseTheme.definition.brand.colors.primary.dark);
+    expect(theme.systemStatus.colors.error).toBe(baseTheme.definition.systemStatus.colors.error.dark);
+  });
+
+  test('licensed org with a custom theme resolves that theme, not baseTheme', () => {
+    setLicense(licensedFeatureAccess());
+    setSelectedTheme(customTheme());
+
+    state().updateExposedTheme('light');
+
+    const theme = state().resolvedStore.modules.canvas.exposedValues.globals.theme;
+
+    expect(theme.themeName).toBe('Custom Brand');
+    expect(theme.brand.colors.primary).toBe('#010101');
+  });
+
+  // Regression guard: isBasic/isDefault were exposed on globals.theme at one point during
+  // review, then deliberately dropped as unneeded — must not silently reappear.
+  test('does not expose isBasic/isDefault', () => {
+    state().updateExposedTheme();
+
+    const theme = state().resolvedStore.modules.canvas.exposedValues.globals.theme;
+
+    expect(theme.isBasic).toBeUndefined();
+    expect(theme.isDefault).toBeUndefined();
+  });
+
+  test('writes into the given moduleId, not canvas', () => {
+    state().initializeResolvedSlice('module-1');
+    state().initializeDependencySlice('module-1');
+
+    state().updateExposedTheme('dark', 'module-1');
+
+    expect(state().resolvedStore.modules['module-1'].exposedValues.globals.theme.name).toBe('dark');
+    expect(state().resolvedStore.modules.canvas.exposedValues.globals.theme).toBeUndefined();
+  });
+});

--- a/frontend/src/AppBuilder/_stores/__tests__/utils.themeResolver.spec.js
+++ b/frontend/src/AppBuilder/_stores/__tests__/utils.themeResolver.spec.js
@@ -1,0 +1,91 @@
+/**
+ * Contract tests for `resolveThemeForMode` in `_stores/utils.js`.
+ *
+ * This walks a theme `definition` tree and collapses every `{ light, dark }` leaf to
+ * the single value for the current mode, which is what ends up under `globals.theme`
+ * in the inspector and in `{{ }}` bindings. Pure function (no store, no DOM) — zero
+ * mocks, only the module under test is imported.
+ *
+ * The key fact pinned here: released apps, public links, preview-for-version, and the
+ * module viewer all run `convertAllKeysToSnakeCase` on the whole app payload before this
+ * resolver ever sees it (`useAppData.js`), and only the top level of `global_settings` is
+ * converted back to camelCase afterwards — the theme's own nested `definition` subtree
+ * stays snake_cased. Without normalizing keys inside the walk, multi-word paths like
+ * `globals.theme.systemStatus.colors.error` resolve to `undefined` in every non-editor
+ * context while working fine in the editor. That was a real bug caught in PR review
+ * (ToolJet/ToolJet#17479) — the camelCase call is what fixes it.
+ */
+import { resolveThemeForMode, baseTheme } from '@/AppBuilder/_stores/utils';
+
+describe('resolveThemeForMode', () => {
+  test('resolves a { light, dark } leaf to the light value in light mode', () => {
+    const definition = { brand: { colors: { primary: { light: '#111111', dark: '#eeeeee' } } } };
+
+    expect(resolveThemeForMode(definition, 'light')).toEqual({ brand: { colors: { primary: '#111111' } } });
+  });
+
+  test('resolves a { light, dark } leaf to the dark value in dark mode', () => {
+    const definition = { brand: { colors: { primary: { light: '#111111', dark: '#eeeeee' } } } };
+
+    expect(resolveThemeForMode(definition, 'dark')).toEqual({ brand: { colors: { primary: '#eeeeee' } } });
+  });
+
+  test('leaves mode-independent leaves (numbers, strings without light/dark) untouched', () => {
+    const definition = { text: { font: 'IBM Plex Sans' }, border: { radius: { default: 6, small: 0 } } };
+
+    expect(resolveThemeForMode(definition, 'light')).toEqual({
+      text: { font: 'IBM Plex Sans' },
+      border: { radius: { default: 6, small: 0 } },
+    });
+  });
+
+  test('camelCases snake_case keys at every depth (the released/public app bug)', () => {
+    const definition = {
+      system_status: { colors: { error: { light: '#D72D39', dark: '#D03F43' } } },
+      surface: { colors: { app_background: { light: '#F6F6F6', dark: '#121518' } } },
+    };
+
+    const resolved = resolveThemeForMode(definition, 'light');
+
+    expect(resolved.systemStatus.colors.error).toBe('#D72D39');
+    expect(resolved.surface.colors.appBackground).toBe('#F6F6F6');
+    // The snake_case paths must not survive alongside the camelCase ones.
+    expect(resolved.system_status).toBeUndefined();
+    expect(resolved.surface.colors.app_background).toBeUndefined();
+  });
+
+  test('is idempotent on already-camelCase input (editor path is unaffected)', () => {
+    const definition = { systemStatus: { colors: { error: { light: '#D72D39', dark: '#D03F43' } } } };
+
+    expect(resolveThemeForMode(definition, 'light')).toEqual({ systemStatus: { colors: { error: '#D72D39' } } });
+  });
+
+  test('does not mutate the input definition', () => {
+    const definition = { brand: { colors: { primary: { light: '#111111', dark: '#eeeeee' } } } };
+    const before = JSON.parse(JSON.stringify(definition));
+
+    resolveThemeForMode(definition, 'light');
+
+    expect(definition).toEqual(before);
+  });
+
+  test('resolves the real baseTheme for both modes with the expected shape', () => {
+    const light = resolveThemeForMode(baseTheme.definition, 'light');
+    const dark = resolveThemeForMode(baseTheme.definition, 'dark');
+
+    expect(light).toEqual({
+      brand: { colors: { primary: '#4368E3', secondary: '#6A727C', tertiary: '#1E823B' } },
+      text: { font: 'IBM Plex Sans', colors: { primary: '#1B1F24', placeholder: '#6A727C' } },
+      border: {
+        radius: { default: 6, small: 0, large: 0 },
+        colors: { default: '#CCD1D5', weak: '#E4E7EB' },
+      },
+      systemStatus: { colors: { success: '#1E823B', error: '#D72D39', warning: '#BF4F03' } },
+      surface: {
+        colors: { appBackground: '#F6F6F6', surface1: '#FFFFFF', surface2: '#F6F8FA', surface3: '#E4E7EB' },
+      },
+    });
+    expect(dark.brand.colors.primary).toBe('#4A6DD9');
+    expect(dark.surface.colors.appBackground).toBe('#121518');
+  });
+});

--- a/frontend/src/AppBuilder/_stores/slices/appSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/appSlice.js
@@ -251,6 +251,14 @@ export const createAppSlice = (set, get) => ({
       console.error('Error updating page:', error);
     }
   },
+  // Single source of truth for "which theme is active": licensed orgs use their selected
+  // theme (if it actually has a definition), everyone else falls back to baseTheme
+  getActiveTheme: () => {
+    const state = get();
+    const hasThemeAccess = state.isLicenseValid() && state.isFeatureAccessible('customThemes');
+    const selectedTheme = state.globalSettings?.theme;
+    return hasThemeAccess && selectedTheme?.definition ? selectedTheme : baseTheme;
+  },
   switchPage: (pageId, handle, queryParams = [], moduleId = 'canvas', isBackOrForward = false) => {
     get().debugger.resetUnreadErrorCount();
 

--- a/frontend/src/AppBuilder/_stores/slices/codeHinterSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/codeHinterSlice.js
@@ -154,7 +154,7 @@ function buildGlobalHints(storeState, moduleId) {
 
   if (Object.keys(globals).length > 0) {
     hints.push({ hint: 'globals', type: 'Object' });
-    hints.push(...traverseObjectToHints(globals, 'globals', 3));
+    hints.push(...traverseObjectToHints(globals, 'globals', 4));
   }
 
   return hints;

--- a/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
@@ -1,4 +1,4 @@
-import { resolveDynamicValues, resolveThemeForMode, baseTheme } from '../utils';
+import { resolveDynamicValues, resolveThemeForMode } from '../utils';
 import { extractAndReplaceReferencesFromString } from '@/AppBuilder/_stores/ast';
 import { componentTypeDefinitionMap } from '@/AppBuilder/WidgetManager';
 import { createBatchManager } from '@/AppBuilder/_stores/batchManager';
@@ -154,16 +154,18 @@ export const createResolvedSlice = (set, get) => {
       get().updateDependencyValues(`globals.${objKey}`, moduleId);
     },
 
-    updateExposedTheme: (mode, moduleId = 'canvas') => {
+    // `overrideMode` is for toggle handlers that fire before the new mode is persisted to
+    // globalSettings/localStorage — they know the mode they're switching to. Everywhere else
+    // (e.g. reacting to a theme/appMode change), omit it and let this derive the current mode itself.
+    updateExposedTheme: (overrideMode, moduleId = 'canvas') => {
       const state = get();
-      const hasThemeAccess = state.isLicenseValid() && state.isFeatureAccessible('customThemes');
-      const theme = (hasThemeAccess && state.globalSettings?.theme) || baseTheme;
+      const appMode = state.globalSettings?.appMode;
+      const mode =
+        overrideMode ??
+        (appMode && appMode !== 'auto' ? appMode : localStorage.getItem('darkMode') === 'true' ? 'dark' : 'light');
+      const theme = state.getActiveTheme();
       const resolvedTheme = resolveThemeForMode(theme.definition, mode);
-      state.setResolvedGlobals(
-        'theme',
-        { name: mode, themeName: theme.name, isBasic: theme.isBasic, isDefault: theme.isDefault, ...resolvedTheme },
-        moduleId
-      );
+      state.setResolvedGlobals('theme', { name: mode, themeName: theme.name, ...resolvedTheme }, moduleId);
     },
 
     setResolvedConstants: (constants = {}, moduleId = 'canvas') => {

--- a/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/resolvedSlice.js
@@ -1,4 +1,4 @@
-import { resolveDynamicValues } from '../utils';
+import { resolveDynamicValues, resolveThemeForMode, baseTheme } from '../utils';
 import { extractAndReplaceReferencesFromString } from '@/AppBuilder/_stores/ast';
 import { componentTypeDefinitionMap } from '@/AppBuilder/WidgetManager';
 import { createBatchManager } from '@/AppBuilder/_stores/batchManager';
@@ -153,6 +153,19 @@ export const createResolvedSlice = (set, get) => {
       );
       get().updateDependencyValues(`globals.${objKey}`, moduleId);
     },
+
+    updateExposedTheme: (mode, moduleId = 'canvas') => {
+      const state = get();
+      const hasThemeAccess = state.isLicenseValid() && state.isFeatureAccessible('customThemes');
+      const theme = (hasThemeAccess && state.globalSettings?.theme) || baseTheme;
+      const resolvedTheme = resolveThemeForMode(theme.definition, mode);
+      state.setResolvedGlobals(
+        'theme',
+        { name: mode, themeName: theme.name, isBasic: theme.isBasic, isDefault: theme.isDefault, ...resolvedTheme },
+        moduleId
+      );
+    },
+
     setResolvedConstants: (constants = {}, moduleId = 'canvas') => {
       set(
         (state) => {

--- a/frontend/src/AppBuilder/_stores/utils.js
+++ b/frontend/src/AppBuilder/_stores/utils.js
@@ -679,6 +679,9 @@ export const parsePropertyPath = (property) => {
 };
 
 export const baseTheme = {
+  name: 'ToolJet',
+  isDefault: true,
+  isBasic: true,
   definition: {
     brand: {
       colors: {
@@ -763,6 +766,23 @@ export const baseTheme = {
       },
     },
   },
+};
+
+// Walks a theme `definition` tree and resolves every { light, dark } leaf to the value for `mode`,
+// leaving mode-independent leaves (e.g. text.font, border.radius.*) untouched.
+export const resolveThemeForMode = (definition = {}, mode) => {
+  const resolveNode = (node) => {
+    if (node == null || typeof node !== 'object') return node;
+    if (Object.prototype.hasOwnProperty.call(node, 'light') || Object.prototype.hasOwnProperty.call(node, 'dark')) {
+      return node[mode];
+    }
+    return Object.keys(node).reduce((resolved, key) => {
+      resolved[key] = resolveNode(node[key]);
+      return resolved;
+    }, {});
+  };
+
+  return resolveNode(definition);
 };
 
 export const blobToDataURL = (blob) => {

--- a/frontend/src/AppBuilder/_stores/utils.js
+++ b/frontend/src/AppBuilder/_stores/utils.js
@@ -680,8 +680,6 @@ export const parsePropertyPath = (property) => {
 
 export const baseTheme = {
   name: 'ToolJet',
-  isDefault: true,
-  isBasic: true,
   definition: {
     brand: {
       colors: {
@@ -777,7 +775,7 @@ export const resolveThemeForMode = (definition = {}, mode) => {
       return node[mode];
     }
     return Object.keys(node).reduce((resolved, key) => {
-      resolved[key] = resolveNode(node[key]);
+      resolved[_.camelCase(key)] = resolveNode(node[key]);
       return resolved;
     }, {});
   };

--- a/frontend/src/_components/DarkModeToggle.jsx
+++ b/frontend/src/_components/DarkModeToggle.jsx
@@ -20,7 +20,7 @@ export const DarkModeToggle = function DarkModeToggle({
   toggleSize = 'default',
   btnClassName = '',
 }) {
-  const setResolvedGlobals = useStore((state) => state.setResolvedGlobals, shallow);
+  const updateExposedTheme = useStore((state) => state.updateExposedTheme, shallow);
   const setGlobalSettings = useStore((state) => state.setGlobalSettings, shallow);
   const globalSettings = useStore((state) => state.globalSettings, shallow);
   const [appLevelDarkMode, setAppLevelDarkMode] = useState(false);
@@ -30,14 +30,14 @@ export const DarkModeToggle = function DarkModeToggle({
   const toggleDarkMode = () => {
     if (toggleForCanvas) {
       const exposedTheme = !appLevelDarkMode ? 'dark' : 'light';
-      setResolvedGlobals('theme', { name: exposedTheme });
+      updateExposedTheme(exposedTheme);
       setAppLevelDarkMode(!appLevelDarkMode);
       switchDarkMode(!darkMode);
     } else {
       posthogHelper.captureEvent('darkMode', { mode: !darkMode ? 'dark' : 'white' });
       switchDarkMode(!darkMode);
       if (appMode === 'auto') {
-        setResolvedGlobals('theme', { name: !darkMode ? 'dark' : 'light' });
+        updateExposedTheme(!darkMode ? 'dark' : 'light');
       }
     }
   };


### PR DESCRIPTION
Issue: https://github.com/ToolJet/tj-ee/issues/5319

## Summary

Previously `globals.theme` in the App Builder inspector only exposed `{ name: 'light' | 'dark' }`. This change resolves the app's full theme definition (brand/text/border/systemStatus/surface colors, plus theme metadata) against the current mode and exposes it under `globals.theme`, so app builders can bind to actual theme values (e.g. `{{globals.theme.brand.colors.primary}}`) instead of only the mode name.

## What's Implemented

- `globals.theme` now exposes, in addition to the existing `name` (mode: `'light'`/`'dark'`):
  - `themeName` — the theme record's own name (e.g. `"ToolJet"`).
  - `isBasic` / `isDefault` — the theme's own metadata flags.
  - The full resolved color/style tree: `brand`, `text`, `border`, `systemStatus`, `surface` — each `{ light, dark }` pair in the underlying theme definition is resolved down to a single value for the current mode; mode-independent leaves (`text.font`, `border.radius.*`) pass through unchanged.
- Licensed orgs with custom-theme access get their selected theme (`globalSettings.theme`) resolved; unlicensed orgs always fall back to `baseTheme` (ToolJet's built-in default), matching existing `useThemeAccess` gating.
- Re-resolves and re-exposes automatically when: app mode changes, dark/light is toggled, or the **selected theme itself** changes (e.g. via the theme dropdown) — previously only mode/dark-mode toggles triggered a refresh.
- Autocomplete (`{{ }}` hint) depth for `globals.*` was bumped from 3 to 4 so nested theme paths (e.g. `globals.theme.brand.colors.primary`) are suggested; other globals (`currentUser`, `environment`, etc.) incidentally gain one more level of hint depth too, with no functional effect (hints don't gate what's resolvable, they're autocomplete-only).
- Removed an unused `setResolvedGlobals` store selector in `CreateVersionModal.jsx` found unused during this work.

### Resolved `globals.theme` shape (example — default `baseTheme`, light mode)

```json
{
  "name": "light",
  "themeName": "ToolJet",
  "isBasic": true,
  "isDefault": true,
  "brand": {
    "colors": {
      "primary": "#4368E3",
      "secondary": "#6A727C",
      "tertiary": "#1E823B"
    }
  },
  "text": {
    "font": "IBM Plex Sans",
    "colors": {
      "primary": "#1B1F24",
      "placeholder": "#6A727C"
    }
  },
  "border": {
    "radius": {
      "default": 6,
      "small": 0,
      "large": 0
    },
    "colors": {
      "default": "#CCD1D5",
      "weak": "#E4E7EB"
    }
  },
  "systemStatus": {
    "colors": {
      "success": "#1E823B",
      "error": "#D72D39",
      "warning": "#BF4F03"
    }
  },
  "surface": {
    "colors": {
      "appBackground": "#F6F6F6",
      "surface1": "#FFFFFF",
      "surface2": "#F6F8FA",
      "surface3": "#E4E7EB"
    }
  }
}
```

Switching `mode` to `"dark"` resolves the same tree against each leaf's `dark` value instead; switching to a licensed custom theme swaps `themeName`/`isBasic`/`isDefault` and every color to that theme's own definition.

## Where It's Implemented

- `frontend/src/AppBuilder/_stores/utils.js` — added `resolveThemeForMode(definition, mode)`, a recursive resolver that walks a theme definition tree and collapses every `{ light, dark }` leaf to the value for the given mode. Also added `name`/`isDefault`/`isBasic` metadata fields to `baseTheme` so the unlicensed fallback theme has the same shape as a real theme record.
- `frontend/src/AppBuilder/_stores/slices/resolvedSlice.js` — added `updateExposedTheme(mode, moduleId)`, a single store action that picks the licensed/selected theme or `baseTheme`, resolves it via `resolveThemeForMode`, and calls `setResolvedGlobals('theme', { name, themeName, isBasic, isDefault, ...resolved }, moduleId)`. Centralizes logic previously duplicated across call sites.
- `frontend/src/AppBuilder/_hooks/useAppData.js` — the two effects that previously called `setResolvedGlobals('theme', { name: exposedTheme })` now call `updateExposedTheme(exposedTheme, moduleId)`. The mode-computation effect's dependency array now also includes `selectedTheme` and `themeAccess`, so a theme change (not just a mode toggle) re-triggers the resolve/expose step.
- `frontend/src/AppBuilder/LeftSidebar/GlobalSettings/AppModeToggle.jsx` and `frontend/src/_components/DarkModeToggle.jsx` — both toggle handlers now call `updateExposedTheme(mode)` instead of manually building `{ name: mode }`.
- `frontend/src/AppBuilder/_stores/slices/codeHinterSlice.js` — `buildGlobalHints`'s `traverseObjectToHints(globals, 'globals', 3)` depth bumped to `4` so nested theme paths surface in autocomplete.
- `frontend/src/AppBuilder/Header/CreateVersionModal.jsx` — removed an unused `setResolvedGlobals` selector (dead code, unrelated leftover found while auditing call sites).

## Areas to Review

- Depth bump in `codeHinterSlice.js` is scoped only to `buildGlobalHints`'s call; other hint builders (`queries`, `components`, `variables`, `page`) keep their own explicit `3` and are unaffected. Confirmed `rebuildGlobalHints` has no callers anywhere in the codebase today — global hints are only built once via `initSuggestions`, gated to `mode === 'edit'`, so this never runs for published/viewer apps and isn't recomputed per keystroke.
- `resolveThemeForMode` assumes theme definitions are non-circular, JSON-derived plain objects (true for both `baseTheme` and API-sourced theme records) — recursion depth is bounded by the actual (≈4-level) definition shape.
- Naming choice: the new theme-name key is `themeName`, not `name`, to avoid clashing with the pre-existing `globals.theme.name` (mode). Worth confirming this naming reads clearly to end users in the inspector.
- One `updateExposedTheme` call site (`useAppData.js`, inside the app-load flow) intentionally omits `moduleId` (defaults to `'canvas'`), matching the pre-existing behavior of the code it replaced — not changed as part of this work, but worth a second look if module-scoped theming was ever intended there.

## Areas to Test

- Toggling Auto/Light/Dark and the sun/moon icon in both editor and preview — confirm `globals.theme` in the inspector shows `name` plus all resolved category values matching the current mode, updating live without a refresh.
- Switching the selected custom theme (licensed org) via the theme dropdown — confirm `globals.theme` re-resolves to the new theme's colors and `themeName`/`isBasic`/`isDefault` update accordingly.
- Unlicensed org (no `customThemes` feature access) — confirm `globals.theme` always reflects `baseTheme` (`themeName: "ToolJet"`, `isBasic: true`, `isDefault: true`) regardless of any org-level custom theme selection.
- `{{globals.theme.brand.colors.primary}}` and similar nested paths autocomplete correctly in code editor fields.
- Existing apps/bindings using only `{{globals.theme.name}}` are unaffected (purely additive change).


## Screenshots
<img width="354" height="399" alt="image" src="https://github.com/user-attachments/assets/c7c729af-3677-47fc-83a0-bb6a3d2b8f59" />
