### PR TITLE
fix(grpcv2): reject queries for services removed from the data source (#17537)

### DIFF
--- a/plugins/packages/grpcv2/__tests__/index.js
+++ b/plugins/packages/grpcv2/__tests__/index.js
@@ -1,7 +1,38 @@
 'use strict';
 
-const grpcv2 = require('../lib');
+const Grpcv2QueryService = require('../lib').default;
 
 describe('grpcv2', () => {
-    it.todo('needs tests');
+  describe('#17537: a query may only target services still configured on the data source', () => {
+    const service = new Grpcv2QueryService();
+
+    const sourceOptions = (selected_services) => ({
+      proto_files: 'server_reflection',
+      url: 'localhost:50051',
+      ...(selected_services !== undefined ? { selected_services } : {}),
+    });
+    const queryOptions = { service: 'grep.Old', method: 'Search', raw_message: '{}' };
+
+    it('rejects a service removed from the configuration before any client work', async () => {
+      await expect(
+        service.run(sourceOptions(['grep.New']), queryOptions, 'ds-id')
+      ).rejects.toThrow(/no longer configured on this data source.*grep\.New/);
+    });
+
+    it('allows the query when the service is still selected', async () => {
+      // Past the configured-service gate the next failure is client creation
+      // against a dead URL — proving the gate let it through.
+      await expect(
+        service.run(sourceOptions(['grep.Old']), queryOptions, 'ds-id')
+      ).rejects.toThrow(/Query could not be completed/);
+    });
+
+    it('stays permissive when no service selection is configured', async () => {
+      // Legacy/unrestricted datasources have no selected_services; the gate
+      // must not start rejecting them (again: dies later, at client creation).
+      await expect(
+        service.run(sourceOptions(undefined), queryOptions, 'ds-id')
+      ).rejects.toThrow(/Query could not be completed/);
+    });
+  });
 });

--- a/plugins/packages/grpcv2/lib/index.ts
+++ b/plugins/packages/grpcv2/lib/index.ts
@@ -31,6 +31,8 @@ export default class Grpcv2QueryService implements QueryService {
     _dataSourceUpdatedAt: string
   ): Promise<QueryResult> {
     try {
+      this.validateServiceConfigured(sourceOptions, queryOptions.service);
+
       const client = await this.createGrpcClient(sourceOptions, queryOptions.service);
 
       this.validateRequestData(queryOptions);
@@ -309,6 +311,23 @@ export default class Grpcv2QueryService implements QueryService {
 
       default:
         throw new GrpcOperationError(`Unsupported proto_files option: ${sourceOptions.proto_files}`);
+    }
+  }
+
+  private validateServiceConfigured(sourceOptions: SourceOptions, serviceName: string): void {
+    // #17537: every client builder validates the service against the LIVE
+    // source (reflection list, proto file, filesystem scan), so a service
+    // removed from the datasource configuration — but still exposed by the
+    // server or present in the proto files — kept executing. The
+    // configuration is the contract: when selected_services is set, a query
+    // may only target what it lists. An unset/empty selection is a legacy or
+    // unrestricted datasource and stays permissive.
+    const configured = sourceOptions.selected_services;
+    if (Array.isArray(configured) && configured.length > 0 && !configured.includes(serviceName)) {
+      throw new GrpcOperationError(
+        `Service ${serviceName} is no longer configured on this data source. ` +
+        `Update the query to use one of the configured services: ${configured.join(', ')}`
+      );
     }
   }
 


### PR DESCRIPTION
Closes #17537.

## Root cause

Every gRPC client builder validates the requested service against the **live source**: `buildReflectionClient` checks the server's reflection list, `buildProtoFileClient` the proto file, `buildFilesystemClient` the filesystem scan. None of them ever consults the datasource **configuration**. So after a service is removed from the data source's Services selection, a saved query targeting it still resolves — the server still exposes it, or the proto files still contain it — and executes successfully, exactly as reported.

## Fix

`run()` now calls a `validateServiceConfigured()` gate before any client work: when `selected_services` is a non-empty array on the source options, the query's `service` must be in it, or the run fails with an error naming the configured alternatives:

> `Service grep.Old is no longer configured on this data source. Update the query to use one of the configured services: grep.New`

The error surfaces through the existing `GrpcOperationError -> QueryError('Query could not be completed', ...)` path, so the UI shows it like any other query failure. An **unset or empty** selection (legacy or unrestricted datasource) stays permissive — the gate only enforces a selection the configuration actually made.

## Tests

First real tests in `plugins/packages/grpcv2/__tests__` (the file was an `it.todo` stub):

- a removed service is rejected with the no-longer-configured message — before any client/network work;
- a still-selected service passes the gate (the run then fails at client creation against a dead URL, proving it got through);
- an unset selection stays permissive (same downstream failure).