### PR TITLE
fix(ui): keep NumberInput clear button hidden when the value is empty

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NumberInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/NumberInput.jsx
@@ -4,6 +4,15 @@ import { useInput } from './BaseComponents/hooks/useInput';
 import { cn } from '@/lib/utils';
 import SolidIcon from '@/_ui/Icon/SolidIcons';
 
+// parseFloat('') / parseFloat(null) is NaN, and a NaN value must never reach
+// BaseInput: <input type="number"> renders NaN as an empty field while
+// `hasValue` (NaN !== '' && NaN !== null && NaN !== undefined) stays true,
+// so the clear button shows on an input that looks empty (#17550).
+const toDisplayValue = (rawValue, decimalPlaces) => {
+  const parsed = parseFloat(rawValue);
+  return Number.isFinite(parsed) ? Number(parsed.toFixed(decimalPlaces)) : '';
+};
+
 export const NumberInput = (props) => {
   const inputRef = useRef(null);
 
@@ -11,7 +20,7 @@ export const NumberInput = (props) => {
     ...props,
     properties: {
       ...props.properties,
-      value: Number(parseFloat(props.properties.value).toFixed(props.properties.decimalPlaces)),
+      value: toDisplayValue(props.properties.value, props.properties.decimalPlaces),
     },
   });
 
@@ -31,7 +40,7 @@ export const NumberInput = (props) => {
   };
 
   const handleBlur = (e) => {
-    const value = Number(parseFloat(e.target.value).toFixed(props.properties.decimalPlaces));
+    const value = toDisplayValue(e.target.value, props.properties.decimalPlaces);
     inputLogic.setInputValue(value);
     inputLogic.handleBlur(e);
   };

--- a/frontend/src/AppBuilder/Widgets/__tests__/NumberInput.test.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/NumberInput.test.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NumberInput } from '../NumberInput';
+
+// useInput pulls in stores/context/phone libs that are irrelevant to the value
+// normalization under test.
+jest.mock('@/_stores/gridStore', () => ({
+  useGridStore: jest.fn(() => undefined),
+}));
+jest.mock('@/AppBuilder/Widgets/Form/FormSignalContext', () => ({
+  useShowValidationOnFormSubmit: jest.fn(),
+  useFormClear: jest.fn(),
+}));
+jest.mock('react-phone-number-input', () => ({
+  getCountryCallingCode: () => '1',
+  formatPhoneNumberIntl: (value) => value,
+}));
+
+let baseInputProps;
+jest.mock('../BaseComponents/BaseInput', () => ({
+  BaseInput: (props) => {
+    baseInputProps = props;
+    // Mirrors BaseInput's real clear-button gating:
+    // shouldShowClearBtn = showClearBtn && hasValue && !disable && !loading
+    const hasValue = props.value !== '' && props.value !== null && props.value !== undefined;
+    return (
+      <div>
+        <input
+          data-testid="number-input"
+          value={String(props.value)}
+          onChange={props.handleChange}
+          onBlur={props.handleBlur}
+        />
+        {props.showClearBtn && hasValue ? <button data-testid="clear-btn">clear</button> : null}
+      </div>
+    );
+  },
+}));
+
+const renderNumberInput = (properties) =>
+  render(
+    <NumberInput
+      id="numberinput1"
+      properties={properties}
+      styles={{}}
+      validation={{}}
+      validate={() => ({ isValid: true, validationError: '' })}
+      setExposedVariable={jest.fn()}
+      fireEvent={jest.fn()}
+      darkMode={false}
+    />
+  );
+
+describe('NumberInput value normalization (#17550)', () => {
+  it('does not treat an empty value as NaN, so the clear button stays hidden on an empty input', () => {
+    renderNumberInput({ value: '', decimalPlaces: 2, showClearBtn: true });
+
+    expect(baseInputProps.value).toBe('');
+    expect(screen.queryByTestId('clear-btn')).toBeNull();
+  });
+
+  it.each([undefined, null])('maps an absent value (%s) to an empty string, not NaN', (absent) => {
+    renderNumberInput({ value: absent, decimalPlaces: 2, showClearBtn: true });
+
+    expect(baseInputProps.value).toBe('');
+    expect(screen.queryByTestId('clear-btn')).toBeNull();
+  });
+
+  it('shows the clear button when a numeric value is present', () => {
+    renderNumberInput({ value: 42, decimalPlaces: 2, showClearBtn: true });
+
+    expect(baseInputProps.value).toBe(42);
+    expect(screen.getByTestId('clear-btn')).toBeInTheDocument();
+  });
+
+  it('rounds numeric values to the configured decimal places', () => {
+    renderNumberInput({ value: 3.14159, decimalPlaces: 2, showClearBtn: true });
+
+    expect(baseInputProps.value).toBe(3.14);
+  });
+
+  it('keeps the value an empty string (not NaN) after blurring an emptied input', () => {
+    renderNumberInput({ value: 5, decimalPlaces: 2, showClearBtn: true });
+
+    const input = screen.getByTestId('number-input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    expect(baseInputProps.value).toBe('');
+    expect(screen.queryByTestId('clear-btn')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #17550.

The clear button on the NumberInput widget stayed visible even when the input looked empty and the FX on the toggle evaluated to hiding it.

## Root cause

Not the FX evaluation — the value normalization feeding `BaseInput`:

```js
// NumberInput.jsx (before)
value: Number(parseFloat(props.properties.value).toFixed(props.properties.decimalPlaces))
```

When the bound value field is empty (`''` / `null` / `undefined` — e.g. the FX-bound source field has no content yet), `parseFloat` yields `NaN`, so the component state becomes `NaN`. In `BaseInput`:

```js
const hasValue = value !== '' && value !== null && value !== undefined;      // NaN passes all three → true
const shouldShowClearBtn = showClearBtn && hasValue && !disable && !loading; // → visible
```

`<input type="number">` refuses to render `NaN` and shows an empty field, so the result is exactly what the issue reports: **an input that looks empty with a visible clear button**, regardless of the configured FX.

The same coercion ran again in `handleBlur`, so clearing the input and blurring brought `NaN` right back.

## Fix

A shared `toDisplayValue(rawValue, decimalPlaces)` helper maps non-finite parses to `''` — the empty sentinel `TextInput` and `handleClear` already use — and is applied at init and in `handleBlur`. Numeric values keep the existing `decimalPlaces` rounding.

## Tests

`frontend/src/AppBuilder/Widgets/__tests__/NumberInput.test.jsx` (jest + @testing-library/react, `BaseInput` mocked to mirror its real `shouldShowClearBtn` gating):

- empty / `undefined` / `null` value → `''` reaches `BaseInput`, clear button hidden;
- numeric value → clear button visible;
- `decimalPlaces` rounding preserved;
- blur on an emptied input keeps `''` (not `NaN`), clear button hidden.

Couldn't run the frontend suite locally (Windows checkout without `node_modules`); relying on CI for the jest run.
