### PR TITLE
Revoke Avatar blob URLs and ignore stale avatar responses

### DIFF
--- a/frontend/src/_ui/Avatar/__tests__/Avatar.test.jsx
+++ b/frontend/src/_ui/Avatar/__tests__/Avatar.test.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import Avatar from '../index';
+import { userService } from '../../../_services';
+
+jest.mock('../../../_services', () => ({
+  userService: { getAvatar: jest.fn() },
+}));
+
+jest.mock('react-tooltip', () => ({
+  Tooltip: () => null,
+}));
+
+// Resolves only when the test says so, so a slow response can be held open
+// while the component moves on to a different avatarId.
+function deferred() {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('Avatar', () => {
+  let created;
+  let revoked;
+
+  beforeEach(() => {
+    created = 0;
+    revoked = [];
+    global.URL.createObjectURL = jest.fn(() => `blob:avatar-${++created}`);
+    global.URL.revokeObjectURL = jest.fn((url) => revoked.push(url));
+    userService.getAvatar.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it('revokes the object url it created when unmounted', async () => {
+    userService.getAvatar.mockResolvedValue(new Blob());
+
+    const { unmount } = render(<Avatar avatarId="a1" title="A" />);
+    await waitFor(() => expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    expect(revoked).toEqual(['blob:avatar-1']);
+  });
+
+  it('revokes the previous object url when avatarId changes', async () => {
+    userService.getAvatar.mockResolvedValue(new Blob());
+
+    const { rerender } = render(<Avatar avatarId="a1" title="A" />);
+    await waitFor(() => expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1));
+
+    rerender(<Avatar avatarId="a2" title="A" />);
+    await waitFor(() => expect(global.URL.createObjectURL).toHaveBeenCalledTimes(2));
+
+    expect(revoked).toContain('blob:avatar-1');
+  });
+
+  it('ignores a response that arrives after avatarId has moved on', async () => {
+    const slow = deferred();
+    userService.getAvatar.mockReturnValueOnce(slow.promise).mockResolvedValue(new Blob());
+
+    const { rerender } = render(<Avatar avatarId="a1" title="A" />);
+    rerender(<Avatar avatarId="a2" title="A" />);
+
+    await waitFor(() => expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1));
+    const urlForSecondAvatar = `blob:avatar-${created}`;
+
+    // The first request now lands, after the component has already moved to a2.
+    slow.resolve(new Blob());
+    await Promise.resolve();
+
+    // It must not create a url or overwrite the one belonging to a2.
+    await waitFor(() => expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1));
+    expect(revoked).not.toContain(urlForSecondAvatar);
+  });
+});

--- a/frontend/src/_ui/Avatar/index.jsx
+++ b/frontend/src/_ui/Avatar/index.jsx
@@ -9,13 +9,28 @@ const Avatar = ({ text, image, avatarId, title = '', borderShape, indexId = 0, c
   const [avatar, setAvatar] = React.useState();
 
   React.useEffect(() => {
+    let objectUrl;
+    let ignore = false;
+
     async function fetchAvatar() {
       const blob = await userService.getAvatar(avatarId);
-      setAvatar(URL.createObjectURL(blob));
+      // avatarId can change while this request is in flight, which happens as
+      // rows are recycled in the virtualized user list. Without this the slower
+      // response wins and the row shows someone else's picture.
+      if (ignore) return;
+      objectUrl = URL.createObjectURL(blob);
+      setAvatar(objectUrl);
     }
     if (avatarId) fetchAvatar();
 
-    () => avatar && URL.revokeObjectURL(avatar);
+    return () => {
+      ignore = true;
+      // Drop the reference before revoking it. The next render happens with
+      // the new avatarId but the old url still in state, so revoking without
+      // clearing would paint a url that has just been invalidated.
+      setAvatar(undefined);
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [avatarId]);
 


### PR DESCRIPTION
**What** — `Avatar` now revokes the blob URLs it creates, and ignores a response that arrives after `avatarId` has changed.

**Why** — Closes #17526.

The cleanup function in the effect was written but never returned:

```js
() => avatar && URL.revokeObjectURL(avatar);
```

That constructs an arrow function and discards it, so `URL.revokeObjectURL` is never reached and every avatar fetch leaks its object URL for the lifetime of the page. The intent was clearly there, it just was not wired up, and `no-unused-expressions` is not enabled in `eslint.config.mjs` so nothing flagged it. Every other blob URL in the frontend is revoked properly, in `Camera.jsx`, `PDF.jsx`, `Chat/index.js`, `_lib/generate-file.js` and `BulkUploadDrawer`, which is what made this one stand out.

It matters more than a single leaked URL because `Avatar` renders per row in `UsersTable` and `VirtualizedUserList`. The virtualized list changes `avatarId` on an already mounted component as rows are recycled, so the effect re-runs while scrolling and leaks each time rather than once per user.

The same recycling causes the second problem in the same twelve lines. There was no ignore flag, so a request for the previous `avatarId` that resolved after the component had moved on would still call `setAvatar` and overwrite the correct picture with a different user's.

**How** — Keep the created URL in a local so the cleanup revokes the one this run actually made rather than reading a stale value from state, and return the cleanup. Add an `ignore` flag checked before `setAvatar`.

One ordering detail worth flagging, since it is the sort of thing that looks unnecessary in review: the cleanup clears the stored URL before revoking it. Without that, when `avatarId` changes the next render happens with the new id but the old URL still in state, so it would paint a blob that had just been invalidated and show a broken image until the new fetch landed. Revoking without clearing would have traded a leak for a flicker.

**Tests** — three cases in `frontend/src/_ui/Avatar/__tests__/Avatar.test.jsx`: revoke on unmount, revoke the previous URL when `avatarId` changes, and ignore a response that lands after the id moved on. The third holds the first request open with a deferred promise so the stale-response ordering is deterministic rather than timing dependent.

All three fail on `main`:

```
✕ revokes the object url it created when unmounted
✕ revokes the previous object url when avatarId changes
✕ ignores a response that arrives after avatarId has moved on
Tests: 3 failed, 3 total
```

and pass with the change.

**Screenshots** — none, there is no visual change on the happy path. The user visible difference is the absence of a wrong avatar during fast scrolling, which I could not capture as a still.

**One thing to know if you try to run the tests.** `frontend/package.json` sets `"testEnvironment": "jest-environment-jsdom"` but does not depend on `jest-environment-jsdom`, and Jest has not bundled it since 28. On a fresh clone `npx jest` fails with `Test environment jest-environment-jsdom cannot be found` before running anything, including existing tests like `src/_helpers/__tests__/validateName.test.js`. No workflow runs frontend jest so nothing is red, but you will need `npm i -D jest-environment-jsdom` locally to run the above. I left it out of this PR to keep the scope to one thing, and mentioned it at the bottom of #17526. Happy to send it as a separate `chore/` PR if you want it fixed.
