### PR TITLE
fix(tooljet-db): add compensating transactions to prevent metadata/DDL divergence on partial commit failure

### DIFF
--- a/server/src/modules/tooljet-db/services/tooljet-db-table-operations.service.ts
+++ b/server/src/modules/tooljet-db/services/tooljet-db-table-operations.service.ts
@@ -385,8 +385,34 @@ export class TooljetDbTableOperationsService {
       //   primaryKeyColumnList
       // );
 
-      await queryRunner.commitTransaction();
-      await tjdbQueryRunner.commitTransaction();
+      let appDbCommitted = false;
+      try {
+        await queryRunner.commitTransaction();
+        appDbCommitted = true;
+        await tjdbQueryRunner.commitTransaction();
+      } catch (commitErr) {
+        if (appDbCommitted) {
+          // App DB committed but ToolJet DB failed — compensate by deleting the metadata row.
+          try { await this.manager.delete(InternalTable, { id: internalTable.id }); } catch (_) {}
+          try { await tjdbQueryRunner.rollbackTransaction(); } catch (_) {}
+        } else {
+          try { await queryRunner.rollbackTransaction(); } catch (_) {}
+          try { await tjdbQueryRunner.rollbackTransaction(); } catch (_) {}
+        }
+        //@ts-expect-error queryRunner has property transactionDepth which is not defined in type EntityManager
+        if (!queryRunner?.transactionDepth || queryRunner.transactionDepth < 1) await queryRunner.release();
+        //@ts-expect-error queryRunner has property transactionDepth which is not defined in type EntityManager
+        if (!tjdbQueryRunner?.transactionDepth || tjdbQueryRunner.transactionDepth < 1) await tjdbQueryRunner.release();
+        const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
+          ([tableName, tableId]): { id: string; tableName: string } => ({ id: tableId as string, tableName })
+        );
+        throw new TooljetDatabaseError(
+          commitErr.message,
+          { origin: 'create_table', internalTables: [...referencedColumnInfoForError] },
+          commitErr
+        );
+      }
+
       await this.tooljetDbManager.query("NOTIFY pgrst, 'reload schema'");
 
       //@ts-expect-error queryRunner has property transactionDepth which is not defined in type EntityManager
