### PR TITLE
Fix: query key-value pair inputs not scrollable when content is large

### DIFF
--- a/frontend/src/_styles/queryManager.scss
+++ b/frontend/src/_styles/queryManager.scss
@@ -1915,15 +1915,23 @@ $border-radius: 4px;
   padding-top: 6px;
 }
 
-.restapi-key-value {
+.restapi-key-value,
+.graphql-key-value {
 
   .code-hinter-wrapper,
   .code-editor-basic-wrapper,
   .codehinter-container,
   .cm-codehinter,
   .code-editor-query-panel {
-    height: 100%;
     max-height: 100px;
+  }
+
+  .cm-editor {
+    max-height: 100px !important;
+  }
+
+  .cm-scroller {
+    overflow: auto !important;
   }
 }
 


### PR DESCRIPTION
## 📝 What this does
Fixes key-value pair inputs (Headers, Params, Body, Cookies) in REST API, GRPCv2, and GraphQL query editors becoming unscrollable when values contain large content like JSON blobs.

## 🔀 Changes
- Capped `.cm-editor` height to 100px inside key-value rows with scrollable overflow
- Overrode `.cm-scroller` overflow from `visible` to `auto` (was inherited from `.fields-container`)
- Removed `height: 100%` on wrapper elements so key column stays compact
- Extended fix to `.graphql-key-value` alongside `.restapi-key-value`

## 🧪 How to test
- [ ] Create a REST API query, add a header with a large JSON value
- [ ] Verify value field caps at ~100px and scrolls vertically
- [ ] Verify key field stays at normal height (doesn't stretch)
- [ ] Repeat with GraphQL query headers
- [ ] Repeat with GRPCv2 metadata