### PR TITLE
Fix visibility of number input clear button based on condition

### DIFF
--- a/frontend/src/AppBuilder/Widgets/BaseComponents/BaseInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/BaseComponents/BaseInput.jsx
@@ -77,7 +77,7 @@ export const BaseInput = ({
   const _width = getLabelWidthOfInput(widthType, width);
   const defaultAlignment = alignment === 'side' || alignment === 'top' ? alignment : 'side';
   const hasLabel = (label?.length > 0 && width > 0) || (auto && width == 0 && label && label?.length != 0);
-  const hasValue = value !== '' && value !== null && value !== undefined;
+  const hasValue = value !== '' && value !== null && value !== undefined && !Number.isNaN(value);
   const shouldShowClearBtn = showClearBtn && hasValue && !disable && !loading;
   const shouldOverridePlaceholderTextColor =
     typeof placeholderTextColor === 'string' &&


### PR DESCRIPTION
Fix
frontend/src/AppBuilder/Widgets/BaseComponents/BaseInput.jsx:80 added a !Number.isNaN(value) guard to hasValue, shared by Text/Email/Number inputs but only functionally relevant to Number Input.

This is a minimal, low-risk change: it doesn't touch the exposed value variable contract (still null for "empty," which other bound components may depend on), and it doesn't touch the FX-resolution engine. it just makes the widget's own "do I have a value" check numerically correct.

Caveat worth flagging: if a user writes a custom FX like {{components.x.value != ""}} referencing another Number Input's exposed value directly, that will still misbehave, because Number Input exposes null (not "") when empty, and null != "" is true in JS — that's a separate, higher-risk inconsistency (changing what "empty" means in the exposed value contract) that I deliberately did not touch here since it could break existing apps relying on === null checks.