### PR TITLE
BugFix: Table widget DateTime column produces wrong value on edit when unit is milliseconds

### DIFF
--- a/frontend/src/AppBuilder/Shared/DataTypes/renderers/DatePickerRenderer.jsx
+++ b/frontend/src/AppBuilder/Shared/DataTypes/renderers/DatePickerRenderer.jsx
@@ -200,7 +200,7 @@ export const DatePickerRenderer = ({
     (newDate) => {
       let processedValue = newDate;
       if (parseInUnixTimestamp && unixTimestamp) {
-        processedValue = moment(newDate).unix();
+        processedValue = unixTimestamp === 'seconds' ? moment(newDate).unix() : moment(newDate).unix() * 1000;
       }
 
       const parsedDate = parseDate({
@@ -220,7 +220,7 @@ export const DatePickerRenderer = ({
 
       setDate(parsedDate);
       if (parseInUnixTimestamp && unixTimestamp) {
-        onChange?.(moment(parsedDate).unix());
+        onChange?.(unixTimestamp === 'seconds' ? moment(parsedDate).unix() : moment(parsedDate).valueOf());
       } else {
         onChange?.(computeDateString(parsedDate));
       }


### PR DESCRIPTION
# table_date_unix_issue: Table widget DateTime column produces wrong value on edit when unit is milliseconds

Issue: No ticket
Replication: https://jam.dev/c/e68804b6-cfad-4ee9-8c4a-97c506d27656

## Issue Description

In the Table widget, when a Datepicker column has "Parse in unix timestamp" enabled and the unit set to `milliseconds`, editing the cell and picking a date (e.g. `12/08/2026 12am`) stores a small, incorrect number (e.g. `1786492`) in the table's edited data instead of a proper millisecond epoch (e.g. `1786492800000`).

## Root Cause

`handleDateChange` in `frontend/src/AppBuilder/Shared/DataTypes/renderers/DatePickerRenderer.jsx` always converted the picked date to **seconds** via `moment(newDate).unix()`, regardless of the column's configured `unixTimestamp` unit:

```js
processedValue = moment(newDate).unix(); // always seconds
```

This seconds value was then passed into `parseDate()`, which — for `unixTimestamp === 'milliseconds'` — interprets a bare number as milliseconds:

```js
momentObj = unixTimestamp === 'seconds' ? moment.unix(value) : moment(parseInt(value));
```

Feeding a seconds-scale number (`1786492800`) into a millisecond-scale parser resolves to a bogus date ~20.7 days after epoch (`1970-01-21T16:14:52.800Z`). That bogus date was then converted back to seconds for the final `onChange` value (`moment(parsedDate).unix()`), yielding `1786492` — mathematically `floor(correctUnixSeconds / 1000)`.

The bug was a unit-mismatch double round-trip: seconds → mis-parsed-as-ms → seconds, instead of a single conversion matching the configured unit. This value flowed unmodified into `editedRows`/`editedFields` (`frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/initSlice.js`) and out to the exposed `changeSet`/`dataUpdates`/`updatedData` variables, since no transformation happens downstream of the renderer.

## Fix

In `frontend/src/AppBuilder/Shared/DataTypes/renderers/DatePickerRenderer.jsx`, `handleDateChange` now branches on the configured unit at both conversion points instead of always assuming seconds:

```js
// Before parseDate: convert to the unit parseDate expects
processedValue = unixTimestamp === 'seconds' ? moment(newDate).unix() : moment(newDate).unix() * 1000;

// After parseDate: emit in the same configured unit
onChange?.(unixTimestamp === 'seconds' ? moment(parsedDate).unix() : moment(parsedDate).valueOf());
```

`.valueOf()` is used for the final millisecond output (rather than `unix() * 1000`) since `parsedDate` is already a correct `Date` object at that point, avoiding an unnecessary floor-to-seconds step.

`handleInputDateChange` (manual text entry) and the value-initialization `useEffect` were not affected — they parse the incoming `value` prop directly via `parseDate` without this seconds/ms round-trip.

## Areas to Test

- Datepicker column with "Parse in unix timestamp" on, unit = `milliseconds`: pick a date via the picker, confirm `changeSet`/`updatedData` holds the correct 13-digit ms epoch.
- Datepicker column with unit = `seconds`: confirm existing behavior (10-digit seconds epoch) is unchanged.
- Datepicker column with "Parse in unix timestamp" off: confirm the formatted date string output (`computeDateString`) is unchanged.
- Round-trip: save an edited unix-timestamp cell back to a DB column (e.g. via `{{ moment(table1.changeSet.col).format(...) }}` in the update query) and confirm the correct date lands in the DB.
- Time selection (`isTimeChecked`) combined with unix timestamp mode, to confirm time-of-day is preserved correctly through the fixed conversion.
- KeyValuePair widget's `DatepickerFieldAdapter`, which shares `DatePickerRenderer` — confirm unix timestamp editing there is also correct.

## Known Follow-up (Out of Scope for This Fix)

The Table widget's `column.transformation` (display-only formatting) has no reverse-transformation mechanism — any value typed into an editable cell is stored as-is into `changeSet`/`dataUpdates`/`updatedData`, without re-applying or inverting the column's transformation. This is expected given `transformation` is an arbitrary, not-necessarily-invertible JS expression, and was not addressed here. The practical workaround, discussed and confirmed independent of the Table's exposed data, is to perform any needed conversion (e.g. unix timestamp back to a DB-appropriate date string) inline in the destination query's own `{{ }}` binding (e.g. `{{ moment.unix(table1.changeSet.col).format('YYYY-MM-DD HH:mm:ss') }}`), since query transformations only run post-execution and cannot intercept outgoing values.
