### PR TITLE
docs: fix macOS setup — use Docker Postgres 13 instead of disabled Homebrew postgresql@13

### DIFF
--- a/docs/docs/contributing-guide/setup/macos.md
+++ b/docs/docs/contributing-guide/setup/macos.md
@@ -29,13 +29,28 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
 
     1.3 Install Postgres
     :::tip
-    ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not plan to support other databases such as MySQL.
+    ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not plan to support other databases such as MySQL. ToolJet recommends PostgreSQL 13.x for local development (matching the `postgres:13` image used in `docker-compose.yaml`).
     :::
 
+    Homebrew no longer ships `postgresql@13`. Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/) if needed, then run PostgreSQL 13 with Docker:
+
     ```bash
-    brew install postgresql@13
+    docker run -d \
+      --name tooljet-postgres \
+      -e POSTGRES_USER=postgres \
+      -e POSTGRES_PASSWORD=postgres \
+      -p 5432:5432 \
+      -v tooljet_pgdata:/var/lib/postgresql/data \
+      postgres:13
     ```
-    
+
+    To stop or start the container later:
+
+    ```bash
+    docker stop tooljet-postgres
+    docker start tooljet-postgres
+    ```
+
     1.4 Install PostgREST
 
     :::info

--- a/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/setup/macos.md
+++ b/docs/versioned_docs/version-2.50.0-LTS/contributing-guide/setup/macos.md
@@ -29,13 +29,28 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
 
     1.3 Install Postgres
     :::tip
-    ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not plan to support other databases such as MySQL.
+    ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not plan to support other databases such as MySQL. ToolJet recommends PostgreSQL 13.x for local development (matching the `postgres:13` image used in `docker-compose.yaml`).
     :::
 
+    Homebrew no longer ships `postgresql@13`. Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/) if needed, then run PostgreSQL 13 with Docker:
+
     ```bash
-    brew install postgresql@13
+    docker run -d \
+      --name tooljet-postgres \
+      -e POSTGRES_USER=postgres \
+      -e POSTGRES_PASSWORD=postgres \
+      -p 5432:5432 \
+      -v tooljet_pgdata:/var/lib/postgresql/data \
+      postgres:13
     ```
-    
+
+    To stop or start the container later:
+
+    ```bash
+    docker stop tooljet-postgres
+    docker start tooljet-postgres
+    ```
+
     1.4 Install PostgREST
 
     :::info

--- a/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/setup/macos.md
+++ b/docs/versioned_docs/version-3.0.0-LTS/contributing-guide/setup/macos.md
@@ -29,13 +29,28 @@ To set up and run ToolJet on macOS for development, begin by opening your termin
 
     1.3 Install Postgres
     :::tip
-    ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not plan to support other databases such as MySQL.
+    ToolJet uses a postgres database as the persistent storage for storing data related to users and apps. We do not plan to support other databases such as MySQL. ToolJet recommends PostgreSQL 13.x for local development (matching the `postgres:13` image used in `docker-compose.yaml`).
     :::
 
+    Homebrew no longer ships `postgresql@13`. Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/) if needed, then run PostgreSQL 13 with Docker:
+
     ```bash
-    brew install postgresql@13
+    docker run -d \
+      --name tooljet-postgres \
+      -e POSTGRES_USER=postgres \
+      -e POSTGRES_PASSWORD=postgres \
+      -p 5432:5432 \
+      -v tooljet_pgdata:/var/lib/postgresql/data \
+      postgres:13
     ```
-    
+
+    To stop or start the container later:
+
+    ```bash
+    docker stop tooljet-postgres
+    docker start tooljet-postgres
+    ```
+
     1.4 Install PostgREST
 
     :::info


### PR DESCRIPTION
## Summary
- Homebrew disabled `postgresql@13`, which broke the macOS contributor setup guide (`brew install postgresql@13`).
- ToolJet expects PostgreSQL 13.x (`docker-compose.yaml` uses `postgres:13`; system requirements recommend 13.x), so the docs now use a Docker `postgres:13` container with credentials matching the macOS `.env` example.
- Updated current docs and both versioned LTS copies of the macOS contributing guide.

Fixes #17330

## Test plan
- [ ] Open https://docs.tooljet.com/docs/contributing-guide/setup/macos/ (after merge/publish) and confirm Postgres steps no longer mention `brew install postgresql@13`
- [ ] On macOS with Docker Desktop, run the documented `docker run ... postgres:13` command and verify it starts and listens on `5432`
- [ ] Confirm example `.env` values (`PG_USER`/`PG_PASS` = `postgres`) connect to the container