### PR TITLE
fix(widgets): number input clear button no longer shows on an empty field (#17550)

### DIFF
--- a/frontend/src/AppBuilder/Widgets/BaseComponents/BaseInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/BaseComponents/BaseInput.jsx
@@ -84,7 +84,8 @@ export const BaseInput = ({
   const _width = getLabelWidthOfInput(widthType, width);
   const defaultAlignment = alignment === 'side' || alignment === 'top' ? alignment : 'side';
   const hasLabel = (label?.length > 0 && width > 0) || (auto && width == 0 && label && label?.length != 0);
-  const hasValue = value !== '' && value !== null && value !== undefined;
+  const hasValue =
+    value !== '' && value !== null && value !== undefined && !Number.isNaN(value);
   const shouldShowClearBtn = showClearBtn && hasValue && !disable && !loading;
   const shouldOverridePlaceholderTextColor =
     typeof placeholderTextColor === 'string' &&

--- a/frontend/src/AppBuilder/Widgets/NumberInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/NumberInput.jsx
@@ -11,7 +11,16 @@ export const NumberInput = (props) => {
     ...props,
     properties: {
       ...props.properties,
-      value: Number(parseFloat(props.properties.value).toFixed(props.properties.decimalPlaces)),
+      // An empty/unparsable value parses to NaN, which BaseInput's emptiness
+      // checks do not recognize (NaN !== null/undefined/'') — the clear
+      // button then shows on an empty field no matter what the visibility
+      // condition evaluates to (#17550). Coerce to null, the same value
+      // handleChange sets when the field is cleared.
+      value: Number.isNaN(Number.parseFloat(props.properties.value))
+        ? null
+        : Number(
+            Number.parseFloat(props.properties.value).toFixed(props.properties.decimalPlaces),
+          ),
     },
   });
 

--- a/frontend/src/AppBuilder/_stores/slices/__tests__/multiplayerSlice.test.js
+++ b/frontend/src/AppBuilder/_stores/slices/__tests__/multiplayerSlice.test.js
@@ -1,0 +1,68 @@
+import { createMultiplayerSlice } from '../multiplayerSlice';
+
+// setComponentProperty(componentId, property, value, paramType, attr, skipResolve, moduleId, options)
+// — 'canvas' used to land on skipResolve and the options object on moduleId, which
+// made getCurrentPageIndex(object) throw and skipped FX resolution for remote updates.
+describe('multiplayerSlice processUpdate — components/update', () => {
+  const makeSlice = () => {
+    const setComponentProperty = jest.fn();
+    const get = () => ({
+      getCurrentPageId: () => 'page1',
+      selectedVersion: { id: 'v1' },
+      setComponentProperty,
+    });
+    return { slice: createMultiplayerSlice(jest.fn(), get), setComponentProperty };
+  };
+
+  const updateDiff = {
+    componentId: 'c1',
+    property: 'value',
+    value: '{{components.text1.value}}',
+    paramType: 'properties',
+    attr: 'value',
+  };
+
+  it('forwards skipResolve=false, moduleId=canvas and the options object in the right positions', () => {
+    const { slice, setComponentProperty } = makeSlice();
+
+    slice.multiplayer.processUpdate({
+      diff: updateDiff,
+      type: 'components',
+      operation: 'update',
+      pageId: 'page1',
+      versionId: 'v1',
+    });
+
+    expect(setComponentProperty).toHaveBeenCalledTimes(1);
+    const args = setComponentProperty.mock.calls[0];
+    expect(args[0]).toBe('c1');
+    expect(args[1]).toBe('value');
+    expect(args[2]).toBe('{{components.text1.value}}');
+    expect(args[3]).toBe('properties');
+    expect(args[4]).toBe('value');
+    expect(args[5]).toBe(false);
+    expect(args[6]).toBe('canvas');
+    expect(args[7]).toEqual({ saveAfterAction: false, skipUndoRedo: true });
+  });
+
+  it('ignores updates for a different page or version', () => {
+    const { slice, setComponentProperty } = makeSlice();
+
+    slice.multiplayer.processUpdate({
+      diff: updateDiff,
+      type: 'components',
+      operation: 'update',
+      pageId: 'other-page',
+      versionId: 'v1',
+    });
+    slice.multiplayer.processUpdate({
+      diff: updateDiff,
+      type: 'components',
+      operation: 'update',
+      pageId: 'page1',
+      versionId: 'other-version',
+    });
+
+    expect(setComponentProperty).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/AppBuilder/_stores/slices/multiplayerSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/multiplayerSlice.js
@@ -80,7 +80,9 @@ export const createMultiplayerSlice = (set, get) => ({
 
               case 'update': {
                 const { componentId, property, value, paramType, attr } = diff;
-                get().setComponentProperty(componentId, property, value, paramType, attr, 'canvas', {
+                // The diff carries the raw (unresolved) value: it must be resolved against
+                // this peer's state, and 'canvas' is the moduleId, not skipResolve.
+                get().setComponentProperty(componentId, property, value, paramType, attr, false, 'canvas', {
                   saveAfterAction: false,
                   skipUndoRedo: true,
                 });


### PR DESCRIPTION
Closes #17550.

## Root cause

`NumberInput` parsed its value through `Number(parseFloat(v).toFixed(dp))`, which yields **NaN** for an empty or unparsable value. `BaseInput`'s emptiness gate compares against `''`/`null`/`undefined` — **NaN equals none of them** — so `hasValue` was `true` on an empty field, and `shouldShowClearBtn` rendered the button no matter what the visibility condition evaluated to. Verified directly: `Number(parseFloat(undefined).toFixed(2))` → `NaN`, and the old `hasValue` expression returns `true` for it.

## Fix — two complementary layers

1. **`NumberInput`** coerces an unparsable value to `null` — the same value `handleChange` already sets when the field is cleared — so the component's value state stays consistent end to end.
2. **`BaseInput`'s `hasValue`** also treats `NaN` as empty (`!Number.isNaN(value)`), protecting every numeric caller of the shared component from the same shape.

With an empty field the clear button is now hidden; with a value (FX-driven or typed) it shows — exactly the reported expectation. The FX condition on `showClearBtn` itself was never broken: the shared gate below it was.