### PR TITLE
Declare jest-environment-jsdom so the frontend tests can run

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -218,6 +218,7 @@
     "html-loader": "^4.2.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.2",
+    "jest-environment-jsdom": "^29.4.2",
     "mini-css-extract-plugin": "^2.9.4",
     "path": "^0.12.7",
     "postcss": "^8.4.35",


### PR DESCRIPTION
Split out from a note at the bottom of #17526, where I mentioned this while writing tests for #17527.

**What** `frontend/package.json` sets `"testEnvironment": "jest-environment-jsdom"` but does not depend on `jest-environment-jsdom`. Jest stopped bundling it in v28 and the frontend is on `jest ^29.4.2`, so on a fresh clone every frontend test fails before a single one runs:

```
Test environment jest-environment-jsdom cannot be found. Make sure the
testEnvironment configuration option points to an existing node module.
```

This is not specific to my tests. `src/_helpers/__tests__/validateName.test.js`, `src/_components/__tests__/Pagination.test.js` and the rest all fail identically. No workflow runs frontend jest today, which is why nothing is red in CI and this has gone unnoticed.

**How** One line, pinned to `^29.4.2` to track the jest major already in use.

**Before**

```
$ npx jest src/_helpers/__tests__/validateName.test.js
Validation Error: Test environment jest-environment-jsdom cannot be found.
```

**After**

```
Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
```

**One thing to check on your side.** I left `package-lock.json` untouched on purpose. Regenerating it in my checkout rewrites several thousand unrelated lines: the sibling `plugins` workspace is not installed here, so npm drops its `../plugins/node_modules/*` entries and reflags `dev` on about 180 packages. None of that is related to this dependency, and shipping it would bury a one line change. Better regenerated where that workspace is present.