### PR TITLE
Fix: gRPC filesystem proto discovery freezing the instance

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/grpcv2.scss
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/grpcv2.scss
@@ -54,10 +54,8 @@
   .grpcv2-dropdown {
     position: relative;
     width: 100%;
-    // contain the overlay/arrow/menu z-indexes — they escape over the preview panel
     isolation: isolate;
 
-    // open menu must clear the body editor (.cm-scroller) and preview panel (z-index 1)
     &:has(.grpcv2-dropdown__button--open) {
       z-index: 2;
     }

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/grpcv2.scss
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/grpcv2.scss
@@ -54,6 +54,13 @@
   .grpcv2-dropdown {
     position: relative;
     width: 100%;
+    // contain the overlay/arrow/menu z-indexes — they escape over the preview panel
+    isolation: isolate;
+
+    // open menu must clear the body editor (.cm-scroller) and preview panel (z-index 1)
+    &:has(.grpcv2-dropdown__button--open) {
+      z-index: 2;
+    }
 
     &--dark {
       .grpcv2-dropdown__button {

--- a/plugins/packages/grpcv2/lib/index.ts
+++ b/plugins/packages/grpcv2/lib/index.ts
@@ -1,10 +1,7 @@
 import { QueryResult, QueryService, ConnectionTestResult, QueryError, getAuthUrl, getRefreshedToken } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions, GrpcService, GrpcOperationError, GrpcClient, toError } from './types';
 import * as grpc from '@grpc/grpc-js';
-import * as os from 'os';
-import * as path from 'path';
 import JSON5 from 'json5';
-import { isEmpty } from 'lodash';
 import fg from 'fast-glob';
 import {
   buildReflectionClient,
@@ -19,7 +16,8 @@ import {
   discoverMethodsForSelectedServices,
   loadProtoFromRemoteUrl,
   extractServicesFromGrpcPackage,
-  executeGrpcMethod
+  executeGrpcMethod,
+  resolveFilesystemConfig,
 } from './operations';
 
 export default class Grpcv2QueryService implements QueryService {
@@ -77,7 +75,7 @@ export default class Grpcv2QueryService implements QueryService {
           break;
 
         case 'import_protos_from_filesystem': {
-          const { directory, pattern } = this.resolveFilesystemConfig(sourceOptions);
+          const { directory, pattern } = resolveFilesystemConfig(sourceOptions);
           const expandedDir = validateFilesystemAccess(directory);
 
           // Count proto files — don't parse them
@@ -222,19 +220,6 @@ export default class Grpcv2QueryService implements QueryService {
     }
   }
 
-  /**
-   * Resolves the filesystem proto directory and glob pattern from source options,
-   * falling back to ~/protos and **\/*.proto respectively.
-   */
-  private resolveFilesystemConfig(sourceOptions: SourceOptions): { directory: string; pattern: string } {
-    const directory = isEmpty(sourceOptions.proto_files_directory)
-      ? path.join(os.homedir(), 'protos')
-      : sourceOptions.proto_files_directory;
-    const pattern = isEmpty(sourceOptions.proto_files_pattern)
-      ? '**/*.proto'
-      : sourceOptions.proto_files_pattern;
-    return { directory, pattern };
-  }
 
   /**
    * Lightweight service name enumeration for the DS config page (filesystem mode).
@@ -243,7 +228,7 @@ export default class Grpcv2QueryService implements QueryService {
    */
   private async listServices(sourceOptions: SourceOptions): Promise<Array<{ label: string; value: string }>> {
     try {
-      const { directory, pattern } = this.resolveFilesystemConfig(sourceOptions);
+      const { directory, pattern } = resolveFilesystemConfig(sourceOptions);
 
       const { serviceNames, failures } = await discoverServiceNamesFromFilesystem(directory, pattern);
 
@@ -272,7 +257,7 @@ export default class Grpcv2QueryService implements QueryService {
 
       if (sourceOptions.proto_files === 'import_protos_from_filesystem') {
         if (!serviceNames?.length) return [];
-        const { directory, pattern } = this.resolveFilesystemConfig(sourceOptions);
+        const { directory, pattern } = resolveFilesystemConfig(sourceOptions);
         const { services } = await discoverMethodsForSelectedServices(directory, pattern, serviceNames);
         return services;
       }

--- a/plugins/packages/grpcv2/lib/operations.ts
+++ b/plugins/packages/grpcv2/lib/operations.ts
@@ -24,8 +24,7 @@ const getDefaultProtoDirectory = (): string => {
   return path.join(os.homedir(), 'protos');
 };
 
-// Single source of truth for directory/pattern defaults — discovery writers and
-// client readers must derive identical discoveryCache keys
+// writers and readers must derive identical discoveryCache keys
 export const resolveFilesystemConfig = (sourceOptions: SourceOptions): { directory: string; pattern: string } => {
   const directory = isEmpty(sourceOptions.proto_files_directory)
     ? getDefaultProtoDirectory()
@@ -388,21 +387,19 @@ type FilesystemDiscovery = {
   failures: Array<{ file: string; error: string }>;
 };
 
-// Discovery results keyed by directory+pattern so data sources pointing at
-// different proto directories don't clobber each other. The proto directory is
-// the source of truth, so entries are only reused while its fingerprint holds.
+// keyed by dir+pattern; reused only while the dir fingerprint holds
 const discoveryCache = new Map<string, { fingerprint: string; result: FilesystemDiscovery }>();
 
 const discoveryCacheKey = (directory: string, pattern: string): string => `${directory}::${pattern}`;
 
-// Paths + mtimes: the glob is cheap, the per-file parse it guards is not
+// glob is cheap, the per-file parse it guards is not
 const fingerprintProtoFiles = (entries: Array<{ path: string; stats?: fs.Stats }>): string =>
   entries
     .map((entry) => `${entry.path}:${entry.stats?.mtimeMs ?? 0}`)
     .sort()
     .join('|');
 
-// Lookup only — no glob, so the query path stays free of filesystem work
+// lookup only — keeps the query path off the filesystem
 const cachedProtoFileForService = (directory: string, pattern: string, serviceName: string): string | undefined =>
   discoveryCache.get(discoveryCacheKey(directory, pattern))?.result.serviceToFileMap.get(serviceName);
 
@@ -490,7 +487,6 @@ export const discoverMethodsForSelectedServices = async (
   pattern: string,
   selectedServiceNames: string[]
 ): Promise<{ services: GrpcService[]; failures: Array<{ file: string; error: string }> }> => {
-  // Cheap when the directory is unchanged — the cache short-circuits the re-parse
   const { serviceToFileMap: fileMap } = await discoverServiceNamesFromFilesystem(directory, pattern);
 
   // Find the proto files for requested services, de-duplicate

--- a/plugins/packages/grpcv2/lib/operations.ts
+++ b/plugins/packages/grpcv2/lib/operations.ts
@@ -147,7 +147,7 @@ export const buildFilesystemClient = async (sourceOptions: SourceOptions, servic
     let packageDefinition: protoLoader.PackageDefinition;
 
     // Try to use the mapping from last discovery to load only the specific file
-    const protoFile = lastServiceToFileMap.get(serviceName);
+    const protoFile = serviceFileMaps.get(serviceFileMapKey(directory, protoFilePattern))?.get(serviceName);
 
     if (protoFile && fs.existsSync(protoFile)) {
       // Load only the specific file containing this service
@@ -380,8 +380,14 @@ export const discoverServicesUsingProtoUrl = async (sourceOptions: SourceOptions
   }
 };
 
-// Module-level storage for service-to-file mapping (not cached with TTL, just per-discovery)
-let lastServiceToFileMap = new Map<string, string>();
+// Service-to-file mappings keyed by directory+pattern so data sources
+// pointing at different proto directories don't clobber each other
+const serviceFileMaps = new Map<string, Map<string, string>>();
+
+const serviceFileMapKey = (directory: string, pattern: string): string => `${directory}::${pattern}`;
+
+// Yield between files so long sweeps don't starve the event loop (health probes, other requests)
+const yieldEventLoop = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 /**
  * Lightweight service name discovery using protobufjs.parse().
@@ -435,10 +441,12 @@ export const discoverServiceNamesFromFilesystem = async (
       const fileName = path.basename(protoFile);
       failures.push({ file: fileName, error: err.message });
     }
+
+    await yieldEventLoop();
   }
 
   // Store mapping for use in buildFilesystemClient
-  lastServiceToFileMap = serviceToFileMap;
+  serviceFileMaps.set(serviceFileMapKey(directory, pattern), serviceToFileMap);
 
   return { serviceNames, serviceToFileMap, failures };
 };
@@ -452,15 +460,16 @@ export const discoverMethodsForSelectedServices = async (
   pattern: string,
   selectedServiceNames: string[]
 ): Promise<{ services: GrpcService[]; failures: Array<{ file: string; error: string }> }> => {
-  // If we don't have a mapping yet, discover service names first to build it
-  if (lastServiceToFileMap.size === 0) {
-    await discoverServiceNamesFromFilesystem(directory, pattern);
+  // If we don't have a mapping for this directory yet, discover service names first to build it
+  let fileMap = serviceFileMaps.get(serviceFileMapKey(directory, pattern));
+  if (!fileMap || fileMap.size === 0) {
+    ({ serviceToFileMap: fileMap } = await discoverServiceNamesFromFilesystem(directory, pattern));
   }
 
   // Find the proto files for requested services, de-duplicate
   const filesToParse = new Set<string>();
   for (const serviceName of selectedServiceNames) {
-    const file = lastServiceToFileMap.get(serviceName);
+    const file = fileMap.get(serviceName);
     if (file) {
       filesToParse.add(file);
     }

--- a/plugins/packages/grpcv2/lib/operations.ts
+++ b/plugins/packages/grpcv2/lib/operations.ts
@@ -25,7 +25,7 @@ const getDefaultProtoDirectory = (): string => {
 };
 
 // Single source of truth for directory/pattern defaults — discovery writers and
-// client readers must derive identical serviceFileMaps keys
+// client readers must derive identical discoveryCache keys
 export const resolveFilesystemConfig = (sourceOptions: SourceOptions): { directory: string; pattern: string } => {
   const directory = isEmpty(sourceOptions.proto_files_directory)
     ? getDefaultProtoDirectory()
@@ -149,7 +149,7 @@ export const buildFilesystemClient = async (sourceOptions: SourceOptions, servic
     let packageDefinition: protoLoader.PackageDefinition;
 
     // Try to use the mapping from last discovery to load only the specific file
-    const protoFile = serviceFileMaps.get(serviceFileMapKey(directory, protoFilePattern))?.get(serviceName);
+    const protoFile = cachedProtoFileForService(directory, protoFilePattern, serviceName);
 
     if (protoFile && fs.existsSync(protoFile)) {
       // Load only the specific file containing this service
@@ -382,36 +382,64 @@ export const discoverServicesUsingProtoUrl = async (sourceOptions: SourceOptions
   }
 };
 
-// Service-to-file mappings keyed by directory+pattern so data sources
-// pointing at different proto directories don't clobber each other
-const serviceFileMaps = new Map<string, Map<string, string>>();
+type FilesystemDiscovery = {
+  serviceNames: string[];
+  serviceToFileMap: Map<string, string>;
+  failures: Array<{ file: string; error: string }>;
+};
 
-const serviceFileMapKey = (directory: string, pattern: string): string => `${directory}::${pattern}`;
+// Discovery results keyed by directory+pattern so data sources pointing at
+// different proto directories don't clobber each other. The proto directory is
+// the source of truth, so entries are only reused while its fingerprint holds.
+const discoveryCache = new Map<string, { fingerprint: string; result: FilesystemDiscovery }>();
+
+const discoveryCacheKey = (directory: string, pattern: string): string => `${directory}::${pattern}`;
+
+// Paths + mtimes: the glob is cheap, the per-file parse it guards is not
+const fingerprintProtoFiles = (entries: Array<{ path: string; stats?: fs.Stats }>): string =>
+  entries
+    .map((entry) => `${entry.path}:${entry.stats?.mtimeMs ?? 0}`)
+    .sort()
+    .join('|');
+
+// Lookup only — no glob, so the query path stays free of filesystem work
+const cachedProtoFileForService = (directory: string, pattern: string, serviceName: string): string | undefined =>
+  discoveryCache.get(discoveryCacheKey(directory, pattern))?.result.serviceToFileMap.get(serviceName);
 
 // Yield between files so long sweeps don't starve the event loop (health probes, other requests)
 const yieldEventLoop = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 /**
  * Lightweight service name discovery using protobufjs.parse().
+ * Re-parses only when the proto directory's file list or mtimes have changed.
  */
 export const discoverServiceNamesFromFilesystem = async (
   directory: string,
   pattern: string
-): Promise<{ serviceNames: string[]; serviceToFileMap: Map<string, string>; failures: Array<{ file: string; error: string }> }> => {
+): Promise<FilesystemDiscovery> => {
   const expandedDir = validateFilesystemAccess(directory);
 
-  const protoFiles = await fg(pattern, {
+  const entries = await fg(pattern, {
     cwd: expandedDir,
     onlyFiles: true,
-    absolute: true
+    absolute: true,
+    stats: true
   });
 
-  if (protoFiles.length === 0) {
+  if (entries.length === 0) {
     throw new GrpcOperationError(
       `No .proto files found in directory: ${expandedDir} with pattern: ${pattern}`
     );
   }
 
+  const cacheKey = discoveryCacheKey(directory, pattern);
+  const fingerprint = fingerprintProtoFiles(entries);
+  const cached = discoveryCache.get(cacheKey);
+  if (cached?.fingerprint === fingerprint) {
+    return cached.result;
+  }
+
+  const protoFiles = entries.map((entry) => entry.path);
   const serviceNames: string[] = [];
   const failures: Array<{ file: string; error: string }> = [];
   const serviceToFileMap = new Map<string, string>();
@@ -447,10 +475,10 @@ export const discoverServiceNamesFromFilesystem = async (
     await yieldEventLoop();
   }
 
-  // Store mapping for use in buildFilesystemClient
-  serviceFileMaps.set(serviceFileMapKey(directory, pattern), serviceToFileMap);
+  const result = { serviceNames, serviceToFileMap, failures };
+  discoveryCache.set(cacheKey, { fingerprint, result });
 
-  return { serviceNames, serviceToFileMap, failures };
+  return result;
 };
 
 /**
@@ -462,11 +490,8 @@ export const discoverMethodsForSelectedServices = async (
   pattern: string,
   selectedServiceNames: string[]
 ): Promise<{ services: GrpcService[]; failures: Array<{ file: string; error: string }> }> => {
-  // If we don't have a mapping for this directory yet, discover service names first to build it
-  let fileMap = serviceFileMaps.get(serviceFileMapKey(directory, pattern));
-  if (!fileMap || fileMap.size === 0) {
-    ({ serviceToFileMap: fileMap } = await discoverServiceNamesFromFilesystem(directory, pattern));
-  }
+  // Cheap when the directory is unchanged — the cache short-circuits the re-parse
+  const { serviceToFileMap: fileMap } = await discoverServiceNamesFromFilesystem(directory, pattern);
 
   // Find the proto files for requested services, de-duplicate
   const filesToParse = new Set<string>();

--- a/plugins/packages/grpcv2/lib/operations.ts
+++ b/plugins/packages/grpcv2/lib/operations.ts
@@ -24,6 +24,16 @@ const getDefaultProtoDirectory = (): string => {
   return path.join(os.homedir(), 'protos');
 };
 
+// Single source of truth for directory/pattern defaults — discovery writers and
+// client readers must derive identical serviceFileMaps keys
+export const resolveFilesystemConfig = (sourceOptions: SourceOptions): { directory: string; pattern: string } => {
+  const directory = isEmpty(sourceOptions.proto_files_directory)
+    ? getDefaultProtoDirectory()
+    : sourceOptions.proto_files_directory;
+  const pattern = isEmpty(sourceOptions.proto_files_pattern) ? '**/*.proto' : sourceOptions.proto_files_pattern;
+  return { directory, pattern };
+};
+
 export const validateFilesystemAccess = (directory: string): string => {
   // Expand ~ to home directory if needed
   const expandedDir = expandPath(directory);
@@ -134,15 +144,7 @@ export const buildProtoFileClient = async (sourceOptions: SourceOptions, service
 
 export const buildFilesystemClient = async (sourceOptions: SourceOptions, serviceName: string): Promise<GrpcClient> => {
   try {
-    const directory =
-      isEmpty(sourceOptions.proto_files_directory) ?
-        getDefaultProtoDirectory() :
-        sourceOptions.proto_files_directory;
-
-    const protoFilePattern =
-      isEmpty(sourceOptions.proto_files_pattern) ?
-        '**/*.proto' :
-        sourceOptions.proto_files_pattern;
+    const { directory, pattern: protoFilePattern } = resolveFilesystemConfig(sourceOptions);
 
     let packageDefinition: protoLoader.PackageDefinition;
 

--- a/server/src/modules/data-sources/service.ts
+++ b/server/src/modules/data-sources/service.ts
@@ -1,5 +1,4 @@
-import { BadRequestException, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
-import { RedisService } from '@modules/redis/service';
+import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { DataSourcesRepository } from './repository';
 import { DataSourcesUtilService } from './util.service';
 import { DataQueriesUtilService } from '@modules/data-queries/util.service';
@@ -29,16 +28,8 @@ import { DataSourceVersion } from '@entities/data_source_version.entity';
 import { dbTransactionWrap } from '@helpers/database.helper';
 import { EntityManager } from 'typeorm';
 
-// gRPC filesystem service discovery sweeps the whole proto directory; cache it
-const GRPC_DISCOVERY_CACHE_PREFIX = 'grpc_service_discovery:';
-const GRPC_DISCOVERY_CACHE_TTL_SECONDS = 300;
-
 @Injectable()
 export class DataSourcesService implements IDataSourcesService {
-  // Property injection: keeps the constructor signature stable for the EE subclass
-  @Inject(RedisService)
-  protected readonly redisService: RedisService;
-
   constructor(
     protected readonly dataSourcesRepository: DataSourcesRepository,
     protected readonly dataSourcesUtilService: DataSourcesUtilService,
@@ -385,12 +376,6 @@ export class DataSourcesService implements IDataSourcesService {
       effectiveBranchId
     );
 
-    const cacheKey = this.invokeMethodCacheKey(dataSource, methodName, dataSourceOptions);
-    if (cacheKey) {
-      const cached = await this.getCachedInvokeResult(cacheKey);
-      if (cached) return cached;
-    }
-
     const sourceOptions = await this.dataSourcesUtilService.parseSourceOptions(
       dataSourceOptions.options,
       user.organizationId,
@@ -424,9 +409,7 @@ export class DataSourcesService implements IDataSourcesService {
         sourceOptions,
         resolvedArgs
       );
-      const queryResult: QueryResult = { status: 'ok', data: result };
-      if (cacheKey) await this.cacheInvokeResult(cacheKey, queryResult);
-      return queryResult;
+      return { status: 'ok', data: result };
     } catch (error) {
       if (error.constructor.name === 'OAuthUnauthorizedClientError') {
         const currentUserToken = sourceOptions['refresh_token']
@@ -513,39 +496,4 @@ export class DataSourcesService implements IDataSourcesService {
       return tokenData;
     }
   };
-
-  // options row id + updatedAt in the key, so branch switches and saves naturally invalidate
-  protected invokeMethodCacheKey(
-    dataSource: DataSource,
-    methodName: string,
-    dataSourceOptions: { id?: string; environmentId?: string; updatedAt?: Date }
-  ): string | null {
-    if (dataSource.kind !== 'grpcv2' || methodName !== 'listServices') return null;
-    const version = dataSourceOptions?.updatedAt ? new Date(dataSourceOptions.updatedAt).getTime() : 0;
-    return `${GRPC_DISCOVERY_CACHE_PREFIX}${dataSource.id}:${dataSourceOptions?.environmentId}:${dataSourceOptions?.id}:${methodName}:${version}`;
-  }
-
-  protected async getCachedInvokeResult(cacheKey: string): Promise<QueryResult | null> {
-    try {
-      const client = this.redisService.getClient();
-      // skip when Redis is down — ioredis offline queue would stall the request for seconds
-      if (client.status !== 'ready') return null;
-      const cached = await client.get(cacheKey);
-      return cached ? (JSON.parse(cached) as QueryResult) : null;
-    } catch {
-      return null;
-    }
-  }
-
-  protected async cacheInvokeResult(cacheKey: string, result: QueryResult): Promise<void> {
-    // listServices returns [] when the directory is invalid; don't cache failures
-    if (Array.isArray(result.data) && result.data.length === 0) return;
-    try {
-      const client = this.redisService.getClient();
-      if (client.status !== 'ready') return;
-      await client.set(cacheKey, JSON.stringify(result), 'EX', GRPC_DISCOVERY_CACHE_TTL_SECONDS);
-    } catch {
-      // cache write failure is non-fatal
-    }
-  }
 }

--- a/server/src/modules/data-sources/service.ts
+++ b/server/src/modules/data-sources/service.ts
@@ -1,4 +1,5 @@
-import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { RedisService } from '@modules/redis/service';
 import { DataSourcesRepository } from './repository';
 import { DataSourcesUtilService } from './util.service';
 import { DataQueriesUtilService } from '@modules/data-queries/util.service';
@@ -28,8 +29,17 @@ import { DataSourceVersion } from '@entities/data_source_version.entity';
 import { dbTransactionWrap } from '@helpers/database.helper';
 import { EntityManager } from 'typeorm';
 
+// gRPC filesystem service discovery sweeps the whole proto directory; cache it
+const GRPC_DISCOVERY_CACHE_PREFIX = 'grpc_service_discovery:';
+const GRPC_DISCOVERY_CACHE_TTL_SECONDS = 300;
+const CACHEABLE_INVOKE_METHODS: Record<string, string[]> = { grpcv2: ['listServices'] };
+
 @Injectable()
 export class DataSourcesService implements IDataSourcesService {
+  // Property injection: keeps the constructor signature stable for the EE subclass
+  @Inject(RedisService)
+  protected readonly redisService: RedisService;
+
   constructor(
     protected readonly dataSourcesRepository: DataSourcesRepository,
     protected readonly dataSourcesUtilService: DataSourcesUtilService,
@@ -376,6 +386,12 @@ export class DataSourcesService implements IDataSourcesService {
       effectiveBranchId
     );
 
+    const cacheKey = this.invokeMethodCacheKey(dataSource, methodName, dataSourceOptions);
+    if (cacheKey) {
+      const cached = await this.getCachedInvokeResult(cacheKey);
+      if (cached) return cached;
+    }
+
     const sourceOptions = await this.dataSourcesUtilService.parseSourceOptions(
       dataSourceOptions.options,
       user.organizationId,
@@ -409,7 +425,9 @@ export class DataSourcesService implements IDataSourcesService {
         sourceOptions,
         resolvedArgs
       );
-      return { status: 'ok', data: result };
+      const queryResult: QueryResult = { status: 'ok', data: result };
+      if (cacheKey) await this.cacheInvokeResult(cacheKey, queryResult);
+      return queryResult;
     } catch (error) {
       if (error.constructor.name === 'OAuthUnauthorizedClientError') {
         const currentUserToken = sourceOptions['refresh_token']
@@ -496,4 +514,36 @@ export class DataSourcesService implements IDataSourcesService {
       return tokenData;
     }
   };
+
+  // options updatedAt is part of the key, so saving the data source naturally invalidates
+  protected invokeMethodCacheKey(
+    dataSource: DataSource,
+    methodName: string,
+    dataSourceOptions: { environmentId?: string; updatedAt?: Date }
+  ): string | null {
+    if (!CACHEABLE_INVOKE_METHODS[dataSource.kind]?.includes(methodName)) return null;
+    const version = dataSourceOptions?.updatedAt ? new Date(dataSourceOptions.updatedAt).getTime() : 0;
+    return `${GRPC_DISCOVERY_CACHE_PREFIX}${dataSource.id}:${dataSourceOptions?.environmentId}:${methodName}:${version}`;
+  }
+
+  protected async getCachedInvokeResult(cacheKey: string): Promise<QueryResult | null> {
+    try {
+      const cached = await this.redisService.getClient().get(cacheKey);
+      return cached ? (JSON.parse(cached) as QueryResult) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  protected async cacheInvokeResult(cacheKey: string, result: QueryResult): Promise<void> {
+    // listServices returns [] when the directory is invalid; don't cache failures
+    if (Array.isArray(result.data) && result.data.length === 0) return;
+    try {
+      await this.redisService
+        .getClient()
+        .set(cacheKey, JSON.stringify(result), 'EX', GRPC_DISCOVERY_CACHE_TTL_SECONDS);
+    } catch {
+      // cache write failure is non-fatal
+    }
+  }
 }

--- a/server/src/modules/data-sources/service.ts
+++ b/server/src/modules/data-sources/service.ts
@@ -32,7 +32,6 @@ import { EntityManager } from 'typeorm';
 // gRPC filesystem service discovery sweeps the whole proto directory; cache it
 const GRPC_DISCOVERY_CACHE_PREFIX = 'grpc_service_discovery:';
 const GRPC_DISCOVERY_CACHE_TTL_SECONDS = 300;
-const CACHEABLE_INVOKE_METHODS: Record<string, string[]> = { grpcv2: ['listServices'] };
 
 @Injectable()
 export class DataSourcesService implements IDataSourcesService {
@@ -515,20 +514,23 @@ export class DataSourcesService implements IDataSourcesService {
     }
   };
 
-  // options updatedAt is part of the key, so saving the data source naturally invalidates
+  // options row id + updatedAt in the key, so branch switches and saves naturally invalidate
   protected invokeMethodCacheKey(
     dataSource: DataSource,
     methodName: string,
-    dataSourceOptions: { environmentId?: string; updatedAt?: Date }
+    dataSourceOptions: { id?: string; environmentId?: string; updatedAt?: Date }
   ): string | null {
-    if (!CACHEABLE_INVOKE_METHODS[dataSource.kind]?.includes(methodName)) return null;
+    if (dataSource.kind !== 'grpcv2' || methodName !== 'listServices') return null;
     const version = dataSourceOptions?.updatedAt ? new Date(dataSourceOptions.updatedAt).getTime() : 0;
-    return `${GRPC_DISCOVERY_CACHE_PREFIX}${dataSource.id}:${dataSourceOptions?.environmentId}:${methodName}:${version}`;
+    return `${GRPC_DISCOVERY_CACHE_PREFIX}${dataSource.id}:${dataSourceOptions?.environmentId}:${dataSourceOptions?.id}:${methodName}:${version}`;
   }
 
   protected async getCachedInvokeResult(cacheKey: string): Promise<QueryResult | null> {
     try {
-      const cached = await this.redisService.getClient().get(cacheKey);
+      const client = this.redisService.getClient();
+      // skip when Redis is down — ioredis offline queue would stall the request for seconds
+      if (client.status !== 'ready') return null;
+      const cached = await client.get(cacheKey);
       return cached ? (JSON.parse(cached) as QueryResult) : null;
     } catch {
       return null;
@@ -539,9 +541,9 @@ export class DataSourcesService implements IDataSourcesService {
     // listServices returns [] when the directory is invalid; don't cache failures
     if (Array.isArray(result.data) && result.data.length === 0) return;
     try {
-      await this.redisService
-        .getClient()
-        .set(cacheKey, JSON.stringify(result), 'EX', GRPC_DISCOVERY_CACHE_TTL_SECONDS);
+      const client = this.redisService.getClient();
+      if (client.status !== 'ready') return;
+      await client.set(cacheKey, JSON.stringify(result), 'EX', GRPC_DISCOVERY_CACHE_TTL_SECONDS);
     } catch {
       // cache write failure is non-fatal
     }


### PR DESCRIPTION
## 📝 What this does
Fixes the reported crash where configuring gRPC data sources with large proto directories froze the instance ("no healthy upstream", constants failing to resolve on the data source page). The filesystem service discovery no longer blocks the event loop, no longer re-parses on every page visit, and multiple gRPC data sources no longer invalidate each other's discovery state.

## 🔀 Changes
- Keyed the service-to-file mapping by proto directory + pattern, so multiple gRPC data sources with different directories stop clobbering each other and forcing full re-sweeps
- Added an event-loop yield between proto file parses, so long sweeps no longer starve health probes and other requests
- Cached discovery results in the plugin, keyed on the proto directory's file list and mtimes. The glob is cheap; the per-file `protobuf.parse` it guards is not, so repeat page visits and environment switches skip the sweep, while adding, editing or removing a `.proto` file invalidates immediately
- The query path keeps lookup-only access to the cached service-to-file mapping, so running a query does no filesystem work

## 🧪 How to test
- [x] Configure a filesystem gRPC data source pointing at a large proto directory
- [x] Open the data source page and switch environment tabs repeatedly; server stays responsive and health endpoint keeps answering
- [x] Reopen the page; services dropdown loads without re-parsing (no discovery log spam)
- [x] Drop a new `.proto` file into the directory and reopen the page; the new service appears immediately
- [x] Edit or delete a `.proto` file and reopen; the services list reflects the change immediately
- [x] Create two gRPC data sources with different proto directories; queries on both keep working without re-discovery log spam

## 🔍 Note on the earlier approach
An earlier revision of this PR cached `listServices` in Redis from `DataSourcesService.invokeMethod`. That key was derived entirely from database state (data source id, environment, options row id and `updatedAt`), while filesystem discovery reads the proto directory — so a `.proto` file added or changed on disk stayed invisible for the full five-minute TTL, and QA hit exactly that. It also defeated the dynamic selector's deliberate "always fetch fresh data for autoFetch" behaviour. That cache has been removed; `server/src/modules/data-sources/service.ts` is untouched by this PR now.
