### PR TITLE
Added automation for app history functionality

### DIFF
--- a/cypress-tests/cypress/constants/selectors/common.js
+++ b/cypress-tests/cypress/constants/selectors/common.js
@@ -418,12 +418,16 @@ export const commonWidgetSelector = {
   changeLayoutToMobileButton: '[data-cy="button-change-layout-to-mobile"]',
   changeLayoutToDesktopButton: '[data-cy="button-change-layout-to-desktop"]',
 
-  // NOTE: data-cy="left-sidebar-inspector" is on the OUTER sidebar wrapper div
-  // (frontend/src/AppBuilder/LeftSidebar/LeftSidebar.jsx:236), not the clickable
-  // Inspector button. The button gets data-cy="left-sidebar-inspector-button"
-  // (SidebarItem.jsx:49, tip="Inspector" -> generateCypressDataCy -> "inspector").
-  // Clicking the wrapper div is a no-op, so target the button to open the panel.
-  sidebarinspector: "[data-cy='left-sidebar-inspector-button']",
+   sidebarinspector: "[data-cy='left-sidebar-inspector-button']",
+
+  appHistoryButton: "[data-cy='left-sidebar-app-history-button']",
+  appHistoryCloseButton: "[data-cy='left-sidebar-close-button']",
+  appHistoryHeaderTitle: ".app-history-header-title",
+  historyTimeline: ".history-timeline",
+  historyDateGroup: ".history-date",
+  historyEntry: ".history-entry",
+  historyEntryName: ".entry-name",
+
   inspectorNodeComponents: "[data-cy='inspector-node-components']> .node-key",
   nodeComponentValue: "[data-cy='inspector-node-value']> .mx-2",
   nodeComponentValues: "[data-cy='inspector-node-values']> .node-key",

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/appHistoryHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/appHistoryHappyPath.cy.js
@@ -1,0 +1,54 @@
+import { fake } from "Fixtures/fake";
+import { commonWidgetSelector } from "Selectors/common";
+
+describe("Editor - App History Panel", { testIsolation: false }, () => {
+  beforeEach(() => {
+    cy.apiLogin();
+    cy.apiCreateApp(`${fake.companyName}-App-History`);
+    cy.openApp();
+    cy.viewport(1800, 1800);
+  });
+
+  afterEach(() => {                                         
+        cy.apiDeleteApp();                                      
+     }); 
+
+  it("should open the app history panel and close it via the close button", () => {
+    cy.get(commonWidgetSelector.appHistoryButton).click();
+    cy.hideTooltip();
+
+    cy.get(commonWidgetSelector.appHistoryHeaderTitle)
+      .should("be.visible")
+      .and("have.text", "App history");
+ cy.get(commonWidgetSelector.appHistoryCloseButton).should("be.visible");
+
+    cy.get(commonWidgetSelector.appHistoryCloseButton).click();
+ cy.get(commonWidgetSelector.appHistoryHeaderTitle).should("not.exist");
+  });
+
+   it("should display history entries in the timeline after a canvas change", () => {
+   cy.dragAndDropWidget("Button", 500, 300);
+    cy.waitForAutoSave();
+
+    cy.get(commonWidgetSelector.appHistoryButton).click();
+    cy.hideTooltip();
+
+    cy.get(commonWidgetSelector.appHistoryHeaderTitle)
+      .should("be.visible")
+      .and("have.text", "App history");
+
+  cy.get(".spinner-center", { timeout: 15000 }).should("not.exist");
+
+    cy.get(commonWidgetSelector.historyTimeline).should("be.visible");
+
+  cy.get(commonWidgetSelector.historyDateGroup)
+      .first()
+      .should("contain.text", "Today");
+
+  cy.get(commonWidgetSelector.historyEntry).should("have.length.greaterThan", 0);
+
+   cy.get(commonWidgetSelector.historyEntryName)
+      .first()
+      .should("have.text", "Current version");
+  });
+});

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/appHistoryHappyPath.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/appHistoryHappyPath.cy.js
@@ -9,9 +9,9 @@ describe("Editor - App History Panel", { testIsolation: false }, () => {
     cy.viewport(1800, 1800);
   });
 
-  afterEach(() => {                                         
-        cy.apiDeleteApp();                                      
-     }); 
+  afterEach(() => {
+    cy.apiDeleteApp();
+  });
 
   it("should open the app history panel and close it via the close button", () => {
     cy.get(commonWidgetSelector.appHistoryButton).click();
@@ -20,14 +20,14 @@ describe("Editor - App History Panel", { testIsolation: false }, () => {
     cy.get(commonWidgetSelector.appHistoryHeaderTitle)
       .should("be.visible")
       .and("have.text", "App history");
- cy.get(commonWidgetSelector.appHistoryCloseButton).should("be.visible");
+    cy.get(commonWidgetSelector.appHistoryCloseButton).should("be.visible");
 
     cy.get(commonWidgetSelector.appHistoryCloseButton).click();
- cy.get(commonWidgetSelector.appHistoryHeaderTitle).should("not.exist");
+    cy.get(commonWidgetSelector.appHistoryHeaderTitle).should("not.exist");
   });
 
-   it("should display history entries in the timeline after a canvas change", () => {
-   cy.dragAndDropWidget("Button", 500, 300);
+  it("should display history entries in the timeline after a canvas change", () => {
+    cy.dragAndDropWidget("Button", 500, 300);
     cy.waitForAutoSave();
 
     cy.get(commonWidgetSelector.appHistoryButton).click();
@@ -37,17 +37,17 @@ describe("Editor - App History Panel", { testIsolation: false }, () => {
       .should("be.visible")
       .and("have.text", "App history");
 
-  cy.get(".spinner-center", { timeout: 15000 }).should("not.exist");
+    cy.get(".spinner-center", { timeout: 15000 }).should("not.exist");
 
     cy.get(commonWidgetSelector.historyTimeline).should("be.visible");
 
-  cy.get(commonWidgetSelector.historyDateGroup)
+    cy.get(commonWidgetSelector.historyDateGroup)
       .first()
       .should("contain.text", "Today");
 
-  cy.get(commonWidgetSelector.historyEntry).should("have.length.greaterThan", 0);
+    cy.get(commonWidgetSelector.historyEntry).should("have.length.greaterThan", 0);
 
-   cy.get(commonWidgetSelector.historyEntryName)
+    cy.get(commonWidgetSelector.historyEntryName)
       .first()
       .should("have.text", "Current version");
   });


### PR DESCRIPTION
Added automation for the app history close button and verified entries
Cypress status:
<img width="1161" height="510" alt="Screenshot 2026-08-12 at 6 44 23 PM" src="https://github.com/user-attachments/assets/bada515e-23f6-48b5-81cb-163d2d25ea14" />