@@ -395,10 +421,10 @@ export class TooljetDbTableOperationsService {
       if (!tjdbQueryRunner?.transactionDepth || tjdbQueryRunner.transactionDepth < 1) await tjdbQueryRunner.release();
       return { id: internalTable.id, table_name: tableName };
     } catch (err) {
-      await queryRunner.rollbackTransaction();
-      await tjdbQueryRunner.rollbackTransaction();
-      await queryRunner.release();
-      await tjdbQueryRunner.release();
+      try { await queryRunner.rollbackTransaction(); } catch (_) {}
+      try { await tjdbQueryRunner.rollbackTransaction(); } catch (_) {}
+      try { await queryRunner.release(); } catch (_) {}
+      try { await tjdbQueryRunner.release(); } catch (_) {}
       const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
         ([tableName, tableId]): { id: string; tableName: string } => {
           return {
@@ -449,20 +475,38 @@ export class TooljetDbTableOperationsService {
       await queryRunner.manager.delete(InternalTable, { id: internalTable.id });
       await tjdbQueryRunner.dropTable(new Table({ schema: tenantSchema, name: internalTable.id }));
 
-      await queryRunner.commitTransaction();
-      await tjdbQueryRunner.commitTransaction();
+      let appDbCommitted = false;
+      try {
+        await queryRunner.commitTransaction();
+        appDbCommitted = true;
+        await tjdbQueryRunner.commitTransaction();
+      } catch (commitErr) {
+        if (appDbCommitted) {
+          // App DB committed the delete; ToolJet DB DDL failed — compensate by re-saving the row.
+          try { await this.manager.save(InternalTable, internalTable); } catch (_) {}
+          try { await tjdbQueryRunner.rollbackTransaction(); } catch (_) {}
+        } else {
+          try { await queryRunner.rollbackTransaction(); } catch (_) {}
+          try { await tjdbQueryRunner.rollbackTransaction(); } catch (_) {}
+        }
+        throw new TooljetDatabaseError(
+          commitErr.message,
+          { origin: 'drop_table', internalTables: [internalTable] },
+          commitErr
+        );
+      }
       return true;
     } catch (err) {
-      await queryRunner.rollbackTransaction();
-      await tjdbQueryRunner.rollbackTransaction();
-      throw new TooljetDatabaseError(
-        err.message,
-        {
-          origin: 'drop_table',
-          internalTables: [internalTable],
-        },
-        err
-      );
+      if (!(err instanceof TooljetDatabaseError)) {
+        try { await queryRunner.rollbackTransaction(); } catch (_) {}
+        try { await tjdbQueryRunner.rollbackTransaction(); } catch (_) {}
+        throw new TooljetDatabaseError(
+          err.message,
+          { origin: 'drop_table', internalTables: [internalTable] },
+          err
+        );
+      }
+      throw err;
     } finally {
       await this.tooljetDbManager.query("NOTIFY pgrst, 'reload schema'");
       await queryRunner.release();
@@ -782,33 +826,59 @@ export class TooljetDbTableOperationsService {
         await tjdbQueryRunnner.createForeignKeys(tableName, foreignKeys);
       }
 
-      await queryRunner.commitTransaction();
-      await tjdbQueryRunnner.commitTransaction();
+      let appDbCommitted = false;
+      try {
+        await queryRunner.commitTransaction();
+        appDbCommitted = true;
+        await tjdbQueryRunnner.commitTransaction();
+      } catch (commitErr) {
+        if (appDbCommitted) {
+          // App DB committed the config update; ToolJet DB DDL failed — compensate by reverting config.
+          try { await this.manager.save(InternalTable, internalTable); } catch (_) {}
+          try { await tjdbQueryRunnner.rollbackTransaction(); } catch (_) {}
+        } else {
+          try { await queryRunner.rollbackTransaction(); } catch (_) {}
+          try { await tjdbQueryRunnner.rollbackTransaction(); } catch (_) {}
+        }
+        try { await queryRunner.release(); } catch (_) {}
+        try { await tjdbQueryRunnner.release(); } catch (_) {}
+        const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
+          ([tableName, tableId]): { id: string; tableName: string } => ({ id: tableId as string, tableName })
+        );
+        throw new TooljetDatabaseError(
+          commitErr.message,
+          { origin: 'add_column', internalTables: [internalTable, ...referencedColumnInfoForError] },
+          commitErr
+        );
+      }
       await this.tooljetDbManager.query("NOTIFY pgrst, 'reload schema'");
       await queryRunner.release();
       await tjdbQueryRunnner.release();
     } catch (err) {
-      await tjdbQueryRunnner.rollbackTransaction();
-      await tjdbQueryRunnner.release();
-      await queryRunner.rollbackTransaction();
-      await queryRunner.release();
-      const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
-        ([tableName, tableId]): { id: string; tableName: string } => {
-          return {
-            id: tableId as string,
-            tableName: tableName,
-          };
-        }
-      );
+      if (!(err instanceof TooljetDatabaseError)) {
+        try { await tjdbQueryRunnner.rollbackTransaction(); } catch (_) {}
+        try { await tjdbQueryRunnner.release(); } catch (_) {}
+        try { await queryRunner.rollbackTransaction(); } catch (_) {}
+        try { await queryRunner.release(); } catch (_) {}
+        const referencedColumnInfoForError = Object.entries(referenced_tables_info).map(
+          ([tableName, tableId]): { id: string; tableName: string } => {
+            return {
+              id: tableId as string,
+              tableName: tableName,
+            };
+          }
+        );
 
-      throw new TooljetDatabaseError(
-        err.message,
-        {
-          origin: 'add_column',
-          internalTables: [internalTable, ...referencedColumnInfoForError],
-        },
-        err
-      );
+        throw new TooljetDatabaseError(
+          err.message,
+          {
+            origin: 'add_column',
+            internalTables: [internalTable, ...referencedColumnInfoForError],
+          },
+          err
+        );
+      }
+      throw err;
     }
   }
 

