### PR TITLE
fix(groups): rename Folder resource copy to App folder and fix visibility

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -313,7 +313,7 @@
                         "email": "email",
                         "resource": "Resource",
                         "createUpdateDelete": "Create/Update/Delete",
-                        "folder": "Folder",
+                        "folder": "App folder",
                         "dataSource": "Data sources",
                         "tooljetDatabase": "ToolJet Database"
                     },

--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGranularAccess/components/AddEditResourceModal/AddEditResourcePermissionsModal.jsx
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGranularAccess/components/AddEditResourceModal/AddEditResourcePermissionsModal.jsx
@@ -53,7 +53,7 @@ function AddEditResourcePermissionsModal({
       case RESOURCE_TYPE.DATA_SOURCES:
         return 'This will select all data sources in the workspace including any new connections created';
       case RESOURCE_TYPE.FOLDERS:
-        return 'This will select all folders in the workspace including any new folders created';
+        return 'This will select all app folders in the workspace including any new app folders created';
       case RESOURCE_TYPE.WORKFLOW_FOLDERS:
         return 'This will select all workflow folders in the workspace including any new workflow folders created';
       case RESOURCE_TYPE.MODULE_FOLDERS:
@@ -66,7 +66,7 @@ function AddEditResourcePermissionsModal({
     [RESOURCE_TYPE.WORKFLOWS]: 'workflows',
     [RESOURCE_TYPE.MODULES]: 'modules',
     [RESOURCE_TYPE.DATA_SOURCES]: 'data sources',
-    [RESOURCE_TYPE.FOLDERS]: 'folders',
+    [RESOURCE_TYPE.FOLDERS]: 'app folders',
     [RESOURCE_TYPE.WORKFLOW_FOLDERS]: 'workflow folders',
     [RESOURCE_TYPE.MODULE_FOLDERS]: 'module folders',
   };
@@ -82,7 +82,7 @@ function AddEditResourcePermissionsModal({
       case RESOURCE_TYPE.DATA_SOURCES:
         return 'All data sources';
       case RESOURCE_TYPE.FOLDERS:
-        return 'All folders';
+        return 'All app folders';
       case RESOURCE_TYPE.WORKFLOW_FOLDERS:
         return 'All workflow folders';
       case RESOURCE_TYPE.MODULE_FOLDERS:

--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGranularAccess/components/AddResourcePermissionsMenu.jsx
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGranularAccess/components/AddResourcePermissionsMenu.jsx
@@ -37,7 +37,7 @@ function AddResourcePermissionsMenu({
     [RESOURCE_TYPE.WORKFLOWS]: 'Workflows',
     [RESOURCE_TYPE.MODULES]: 'Modules',
     [RESOURCE_TYPE.DATA_SOURCES]: 'Data source',
-    [RESOURCE_TYPE.FOLDERS]: 'Folders',
+    [RESOURCE_TYPE.FOLDERS]: 'App folders',
     [RESOURCE_TYPE.WORKFLOW_FOLDERS]: 'Workflow folders',
     [RESOURCE_TYPE.MODULE_FOLDERS]: 'Module folders',
   };

--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
@@ -721,7 +721,7 @@ class BaseManageGroupPermissionResources extends React.Component {
             class={`tj-text-xxsm ${disableNonPromoteReleasePermissions && 'check-label-disable'}`}
             data-cy="folder-delete-helper-text"
           >
-            Delete any folders in this workspace
+            Delete any app folders in this workspace
           </span>
         </label>
       </>
@@ -1512,21 +1512,19 @@ class BaseManageGroupPermissionResources extends React.Component {
                                     </div>
                                   </div>
                                 )}
-                                {isModulesEnabled && (
-                                  <div className="manage-groups-permission-apps">
-                                    <div data-cy="resource-module-folders">Module folder</div>
-                                    <div className="text-muted">
-                                      <div className="d-flex apps-permission-wrap flex-column">
-                                        {this.renderModuleFolderPermissions({
-                                          groupPermission,
-                                          isCE,
-                                          isBasicPlan,
-                                          disableNonPromoteReleasePermissions,
-                                        })}
-                                      </div>
+                                <div className="manage-groups-permission-apps">
+                                  <div data-cy="resource-module-folders">Module folder</div>
+                                  <div className="text-muted">
+                                    <div className="d-flex apps-permission-wrap flex-column">
+                                      {this.renderModuleFolderPermissions({
+                                        groupPermission,
+                                        isCE,
+                                        isBasicPlan,
+                                        disableNonPromoteReleasePermissions,
+                                      })}
                                     </div>
                                   </div>
-                                )}
+                                </div>
                                 <div className="manage-groups-permission-apps">
                                   <div data-cy="resource-workspace-variable">
                                     {this.props.t('globals.environmentVar', 'Workspace constant/variable')}
@@ -1697,8 +1695,8 @@ class BaseManageGroupPermissionResources extends React.Component {
                                     selectedAdminUsers.length !== 0
                                       ? '#ffffff'
                                       : this.props.darkMode
-                                        ? '#131620'
-                                        : '#C1C8CD'
+                                      ? '#131620'
+                                      : '#C1C8CD'
                                   }
                                   iconWidth="16"
                                   className="add-users-button"

--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/constants.js
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/constants.js
@@ -18,7 +18,7 @@ export const RESOURCE_NAME_MAPPING = {
   [RESOURCE_TYPE.APPS]: 'Apps',
   [RESOURCE_TYPE.DATA_SOURCES]: 'Data Sources',
   [RESOURCE_TYPE.WORKFLOWS]: 'Workflows',
-  [RESOURCE_TYPE.FOLDERS]: 'Folder',
+  [RESOURCE_TYPE.FOLDERS]: 'App folders',
   [RESOURCE_TYPE.MODULES]: 'Modules',
   [RESOURCE_TYPE.WORKFLOW_FOLDERS]: 'Workflow folders',
   [RESOURCE_TYPE.MODULE_FOLDERS]: 'Module folders',


### PR DESCRIPTION
## Summary
- Rename plain "Folder"/"Folders" copy to "App folder(s)" across Groups permission constants, i18n, and duplicate-group menu to match the existing Workflow/Module folder naming convention
- Fix a stale i18n value (`header.organization.menus.manageGroups.permissionResources.folder`) that was shadowing the code's own `'App folder'` fallback default
- Normalize "App Folders" casing to "App folders"
- Remove a license-flag gate that was hiding the "Module folder" row for Admin/Builder in the default group permissions tab — per the permission matrix, Modules/Module folders should be visible for Admin/Builder on both Free and Paid plans, with only editability (not visibility) differing by plan