### PR TITLE
Fix: prevent spurious table component save on app builder open

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/columnSlice.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/columnSlice.js
@@ -67,7 +67,6 @@ export const createColumnSlice = (set, get) => ({
   ) => {
     if (autogenerateColumnsFlag) {
       const setComponentProperty = useStore.getState().setComponentProperty;
-      const existingGeneratedColumn = get().getColumnProperties(id);
       const generatedColumns = autogenerateColumns(
         firstRowOfTable,
         columns,
@@ -77,7 +76,7 @@ export const createColumnSlice = (set, get) => ({
         autogenerateColumns ?? false
       );
 
-      if (!isDynamicColumnSelected && !isEqual(existingGeneratedColumn, generatedColumns)) {
+      if (!isDynamicColumnSelected && !isEqual(columns, generatedColumns)) {
         setComponentProperty(id, 'columns', generatedColumns, 'properties', 'value', false, moduleId, {
           skipUndoRedo: true,
           saveAfterAction: true,


### PR DESCRIPTION
## 📝 What this does
Fixes a bug where opening the App Builder with a Table component always fired a PUT to update components — causing \"Cannot edit a saved version\" errors when git-sync is active on the default branch.

## 🔀 Changes
- Changed `generateColumns` to compare autogenerated columns against the app store's saved `columns` prop instead of the local table store's just-initialized empty array
- Removed the unused `existingGeneratedColumn` variable

## 🧪 How to test
- [ ] Enable git-sync on a workspace with multi-branching
- [ ] Open an app with a Table component on the default branch
- [ ] Verify no \"app could not be saved\" error appears
- [ ] Modify table data to add a new column key — verify autogeneration still triggers a save correctly