### PR TITLE
test(cypress): remove unused multipage helper exports

### DIFF
--- a/cypress-tests/cypress/support/utils/multipage.js
+++ b/cypress-tests/cypress/support/utils/multipage.js
@@ -24,7 +24,7 @@ export const openPageEditor = (pageName) => {
 // Close the AddEditPagePopup. Dismiss any nested Radix popover (e.g. the event
 // add-menu) first with Escape, then click far from any overlay to trigger the
 // react-bootstrap rootClose.
-export const closePageEditor = () => {
+const closePageEditor = () => {
   cy.get("body").type("{esc}");
   cy.wait(200);
   cy.get("body").click(5, 5);
@@ -53,16 +53,6 @@ const toggleFormLabelSwitch = (label) => {
     .parent()
     .find('.form-switch input[type="checkbox"]')
     .click({ force: true });
-};
-
-export const searchPage = (pageName) => {
-  // Search input lives in the panel header — AddPageButton/PageSettings header.
-  cy.get('[title="Search"]').click();
-  cy.get('[data-cy="search-input-field"]').type(pageName);
-};
-
-export const clearSearch = () => {
-  cy.get(".clear-icon").click();
 };
 
 // New page creation: the "New page" button auto-creates "Page N" and opens the
@@ -162,12 +152,4 @@ export const disableOrEnablePage = (pageName, option = "disable") => {
   toggleFormLabelSwitch("Disable page");
   cy.wait(500);
   closePageEditor();
-};
-
-// hideOrUnhidePageMenu / page-menu disable were part of the removed left-sidebar
-// "Page settings header" UI; the toggle now lives under Header & navigation in the
-// PageSettings Properties tab and has no data-cy. Kept as a no-op-safe stub so any
-// stale import resolves; real coverage is quarantined in the spec.
-export const hideOrUnhidePageMenu = () => {
-  openPagesPanel();
 };


### PR DESCRIPTION
## What

Remove unused multipage Cypress utility exports: `searchPage`, `clearSearch`, and `hideOrUnhidePageMenu`. Keep `closePageEditor` local to `multipage.js`, where it is still used.

## Why

These helpers no longer have callers in the repository. `hideOrUnhidePageMenu` was only a stale wrapper around opening the pages panel, while the active multipage helpers use the RightSideBar page-settings flow.

## How

- Deleted the three unreferenced helper exports.
- Removed `export` from `closePageEditor`.
- Left existing multipage helper call sites unchanged.

## Screenshots / recordings

Not applicable; this only removes unused Cypress utility code.

## Validation

- `node --check cypress-tests/cypress/support/utils/multipage.js`
- `git diff --check origin/main...HEAD`
- Webpack compilation of `multipageHappypath.cy.js` completed with 0 errors and 0 warnings
- Repository-wide symbol audit found no references to the removed helpers
- All six `closePageEditor` call sites remain inside `multipage.js`

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
