### PR TITLE
fix(data-queries): pass transaction manager to deleteOne to prevent orphaned EventHandler records

### DIFF
--- a/server/src/modules/data-queries/service.ts
+++ b/server/src/modules/data-queries/service.ts
@@ -198,7 +198,7 @@ export class DataQueriesService implements IDataQueriesService {
 
     await dbTransactionWrap(async (manager: EntityManager) => {
       await this.dataQueryRepository.deleteDataQueryEvents(dataQueryId, manager);
-      await this.dataQueryRepository.deleteOne(dataQueryId);
+      await this.dataQueryRepository.deleteOne(dataQueryId, manager);
     });
 
     const operationTimestamp = Date.now();

--- a/server/test/modules/data-queries/unit/data-queries.service.spec.ts
+++ b/server/test/modules/data-queries/unit/data-queries.service.spec.ts
@@ -1,0 +1,64 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataQueryRepository } from '../../../../src/modules/data-queries/repository';
+import { DataQueriesService } from '../../../../src/modules/data-queries/service';
+import { EntityManager } from 'typeorm';
+import { DataQueriesUtilService } from '../../../../src/modules/data-queries/util.service';
+
+jest.mock('src/helpers/database.helper', () => ({
+  dbTransactionWrap: jest.fn().mockImplementation(async (cb) => {
+    const fakeManager = {} as EntityManager;
+    return cb(fakeManager);
+  }),
+}));
+
+describe('DataQueriesService', () => {
+  describe('delete', () => {
+    let service: DataQueriesService;
+    let repoDeleteEvents: jest.Mock;
+    let repoDeleteOne: jest.Mock;
+
+    beforeEach(async () => {
+      repoDeleteEvents = jest.fn().mockResolvedValue(undefined);
+      repoDeleteOne = jest.fn().mockResolvedValue(undefined);
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          DataQueriesService,
+          {
+            provide: DataQueryRepository,
+            useValue: {
+              deleteDataQueryEvents: repoDeleteEvents,
+              deleteOne: repoDeleteOne,
+              findOneOrFail: jest.fn(),
+            },
+          },
+          {
+            provide: DataQueriesUtilService,
+            useValue: {
+              getQueryContext: jest.fn().mockResolvedValue({}),
+              emitAfterDeleteHooks: jest.fn(),
+            },
+          },
+        ],
+      }).compile();
+
+      service = module.get<DataQueriesService>(DataQueriesService);
+      // Suppress fire-and-forget afterQueryDelete errors in test output
+      jest.spyOn(service as any, 'afterQueryDelete').mockResolvedValue(undefined);
+      jest.spyOn(service as any, 'beforeQueryDelete').mockResolvedValue({});
+    });
+
+    it('passes the transaction manager to deleteOne so both ops share the same transaction', async () => {
+      await service.delete('query-id-1');
+
+      // Both calls should have received the same fake manager from dbTransactionWrap
+      expect(repoDeleteEvents).toHaveBeenCalledWith('query-id-1', expect.anything());
+      expect(repoDeleteOne).toHaveBeenCalledWith('query-id-1', expect.anything());
+
+      // The manager arg must be the same object passed to both
+      const eventsManager = repoDeleteEvents.mock.calls[0][1];
+      const deleteOneManager = repoDeleteOne.mock.calls[0][1];
+      expect(eventsManager).toBe(deleteOneManager);
+    });
+  });
+});


### PR DESCRIPTION
## What

Pass the outer `dbTransactionWrap` manager to `dataQueryRepository.deleteOne` so both the event-handler deletion and the data-query deletion run inside a single atomic transaction.

## Why

`DataQueryService.delete` wraps `deleteDataQueryEvents` and `deleteOne` in a `dbTransactionWrap` callback, but `deleteOne` is called without the outer `manager` argument (see `service.ts` line 201). This causes `deleteOne` to fall back to the class-level `this.manager`, which opens its own auto-committing transaction.

Result: `deleteOne` commits the `DataQuery` deletion immediately. If the outer transaction later rolls back (e.g., network error after `deleteDataQueryEvents` commits), the `DataQuery` row is already gone from the database while its `EventHandler` rows remain, leaving orphaned records that are invisible in the UI but persistent in the database.

## How

One-character change: add `manager` as the second argument to `deleteOne` at the call site.

```diff
- await this.dataQueryRepository.deleteOne(dataQueryId);
+ await this.dataQueryRepository.deleteOne(dataQueryId, manager);
```

A new unit test (using Jest mocks and a `dbTransactionWrap` mock that passes a fake manager) verifies both calls receive the same manager object.

Closes #17496

harsh4vardhan