### PR TITLE
fix(ui): revoke Avatar blob URLs and guard against stale fetch responses

### DIFF
--- a/frontend/src/_ui/Avatar/index.jsx
+++ b/frontend/src/_ui/Avatar/index.jsx
@@ -9,13 +9,25 @@ const Avatar = ({ text, image, avatarId, title = '', borderShape, indexId = 0, c
   const [avatar, setAvatar] = React.useState();
 
   React.useEffect(() => {
+    // #17526: the cleanup was constructed but never returned, so blob URLs
+    // were never revoked. The stale-response guard prevents a late fetch for
+    // a previous avatarId from overwriting the current one when the
+    // virtualized list recycles this component.
+    let stale = false;
     async function fetchAvatar() {
-      const blob = await userService.getAvatar(avatarId);
-      setAvatar(URL.createObjectURL(blob));
+      try {
+        const blob = await userService.getAvatar(avatarId);
+        if (!stale) setAvatar(URL.createObjectURL(blob));
+      } catch {
+        // Avatar fetch failures leave the fallback text visible; not an error state.
+      }
     }
     if (avatarId) fetchAvatar();
 
-    () => avatar && URL.revokeObjectURL(avatar);
+    return () => {
+      stale = true;
+      if (avatar) URL.revokeObjectURL(avatar);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [avatarId]);
 


### PR DESCRIPTION
Fixes #17526.

Two bugs in `frontend/src/_ui/Avatar/index.jsx`:

1. **Blob URL leak**: the cleanup function was written but never `return`ed — `() => avatar && URL.revokeObjectURL(avatar)` constructs an arrow function and discards it. Every avatar change (which happens constantly in the virtualized user list) leaked the previous URL for the lifetime of the page. Added the missing `return`.

2. **Stale response overwrite**: no ignore flag, so a late response for a previous `avatarId` could call `setAvatar` and show the wrong user's picture when rows are recycled. Added a `stale` flag that the cleanup sets, which the fetch checks before calling `setAvatar`.

Also added a try/catch so avatar fetch failures degrade to the fallback text instead of an unhandled rejection.