### PR TITLE
fix(frontend): clear metadata refresh interval on App unmount

### DIFF
--- a/frontend/src/App/App.jsx
+++ b/frontend/src/App/App.jsx
@@ -130,7 +130,7 @@ class AppComponent extends React.Component {
         showBanner: false, // show banner when required for ee or cloud
       });
     }
-    setInterval(this.fetchMetadata, 1000 * 60 * 60 * 1);
+    this._metadataInterval = setInterval(this.fetchMetadata, 1000 * 60 * 60 * 1);
     this.updateMargin(); // Set initial margin
     let counter = 0;
     let interval;
@@ -153,6 +153,10 @@ class AppComponent extends React.Component {
     }
     return false;
   };
+
+  componentWillUnmount() {
+    clearInterval(this._metadataInterval);
+  }
 
   componentDidUpdate(prevProps, prevState) {
     // Check if the current location is the dashboard (homepage)


### PR DESCRIPTION
### What
Stores the metadata refresh \setInterval\ handle from \App.jsx\ in an instance property and clears it in a new \componentWillUnmount()\ lifecycle method.

### Why
\App.jsx\ started \setInterval(this.fetchMetadata, 1000 * 60 * 60 * 1)\ without ever storing or clearing the return value. On every unmount/remount (e.g. HMR reloads in development or future routing changes) a new interval was added without cancelling the previous one, so multiple intervals accumulated and kept firing \etchMetadata\ - including stale authenticated HTTP requests after the user logs out, causing unnecessary 401 traffic for the session lifetime.

### How
- In \componentDidMount\, assign the interval id to \	his._metadataInterval\ instead of discarding it.
- Add \componentWillUnmount\ that calls \clearInterval(this._metadataInterval)\.
- This matches the existing correct pattern in \ViewerApp.jsx\, which stores and clears its refresh interval.

Closes #17498