### PR TITLE
Fix: external API save/release skipped module-draft-pin and dup-name guards

### DIFF
--- a/server/test/modules/external-apis/e2e/app-import.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/app-import.e2e-spec.ts
@@ -119,8 +119,7 @@ describe('External API — POST /ext/import/workspace/:workspaceId/apps', () => 
         .expect(400);
     });
 
-    // skip: dead branch_id IS NULL pre-flight, 500 not 400 — src bug, #17333 (6)
-    it.skip('returns 400 when the target app name is already taken in the workspace', async () => {
+    it('returns 400 when the target app name is already taken in the workspace', async () => {
       const { user, organization } = await createUser(app, { email: `app-import-dupname-${Date.now()}@tooljet.io` });
       const seededApp = await createApplication(app, { name: 'Source App', user });
       await createApplicationVersion(app, seededApp);
@@ -190,9 +189,7 @@ describe('External API — POST /ext/import/workspace/:workspaceId/apps', () => 
       expect(names).toContain('Imported Copy');
     });
 
-    // Skipped: cross-workspace import throws 500 on app_versions_default_branch_slug_unique —
-    // slug preservation (commit f643adb520) isn't scoped per-workspace. Feature owner to fix.
-    it.skip('imports into a different workspace than the source', async () => {
+    it('imports into a different workspace than the source', async () => {
       const { user: user1, organization: org1 } = await createUser(app, {
         email: `app-import-cross-1-${Date.now()}@tooljet.io`,
       });

--- a/server/test/modules/external-apis/e2e/app-roundtrip.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/app-roundtrip.e2e-spec.ts
@@ -31,9 +31,7 @@ describe('External API — app export/import/list round trip', () => {
     await closeTestApp(app);
   }, 60000);
 
-  // Skipped: cross-workspace import throws 500 on app_versions_default_branch_slug_unique —
-  // slug preservation (commit f643adb520) isn't scoped per-workspace. Feature owner to fix.
-  it.skip('preserves all versions across export (exportAllVersions=true) → import → list', async () => {
+  it('preserves all versions across export (exportAllVersions=true) → import → list', async () => {
     const { user, organization } = await createUser(app, { email: `app-roundtrip-${Date.now()}@tooljet.io` });
     const seededApp = await createApplication(app, { name: 'Multi-Version App', user });
     await createApplicationVersion(app, seededApp, { name: 'v1' });

--- a/server/test/modules/external-apis/e2e/auto-deploy.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/auto-deploy.e2e-spec.ts
@@ -9,10 +9,15 @@ import {
   createApplication,
   createApplicationVersion,
   getDefaultDataSource,
+  findEntityOrFail,
+  saveEntity,
+  updateEntity,
 } from 'test-helper';
 import { AppVersion, AppVersionStatus } from 'src/entities/app_version.entity';
 import { AppEnvironment } from 'src/entities/app_environments.entity';
 import { App } from 'src/entities/app.entity';
+import { Page } from 'src/entities/page.entity';
+import { Component } from 'src/entities/component.entity';
 import { Repository } from 'typeorm';
 
 /**
@@ -24,7 +29,7 @@ import { Repository } from 'typeorm';
  *   - Auth: missing header, wrong token
  *   - 404: app not found, versionId not found for app
  *   - 400: versionId/versionName is a draft, versionName not found, no target
- *     resolvable because the app isn't git-synced
+ *     resolvable because the app isn't git-synced, released version pins a draft module
  *   - 201 happy path: by versionId, by versionName, by slug, redeploy of an
  *     already-published version
  *   - DB persistence + isolation from other versions on the same app
@@ -89,6 +94,25 @@ describe('External API — POST /ext/apps/:appIdOrSlug/git-sync/release', () => 
 
   async function prodEnvFor(organizationId: string) {
     return envRepo.findOne({ where: { organizationId }, order: { priority: 'DESC' } });
+  }
+
+  // Pins a ModuleViewer component on the app's home page directly at a module
+  // version's id (UUID pin, resolves via the byId clause regardless of branch).
+  async function embedModule(consumerVersionId: string, moduleCoRelationId: string, moduleVersionId: string) {
+    const homePage = await findEntityOrFail(Page, { appVersionId: consumerVersionId } as any);
+    await saveEntity(Component, {
+      name: 'module1',
+      type: 'ModuleViewer',
+      pageId: homePage.id,
+      properties: {
+        moduleAppId: { value: moduleCoRelationId },
+        moduleVersionId: { value: moduleVersionId },
+      },
+      general: {},
+      styles: {},
+      generalStyles: {},
+      validation: {},
+    } as any);
   }
 
   // ---------------------------------------------------------------------------
@@ -212,6 +236,32 @@ describe('External API — POST /ext/apps/:appIdOrSlug/git-sync/release', () => 
         .expect(400);
 
       expect(response.body.message).toBe('App is not synced with Git');
+    });
+
+    // Regression: the manual/UI promote flow blocks promoting a version whose pinned
+    // module hasn't reached the target environment yet — e.g. still a fresh DRAFT
+    // sitting in dev (VersionService.promoteVersion -> checkModulesPromotableToEnvironment).
+    // autoDeployApp went straight to versionUtilService.publishVersionWithEnvironment
+    // without that check, so the same app could be released to prod via the External
+    // API despite carrying an unreleased module pin.
+    it('returns 400 when the released version pins a module version not yet promoted to production', async () => {
+      const { user } = await seedOrg();
+
+      const moduleApp = await createApplication(nestApp, { user, name: `Module-${Date.now()}`, type: 'module' });
+      await updateEntity(App, moduleApp.id, { co_relation_id: moduleApp.id } as any);
+      const moduleDraft = await createApplicationVersion(nestApp, moduleApp as any, { name: 'm1' });
+
+      const app = await seedApp(user);
+      const published = await seedVersion(app as any, 'v1', AppVersionStatus.PUBLISHED);
+      await embedModule(published.id, moduleApp.id, moduleDraft.id);
+
+      const response = await request(nestApp.getHttpServer())
+        .post(`/api/ext/apps/${app.id}/git-sync/release`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ versionId: published.id })
+        .expect(400);
+
+      expect(response.body.message.error ?? response.body.message).toContain('not promoted');
     });
   });
 

--- a/server/test/modules/external-apis/e2e/modules.spec.ts
+++ b/server/test/modules/external-apis/e2e/modules.spec.ts
@@ -430,8 +430,7 @@ describe('ExternalApisModulesController (EE enterprise)', () => {
       expect(names).toContain('Renamed Module');
     });
 
-    // skip: dead branch_id IS NULL pre-flight, 500 not 400 — src bug, #17333 (6)
-    it.skip('returns 400 when the target module name already exists in the workspace', async () => {
+    it('returns 400 when the target module name already exists in the workspace', async () => {
       const { user } = await createUser(app, { email: 'admin@tooljet.io' });
       const orgId = user.defaultOrganizationId;
 
@@ -460,9 +459,7 @@ describe('ExternalApisModulesController (EE enterprise)', () => {
       expect(res.body.message).toContain('already taken');
     });
 
-    // Skipped: cross-workspace import throws 500 on app_versions_default_branch_slug_unique —
-    // slug preservation (commit f643adb520) isn't scoped per-workspace. Feature owner to fix.
-    it.skip('imports into a different workspace than the source', async () => {
+    it('imports into a different workspace than the source', async () => {
       const { user: user1 } = await createUser(app, { email: 'user1@tooljet.io' });
       const { user: user2 } = await createUser(app, { email: 'user2@tooljet.io' });
 

--- a/server/test/modules/external-apis/e2e/promote-to-next-version.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/promote-to-next-version.e2e-spec.ts
@@ -207,30 +207,6 @@ describe('External API — promote to next version (handleDefaultBranchPublish)'
       expect(versions[0].branchId).toBe(featureBranch.id);
     });
 
-    // QUARANTINE(git-sync-phase-2): every org gets a default branch at creation — "no default branch" premise is unconstructible
-    it.skip('publishes the version and detaches branchId, but does not seed a new draft, when the org has no default branch', async () => {
-      const { user, organization } = await seedOrgWithGit();
-      const nonDefaultBranch = await saveEntity(WorkspaceBranch, {
-        organizationId: organization.id,
-        name: 'main',
-        isDefault: false,
-      });
-      const app = await seedApp(user);
-      const draft = await seedDefaultBranchDraft(app as any, nonDefaultBranch.id, 'v1');
-
-      await request(nestApp.getHttpServer())
-        .post(`/api/ext/apps/${app.id}/versions/save`)
-        .set('Authorization', AUTH_HEADER)
-        .send({})
-        .expect(201);
-
-      const versions = await versionRepo.find({ where: { appId: app.id } });
-      expect(versions).toHaveLength(1);
-      expect(versions[0].id).toBe(draft.id);
-      expect(versions[0].status).toBe(AppVersionStatus.PUBLISHED);
-      expect(versions[0].branchId).toBeNull();
-    });
-
     it('does not seed a new draft when the version has no branchId', async () => {
       const { user } = await seedOrgWithGit();
       const app = await seedApp(user);

--- a/server/test/modules/external-apis/e2e/save-version.e2e-spec.ts
+++ b/server/test/modules/external-apis/e2e/save-version.e2e-spec.ts
@@ -9,10 +9,15 @@ import {
   createApplication,
   createApplicationVersion,
   getDefaultDataSource,
+  findEntityOrFail,
+  saveEntity,
+  updateEntity,
 } from 'test-helper';
 import { AppVersion, AppVersionStatus } from 'src/entities/app_version.entity';
 import { AppEnvironment } from 'src/entities/app_environments.entity';
 import { App } from 'src/entities/app.entity';
+import { Page } from 'src/entities/page.entity';
+import { Component } from 'src/entities/component.entity';
 import { SourceControlProviderService } from '@ee/app-git/source-control-provider';
 import { Repository } from 'typeorm';
 
@@ -94,6 +99,25 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
     const version = await createApplicationVersion(nestApp, app, { name });
     await versionRepo.update(version.id, { status: AppVersionStatus.PUBLISHED });
     return versionRepo.findOne({ where: { id: version.id } });
+  }
+
+  // Pins a ModuleViewer component on the app's home page directly at a module
+  // version's id (UUID pin, resolves via the byId clause regardless of branch).
+  async function embedModule(consumerVersionId: string, moduleCoRelationId: string, moduleVersionId: string) {
+    const homePage = await findEntityOrFail(Page, { appVersionId: consumerVersionId } as any);
+    await saveEntity(Component, {
+      name: 'module1',
+      type: 'ModuleViewer',
+      pageId: homePage.id,
+      properties: {
+        moduleAppId: { value: moduleCoRelationId },
+        moduleVersionId: { value: moduleVersionId },
+      },
+      general: {},
+      styles: {},
+      generalStyles: {},
+      validation: {},
+    } as any);
   }
 
   // ---------------------------------------------------------------------------
@@ -182,6 +206,32 @@ describe('External API — POST /ext/apps/:appIdOrSlug/versions/save', () => {
         .set('Authorization', AUTH_HEADER)
         .send({ name: 'a'.repeat(26) })
         .expect(400);
+    });
+
+    // Regression: the manual/UI save flow blocks publishing a version that pins a
+    // DRAFT module (VersionService.update -> checkDraftModulesInApp). This endpoint
+    // went straight to versionUtilService.publishVersionWithEnvironment without that
+    // check, so the same app could be saved via the External API despite carrying an
+    // unreleased module pin.
+    it('returns 400 when the version pins a draft module version', async () => {
+      const { user } = await seedOrg();
+
+      const moduleApp = await createApplication(nestApp, { user, name: `Module-${Date.now()}`, type: 'module' });
+      await updateEntity(App, moduleApp.id, { co_relation_id: moduleApp.id } as any);
+      const moduleDraft = await createApplicationVersion(nestApp, moduleApp as any, { name: 'm1' });
+      await updateEntity(AppVersion, moduleDraft.id, { status: AppVersionStatus.DRAFT } as any);
+
+      const app = await seedApp(user);
+      const draft = await seedDraftVersion(app as any, 'v1');
+      await embedModule(draft.id, moduleApp.id, moduleDraft.id);
+
+      const response = await request(nestApp.getHttpServer())
+        .post(`/api/ext/apps/${app.id}/versions/save`)
+        .set('Authorization', AUTH_HEADER)
+        .send({})
+        .expect(400);
+
+      expect(response.body.message.error ?? response.body.message).toContain('draft');
     });
   });
 


### PR DESCRIPTION
## 📝 What this does
The External API's app-import, save, and release paths bypassed guards the UI enforces: a dead `branch_id IS NULL` filter let duplicate app names through on import, and `saveAppVersion`/`autoDeployApp` skipped the checks that block saving or releasing an app whose pinned module is still a draft (or not yet promoted to the target environment). Also swept the git-sync external-api e2e suite for stale/dead skips per `server/docs/testing.md`.
- [ee-server](https://github.com/ToolJet/ee-server/pull/782)
- [ee-frontend](no changes)

## 🔀 Changes
- Fixed the app-import duplicate-name pre-flight to join the org's default branch instead of a dead `branch_id IS NULL` filter
- Added `checkDraftModulesInApp` to the save-version External API endpoint, blocking saves of apps that pin a draft module version
- Added `checkModulesPromotableToEnvironment` to the release (auto-deploy) External API endpoint, blocking releases of apps whose pinned module hasn't reached the target environment
- Unskipped 2 stale tests whose original 500-causing bug was already fixed elsewhere, and deleted 1 test asserting an unreachable "no default branch" scenario
- Added regression coverage for both module-pin guard gaps, confirmed red against pre-fix behavior then green after the fix

## 🧪 How to test
- [ ] Pin a `ModuleViewer` component to a draft module version, then `POST /ext/apps/:id/versions/save` via the External API — expect 400, not 201
- [ ] Same setup, `POST /ext/apps/:id/git-sync/release` — expect 400, not 201
- [ ] `POST /ext/import/workspace/:id/apps` twice with the same `appName` in the same workspace — expect 400 on the second call, not 500