--- a/server/test/modules/tooljet-db/unit/tooljet-db-table-operations-compensating.spec.ts
+++ b/server/test/modules/tooljet-db/unit/tooljet-db-table-operations-compensating.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for compensating-transaction logic in TooljetDbTableOperationsService.
+ * These tests verify that when the app-DB (TypeORM) commit succeeds but the
+ * ToolJet-DB (DDL) commit fails, the service applies a compensating action so
+ * the two databases do not diverge.
+ */
+import { TooljetDbTableOperationsService } from '../../../../src/modules/tooljet-db/services/tooljet-db-table-operations.service';
+import { EntityManager } from 'typeorm';
+import { InternalTable } from '../../../../src/entities/internal_table.entity';
+
+function makeQueryRunner(opts: { commitFails?: boolean } = {}) {
+  let started = false;
+  return {
+    connect: jest.fn().mockResolvedValue(undefined),
+    startTransaction: jest.fn().mockImplementation(() => { started = true; }),
+    commitTransaction: jest.fn().mockImplementation(() => {
+      if (opts.commitFails) throw new Error('simulated DDL commit failure');
+    }),
+    rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+    release: jest.fn().mockResolvedValue(undefined),
+    manager: {
+      create: jest.fn().mockImplementation((_, data) => ({ id: 'new-table-uuid', ...data })),
+      save: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      findOne: jest.fn().mockResolvedValue(null),
+    },
+  };
+}
+
+function makeService(overrides: Record<string, any> = {}) {
+  const mockAppManager = {
+    connection: { createQueryRunner: jest.fn() },
+    findOne: jest.fn().mockResolvedValue(null),
+    delete: jest.fn().mockResolvedValue(undefined),
+    save: jest.fn().mockResolvedValue(undefined),
+    query: jest.fn().mockResolvedValue(undefined),
+    queryRunner: null,
+  };
+
+  const mockTjdbManager = {
+    connection: { createQueryRunner: jest.fn() },
+    query: jest.fn().mockResolvedValue(undefined),
+    queryRunner: null,
+  };
+
+  const service: any = Object.create(TooljetDbTableOperationsService.prototype);
+  Object.assign(service, {
+    manager: mockAppManager,
+    tooljetDbManager: mockTjdbManager,
+    licenseTermsService: { getLicenseTerms: jest.fn().mockResolvedValue({ table_count: 100 }) },
+    prepareColumnListForCreateTable: jest.fn().mockReturnValue([]),
+    prepareForeignKeyDetailsJSON: jest.fn().mockReturnValue([]),
+    fetchAndCheckIfValidForeignKeyTables: jest.fn().mockResolvedValue({}),
+    checkIfForeignKeyReferencedColumnsAreFromCompositePrimaryKey: jest.fn().mockResolvedValue(false),
+    ...overrides,
+  });
+
+  return { service, mockAppManager, mockTjdbManager };
+}
+
+describe('TooljetDbTableOperationsService compensating transactions', () => {
+  describe('createTable', () => {
+    it('compensates by deleting InternalTable when app DB commits but ToolJet DB commit fails', async () => {
+      const appQR = makeQueryRunner({ commitFails: false });
+      const tjdbQR = makeQueryRunner({ commitFails: true });
+
+      const { service, mockAppManager, mockTjdbManager } = makeService();
+      mockAppManager.connection.createQueryRunner.mockReturnValue(appQR);
+      mockTjdbManager.connection.createQueryRunner.mockReturnValue(tjdbQR);
+      // Simulate create inside queryRunner.manager.create
+      const createdTable = { id: 'table-uuid-123', tableName: 'test_table', organizationId: 'org-1', configurations: {} };
+      appQR.manager.create.mockReturnValue(createdTable);
+      appQR.manager.save.mockResolvedValue(createdTable);
+      // tjdb DDL succeeds but commit fails
+      const mockCreateTable = jest.fn().mockResolvedValue(undefined);
+      const mockCreatePrimaryKey = jest.fn().mockResolvedValue(undefined);
+      tjdbQR['createTable'] = mockCreateTable;
+      tjdbQR['createPrimaryKey'] = mockCreatePrimaryKey;
+
+      const params = {
+        table_name: 'test_table',
+        columns: [{ column_name: 'id', data_type: 'integer', constraints_type: { is_primary_key: true }, configurations: {} }],
+        foreign_keys: [],
+      };
+
+      await expect(
+        service.createTable('org-1', params, { appManager: mockAppManager, tjdbManager: mockTjdbManager })
+      ).rejects.toThrow('simulated DDL commit failure');
+
+      // Compensating delete must have been called
+      expect(mockAppManager.delete).toHaveBeenCalledWith(InternalTable, { id: createdTable.id });
+    });
+  });
+
+  describe('dropTable', () => {
+    it('compensates by re-saving InternalTable when app DB commits delete but ToolJet DB commit fails', async () => {
+      const existingTable = new InternalTable();
+      Object.assign(existingTable, { id: 'tbl-1', tableName: 'victim', organizationId: 'org-1', configurations: { columns: { column_names: {}, configurations: {} } } });
+
+      const appQR = makeQueryRunner({ commitFails: false });
+      const tjdbQR = makeQueryRunner({ commitFails: true });
+
+      const { service, mockAppManager, mockTjdbManager } = makeService();
+      mockAppManager.findOne.mockResolvedValue(existingTable);
+      mockAppManager.connection.createQueryRunner.mockReturnValue(appQR);
+      mockTjdbManager.connection.createQueryRunner.mockReturnValue(tjdbQR);
+      tjdbQR['dropTable'] = jest.fn().mockResolvedValue(undefined);
+
+      // Stub out findQueriesLinkedToTable
+      service.findQueriesLinkedToTable = jest.fn().mockResolvedValue(false);
+      service.findTenantSchema = jest.fn().mockReturnValue('org_1');
+
+      await expect(
+        service.dropTable('org-1', { table_name: 'victim' })
+      ).rejects.toThrow();
+
+      // Compensating save must have been called to restore the deleted row
+      expect(mockAppManager.save).toHaveBeenCalledWith(InternalTable, existingTable);
+    });
+  });
+});


