### PR TITLE
Fix: workflow query in a module fails on public apps

### DIFF
--- a/server/src/modules/data-queries/repository.ts
+++ b/server/src/modules/data-queries/repository.ts
@@ -74,9 +74,15 @@ export class DataQueryRepository extends Repository<DataQuery> {
         .andWhere('app.organization_id = module_app.organization_id')
         .andWhere("component.properties::jsonb -> 'moduleAppId' ->> 'value' = module_app.co_relation_id::text")
         .andWhere(
-          `(component.properties::jsonb -> 'moduleVersionId' ->> 'value' = ''
-          OR component.properties::jsonb -> 'moduleVersionId' ->> 'value' = module_version.module_reference_id::text
-          OR component.properties::jsonb -> 'moduleVersionId' ->> 'value' = data_query.app_version_id::text)`
+          `COALESCE(
+             NULLIF(component.properties::jsonb -> 'moduleVersionId' ->> 'versionName', ''),
+             COALESCE(component.properties::jsonb -> 'moduleVersionId' ->> 'value', '')
+           ) IN (
+             '', '__default_branch_draft__',
+             module_version.module_reference_id::text,
+             module_version.name,
+             data_query.app_version_id::text
+           )`
         )
         .limit(1)
         .getOne()


### PR DESCRIPTION
## 📝 What this does
A public app that embeds a module could render the module but not run its workflow query — anonymous viewers got a 401. The guard that authorizes module queries under a public parent was comparing the wrong module-pin field, so a pulled app never matched.
- [ee-server](no changes)
- [ee-frontend](no changes)

## 🔀 Changes
- Matched the module pin the same way the runtime resolver does: version name takes precedence over the workspace-local uuid, which is meaningless after a git pull
- Accepted the two pin forms the guard was missing — version name and the default-branch draft sentinel

## 🧪 How to test
- [ ] Build an app with a workflow query, embed a module that also has one
- [ ] Release the workflow, the module and the app, then make the app public
- [ ] Open the public app in a logged-out browser
- [ ] Run the app's own workflow query — should work before and after this change
- [ ] Run the module's workflow query — 401 `Authentication is required to access this app` before, works after
- [ ] Pull the same app into another workspace and repeat, since that is where the pin uuid goes stale
- [ ] Confirm a module that is only embedded in a private app still requires auth

## 📋 Notes for reviewers
- Root cause: `moduleVersionId.value` holds a workspace-local uuid, `versionName` is the portable form. The runtime resolves `COALESCE(versionName, value)`; the guard read `value` only. After a pull, `value` still points at the source workspace's version and resolves to nothing locally.
- Version scoping is deliberately kept. `queryId` arrives in the request body and is not proof the caller was served it, so the guard still has to tie the query's version to the version the public parent actually runs — otherwise any version of an embedded module becomes anonymously triggerable.
- The unpinned and sentinel arms authorize any non-stub version of the module. That matches the pre-existing behaviour of the empty-pin arm, so the trust boundary is unchanged.
- Same helper backs the non-workflow module query guard, so that path is fixed too.
- Followup worth filing: three places now spell out "what counts as a module pin" (the runtime resolver, the version-delete check, this guard) with three different subsets. Extracting one shared SQL fragment would stop the next tier from silently leaving a guard behind.