### PR TITLE
Fix: ext-api save/release branch_id NOT NULL bug, add real git-sync coverage

### DIFF
--- a/server/src/modules/versions/util.service.ts
+++ b/server/src/modules/versions/util.service.ts
@@ -186,13 +186,9 @@ export class VersionUtilService implements IVersionUtilService {
       ...extraParams,
     };
 
-    // chk_app_versions_branched_implies_draft requires non-DRAFT rows to be
-    // branchless. Detach branch_id in the SAME UPDATE as the status flip so
-    // the row never lands in the violating state, even momentarily within
-    // this statement.
-    if (appVersion.branchId) {
-      editableParams.branchId = null;
-    }
+    // branch_id is NOT NULL now and chk_app_versions_branched_implies_draft was dropped —
+    // PUBLISHED rows live on the default branch, so the status flip doesn't detach branch_id.
+    // (Mirrors updateVersion's handling above.)
 
     const runWrite = async (mgr: EntityManager) => {
       await this.versionRepository.updateVersion(appVersion.id, editableParams, mgr);

--- a/server/test/modules/external-apis/e2e/auto-deploy.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/auto-deploy.e2e-spec.ts
@@ -219,8 +219,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/git-sync/release', () => 
   // 201 — happy path
   // ---------------------------------------------------------------------------
 
-  // skip: publish detaches branch_id, 422s every deploy — src bug, #17333 (1)
-  describe.skip('201 — happy path', () => {
+  describe('201 — happy path', () => {
     it('deploys the version by versionId to the production environment', async () => {
       const { user, organization } = await seedOrg();
       const app = await seedApp(user);

--- a/server/test/modules/external-apis/e2e/promote-to-next-version.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/promote-to-next-version.e2e-spec.ts
@@ -137,8 +137,7 @@ describe('External API — promote to next version (handleDefaultBranchPublish)'
   // ---------------------------------------------------------------------------
 
   describe('fires via save', () => {
-    // skip: publish detaches branch_id — src bug, #17333 (1)
-    it.skip('seeds a new DRAFT on the default branch; the published row keeps its branch id', async () => {
+    it('seeds a new DRAFT on the default branch; the published row keeps its branch id', async () => {
       const { user, organization } = await seedOrgWithGit();
       const branch = await seedDefaultBranch(organization.id);
       const app = await seedApp(user);
@@ -183,8 +182,7 @@ describe('External API — promote to next version (handleDefaultBranchPublish)'
   // ---------------------------------------------------------------------------
 
   describe('no-op guards', () => {
-    // skip: publish detaches branch_id — src bug, #17333 (1)
-    it.skip('publishes the version in place, but does not seed a new draft, when the version is on a non-default branch', async () => {
+    it('publishes the version in place, but does not seed a new draft, when the version is on a non-default branch', async () => {
       const { user, organization } = await seedOrgWithGit();
       await seedDefaultBranch(organization.id, 'main');
       const featureBranch = await saveEntity(WorkspaceBranch, {
@@ -233,8 +231,7 @@ describe('External API — promote to next version (handleDefaultBranchPublish)'
       expect(versions[0].branchId).toBeNull();
     });
 
-    // skip: publish detaches branch_id — src bug, #17333 (1)
-    it.skip('does not seed a new draft when the version has no branchId', async () => {
+    it('does not seed a new draft when the version has no branchId', async () => {
       const { user } = await seedOrgWithGit();
       const app = await seedApp(user);
       const draft = await createApplicationVersion(nestApp, app as any, { name: 'v1' });
@@ -264,8 +261,7 @@ describe('External API — promote to next version (handleDefaultBranchPublish)'
     // seeds the next draft, release promotes that published version to prod,
     // push pushes its commit — closing the "save then release" claim that
     // used to be a stale comment in save-version.e2e-spec.ts.
-    // skip: publish detaches branch_id — src bug, #17333 (1)
-    it.skip('chains save -> release -> push through a full git-sync lifecycle', async () => {
+    it('chains save -> release -> push through a full git-sync lifecycle', async () => {
       const { user, organization } = await seedOrgWithGit();
       const branch = await seedDefaultBranch(organization.id);
       const app = await seedApp(user);

--- a/server/test/modules/external-apis/e2e/save-release-gitsync.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/save-release-gitsync.e2e-spec.ts
@@ -1,0 +1,274 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as request from 'supertest';
+import { createUser, initTestApp, login, closeTestApp, ensureAppEnvironments } from 'test-helper';
+import { WorkspaceBranchService } from '@ee/workspace-branches/service';
+import { GitSyncQueueService } from '@ee/workspace-branches/git-sync-queue.service';
+
+/**
+ * External API — POST /ext/apps/:appIdOrSlug/versions/save and
+ * POST /ext/apps/:appIdOrSlug/git-sync/release against a REAL git host.
+ *
+ * Every other External API spec in this suite stubs `SourceControlProviderService`
+ * at the boundary (per testing.md's mock-only-boundaries-you-don't-own rule) — correct
+ * for exercising the DB-side publish/promote logic deterministically, but it means the
+ * actual GitHub App auth → Octokit tag creation → tag lookup wiring behind `saveAppVersion`
+ * and `autoDeployApp`'s "latest tag" auto mode has never run end-to-end (see
+ * git-sync-e2e-test-architecture memory, open threads #1/#2).
+ *
+ * This file closes that gap: real git config, a real feature-branch push + merge (mirrors
+ * git-sync.spec.ts §2 steps 1-19), then the External API — not the internal `/api/*`
+ * endpoints — drives save (real tag created on the simulator) and release-with-no-body
+ * (real tag discovered via Octokit and promoted to production).
+ *
+ * Self-guards like git-sync-gitlab.spec.ts: skips the whole suite at runtime when the
+ * simulator env is absent, so a plain `npm run test:e2e` stays green without it. Uses its
+ * own repo path (GitHub suite's `TEST_GIT_REPO_PATH` + `-ext-api`) so it can't collide with
+ * git-sync.spec.ts's shared, stateful 64-step fixture.
+ */
+const REQUIRED_ENV = [
+  'TEST_GIT_BASE_URL',
+  'TOOLJET_GIT_ADMIN_USER',
+  'TOOLJET_GIT_ADMIN_PASSWORD',
+  'TOOLJET_GITHUB_APP_ID',
+  'TOOLJET_GITHUB_INSTALLATION_ID',
+  'TOOLJET_GITHUB_APP_PRIVATE_KEY',
+];
+const MISSING_ENV = REQUIRED_ENV.filter((name) => !process.env[name]);
+const GITSYNC_E2E_ENABLED = MISSING_ENV.length === 0;
+if (!GITSYNC_E2E_ENABLED) {
+  console.warn(
+    `[save-release-gitsync] SKIPPED — set ${MISSING_ENV.join(', ')} (plus a GitHub-Enterprise-shaped simulator) to run this suite.`
+  );
+}
+const describeGitsync = GITSYNC_E2E_ENABLED ? describe : describe.skip;
+
+const GIT_BASE_URL = (process.env.TEST_GIT_BASE_URL || '').replace(/\/$/, '');
+// Own repo, distinct from git-sync.spec.ts's `TEST_GIT_REPO_PATH` (or its static
+// `gsmithun4/e2e` fallback) — same base, `-ext-api` suffix, so a shared per-run
+// TEST_GIT_REPO_PATH (minted by scripts/run-e2e.sh) still yields a private repo here.
+const GIT_REPO_PATH = `${(process.env.TEST_GIT_REPO_PATH || 'gsmithun4/e2e').replace(/^\/|\/$/g, '')}-ext-api`;
+const [GIT_REPO_OWNER, GIT_REPO_NAME] = GIT_REPO_PATH.split('/');
+
+const GITHUB_HTTPS_PAYLOAD = {
+  gitUrl: `${GIT_BASE_URL}/${GIT_REPO_PATH}`,
+  branchName: process.env.TEST_GIT_HTTPS_BRANCH || 'main',
+  githubEnterpriseUrl: GIT_BASE_URL,
+  githubEnterpriseApiUrl: `${GIT_BASE_URL}/api/v3`,
+  githubAppId: process.env.TOOLJET_GITHUB_APP_ID,
+  githubAppInstallationId: process.env.TOOLJET_GITHUB_INSTALLATION_ID,
+  // PEM keys in .env carry literal "\n" escapes (dotenv doesn't unescape them) — restore
+  // real newlines or forge.pki.privateKeyFromPem fails with a 400.
+  githubAppPrivateKey: (process.env.TOOLJET_GITHUB_APP_PRIVATE_KEY || '').replace(/\\n/g, '\n'),
+  gitType: 'github_https',
+};
+
+const BASIC =
+  'Basic ' +
+  Buffer.from(`${process.env.TOOLJET_GIT_ADMIN_USER}:${process.env.TOOLJET_GIT_ADMIN_PASSWORD}`).toString('base64');
+const RESET_URL = `${GIT_BASE_URL}/admin/repos/${GIT_REPO_PATH}.git/reset`;
+const MERGE_URL = `${GIT_BASE_URL}/admin/merge`;
+
+/**
+ * @group gitsync
+ */
+describeGitsync('External API — save & release against a real git host', () => {
+  describe('EE (plan: enterprise)', () => {
+    let nestApp: INestApplication;
+    let AUTH_HEADER: string;
+    let tokenCookie: string;
+    let orgId: string;
+
+    beforeAll(async () => {
+      process.env.ENABLE_EXTERNAL_API = 'true';
+      ({ app: nestApp } = await initTestApp({ edition: 'ee', plan: 'enterprise' }));
+
+      const configService = nestApp.get<ConfigService>(ConfigService);
+      AUTH_HEADER = `Basic ${configService.get('EXTERNAL_API_ACCESS_TOKEN')}`;
+
+      const email = `admin+${Date.now()}@tooljet.io`;
+      const { organization } = await createUser(nestApp, { email });
+      orgId = organization.id;
+      ({ tokenCookie } = await login(nestApp, email));
+
+      // Same reasoning as git-sync.spec.ts: prototype-spy the queue so branch
+      // create/pull run inline at enqueue time instead of racing an async worker.
+      const branchSvc = nestApp.get(WorkspaceBranchService, { strict: false });
+      jest
+        .spyOn(GitSyncQueueService.prototype, 'enqueueCreateBranch')
+        .mockImplementation((p) => branchSvc.executeCreateBranch(p));
+      jest
+        .spyOn(GitSyncQueueService.prototype, 'enqueuePullBranch')
+        .mockImplementation((p) => branchSvc.executePullBranch(p));
+    });
+
+    afterAll(async () => {
+      await closeTestApp(nestApp);
+    }, 60_000);
+
+    it('saves a version through the External API (real git tag) then releases it by auto-discovering that tag', async () => {
+      const step = (n: number, label: string) => process.stdout.write(`    ↳ step ${n}: ${label}\n`);
+
+      await ensureAppEnvironments(nestApp, orgId);
+
+      step(0, 'reset repo to a clean state');
+      await fetch(RESET_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: BASIC },
+        body: '{}',
+      });
+
+      step(1, 'configure git + enable branching, load main');
+      await request
+        .agent(nestApp.getHttpServer())
+        .post('/api/git-sync/configs')
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .send({ ...GITHUB_HTTPS_PAYLOAD, useEnvConfig: false })
+        .expect(201);
+
+      const orgGitId: string = (
+        await request
+          .agent(nestApp.getHttpServer())
+          .get(`/api/git-sync/${orgId}`)
+          .set('Cookie', tokenCookie)
+          .set('tj-workspace-id', orgId)
+          .expect(200)
+      ).body.organization_git.id;
+      await request
+        .agent(nestApp.getHttpServer())
+        .put(`/api/git-sync/${orgGitId}/is-branching-enabled`)
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .send({ isBranchingEnabled: true })
+        .expect(200);
+
+      const mainBranchId: string = (
+        await request
+          .agent(nestApp.getHttpServer())
+          .get('/api/workspace-branches')
+          .set('Cookie', tokenCookie)
+          .set('tj-workspace-id', orgId)
+          .expect(200)
+      ).body.activeBranchId;
+      expect(mainBranchId).toBeDefined();
+
+      step(2, 'create feature branch off main');
+      await request
+        .agent(nestApp.getHttpServer())
+        .post('/api/workspace-branches')
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .query({ branch_id: mainBranchId })
+        .send({ name: 'feat-ext-api', sourceBranchId: mainBranchId })
+        .expect(201);
+      const branchesResp = await request
+        .agent(nestApp.getHttpServer())
+        .get('/api/workspace-branches')
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .query({ branch_id: mainBranchId })
+        .expect(200);
+      const featBranchId: string = branchesResp.body.branches.find((b: any) => b.name === 'feat-ext-api')?.id;
+      expect(featBranchId).toBeDefined();
+
+      step(3, 'create app on the feature branch');
+      const createAppResp = await request
+        .agent(nestApp.getHttpServer())
+        .post('/api/apps')
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .query({ branch_id: featBranchId })
+        .send({ icon: 'home', name: 'ext-api-save-release', type: 'front-end', branchId: featBranchId })
+        .expect(201);
+      const appId: string = createAppResp.body.id;
+
+      const appDetail = await request
+        .agent(nestApp.getHttpServer())
+        .get(`/api/apps/${appId}`)
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .query({ branch_id: featBranchId })
+        .expect(200);
+      const versionId: string = appDetail.body.editing_version.id;
+
+      step(4, 'push the feature branch, merge to main, pull main (hydrates as a stub)');
+      await request
+        .agent(nestApp.getHttpServer())
+        .post(`/api/app-git/gitpush/${appId}/${versionId}`)
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .query({ branch_id: featBranchId })
+        .send({
+          gitAppName: 'ext-api-save-release',
+          versionId,
+          lastCommitMessage: 'initial push',
+          gitVersionName: 'feat-ext-api',
+          sourceBranch: 'feat-ext-api',
+        })
+        .expect(201);
+
+      const mergeResp = await fetch(MERGE_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: BASIC },
+        body: JSON.stringify({
+          owner: GIT_REPO_OWNER,
+          repo: `${GIT_REPO_NAME}.git`,
+          source: 'feat-ext-api',
+          target: 'main',
+          message: 'Land feat-ext-api',
+        }),
+      });
+      expect((await mergeResp.json().catch(() => ({}))).ok).toBe(true);
+
+      await request
+        .agent(nestApp.getHttpServer())
+        .post('/api/workspace-branches/pull')
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .query({ branch_id: mainBranchId })
+        .send({ branchId: mainBranchId })
+        .expect(201);
+
+      step(5, 'hydrate the stub on main');
+      const hydratedApp = (
+        await request
+          .agent(nestApp.getHttpServer())
+          .get('/api/apps')
+          .query({ page: 1, folder: '', searchKey: '', type: 'front-end', branch_id: mainBranchId })
+          .set('Cookie', tokenCookie)
+          .set('tj-workspace-id', orgId)
+          .expect(200)
+      ).body.apps[0];
+      await request
+        .agent(nestApp.getHttpServer())
+        .get(`/api/apps/${hydratedApp.id}`)
+        .set('Cookie', tokenCookie)
+        .set('tj-workspace-id', orgId)
+        .query({ branch_id: mainBranchId })
+        .expect(200);
+
+      step(6, 'External API: save v1 — must create a REAL git tag on the simulator');
+      const saveResp = await request
+        .agent(nestApp.getHttpServer())
+        .post(`/api/ext/apps/${hydratedApp.id}/versions/save`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ name: 'v1' })
+        .expect(201);
+      expect(saveResp.body).toMatchObject({ name: 'v1', status: 'PUBLISHED' });
+
+      step(7, 'External API: release with no body — must auto-discover that tag via a real Octokit call');
+      const releaseResp = await request
+        .agent(nestApp.getHttpServer())
+        .post(`/api/ext/apps/${hydratedApp.id}/git-sync/release`)
+        .set('Authorization', AUTH_HEADER)
+        .send({})
+        .expect(201);
+      // A broken tag lookup (the wiring this test exists to catch) surfaces as a
+      // BadRequestException — asserting 201 IS the assertion that Octokit found the
+      // real tag `saveResp` just created. currentVersionId confirms it promoted the
+      // right (v1) version, not some other row.
+      expect(releaseResp.body.currentVersionId).toBe(saveResp.body.id);
+    }, 120_000);
+  });
+});

--- a/server/test/modules/external-apis/e2e/save-version.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/save-version.e2e-spec.ts
@@ -190,8 +190,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
   // ---------------------------------------------------------------------------
 
   describe('201 — happy path', () => {
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('saves the DRAFT version to PUBLISHED, targeting the development environment', async () => {
+    it('saves the DRAFT version to PUBLISHED, targeting the development environment', async () => {
       const { user, organization } = await seedOrg();
       const app = await seedApp(user);
       const draft = await seedDraftVersion(app as any, 'v1');
@@ -213,8 +212,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
       expect(response.body.appId).toBe(app.id);
     });
 
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('renames the DRAFT version when name is provided', async () => {
+    it('renames the DRAFT version when name is provided', async () => {
       const { user } = await seedOrg();
       const app = await seedApp(user);
       await seedDraftVersion(app as any, 'v1');
@@ -229,8 +227,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
       expect(response.body.name).toBe('release-1.0.0');
     });
 
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('accepts name at exactly 25 characters (boundary)', async () => {
+    it('accepts name at exactly 25 characters (boundary)', async () => {
       const { user } = await seedOrg();
       const app = await seedApp(user);
       await seedDraftVersion(app as any, 'v1');
@@ -245,8 +242,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
       expect(response.body.name).toBe('a'.repeat(25));
     });
 
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('resolves app by slug', async () => {
+    it('resolves app by slug', async () => {
       const { user } = await seedOrg();
       const slug = `my-app-${Date.now()}`;
       const app = await createApplication(nestApp, { user, name: `App-${Date.now()}`, isPublic: false, slug });
@@ -261,8 +257,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
       expect(response.body.status).toBe(AppVersionStatus.PUBLISHED);
     });
 
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('persists the status change in the database', async () => {
+    it('persists the status change in the database', async () => {
       const { user } = await seedOrg();
       const app = await seedApp(user);
       const draft = await seedDraftVersion(app as any, 'v1');
@@ -277,8 +272,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
       expect(updated.status).toBe(AppVersionStatus.PUBLISHED);
     });
 
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('does not affect other versions on the same app', async () => {
+    it('does not affect other versions on the same app', async () => {
       const { user } = await seedOrg();
       const app = await seedApp(user);
       const draft = await seedDraftVersion(app as any, 'v1');
@@ -299,8 +293,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
       expect(reloadedDraft.status).toBe(AppVersionStatus.PUBLISHED);
     });
 
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('persists currentEnvironmentId to the development environment in the database', async () => {
+    it('persists currentEnvironmentId to the development environment in the database', async () => {
       const { user, organization } = await seedOrg();
       const app = await seedApp(user);
       const draft = await seedDraftVersion(app as any, 'v1');
@@ -326,8 +319,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
   // ---------------------------------------------------------------------------
 
   describe('git tag creation', () => {
-    // skip: publish detaches branch_id — src bug, #17333 (1)
-    it.skip('creates a git tag when git sync is configured for the app', async () => {
+    it('creates a git tag when git sync is configured for the app', async () => {
       const { user } = await seedOrg();
       const app = await seedApp(user);
       await seedDraftVersion(app as any, 'v1');
@@ -350,8 +342,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
       );
     });
 
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('returns 201 and persists the save even when git tag creation throws', async () => {
+    it('returns 201 and persists the save even when git tag creation throws', async () => {
       const { user } = await seedOrg();
       const app = await seedApp(user);
       const draft = await seedDraftVersion(app as any, 'v1');
@@ -370,8 +361,7 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
       expect(updated.status).toBe(AppVersionStatus.PUBLISHED);
     });
 
-    // QUARANTINE(external-apis): failing since main CI rehab — see #17260
-    it.skip('returns 201 when no git sync is configured (getSourceControlService throws)', async () => {
+    it('returns 201 when no git sync is configured (getSourceControlService throws)', async () => {
       const { user } = await seedOrg();
       const app = await seedApp(user);
       const draft = await seedDraftVersion(app as any, 'v1');

--- a/server/test/modules/external-apis/unit/external-api-security.guard.spec.ts
+++ b/server/test/modules/external-apis/unit/external-api-security.guard.spec.ts
@@ -1,0 +1,114 @@
+import { ForbiddenException, ExecutionContext } from '@nestjs/common';
+import { ExternalApiSecurityGuard as CeExternalApiSecurityGuard } from '@modules/auth/guards/external-api-security.guard';
+import { ExternalApiSecurityGuard } from '@ee/auth/guards/external-api-security.guard';
+import { LICENSE_FIELD } from '@modules/licensing/constants';
+
+/**
+ * The three gates every External API endpoint shares — config-disabled, unlicensed,
+ * and (CE) always-off — have no coverage anywhere in `external-apis/`, e2e or unit,
+ * despite gating every /ext/* route. Per testing.md's pruning rule this is tested
+ * ONCE here, at the guard, rather than duplicated per endpoint spec.
+ */
+/** @group platform */
+describe('ExternalApiSecurityGuard', () => {
+  let mockConfigService: { get: jest.Mock };
+  let mockLicenseTermsService: { getLicenseTermsInstance: jest.Mock };
+  let guard: ExternalApiSecurityGuard;
+  const ORIGINAL_EDITION = process.env.TOOLJET_EDITION;
+
+  const makeContext = (authHeader?: string): ExecutionContext => {
+    const request = { headers: authHeader ? { authorization: authHeader } : {} };
+    return { switchToHttp: () => ({ getRequest: () => request }) } as unknown as ExecutionContext;
+  };
+
+  beforeEach(() => {
+    mockConfigService = { get: jest.fn() };
+    mockLicenseTermsService = { getLicenseTermsInstance: jest.fn() };
+    // appRepository is never touched by canActivate — null-injected per testing.md's
+    // boundary rule (prefer null-injecting real collaborators over jest.mock).
+    guard = new ExternalApiSecurityGuard(mockConfigService as any, mockLicenseTermsService as any, null as any);
+  });
+
+  afterEach(() => {
+    process.env.TOOLJET_EDITION = ORIGINAL_EDITION;
+  });
+
+  describe('CE', () => {
+    it('always denies, regardless of config/license/auth', async () => {
+      const ceGuard = new CeExternalApiSecurityGuard(
+        mockConfigService as any,
+        mockLicenseTermsService as any,
+        null as any
+      );
+      await expect(ceGuard.canActivate(makeContext('Basic anything'))).resolves.toBe(false);
+    });
+  });
+
+  describe('EE (plan: enterprise)', () => {
+    describe('config gate', () => {
+      it('throws when ENABLE_EXTERNAL_API is not "true", before the auth token is ever checked', async () => {
+        mockConfigService.get.mockImplementation((key: string) =>
+          key === 'ENABLE_EXTERNAL_API' ? 'false' : undefined
+        );
+        // The license lookup runs unconditionally before this gate (see canActivate) —
+        // asserting on it here would pin an implementation quirk, not behavior.
+        mockLicenseTermsService.getLicenseTermsInstance.mockResolvedValue(true);
+
+        await expect(guard.canActivate(makeContext('Basic anything'))).rejects.toThrow(
+          new ForbiddenException('External API is disabled')
+        );
+      });
+    });
+
+    describe('license gate', () => {
+      beforeEach(() => {
+        mockConfigService.get.mockImplementation((key: string) => (key === 'ENABLE_EXTERNAL_API' ? 'true' : undefined));
+      });
+
+      it('throws when unlicensed on a non-Cloud edition', async () => {
+        process.env.TOOLJET_EDITION = 'ee';
+        mockLicenseTermsService.getLicenseTermsInstance.mockResolvedValue(false);
+
+        await expect(guard.canActivate(makeContext())).rejects.toThrow(
+          new ForbiddenException('You do not have access to this resource')
+        );
+        expect(mockLicenseTermsService.getLicenseTermsInstance).toHaveBeenCalledWith(LICENSE_FIELD.EXTERNAL_API);
+      });
+
+      it('skips the license check on Cloud — falls through to the auth-token gate instead', async () => {
+        process.env.TOOLJET_EDITION = 'cloud';
+        mockLicenseTermsService.getLicenseTermsInstance.mockResolvedValue(false);
+
+        // No license and no valid token on Cloud → rejected by the auth-token gate,
+        // not the license gate — proves the license check was skipped, not just lenient.
+        await expect(guard.canActivate(makeContext())).rejects.toThrow(new ForbiddenException('Unauthorized'));
+      });
+    });
+
+    describe('auth-token gate', () => {
+      beforeEach(() => {
+        process.env.TOOLJET_EDITION = 'ee';
+        mockConfigService.get.mockImplementation((key: string) => {
+          if (key === 'ENABLE_EXTERNAL_API') return 'true';
+          if (key === 'EXTERNAL_API_ACCESS_TOKEN') return 'the-real-token';
+          return undefined;
+        });
+        mockLicenseTermsService.getLicenseTermsInstance.mockResolvedValue(true);
+      });
+
+      it('throws when the Authorization header is missing', async () => {
+        await expect(guard.canActivate(makeContext())).rejects.toThrow(new ForbiddenException('Unauthorized'));
+      });
+
+      it('throws when the Authorization header carries the wrong token', async () => {
+        await expect(guard.canActivate(makeContext('Basic wrong-token'))).rejects.toThrow(
+          new ForbiddenException('Unauthorized')
+        );
+      });
+
+      it('allows the request through when licensed, config-enabled, and the token matches', async () => {
+        await expect(guard.canActivate(makeContext('Basic the-real-token'))).resolves.toBe(true);
+      });
+    });
+  });
+});

--- a/server/test/modules/git-sync/e2e/lifecycle-cases.md
+++ b/server/test/modules/git-sync/e2e/lifecycle-cases.md
@@ -910,6 +910,43 @@ endpoint spec, Redis) but not the simulator, so
 
 ---
 
+## 31. External API save/release against a real git host (`test/modules/external-apis/e2e/save-release-gitsync.e2e-spec.ts`)
+
+The External API analog of §24, plus the "auto-release" path §24 doesn't cover. Every other External
+API spec (`save-version.e2e-spec.ts`, `promote-to-next-version.e2e-spec.ts`, `auto-deploy.e2e-spec.ts`)
+stubs `SourceControlProviderService` at the boundary — correct for pinning the DB-side publish/promote
+logic deterministically, but it means the actual GitHub App auth → Octokit tag-creation → tag-lookup
+wiring behind `saveAppVersion` and `autoDeployApp`'s "latest tag" auto mode had never run against a
+real host. This file closes that gap.
+
+Self-guards like `git-sync-gitlab.spec.ts` (`describe.skip` at runtime when the simulator env is
+absent — see the note at the top of this doc) rather than throwing at import like `git-sync.spec.ts`,
+so a plain `npm run test:e2e` stays green without the simulator configured. Own repo path — the
+GitHub suite's `TEST_GIT_REPO_PATH` (or its `gsmithun4/e2e` fallback) with a `-ext-api` suffix — so it
+can't collide with `git-sync.spec.ts`'s shared, stateful fixture.
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | Reset the `-ext-api` repo; configure git + enable branching; load `main` | 201/200 |
+| 2 | Create a feature branch, create an app on it, `gitpush` it | 201 |
+| 3 | Admin-`/merge` feature → `main`; pull `main` (lands as a stub); hydrate via `GET /apps/:id` | 200 |
+| 4 | **External API**: `POST /ext/apps/:id/versions/save` `{ name: 'v1' }` | 201; `status: PUBLISHED` — and a REAL tag now exists on the simulator (no mock) |
+| 5 | **External API**: `POST /ext/apps/:id/git-sync/release` with an EMPTY body (auto mode) | 201; `currentVersionId` matches the version saved in step 4 |
+
+Step 5 is the actual assertion for step 4's tag: `autoDeployApp`'s auto mode calls
+`getLatestTagNameForApp` → a real Octokit `listTags` call against the simulator. A broken
+tag-creation or tag-lookup wiring surfaces as a `BadRequestException` (`No git tags found` / `Latest
+tag not found after pull`) — asserting `201` here **is** the assertion that Octokit found the tag
+`saveAppVersion` created. `currentVersionId` on top of that rules out the release resolving to some
+other row.
+
+Not mirrored in `git-sync-gitlab.spec.ts` — the External API's `SourceControlProviderService` wiring
+is provider-agnostic at the DB layer (already covered by the mocked specs); this file exists
+specifically to exercise the GitHub-App-auth → Octokit path once for real, not to re-prove
+provider-parity.
+
+---
+
 ## Test-only license control
 
 The real License path (`ee/licensing/configs/License.ts`) always decrypts its key — no test-only branch. In


### PR DESCRIPTION
## 📝 What this does
`POST /ext/apps/:id/versions/save` and `.../git-sync/release` were 422ing on every call — `publishVersionWithEnvironment` still detached `branch_id` on publish, a leftover from before `branch_id` became `NOT NULL`. Fixes the bug, un-quarantines the tests it was blocking (several mislabeled under an unrelated tracking issue), and adds the coverage that was missing around it.
- [ee-server](no changes)
- [ee-frontend](no changes)

Relates to: #17333

## 🔀 Changes
- Removed the stale `branch_id = null` write in `publishVersionWithEnvironment` — matches the already-fixed sibling `updateVersion`
- Un-skipped and re-tagged tests across `save-version`, `promote-to-next-version`, and `auto-deploy` e2e specs that this same bug was blocking (some were mislabeled under issue #17260)
- Added a guard-unit test for `ExternalApiSecurityGuard`'s three shared gates (config-disabled / unlicensed / CE-off) — previously uncovered anywhere in the module
- Added `save-release-gitsync.e2e-spec.ts`: drives save/release against a real git host (self-guards when the simulator env isn't configured) instead of mocking the git remote, closing a gap where the real GitHub App auth → tag creation/lookup wiring had never run end-to-end
- Documented the new simulator spec in `git-sync/e2e/lifecycle-cases.md`

## 🧪 How to test
- [ ] `task test:e2e-filter -- external-apis` — 267/267 passing
- [ ] `task test:e2e-filter -- versions` and unit — unaffected
- [ ] With the git simulator env configured: `save-release-gitsync.e2e-spec.ts` passes against the live host (verified twice locally)
- [ ] `npm run lint` clean