### PR TITLE
fix(ci): pin netlify-cli in docs deploy workflow to a Node 20-compati…

### DIFF
--- a/.github/workflows/docs-netlify.yml
+++ b/.github/workflows/docs-netlify.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.18.2
+          node-version: 20.20.0
 
       - name: Install dependencies
         working-directory: docs
@@ -39,5 +39,5 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
-          npm install -g netlify-cli
+          npm install -g netlify-cli@26
           netlify deploy --prod --dir=docs/build --site=${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
…ble major

netlify-cli@22+ raised its Node requirement past 18, but this workflow was still pinned to 18.18.2, causing the deploy step to fail with a syntax error on JSON import attributes. Pin netlify-cli to major v26 (last major still compatible with Node >=20.12.2) and bump the runner to 20.20.0, matching the Node version already used elsewhere, instead of installing unpinned "latest" which will break again on the next netlify-cli major bump.