### PR TITLE
Fix: prevent table autogenerated columns from triggering save on frozen versions

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/columnSlice.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/columnSlice.js
@@ -66,7 +66,7 @@ export const createColumnSlice = (set, get) => ({
     moduleId
   ) => {
     if (autogenerateColumnsFlag) {
-      const setComponentProperty = useStore.getState().setComponentProperty;
+      const { setComponentProperty, getShouldFreeze } = useStore.getState();
       const generatedColumns = autogenerateColumns(
         firstRowOfTable,
         columns,
@@ -77,9 +77,10 @@ export const createColumnSlice = (set, get) => ({
       );
 
       if (!isDynamicColumnSelected && !isEqual(columns, generatedColumns)) {
+        const shouldFreeze = getShouldFreeze();
         setComponentProperty(id, 'columns', generatedColumns, 'properties', 'value', false, moduleId, {
           skipUndoRedo: true,
-          saveAfterAction: true,
+          saveAfterAction: !shouldFreeze,
         });
       }
       return generatedColumns;


### PR DESCRIPTION
## 📝 What this does
Fixes a bug where the Table component's autogenerated columns feature fired a PUT request to save component changes on app builder open and on data shape changes — causing "app could not be saved" errors on git-synced default branches and released versions.

## 🔀 Changes
- Compared autogenerated columns against the app store's saved `columns` prop instead of the local table store's just-initialized empty array, preventing spurious saves on mount
- Gated `saveAfterAction` on `getShouldFreeze()` so autogenerated column updates skip persistence on frozen versions while still rendering correctly

## 🧪 How to test
- [ ] Enable git-sync on a workspace with multi-branching
- [ ] Open an app with a Table component on the default branch — verify no "app could not be saved" error
- [ ] Configure a REST API data source with different endpoints per environment, run a query that populates the table — verify no save error
- [ ] On a feature branch, add a Table and connect data — verify columns auto-generate and persist normally