### PR TITLE
fix(notifications): add notifyOrgAdminsAndBuilders for auto-sync events

### DIFF
--- a/server/src/modules/notifications/repository.ts
+++ b/server/src/modules/notifications/repository.ts
@@ -256,4 +256,25 @@ export class NotificationRepository extends Repository<Notification> {
     );
     return rows.map((r) => r.user_id);
   }
+
+  /**
+   * Returns user IDs of all active admins AND builders in an organization.
+   * Same join pattern as getOrgAdminUserIds, widened to the 'builder' default group —
+   * used where builders actively working in the app need to know about a change too
+   * (e.g. auto-sync), not just org admins.
+   */
+  async getOrgAdminAndBuilderUserIds(organizationId: string): Promise<string[]> {
+    const rows: { user_id: string }[] = await this.manager.query(
+      `SELECT DISTINCT gu.user_id
+         FROM group_users gu
+         JOIN permission_groups pg ON pg.id = gu.group_id
+         JOIN organization_users ou ON ou.user_id = gu.user_id AND ou.organization_id = $1
+        WHERE pg.organization_id = $1
+          AND pg.type = 'default'
+          AND pg.name IN ('admin', 'builder')
+          AND ou.status != 'archived'`,
+      [organizationId]
+    );
+    return rows.map((r) => r.user_id);
+  }
 }

--- a/server/src/modules/notifications/service.ts
+++ b/server/src/modules/notifications/service.ts
@@ -71,6 +71,38 @@ export class NotificationService implements INotificationService {
     }
   }
 
+  /**
+   * Same as notifyOrgAdmins but also includes builders — for events builders
+   * actively working in the app need to know about (e.g. auto-sync updating
+   * or deleting the branch they have open), not just org admins.
+   */
+  async notifyOrgAdminsAndBuilders(params: NotifyOrgAdminsParams): Promise<void> {
+    const userIds = await this.repository.getOrgAdminAndBuilderUserIds(params.organizationId);
+    if (!userIds.length) return;
+
+    const persisted = await this.repository.createForUsers({
+      organizationId: params.organizationId,
+      userIds,
+      type: params.type,
+      title: params.title,
+      body: params.body,
+      link: params.link,
+      metadata: params.metadata,
+      dedupeKey: params.dedupeKey,
+    });
+    if (!persisted) return; // fully deduped — everyone already has this notification
+
+    const enabled = params.channels ?? DEFAULT_CHANNELS;
+    for (const recipient of persisted.recipients) {
+      for (const channel of this.channels) {
+        if (!enabled.includes(channel.key)) continue;
+        await channel
+          .deliver(persisted.notification, recipient, { toast: params.toast })
+          .catch((e) => this.logger.error(`channel ${channel.key} failed for user ${recipient.userId}: ${e?.message}`));
+      }
+    }
+  }
+
   async list(
     userId: string,
     organizationId: string,


### PR DESCRIPTION
PR Description
server: https://github.com/ToolJet/ee-server/pull/762
frontend : https://github.com/ToolJet/ee-frontend/pull/594

## ISsues : 
1. https://github.com/orgs/ToolJet/projects/28/views/1?filterQuery=17253&pane=issue&itemId=226308742
2.https://github.com/orgs/ToolJet/projects/28/views/1?filterQuery=17253&pane=issue&itemId=226775477

## Summary
Two related auto-sync bugs, fixed together on this branch:

1. **Builders weren't getting bell notifications for auto-sync/webhook events** — only org admins were.
2. **Single-branch mode still showed "pull request" and "delete" chips** under the Auto-sync toggle in workspace git settings, even though those webhook events don't apply outside branching mode.

## Problem

### 1. Builder notifications missing
Builders never got a notification_recipient row created for them, so they had nothing to see — even though the frontend's useAutoSyncNotifications hook is already mounted globally for every logged-in user regardless of role.

2. Stale event chips in single-branch mode
ConfigureGitSync.jsx's outer settings card rendered the push / pull request / delete chip summary unconditionally:
Changes

Backend (server/src/modules/notifications/, server/ee/git-sync-webhooks/)
- Added NotificationRepository.getOrgAdminAndBuilderUserIds() — same admin lookup, widened to include the builder default group.
- Added NotificationService.notifyOrgAdminsAndBuilders() alongside the existing admin-only notifyOrgAdmins() (left untouched for other callers that may legitimately want admins-only).
- Switched all three auto-sync notification call sites in GitSyncWebhookWorker to notifyOrgAdminsAndBuilders.

Frontend (frontend/ee/modules/WorkspaceSettings/pages/GitSync/ConfigureGitSync.jsx)
- Filter the auto-sync event chip summary with .filter((evt) => branchingEnabled || evt === 'push'), mirroring the drawer's existing single-branch restriction.
