### PR TITLE
fix(app): clear the metadata-refresh interval on unmount

### DIFF
--- a/frontend/src/App/App.jsx
+++ b/frontend/src/App/App.jsx
@@ -130,7 +130,7 @@ class AppComponent extends React.Component {
         showBanner: false, // show banner when required for ee or cloud
       });
     }
-    setInterval(this.fetchMetadata, 1000 * 60 * 60 * 1);
+    this.metadataRefreshInterval = setInterval(this.fetchMetadata, 1000 * 60 * 60 * 1);
     this.updateMargin(); // Set initial margin
     let counter = 0;
     let interval;
@@ -146,6 +146,14 @@ class AppComponent extends React.Component {
       }
     }, 1000);
   }
+
+  componentWillUnmount() {
+    // Without this the hourly metadata refresh keeps running after the
+    // component unmounts (e.g. on logout) and on remount a second interval
+    // is added, so authenticated fetchMetadata calls accumulate.
+    clearInterval(this.metadataRefreshInterval);
+  }
+
   // check if its getting routed from editor
   checkPreviousRoute = (route) => {
     if (route.includes('/apps')) {

--- a/frontend/src/App/App.jsx
+++ b/frontend/src/App/App.jsx
@@ -133,16 +133,15 @@ class AppComponent extends React.Component {
     this.metadataRefreshInterval = setInterval(this.fetchMetadata, 1000 * 60 * 60 * 1);
     this.updateMargin(); // Set initial margin
     let counter = 0;
-    let interval;
 
-    interval = setInterval(async () => {
+    this.userCheckInterval = setInterval(async () => {
       ++counter;
       const current_user = authenticationService.currentSessionValue?.current_user;
       if (current_user?.id) {
         this.initTelemetryAndSupport(current_user); //Call when currentuser is available
-        clearInterval(interval);
+        clearInterval(this.userCheckInterval);
       } else if (counter > 10) {
-        clearInterval(interval);
+        clearInterval(this.userCheckInterval);
       }
     }, 1000);
   }
@@ -152,6 +151,10 @@ class AppComponent extends React.Component {
     // component unmounts (e.g. on logout) and on remount a second interval
     // is added, so authenticated fetchMetadata calls accumulate.
     clearInterval(this.metadataRefreshInterval);
+    // The user-availability poll above self-clears after login or ~10s, but
+    // clear it on unmount too so a quick unmount/remount cannot leave the old
+    // instance's poll running against a stale `this`.
+    clearInterval(this.userCheckInterval);
   }
 
   // check if its getting routed from editor


### PR DESCRIPTION
Fixes #17498.

`App.componentDidMount` starts an hourly metadata refresh but throws the timer id away:

```js
setInterval(this.fetchMetadata, 1000 * 60 * 60 * 1);
```

Nothing ever clears it, and `App` has no `componentWillUnmount`. So when `App` unmounts and remounts a fresh interval is added each time on top of the old ones, and the stale intervals keep calling `fetchMetadata` (an authenticated request) even after the user logs out.

The viewer side already does this correctly by storing the id and clearing it on unmount. This does the same: keep the id on the instance and clear it in `componentWillUnmount`.

The nearby telemetry interval a few lines down is unaffected since it already clears itself from inside its own callback.