### PR TITLE
Fix: Component/query id-to-name resolution breaking next to operators like < and >

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -3109,16 +3109,16 @@ export const createComponentsSlice = (set, get) => ({
       queries: getQueryIdNameMapping(moduleId),
     };
 
+    // The trailing path (".value", "?.value", "[0].name", ...) is matched with an include-list
+    // of what a JS member-path can actually contain, instead of an exclude-list of characters
+    // that "shouldn't" appear there — an exclude-list has to anticipate every operator that
+    // might sit next to a reference (this is what missed `<`/`>` previously); an include-list
+    // of valid identifier/index characters can't miss anything because it's a closed set.
     const regex =
-      /(components|queries)(\??\.|\??\.?\[['"]?)([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(['"]?\])?(\??\.|\[['"]?)?([^\s:?[\]'"+\-&|}}]+)?/g;
-    return input.replace(regex, (match, category, prefix, id, suffix, optionalChaining, property) => {
+      /(components|queries)(\??\.|\??\.?\[['"]?)([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(['"]?\])?((?:\??\.[A-Za-z_$][\w$]*|\[\d+\]|\['[^']*'\]|\["[^"]*"\])*)/g;
+    return input.replace(regex, (match, category, prefix, id, closingBracket, path) => {
       if (mappings[category] && mappings[category][id]) {
-        let name;
-        if (category === 'components') {
-          name = mappings[category][id];
-        } else {
-          name = mappings[category][id];
-        }
+        const name = mappings[category][id];
 
         // Reconstruct the string with the name instead of UUID
         let result = `${category}`;
@@ -3137,15 +3137,8 @@ export const createComponentsSlice = (set, get) => ({
           result += name;
         }
 
-        // Handle optional chaining after the name
-        if (optionalChaining) {
-          result += optionalChaining;
-        }
-
-        // Add the property if it exists
-        if (property) {
-          result += property;
-        }
+        // Append the rest of the member path as-is (already validated by the regex above)
+        result += path;
 
         return result;
       }


### PR DESCRIPTION
## 📝 What this does
Custom validation and other `{{ }}` expressions referencing another component/query (e.g. `components.ctrl_value.value<components.ctrl_min.value`) could show a raw component/query UUID instead of its friendly name whenever the reference sat directly against an operator like `<` or `>` with no space. The id-to-name display regex used an exclude-list of "stop" characters for the trailing property path, and `<`/`>` weren't on it.

## 🔀 Changes
- Replaced the exclude-list character class for the trailing member-path (`.value`, `?.value`, `[0].name`, etc.) with an include-list of valid JS identifier/index characters, so it can't miss an operator that wasn't explicitly excluded
- Consolidated the previous two-group (separator + property) capture into a single path-matching group

## 🧪 How to test
- [ ] Add a custom validation expression like `{{components.ctrl_value.value<components.ctrl_min.value || components.ctrl_value.value>components.ctrl_max.value}}` referencing two other components without spaces around `<`/`>`
- [ ] Confirm both referenced components show their friendly names, not raw UUIDs, when reopening the field
- [ ] Confirm existing expressions with spaces, bracket notation, optional chaining, and multi-segment paths (e.g. `.data.nested.value`) still display correctly