### PR TITLE
Fix: Resolve blank canvas when switching versions in git-sync workspace

### DIFF
--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -927,9 +927,8 @@ const useAppData = (
         setPageSettings(
           computePageSettings(deepCamelCase(appData?.editing_version?.pageSettings ?? appData?.pageSettings))
         );
-        let startingPage = appData.pages.find(
-          (page) => page.id === appData.editing_version.home_page_id || appData.editing_version.homePageId
-        );
+        const homePageId = appData.editing_version.homePageId || appData.editing_version.home_page_id;
+        let startingPage = appData.pages.find((page) => page.id === homePageId) || appData.pages[0];
         setCurrentPageId(startingPage.id, moduleId);
         setComponentNameIdMapping(moduleId);
         updateEventsField('events', appData.events, moduleId);


### PR DESCRIPTION
## 📝 What this does
Fixes an operator precedence bug that caused the app canvas to render empty when switching versions or environments in a git-sync-connected workspace on the default branch.

## 🔀 Changes
- Fixed operator precedence in the version-switch effect's `startingPage` lookup that always resolved to the first page in the array instead of the actual home page
- Added fallback to `pages[0]` when the home page ID doesn't match any page

## 🧪 How to test
- [x] Open a git-sync workspace with branching enabled on the default branch
- [x] Open a large app with multiple pages (where the home page is NOT the first in the pages array)
- [x] Switch between versions using the Versions dropdown
- [x] Confirm the canvas renders the home page's components instead of showing the empty-app placeholder