### PR TITLE
fix(multiplayer): pass skipResolve/moduleId correctly to setComponentProperty

### DIFF
--- a/frontend/src/AppBuilder/_stores/slices/__tests__/multiplayerSlice.test.js
+++ b/frontend/src/AppBuilder/_stores/slices/__tests__/multiplayerSlice.test.js
@@ -1,0 +1,68 @@
+import { createMultiplayerSlice } from '../multiplayerSlice';
+
+// setComponentProperty(componentId, property, value, paramType, attr, skipResolve, moduleId, options)
+// — 'canvas' used to land on skipResolve and the options object on moduleId, which
+// made getCurrentPageIndex(object) throw and skipped FX resolution for remote updates.
+describe('multiplayerSlice processUpdate — components/update', () => {
+  const makeSlice = () => {
+    const setComponentProperty = jest.fn();
+    const get = () => ({
+      getCurrentPageId: () => 'page1',
+      selectedVersion: { id: 'v1' },
+      setComponentProperty,
+    });
+    return { slice: createMultiplayerSlice(jest.fn(), get), setComponentProperty };
+  };
+
+  const updateDiff = {
+    componentId: 'c1',
+    property: 'value',
+    value: '{{components.text1.value}}',
+    paramType: 'properties',
+    attr: 'value',
+  };
+
+  it('forwards skipResolve=false, moduleId=canvas and the options object in the right positions', () => {
+    const { slice, setComponentProperty } = makeSlice();
+
+    slice.multiplayer.processUpdate({
+      diff: updateDiff,
+      type: 'components',
+      operation: 'update',
+      pageId: 'page1',
+      versionId: 'v1',
+    });
+
+    expect(setComponentProperty).toHaveBeenCalledTimes(1);
+    const args = setComponentProperty.mock.calls[0];
+    expect(args[0]).toBe('c1');
+    expect(args[1]).toBe('value');
+    expect(args[2]).toBe('{{components.text1.value}}');
+    expect(args[3]).toBe('properties');
+    expect(args[4]).toBe('value');
+    expect(args[5]).toBe(false);
+    expect(args[6]).toBe('canvas');
+    expect(args[7]).toEqual({ saveAfterAction: false, skipUndoRedo: true });
+  });
+
+  it('ignores updates for a different page or version', () => {
+    const { slice, setComponentProperty } = makeSlice();
+
+    slice.multiplayer.processUpdate({
+      diff: updateDiff,
+      type: 'components',
+      operation: 'update',
+      pageId: 'other-page',
+      versionId: 'v1',
+    });
+    slice.multiplayer.processUpdate({
+      diff: updateDiff,
+      type: 'components',
+      operation: 'update',
+      pageId: 'page1',
+      versionId: 'other-version',
+    });
+
+    expect(setComponentProperty).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/AppBuilder/_stores/slices/multiplayerSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/multiplayerSlice.js
@@ -80,7 +80,9 @@ export const createMultiplayerSlice = (set, get) => ({
 
               case 'update': {
                 const { componentId, property, value, paramType, attr } = diff;
-                get().setComponentProperty(componentId, property, value, paramType, attr, 'canvas', {
+                // The diff carries the raw (unresolved) value: it must be resolved against
+                // this peer's state, and 'canvas' is the moduleId, not skipResolve.
+                get().setComponentProperty(componentId, property, value, paramType, attr, false, 'canvas', {
                   saveAfterAction: false,
                   skipUndoRedo: true,
                 });


### PR DESCRIPTION
## Summary

`multiplayerSlice.processUpdate` forwarded remote `components/update` diffs to `setComponentProperty` with misaligned positional arguments.

## The bug

```js
// before
get().setComponentProperty(componentId, property, value, paramType, attr, 'canvas', {
  saveAfterAction: false,
  skipUndoRedo: true,
});
```

`setComponentProperty`'s signature is `(componentId, property, value, paramType, attr = 'value', skipResolve = false, moduleId = 'canvas', { skipUndoRedo, saveAfterAction } = {})`, so:

- `'canvas'` landed on **`skipResolve`** (truthy),
- the options object landed on **`moduleId`**.

Two consequences for **every remote property update** in a multiplayer session:

1. `getCurrentPageIndex(moduleId)` reads `modules[optionsObject]` → `undefined` → `TypeError`, so the update never applies on the receiving peer (remote property edits are simply lost / break the sync handler).
2. Even ignoring the crash, `skipResolve` being truthy means the raw `{{...}}` template is stored into the resolved store — for boolean (toggle) properties the validation layer coerces any non-empty string to `true` — and `generateDependencyGraphForRefs` is skipped, so the FX would never re-evaluate on dependency changes.

Every sibling call in the same slice (`addComponentToCurrentPage`, `setParentComponent`, `setComponentLayout`, `deleteComponents`) uses the `(…, moduleId, options)` shape and was already correct; `setComponentProperty` is the only one that interleaves `skipResolve` before `moduleId`, which is how the copy-pasted pattern slipped.

## Fix

```js
get().setComponentProperty(componentId, property, value, paramType, attr, false, 'canvas', {
  saveAfterAction: false,
  skipUndoRedo: true,
});
```

The diff carries the raw unresolved value, so the receiving peer must resolve it locally (`skipResolve = false`).

## Test

`frontend/src/AppBuilder/_stores/slices/__tests__/multiplayerSlice.test.js` renders the slice with a mocked `get()` and asserts the positional arguments of the `setComponentProperty` call for an `update` diff (fails on `main`), plus the page/version gating (`processUpdate` must ignore diffs for other pages or versions).

Couldn't run the frontend suite locally (Windows checkout without `node_modules`); relying on CI for the jest run.
