### PR TITLE
Number Input Decimal increment/decrement issue resolved

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NumberInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/NumberInput.jsx
@@ -38,7 +38,7 @@ export const NumberInput = (props) => {
 
   const handleIncrement = (e) => {
     e.preventDefault();
-    const newValue = (inputLogic.value || 0) + 1;
+    const newValue = Number(((inputLogic.value || 0) + 1).toFixed(props.properties.decimalPlaces));
     inputLogic.setInputValue(newValue);
     inputLogic.setShowValidationError(true);
     if (!isNaN(newValue)) {
@@ -48,7 +48,7 @@ export const NumberInput = (props) => {
 
   const handleDecrement = (e) => {
     e.preventDefault();
-    const newValue = (inputLogic.value || 0) - 1;
+    const newValue = Number(((inputLogic.value || 0) - 1).toFixed(props.properties.decimalPlaces));
     inputLogic.setInputValue(newValue);
     inputLogic.setShowValidationError(true);
     if (!isNaN(newValue)) {


### PR DESCRIPTION
# num_input_decimal_increment: Number Input increment/decrement drifts to floating-point noise

## Issue Description

On the Number Input widget, setting a decimal value (e.g. `37.88`) and then clicking the decrement (or increment) arrow multiple times occasionally produces values like `31.880000000000003` instead of the expected `31.88`. The extra trailing digits appear even though the widget has a configured `decimalPlaces` setting.

## Root Cause

`frontend/src/AppBuilder/Widgets/NumberInput.jsx` rounds the value to `decimalPlaces` in `handleChange`/`handleBlur`, but not in `handleIncrement`/`handleDecrement`:

```js
// handleBlur — rounds to decimalPlaces
const value = Number(parseFloat(e.target.value).toFixed(props.properties.decimalPlaces));

// handleIncrement/handleDecrement (before fix) — raw float math, no rounding
const newValue = (inputLogic.value || 0) + 1; // or - 1
```

`37.88` isn't exactly representable in IEEE-754 double precision — it's stored as the closest binary approximation. JS's default number-to-string conversion hides this (it prints the shortest string that round-trips), so `37.88` looks clean. But every `+1`/`-1` operation re-rounds the running total to the nearest representable double, and after enough increments/decrements the accumulated rounding error surfaces in the displayed value.

Since `handleIncrement`/`handleDecrement` pass the raw float straight to `inputLogic.setInputValue()` with no rounding step, and `setInputValue` (`useInput.js:240-246`) does no coercion or rounding of its own — it just stores exactly what it's given into the exposed `value` variable — the drift is never cleaned up on this path, unlike the type/blur path where `.toFixed(decimalPlaces)` re-rounds on every edit.

## Fix

In `frontend/src/AppBuilder/Widgets/NumberInput.jsx`, `handleIncrement` and `handleDecrement` now round the result to `decimalPlaces` before storing it, matching the pattern already used in `handleBlur`:

```js
const handleIncrement = (e) => {
  e.preventDefault();
  const newValue = Number(((inputLogic.value || 0) + 1).toFixed(props.properties.decimalPlaces));
  inputLogic.setInputValue(newValue);
  ...
};

const handleDecrement = (e) => {
  e.preventDefault();
  const newValue = Number(((inputLogic.value || 0) - 1).toFixed(props.properties.decimalPlaces));
  inputLogic.setInputValue(newValue);
  ...
};
```

`.toFixed(decimalPlaces)` does the actual rounding (returns a string); `Number(...)` converts that string back to a numeric type before it's stored. The `Number(...)` wrapper is necessary, not cosmetic — `setInputValue` has no built-in coercion, so passing a string through would make the widget's exposed `value` a string instead of a number, breaking subsequent arithmetic (e.g. the next increment doing `"36.88" + 1` → `"36.881"` via string concatenation) and anything else reading `value` expecting a number.

## Areas to Test

- Set a decimal value (e.g. `37.88` with `decimalPlaces: 2`) and click decrement/increment repeatedly — value should stay exactly `36.88`, `35.88`, etc. with no floating-point noise.
- Confirm the exposed `value` variable remains typeof `number` (not string) after increment/decrement, including when read back into further arithmetic or bound into other components/queries.
- Test with `decimalPlaces: 0` and a whole-number starting value — increment/decrement should behave unchanged.
- Regression check: `handleChange`/`handleBlur` rounding behavior is unaffected by this change.