### PR DESCRIPTION
## What

Restructure the commit sequence in `createTable`, `dropTable`, and `addColumn` to apply a compensating action when the app-DB commit succeeds but the ToolJet-DB DDL commit fails, preventing permanent state divergence between the two databases.

## Why

Each DDL method commits two independent transactions sequentially:
1. App DB (TypeORM) -- saves/deletes/updates the `InternalTable` metadata row.
2. ToolJet DB (PostgreSQL DDL) -- issues `CREATE TABLE`, `DROP TABLE`, or `ADD COLUMN`.

If commit 1 succeeds but commit 2 fails (e.g., network partition between the app server and the ToolJet Postgres host), the metadata and the physical schema diverge permanently with no automatic recovery.

Additionally, the existing `catch` block calls `rollbackTransaction()` on an already-committed runner, which throws `'not in transaction mode'`, masking the original error.

## How

After the app-DB commit, the DDL commit is wrapped in its own `try/catch`. If the DDL commit fails:
- **`createTable`**: delete the `InternalTable` row that was just saved.
- **`dropTable`**: re-save the `InternalTable` row that was just deleted.
- **`addColumn`**: re-save the original `InternalTable` (with the old column configuration).

All `rollbackTransaction`/`release` calls are wrapped in individual `try/catch` blocks so a secondary cleanup failure does not mask the primary error.

Closes #17497

harsh4vardhan