### PR TITLE
Number Input Inc/Dec button shadow issue resolved

### DIFF
--- a/frontend/src/AppBuilder/Widgets/BaseComponents/baseInput.scss
+++ b/frontend/src/AppBuilder/Widgets/BaseComponents/baseInput.scss
@@ -1,4 +1,6 @@
 .tj-text-input-widget-container {
+  overflow: hidden;
+
   &:hover:not(:focus-within) {
     border: 1px solid var(--tblr-input-border-color-darker) !important;
   }


### PR DESCRIPTION
# num_input_shadow: Number Input's increment/decrement box isn't clipped to the rounded corner, so its shadow bleeds past the curve

<img width="542" height="106" alt="image" src="https://github.com/user-attachments/assets/c5ce07be-c0b3-420c-807a-053ff5bb13d4" />

## Issue Description

On the Number Input widget, the increment/decrement arrow control box (rendered on the right edge of the input) visually collides with the input's rounded corner — its square edge overlaps where the border curves — while a shadow around that same area remains fully visible outside the rounded boundary, instead of being cut off at the curve like the rest of the input.

## Root Cause

`frontend/src/AppBuilder/Widgets/BaseComponents/BaseInput.jsx` sets `border-radius` (line 215) and a configurable `boxShadow` (line 237) on the container div `tj-text-input-widget-container`, but nothing pairs that `border-radius` with `overflow: hidden`. Without an overflow clip, setting `border-radius` on a container doesn't actually constrain its children to the rounded shape — it only rounds the container's own border/background.

The increment/decrement arrow block (`NumberInput.jsx`, `numberControls`) is a normal in-flow child of that same container, passed in as `rightIcon` (`BaseInput.jsx` line 292). `NumberInput.jsx` also strips the container's padding via `classes={{ inputContainer: cn({ 'tw-pr-0 tw-py-0': !inputLogic.loading }) }}`, so the arrow block sits flush against the container's right/top/bottom edges — exactly where the border curves. Its own square corners visually intrude into the curved region, while the container's shadow (drawn outside the border, following the container's own rounded shape) keeps tracing a smooth curve — producing the mismatch: the box looks "cut off" by the radius, but the shadow around it isn't.

No dedicated `.number-input-arrow` styling (`frontend/src/_styles/theme.scss:15258-15266`) or any other rule in the codebase adds clipping — that selector only defines hover/active background colors.

## Fix

Added `overflow: hidden` to `.tj-text-input-widget-container` in `frontend/src/AppBuilder/Widgets/BaseComponents/baseInput.scss`, alongside the existing hover/focus border rules. This makes the container actually clip all of its children — the `<input>`, the arrow-controls block, and any shadow/outline drawn on them — to its own rounded rectangle, so the increment/decrement box and its surrounding shadow now consistently follow the same curve as the rest of the input.

`tj-text-input-widget-container` is shared by every text-like input built on `BaseInput` (`TextInput`, `NumberInput`, `EmailInput`, `PasswordInput`, `TextArea`). Confirmed none of these render a dropdown/popover as an in-flow or absolutely-positioned child of this container — `PhoneInput`/`CurrencyInput` (the only widgets with an actual dropdown, a country/flag selector) don't use `BaseInput` at all and additionally portal their dropdown menu to `document.body`, so they're unaffected by this change.

## Areas to Test

- Number Input: increment/decrement arrow box corners should now follow the input's rounded corner cleanly, with no shadow visible past the curve, at various `borderRadius` widget-style values (including `0` and a large radius).
- Number Input: hover/active states on the increment/decrement arrows (`.number-input-arrow` background color) still render correctly with the new clip.
- Regression check across all `BaseInput` consumers (`TextInput`, `EmailInput`, `PasswordInput`, `TextArea`, `NumberInput`): focus ring/border-color change, validation-error border, and any custom `boxShadow` widget style still look correct with `overflow: hidden` applied.
- Password Input's show/hide icon and any clear-button (`showClearBtn`) rendering — confirm they're still fully visible and not accidentally clipped by the new rule.
