### PR TITLE
[UI BUG FIX]: Component config handle position issue resolved

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/ConfigHandle/ConfigHandle.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/ConfigHandle/ConfigHandle.jsx
@@ -18,7 +18,6 @@ import { Button as ButtonComponent } from '@/components/ui/Button/Button.jsx';
 // Lazy load editor-only component to reduce viewer bundle size
 const MentionComponentInChat = lazy(() => import('./MentionComponentInChat'));
 
-const CONFIG_HANDLE_HEIGHT = 20;
 const BUFFER_HEIGHT = 1;
 
 export const ConfigHandle = ({
@@ -205,7 +204,7 @@ export const ConfigHandle = ({
             ? '0px'
             : position === 'top'
             ? '-26px'
-            : `${height - (CONFIG_HANDLE_HEIGHT + BUFFER_HEIGHT)}px`,
+            : `${height + BUFFER_HEIGHT}px`,
         visibility: _showHandle || visibility === false ? 'visible' : 'hidden',
         left: '-1px',
         display: 'flex',


### PR DESCRIPTION
# Config handle overlaps component at top of canvas
Issue Replication: https://jam.dev/c/148fab57-f0ce-43cd-9686-375001b44dc3

## Issue Description

When a component (e.g. a Button) is placed at the very top of the app canvas, the floating selection toolbar — the badge showing the component name plus the state-inspector, properties, and delete icon buttons — normally appears just above the component. With no room above, it instead overlapped the lower portion of the component itself, hiding part of it and getting in the way of interacting with it.

## Root Cause

The handle is rendered by `ConfigHandle` in `frontend/src/AppBuilder/AppCanvas/ConfigHandle/ConfigHandle.jsx`, as a sibling of the widget inside the same wrapper `div` in `frontend/src/AppBuilder/AppCanvas/WidgetWrapper.jsx:263-277`. That wrapper has `transform: translate(...)` (`WidgetWrapper.jsx:184`), which makes it the containing block for the handle's `position: fixed`, so the handle's `top` CSS value is relative to the widget's own top-left corner.

`ConfigHandle.jsx:58` already detects when there isn't room above:

```js
const position = widgetTop < 15 ? 'bottom' : 'top';
```

But the `'bottom'` branch's offset was wrong. It computed:

```js
top: `${height - (CONFIG_HANDLE_HEIGHT + BUFFER_HEIGHT)}px`
```

`height` is the widget's own height, so `height - 21px` places the handle's top edge *inside* the widget, near its bottom edge — not below it. For a typical Button, this put the name badge and icon buttons directly over the lower part of the component instead of underneath it.

## Fix

In `frontend/src/AppBuilder/AppCanvas/ConfigHandle/ConfigHandle.jsx`, the `'bottom'` offset was changed to place the handle just outside the widget's bottom edge instead of inside it:

```js
top: `${height + BUFFER_HEIGHT}px`
```

This sets the handle's top edge to sit right at the widget's bottom edge, so it renders directly below the component with no overlap. The now-unused `CONFIG_HANDLE_HEIGHT` constant was removed.

## Areas to Test

- A Button (or any component) dropped at the very top of the canvas (y ≈ 0) — handle should appear fully below the component, not overlapping it.
- A component placed anywhere else on the canvas with normal space above — handle should still appear above, unchanged.
- A very short/hidden component near the top of the canvas (`visibility: false`, collapsed height) — confirm the handle still renders below without overlapping the collapsed slot.
- Modal components (open state) — unaffected, since they use a separate `top: '0px'` branch.
- Flex-layout children near the top of a flex container (uses `position: absolute` via the `flex-child-config-handle` class but shares the same `top` calculation) — confirm no overlap there either.

## Fix Screenshot:
<img width="281" height="169" alt="image" src="https://github.com/user-attachments/assets/fe1b9dc3-a7df-4fcb-b0aa-9278488bd2f3" />
