### PR TITLE
Number Input Widget setFocus and setBlur issue fixed

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NumberInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/NumberInput.jsx
@@ -1,12 +1,10 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { BaseInput } from './BaseComponents/BaseInput';
 import { useInput } from './BaseComponents/hooks/useInput';
 import { cn } from '@/lib/utils';
 import SolidIcon from '@/_ui/Icon/SolidIcons';
 
 export const NumberInput = (props) => {
-  const inputRef = useRef(null);
-
   const inputLogic = useInput({
     ...props,
     properties: {
@@ -93,9 +91,9 @@ export const NumberInput = (props) => {
   );
 
   useEffect(() => {
-    if (!disableStepControls || !inputRef.current) return;
+    if (!disableStepControls || !inputLogic.inputRef.current) return;
 
-    const el = inputRef.current;
+    const el = inputLogic.inputRef.current;
 
     // undefined = not yet searched, null = searched but no scrollable ancestor found
     let scrollableParent = undefined;
@@ -133,6 +131,7 @@ export const NumberInput = (props) => {
     el.addEventListener('wheel', handleWheel, { passive: false });
 
     return () => el.removeEventListener('wheel', handleWheel);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [disableStepControls]);
 
   useEffect(() => {
@@ -148,7 +147,6 @@ export const NumberInput = (props) => {
       inputType="number"
       handleChange={handleChange}
       handleBlur={handleBlur}
-      inputRef={inputRef}
       additionalInputProps={{
         min: props.validation?.minValue ?? null,
         max: props.validation?.maxValue ?? null,


### PR DESCRIPTION
# num_input_set_focus: Number Input's `setFocus`/`setBlur` exposed actions don't work

## Issue Description

On the Number Input widget, the exposed component actions `setFocus` and `setBlur` (callable from queries/workflows/events) had no effect — the input never actually gained or lost focus when these actions were triggered. The equivalent actions worked correctly on Text Input and other text-like widgets.

## Root Cause

All text-like input widgets (Text Input, Number Input, Currency Input, etc.) share the `useInput()` hook (`frontend/src/AppBuilder/Widgets/BaseComponents/hooks/useInput.js`), which owns an internal `inputRef` (`useInput.js:46`) and exposes `setFocus`/`setBlur` as functions that call `inputRef.current.focus()` / `.blur()`.

`frontend/src/AppBuilder/Widgets/NumberInput.jsx` declared a **second, local** `inputRef` (via its own `useRef(null)`) to support the scroll-wheel/step-control feature. In the render output, this local ref was passed to `BaseInput` as `inputRef={inputRef}` *after* `{...inputLogic}` was spread:

```jsx
<BaseInput
  {...props}
  {...inputLogic}     // includes inputLogic.inputRef
  ...
  inputRef={inputRef} // overrides it with NumberInput's own local ref
  ...
/>
```

Because the local `inputRef` prop came after the spread, it won the JSX prop collision. `BaseInput` attached the real `<input>` DOM node only to NumberInput's local ref — not to the ref living inside `useInput()`. As a result, `inputLogic`'s `setFocus`/`setBlur` closures always operated on an `inputRef.current` that was `undefined`, so calling `.focus()`/`.blur()` silently failed.

`TextInput.jsx` never declares a local `inputRef`, so it doesn't hit this collision — `{...inputLogic}` passes its ref straight through to `BaseInput` untouched, which is why focus/blur worked there.

## Fix

In `frontend/src/AppBuilder/Widgets/NumberInput.jsx`:
- Removed the local `const inputRef = useRef(null);`.
- The scroll-wheel effect (previously reading `inputRef.current`) now reads/writes `inputLogic.inputRef.current` instead.
- Removed the `inputRef={inputRef}` prop passed to `BaseInput`, so `{...inputLogic}` now supplies the ref uncontested, matching the pattern already used in `TextInput.jsx`.
- Since `inputLogic.inputRef` is a referentially-stable object (a `useRef()` created once inside `useInput.js`), it doesn't need to be listed in the wheel effect's dependency array to be correct at runtime. To avoid padding the deps array with an inert value just to silence `react-hooks/exhaustive-deps`, a `// eslint-disable-next-line react-hooks/exhaustive-deps` comment was added above the array instead, which is left as `[disableStepControls]`.

Confirmed no other widget under `frontend/src/AppBuilder/Widgets/*.jsx` overrides `inputRef` after spreading `inputLogic`, so this bug was isolated to Number Input.

## Areas to Test

- `setFocus` and `setBlur` exposed actions on the Number Input widget, triggered from a query/event, actually move focus to/away from the input.
- Scroll-wheel behavior when `disableStepControls` is enabled — scrolling over the input should still be blocked from changing the value and should still scroll the page/nearest scrollable ancestor instead.
- Increment/decrement arrow controls and keyboard arrow-key stepping still work as before (regression check — unrelated to this fix, but shares the same component).
- Other input widgets (Text Input, Currency Input, Password Input, Email Input) continue to have working `setFocus`/`setBlur` — unaffected by this change but worth a quick spot check since they share `useInput()`.

