### PR TITLE
test(cypress): refactor event-handler helpers and add CSA config utils

### DIFF
--- a/cypress-tests/cypress/constants/selectors/table.js
+++ b/cypress-tests/cypress/constants/selectors/table.js
@@ -86,6 +86,63 @@ export const tableSelector = {
 
   labelAnd: (index = 0) => `[data-cy="filter-and-label"]:eq(${index})`,
 
+  // ---- inline editing (column-editable toggles) ----
+  // ProgramaticallyHandleProperties feeds paramLabel={paramMeta.displayName} to the
+  // toggle, whose data-cy = displayName lowercased, spaces->'-', + '-toggle-button'
+  // (CodeBuilder/Elements/Toggle.jsx). Verified in frontend source:
+  //   - per column   : "Make editable"            -> make-editable-toggle-button
+  //                     (Table/ColumnManager/PropertiesTabElements.jsx:389)
+  //   - all columns  : "Make all columns editable"-> make-all-columns-editable-toggle-button
+  //                     (Inspector/Components/Table/Table.jsx:606-617)
+  makeEditableToggle: '[data-cy="make-editable-toggle-button"]',
+  makeAllColumnsEditableToggle:
+    '[data-cy="make-all-columns-editable-toggle-button"]',
+  // Column list item in the inspector's column manager (opens the column popover).
+  // Keyed by column KEY, not the display header (Support/utils/table.js already uses
+  // `column-<name>` in deleteAndVerifyColumn).
+  columnItem: (columnKey) => `[data-cy="column-${normalize(columnKey)}"]`,
+
+  // ---- change bar (renders in footer when there are pending inline edits) ----
+  // ChangeSetUI.jsx:17,35 — text spans only render when table width > 650.
+  saveChangesButton: '[data-cy="table-button-save-changes"]',
+  discardChangesButton: '[data-cy="table-button-discard-changes"]',
+
+  // ---- add-new-row modal (AddNewRow.jsx) ----
+  addNewRowSaveButton: '[data-cy="save-button"]',
+  addNewRowDiscardButton: '[data-cy="discard-button"]',
+  addAnotherRowButton: '[data-cy="add-another-row-button"]',
+  addNewRowsHeader: '[data-cy="add-new-rows-header"]',
+
+  // ---- selection (Chunk 3) ----
+  // The selector column is `id: 'selection'` with a FUNCTION header, so TableRow falls
+  // back to `cell.column.id` for the cell data-cy -> `<name>-selection-row-<i>`
+  // (buildTableColumn.js:62, TableRow.jsx:103-105). The checkbox itself is a plain
+  // `checkbox-input` (IndeterminateCheckbox.jsx:19) — NOT unique on its own, so always
+  // scope it to a row (or to thead for the bulk select-all).
+  rowCheckbox: (rowIndex, name = "table1") =>
+    `[data-cy="${normalize(name)}-selection-row-${rowIndex}"] [data-cy="checkbox-input"]`,
+  // Bulk select-all lives in the header row and only renders when showBulkSelector is
+  // on (buildTableColumn.js:74-83).
+  selectAllRowsCheckbox: 'thead [data-cy="checkbox-input"]',
+  anyRowCheckbox: '[data-cy="checkbox-input"]',
+
+  // ---- sort (Chunk 3) ----
+  // The sort arrow only renders once a column IS sorted (TableHeader.jsx:165-179), so
+  // its existence is the assertion that a sort was applied, and asc/desc distinguishes
+  // the first click from the second.
+  sortIconAscending: (column) =>
+    `[data-cy="${normalize(column)}-sort-icon-ascending"]`,
+  sortIconDescending: (column) =>
+    `[data-cy="${normalize(column)}-sort-icon-descending"]`,
+
+  // ---- pagination (Chunk 3) ----
+  // Verified vs Pagination.jsx dataCy props (:122,170,180,189,203,213,223).
+  paginationButtonToFirst: '[data-cy="pagination-button-to-first"]',
+  paginationButtonToLast: '[data-cy="pagination-button-to-last"]',
+  // Page buttons inside the go-to-page popover are 1-based.
+  pageOptionButton: (pageNumber) =>
+    `[data-cy="page-${pageNumber}-button-option"]`,
+
   // ---- misc ----
   addNewRowButton: (name = "table1") =>
     `[data-cy="${normalize(name)}-add-new-row-button"]`,

--- a/cypress-tests/cypress/constants/texts/table.js
+++ b/cypress-tests/cypress/constants/texts/table.js
@@ -44,6 +44,73 @@ export const tableText = {
   name: "name",
   optionEquals: "equals",
 
+  // ---- event trigger display names (WidgetManager/widgets/table.js:348-363) ----
+  // These are the LABELS the add-event-handler popover lists; selectEvent matches them
+  // case-insensitively against `event-trigger-option-*`.
+  eventRowClicked: "Row clicked",
+  eventRowHovered: "Row hovered",
+  eventPageChanged: "Page changed",
+  eventSearch: "Search",
+  eventSortApplied: "Sort applied",
+  eventFilterChanged: "Filter changed",
+  eventCellValueChanged: "Cell value changed",
+  eventAddNewRows: "Add new rows",
+  eventSaveChanges: "Save changes",
+  eventCancelChanges: "Cancel changes",
+
+  // ---- per-event toast messages used by the interactions chunk ----
+  // IMPORTANT: alphanumerics, spaces, `.`, `_` and `-` ONLY. These strings are typed
+  // into the Show Alert message CodeHinter through `clearAndTypeOnCodeMirror`
+  // (commands/commands.js), which tokenizes the value with
+  //   /(\{|\}|\(|\)|\[|\]|,|:|;|=>|\*|"[^"]*"|'[^']*'|[a-zA-Z0-9._-]+|\s+)/g
+  // and KEEPS ONLY MATCHED SUBSTRINGS — any character absent from every alternative is
+  // silently dropped before it is ever typed. A trailing `!` therefore never reaches
+  // the field, the alert fires with the punctuation-stripped text, and the toast
+  // assertion fails on a message that looks correct in the spec. Do not add `!`, `?`
+  // or other punctuation to these constants.
+  toastRowClicked: "row clicked",
+  toastPageChanged: "page changed",
+  toastSearch: "search fired",
+  toastSortApplied: "sort applied",
+  toastFilterChanged: "filter changed",
+  toastCellValueChanged: "cell value changed",
+  toastNewRowsAdded: "new rows added",
+
+  // ---- CSA display names (WidgetManager/widgets/table.js:545-660) ----
+  // Passed to selectCSA(); param labels are passed to wireTableCSA as { label }.
+  csaSetPage: "Set page",
+  csaSelectRow: "Select row",
+  csaDeselectRow: "Deselect row",
+  csaSelectRows: "Select rows",
+  csaDeselectRows: "Deselect rows",
+  csaSelectAllRows: "Select all rows",
+  csaDeselectAllRows: "Deselect all rows",
+  csaSetSort: "Set sort",
+  csaSetFilters: "Set filters",
+  csaClearFilters: "Clear filters",
+  csaDiscardChanges: "Discard Changes",
+  csaDiscardNewlyAddedRows: "Discard newly added rows",
+  csaDownloadTableData: "Download table data",
+  csaSetDisable: "Set disable",
+  csaSetLoading: "Set loading",
+  csaSetVisibility: "Set visibility",
+
+  // CSA param displayNames -> field data-cy is `event-<label>-input-field` (raw case).
+  csaParamPage: "Page",
+  csaParamKey: "Key",
+  csaParamValue: "Value",
+  csaParamValues: "Values",
+  csaParamParameters: "Parameters",
+  csaParamColumnKey: "Column key",
+
+  // ---- property toggle display names (table.js:82,117,222,230,238) ----
+  // tableSelector.toggleButton(<displayName>) -> `<slug>-toggle-button`.
+  toggleAllowSelection: "Allow selection",
+  toggleBulkSelection: "Bulk selection",
+  toggleHighlightSelectedRow: "Highlight selected row",
+  toggleEnablePagination: "Enable pagination",
+  toggleEnableColumnSorting: "Enable column sorting",
+
   labelDynamicColumn: "Use dynamic column",
   makeEditable: "Make editable",
   lableDisableActionButton: "Disable action button",

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/queries/chainingOfQueries.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/queries/chainingOfQueries.cy.js
@@ -39,7 +39,7 @@ describe("Chaining of queries", () => {
   //       (frontend/.../shadcn/select.jsx:13 → @radix-ui/react-select). It lives
   //       inside the `popover-card` (a Radix Popover) which scroll-locks
   //       `body { pointer-events:none }`, so opening it by clicking the trigger —
-  //       synthetic (events.js chooseRocketOption force-click) OR native
+  //       synthetic (events.js selectListboxOption) OR native
   //       (realClick) — is swallowed. AND EventManager controls the select's
   //       `open` prop via autoOpenActionSelect (EventManager.jsx:579), so when
   //       auto-open is active a trigger click *closes* the already-open listbox.
@@ -156,7 +156,7 @@ describe("Chaining of queries", () => {
     openEditorSidebar(buttonText.defaultWidgetName);
     // Use the Radix-Select-aware helper (queries.js) instead of events.js
     // selectEvent: the "Run Query" action pick goes through the same flaky
-    // chooseRocketOption otherwise. selectRunQueryEvent drives the
+    // selectListboxOption otherwise. selectRunQueryEvent drives the
     // action-selection Radix Select with a native pointer click (realClick).
     selectRunQueryEvent("On Click", `[data-cy="add-event-handler"]`, 0, 0);
     cy.wait(500);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableColumnTypes.skip.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableColumnTypes.skip.js
@@ -1,0 +1,78 @@
+import { fake } from "Fixtures/fake";
+import { commonWidgetSelector } from "Selectors/common";
+import { tableText } from "Texts/table";
+import { tableSelector } from "Selectors/table";
+import {
+  resizeTableWidget,
+  addAndOpenColumnOption,
+  verifyAndEnterColumnOptionInput,
+  deleteAndVerifyColumn,
+  selectDropdownOption,
+  verifySingleValueOnTable,
+} from "Support/utils/table";
+import { openEditorSidebar } from "Support/utils/commonWidget";
+import { resizeQueryPanel } from "Support/utils/dataSource";
+
+// ---------------------------------------------------------------------------
+// Chunk 4 (DEFERRED STUB) — Table column data types.
+//
+// Scope when picked up: the 14 column adapter types the column manager can assign
+// via `dropdown-column-type` — default, string, number, text, badge, multipleBadges,
+// tags, dropdown, link, radio, multiselect, toggleSwitch, datePicker, image. The
+// index map for each type already lives in `selectDropdownOption`
+// (Support/utils/table.js) — pass the type NAME, e.g.
+// `selectDropdownOption('[data-cy="dropdown-column-type"]>>:eq(0)', "badge")`.
+//
+// Helpers that already exist and should be reused rather than re-written:
+//   - addAndOpenColumnOption(name, type)   — adds a column and opens its popover,
+//                                            then sets the column name.
+//   - verifyAndEnterColumnOptionInput(label, value)
+//                                          — drives any `input-and-label-<param>`
+//                                            field inside the column popover.
+//   - deleteAndVerifyColumn(columnName)    — removes a column and asserts both the
+//                                            list item and the header are gone.
+//   - tableSelector.columnItem(key)        — opens an existing column's popover.
+//   - verifySingleValueOnTable(col, row, v)— asserts a rendered cell value.
+//
+// Deferred because each adapter type needs its own rendered-cell assertion (badge
+// pills, tag chips, toggle inputs, date formatting, image <img> src) and that is a
+// separate research pass against the renderers in
+// frontend/src/AppBuilder/Widgets/NewTable/_components/CellRenderers.
+//
+// Priority order agreed with the suite owner: editing (Chunk 1) -> CSA (Chunk 2)
+// -> interactions (Chunk 3) -> column types (here) -> styles (Chunk 5).
+// ---------------------------------------------------------------------------
+const tableWidget = (name) =>
+  `${commonWidgetSelector.draggableWidget(name)}:eq(0)`;
+
+describe.skip("Table — column data types", { testIsolation: false }, () => {
+  const name = tableText.defaultWidgetName;
+
+  beforeEach(() => {
+    cy.apiLogin();
+    cy.apiCreateApp(`${fake.companyName}-table-column-types-App`);
+    cy.openApp();
+    cy.viewport(1400, 2200);
+    cy.dragAndDropWidget("Table", 250, 100);
+    cy.hideTooltip();
+    cy.modifyCanvasSize(900, 800);
+    cy.get("[data-cy='left-sidebar-settings-button']").click();
+    resizeTableWidget(name, 750, 600);
+    resizeQueryPanel("1");
+    openEditorSidebar(name);
+  });
+  afterEach(() => {
+    cy.apiDeleteApp();
+  });
+
+  it("renders each column adapter type with its own cell renderer", () => {
+    // TODO: for each type in selectDropdownOption's map, addAndOpenColumnOption(...)
+    // then assert the rendered cell (badge pill / tag chip / toggle input / <img>).
+  });
+
+  it("adds, renames and deletes a column via the column manager", () => {
+    // TODO: addAndOpenColumnOption("Region", "string") ->
+    // verifyAndEnterColumnOptionInput("Column name", "Region") ->
+    // assert tableSelector.columnHeader("Region") -> deleteAndVerifyColumn("Region").
+  });
+});

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableCsa.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableCsa.cy.js
@@ -1,0 +1,319 @@
+import { fake } from "Fixtures/fake";
+import { commonWidgetSelector } from "Selectors/common";
+import { commonWidgetText } from "Texts/common";
+import { tableText } from "Texts/table";
+import { tableSelector } from "Selectors/table";
+import {
+  resizeTableWidget,
+  toggleTableProperty,
+  setRowsPerPage,
+  wireTableCSA,
+  triggerTableCSA,
+  verifySelectedRowCount,
+  selectTableRow,
+  verifyTableElements,
+  verifySingleValueOnTable,
+  makeAllColumnsEditable,
+  editTableCell,
+  addFilter,
+} from "Support/utils/table";
+import { openEditorSidebar, openAccordion } from "Support/utils/commonWidget";
+import { resizeQueryPanel } from "Support/utils/dataSource";
+
+// ---------------------------------------------------------------------------
+// Chunk 2 — Table component-specific actions (CSAs).
+// All 16 CSAs from WidgetManager/widgets/table.js:545-660.
+//
+// Each test wires one CSA onto the Table's own `Row hovered` event (wireTableCSA),
+// fires it by hovering a row (triggerTableCSA), and asserts through the DOM.
+//
+// RULES (see setCSAParam in Support/utils/events.js):
+//   - string params MUST be quoted expressions: {{"id"}}, {{"name"}}
+//   - numbers/arrays need braces only: {{3}}, {{[1,2]}}
+//   - toggle params take an explicit `value: true|false` (a click flips, not sets)
+//   - setSort needs an explicit Order — its {{asc}} default evaluates to undefined
+//   - setFilters takes [{column, condition, value}] matched on columnDef.header
+//
+// Object/array exposed vars (selectedRow, sortApplied, filters) do not resolve through
+// `inspector-<key>-value`, so assertions use observable DOM instead.
+//
+// NOTE on drags: a Button drag after the Table drag lands fine; what breaks is panel
+// state — dragAndDropWidget clicks `right-sidebar-components-button`, so a preceding
+// forceClickOnCanvas() (components panel already open) makes that click CLOSE it.
+// ---------------------------------------------------------------------------
+const tableWidget = (name) =>
+  `${commonWidgetSelector.draggableWidget(name)}:eq(0)`;
+
+describe("Table — component specific actions", { testIsolation: false }, () => {
+  const name = tableText.defaultWidgetName;
+
+  beforeEach(() => {
+    cy.apiLogin();
+    cy.apiCreateApp(`${fake.companyName}-table-csa-App`);
+    cy.openApp();
+    cy.viewport(1400, 2200);
+    cy.dragAndDropWidget("Table", 250, 100);
+    cy.hideTooltip();
+    cy.modifyCanvasSize(900, 800);
+    cy.get("[data-cy='left-sidebar-settings-button']").click();
+    resizeTableWidget(name, 750, 600);
+    resizeQueryPanel("1");
+    openEditorSidebar(name);
+  });
+  afterEach(() => {
+    cy.apiDeleteApp();
+  });
+
+  // ---- selection CSAs -------------------------------------------------
+
+  it.only("selectRow selects the matching row", () => {
+    toggleTableProperty(tableText.toggleBulkSelection);
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    // Select the row whose `id` is 3 -> Sophia Reyes, row index 2.
+    wireTableCSA(
+      tableText.csaSelectRow,
+      [
+        { label: tableText.csaParamKey, value: '{{"id"}}' },
+        { label: tableText.csaParamValue, value: "{{3}}" },
+      ],
+      name
+    );
+    triggerTableCSA(0, name);
+    cy.get(tableSelector.rowCheckbox(2, name)).should("be.checked");
+  });
+
+  it("deselectRow clears the current selection", () => {
+    toggleTableProperty(tableText.toggleBulkSelection);
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(tableText.csaDeselectRow, [], name);
+    cy.forceClickOnCanvas();
+    // Row 0 arrives selected via defaultSelectedRow `{id: 1}` (initSlice.js:72).
+    // deselectRow is declared with NO params (table.js:566-569) yet implemented as
+    // deselectRow(key, value); called with no args its findIndex compares
+    // `item[undefined] == undefined`, which matches index 0. So it deterministically
+    // clears row 0 — assert exactly that.
+    cy.get(tableSelector.rowCheckbox(0, name)).should("be.checked");
+    triggerTableCSA(1, name);
+    cy.get(tableSelector.rowCheckbox(0, name)).should("not.be.checked");
+  });
+
+  it("selectRows selects every matching row", () => {
+    toggleTableProperty(tableText.toggleBulkSelection);
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(
+      tableText.csaSelectRows,
+      [
+        { label: tableText.csaParamKey, value: '{{"id"}}' },
+        { label: tableText.csaParamValues, value: "{{[1,2]}}" },
+      ],
+      name
+    );
+    triggerTableCSA(0, name);
+    verifySelectedRowCount(2, name);
+  });
+
+  it("deselectRows clears the matching rows", () => {
+    toggleTableProperty(tableText.toggleBulkSelection);
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(
+      tableText.csaDeselectRows,
+      [
+        { label: tableText.csaParamKey, value: '{{"id"}}' },
+        { label: tableText.csaParamValues, value: "{{[1,2]}}" },
+      ],
+      name
+    );
+    cy.forceClickOnCanvas();
+    cy.get(tableSelector.selectAllRowsCheckbox).click({ force: true });
+    verifySelectedRowCount(tableText.defaultInput.length, name);
+    triggerTableCSA(4, name);
+    verifySelectedRowCount(tableText.defaultInput.length - 2, name);
+  });
+
+  it("selectAllRows selects every row", () => {
+    toggleTableProperty(tableText.toggleBulkSelection);
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(tableText.csaSelectAllRows, [], name);
+    triggerTableCSA(0, name);
+    verifySelectedRowCount(tableText.defaultInput.length, name);
+  });
+
+  it("deselectAllRows clears every row", () => {
+    toggleTableProperty(tableText.toggleBulkSelection);
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(tableText.csaDeselectAllRows, [], name);
+    cy.forceClickOnCanvas();
+    cy.get(tableSelector.selectAllRowsCheckbox).click({ force: true });
+    verifySelectedRowCount(tableText.defaultInput.length, name);
+    triggerTableCSA(0, name);
+    verifySelectedRowCount(0, name);
+  });
+
+  // ---- pagination / sort / filter CSAs --------------------------------
+
+  it("setPage moves to the requested page", () => {
+    setRowsPerPage(4);
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(
+      tableText.csaSetPage,
+      [{ label: tableText.csaParamPage, value: "{{2}}" }],
+      name
+    );
+    triggerTableCSA(0, name);
+    verifyTableElements(tableText.defaultInput.slice(4, 8));
+  });
+
+  it("setSort sorts the given column", () => {
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(
+      tableText.csaSetSort,
+      [
+        { label: tableText.csaParamColumnKey, value: '{{"name"}}' },
+        { label: "Order", type: "select", value: "Ascending" }, // -> 'asc'
+      ],
+      name
+    );
+    triggerTableCSA(0, name);
+    cy.get(
+      `${tableSelector.sortIconAscending(tableText.name)}, ${tableSelector.sortIconDescending(
+        tableText.name
+      )}`
+    ).should("exist");
+  });
+
+  it("clearFilters removes an applied filter", () => {
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(tableText.csaClearFilters, [], name);
+    cy.forceClickOnCanvas();
+    addFilter(
+      [{ column: tableText.name, operation: "contains", value: "Reyes" }],
+      true
+    );
+    // Filtered down to Sophia Reyes + Michael Reyes.
+    verifyTableElements([
+      tableText.defaultInput[2],
+      tableText.defaultInput[9],
+    ]);
+    triggerTableCSA(0, name);
+    verifyTableElements(tableText.defaultInput.slice(0, 3));
+  });
+
+  it("setFilters applies a filter", () => {
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    // setFilters takes an array of { id, value: { operation, value } }
+    // (TableExposedVariables.jsx:362-372).
+    wireTableCSA(
+      tableText.csaSetFilters,
+      [
+        {
+          label: tableText.csaParamParameters,
+          // Shape per TableExposedVariables.jsx:362-372 — setFilters destructures
+          // { column, condition, value } and matches column against
+          // columnDef.header. An {id, value:{operation,...}} shape is silently
+          // dropped because `filterFunctions[condition]` is undefined.
+          value:
+            '{{[{column: "name", condition: "contains", value: "Reyes"}]}}',
+        },
+      ],
+      name
+    );
+    triggerTableCSA(0, name);
+    verifyTableElements([
+      tableText.defaultInput[2],
+      tableText.defaultInput[9],
+    ]);
+  });
+
+  // ---- edit lifecycle CSAs --------------------------------------------
+
+  it("discardChanges reverts a pending inline edit", () => {
+    makeAllColumnsEditable();
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(tableText.csaDiscardChanges, [], name);
+    cy.forceClickOnCanvas();
+    editTableCell("name", 0, "Temp Edit");
+    verifySingleValueOnTable("name", 0, "Temp Edit");
+    triggerTableCSA(1, name);
+    verifySingleValueOnTable("name", 0, tableText.defaultInput[0].name);
+  });
+
+  it("discardNewlyAddedRows closes the add-new-row panel", () => {
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(tableText.csaDiscardNewlyAddedRows, [], name);
+    cy.forceClickOnCanvas();
+    cy.get(tableSelector.addNewRowButton(name)).click({ force: true });
+    cy.get(".table-add-new-row").should("exist");
+    triggerTableCSA(0, name);
+    cy.get(".table-add-new-row").should("not.exist");
+  });
+
+  // ---- misc CSAs -------------------------------------------------------
+
+  it("setVisibility hides the table", () => {
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(
+      tableText.csaSetVisibility,
+      // Explicit FALSE — setVisibility(false) is what hides the table. Previously this
+      // relied on a blind toggle click landing (or silently missing) on the declared
+      // `{{false}}` default, which is why it flip-flopped between runs.
+      [{ label: tableText.csaParamValue, type: "toggle", value: false }],
+      name
+    );
+    triggerTableCSA(0, name);
+    cy.get(tableWidget(name)).should("not.be.visible");
+  });
+
+  it("setLoading puts the table into its loading state", () => {
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(
+      tableText.csaSetLoading,
+      [{ label: tableText.csaParamValue, type: "toggle", value: true }],
+      name
+    );
+    triggerTableCSA(0, name);
+    // loadingState swaps the body for <LoadingState/>, whose spinner carries
+    // `.loading-spinner-table-component` (TableData.jsx:162-168).
+    cy.get(".loading-spinner-table-component").should("exist");
+  });
+
+  it("setDisable disables the table", () => {
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(
+      tableText.csaSetDisable,
+      [{ label: tableText.csaParamValue, type: "toggle", value: true }],
+      name
+    );
+    triggerTableCSA(0, name);
+    cy.get(tableWidget(name))
+      .find('[class*="disabled"]')
+      .should("exist");
+  });
+
+  // DEFERRED: downloadTableData's only param is `type`, a SELECT rendered with the
+  // same data-cy as the action picker (`action-options-action-selection-field`,
+  // EventManager.jsx:1044) so it needs the .eq(1) form in selectSupportCSAData rather
+  // than the CodeHinter path wireTableCSA uses. Asserting it also needs a downloads
+  // -folder read (deleteDownloadsFolder + dataCsvAssertionHelper), which belongs with
+  // the Chunk 5 download-menu work.
+  it.skip("downloadTableData downloads the table as CSV", () => {
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    wireTableCSA(tableText.csaDownloadTableData, [], name);
+    triggerTableCSA(0, name);
+  });
+});

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableEditing.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableEditing.cy.js
@@ -1,0 +1,136 @@
+import { fake } from "Fixtures/fake";
+import { commonSelectors, commonWidgetSelector } from "Selectors/common";
+import { commonWidgetText } from "Texts/common";
+import { tableText } from "Texts/table";
+import { tableSelector } from "Selectors/table";
+import {
+  resizeTableWidget,
+  makeAllColumnsEditable,
+  editTableCell,
+  verifySingleValueOnTable,
+  verifyTableExposedVars,
+  addNewRow,
+} from "Support/utils/table";
+import { openEditorSidebar, openAccordion } from "Support/utils/commonWidget";
+import { addMultiEventsWithAlert } from "Support/utils/events";
+import { resizeQueryPanel } from "Support/utils/dataSource";
+
+// ---------------------------------------------------------------------------
+// Chunk 1 — Table inline editing + add row (NewTable).
+// Priority-1 facet of the chunked Table suite. Covers: make-editable toggles,
+// inline cell edit, changeSet/dataUpdates exposed vars, add-new-row, discard,
+// and the onCellValueChanged / onNewRowsAdded events.
+//
+// beforeEach mirrors the proven-green tableRegression.cy.js:37-58 harness
+// (drag -> widen canvas -> close settings panel -> resize table -> open right
+// EVENT WIRING: addMultiEventsWithAlert passes isWait=TRUE. With false, selectEvent
+// skips `cy.wait("@events")` after creating the handler, so addSupportCSAData types the
+// alert message before the handler's POST /events resolves and the write is silently
+// dropped — the handler keeps its DEFAULT message and the toast reads "Hello world!".
+// Proven by probe while debugging tableInteractions.cy.js.
+//
+// inspector). The Table renders `draggable-widget-<name>` on BOTH the outer
+// RenderWidget wrapper AND its inner <table>, so scope the outer box to :eq(0).
+// ---------------------------------------------------------------------------
+const tableWidget = (name) =>
+  `${commonWidgetSelector.draggableWidget(name)}:eq(0)`;
+
+describe("Table — inline editing & add row", { testIsolation: false }, () => {
+  const name = tableText.defaultWidgetName;
+
+  beforeEach(() => {
+    cy.apiLogin();
+    cy.apiCreateApp(`${fake.companyName}-table-edit-App`);
+    cy.openApp();
+    cy.viewport(1400, 2200);
+    cy.dragAndDropWidget("Table", 250, 100);
+    cy.hideTooltip();
+    cy.modifyCanvasSize(900, 800);
+    cy.get("[data-cy='left-sidebar-settings-button']").click();
+    resizeTableWidget(name, 750, 600);
+    resizeQueryPanel("1");
+    openEditorSidebar(name);
+  });
+  afterEach(() => {
+    cy.apiDeleteApp();
+  });
+
+  it("edits a cell inline and renders the new value", () => {
+    makeAllColumnsEditable();
+    cy.forceClickOnCanvas();
+    // Default row 0 = Olivia Nguyen (id 1). Edit the name cell.
+    editTableCell("name", 0, "Edited Name");
+    verifySingleValueOnTable("name", 0, "Edited Name");
+  });
+
+  // DEFERRED: exposed-var assertion via the left inspector. changeSet/dataUpdates are
+  // OBJECT values rendered as JSON in the detail JSONViewer; the row data-cy did not
+  // resolve as `inspector-changeset-label` from the inspect-button flow. Object-value
+  // assertion needs a bound-widget approach (Text = {{components.table1.changeSet}}),
+  // which requires a 2nd in-test drag — folding into a dedicated exposed-var pass.
+  it.skip("exposes changeSet & dataUpdates after an inline edit", () => {
+    makeAllColumnsEditable();
+    cy.forceClickOnCanvas();
+    editTableCell("name", 0, "Edited Name");
+    verifyTableExposedVars(
+      [{ key: "changeSet", type: "Object", value: "Edited Name" }],
+      name
+    );
+  });
+
+  it("fires onCellValueChanged when a cell is edited", () => {
+    makeAllColumnsEditable();
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    // Message must stay punctuation-free — clearAndTypeOnCodeMirror drops any char
+    // outside [a-zA-Z0-9._-] before typing (see the note on tableText.toast*).
+    addMultiEventsWithAlert(
+      [
+        {
+          event: tableText.eventCellValueChanged,
+          message: tableText.toastCellValueChanged,
+        },
+      ],
+      true
+    );
+    cy.forceClickOnCanvas();
+    editTableCell("name", 0, "Zed");
+    cy.verifyToastMessage(
+      commonSelectors.toastMessage,
+      tableText.toastCellValueChanged
+    );
+  });
+
+  it("adds a new row via the add-new-row bar and fires onNewRowsAdded", () => {
+    // showAddNewRowButton defaults true. Wire onNewRowsAdded -> Show Alert first.
+    openEditorSidebar(name);
+    openAccordion(commonWidgetText.accordionEvents);
+    addMultiEventsWithAlert(
+      [
+        {
+          event: tableText.eventAddNewRows,
+          message: tableText.toastNewRowsAdded,
+        },
+      ],
+      true
+    );
+    cy.forceClickOnCanvas();
+    // addNewRow opens the modal, fills id/name/email (5/Nick/nick@example.com).
+    addNewRow(name);
+    cy.get(tableSelector.addNewRowSaveButton).click({ force: true });
+    cy.verifyToastMessage(
+      commonSelectors.toastMessage,
+      tableText.toastNewRowsAdded
+    );
+  });
+
+  it("discards an inline edit and reverts the cell", () => {
+    makeAllColumnsEditable();
+    cy.forceClickOnCanvas();
+    editTableCell("name", 0, "Temp Edit");
+    verifySingleValueOnTable("name", 0, "Temp Edit");
+    // The Save/Discard change bar renders in the footer when edits are pending.
+    cy.get(tableSelector.discardChangesButton).click({ force: true });
+    verifySingleValueOnTable("name", 0, tableText.defaultInput[0].name);
+  });
+});

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableInteractions.cy.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableInteractions.cy.js
@@ -1,0 +1,270 @@
+import { fake } from "Fixtures/fake";
+import { commonSelectors, commonWidgetSelector } from "Selectors/common";
+import { commonWidgetText } from "Texts/common";
+import { tableText } from "Texts/table";
+import { tableSelector } from "Selectors/table";
+import {
+  resizeTableWidget,
+  toggleTableProperty,
+  setRowsPerPage,
+  selectTableRow,
+  toggleRowCheckbox,
+  verifySelectedRowCount,
+  sortByColumn,
+  searchOnTable,
+  addFilter,
+  verifyTableElements,
+  verifySingleValueOnTable,
+  verifyTableExposedVars,
+} from "Support/utils/table";
+import { openEditorSidebar, openAccordion } from "Support/utils/commonWidget";
+import { addMultiEventsWithAlert } from "Support/utils/events";
+import { resizeQueryPanel } from "Support/utils/dataSource";
+
+// ---------------------------------------------------------------------------
+// Chunk 3 — Table selection / pagination / sort / filter / search (NewTable).
+// Priority-3 facet of the chunked Table suite. Covers the props allowSelection,
+// showBulkSelector, enablePagination, enabledSort and the events onRowClicked,
+// onPageChanged, onSort, onFilterChanged, onSearch.
+//
+// beforeEach mirrors the proven-green tableRegression.cy.js:37-58 harness
+// (drag -> widen canvas -> close settings panel -> resize table -> open right
+// inspector). Only ONE in-test drag (the Table itself), so this chunk is not
+// exposed to the second-drag `cypress-real-dnd` flake.
+//
+// The Table renders `draggable-widget-<name>` on BOTH the outer RenderWidget
+// wrapper (RenderWidget.jsx:308) AND its inner <table> (Table.jsx:340), so scope
+// the outer box to :eq(0).
+//
+// Assertion strategy: exposed vars that are OBJECTS/ARRAYS (selectedRow,
+// selectedRows, sortApplied, filters) render as JSON in the inspector's detail
+// JSONViewer and do not resolve through `inspector-<key>-value` — the same
+// limitation that deferred the changeSet assertion in tableEditing.cy.js. So the
+// object-valued facets are asserted through the DOM (row `.selected` class,
+// `:checked` checkboxes, `<col>-sort-icon-*`, filtered row contents) plus their
+// event toast, and only the SCALAR exposed vars (searchText, pageIndex) are read
+// EVENT WIRING: every addMultiEventsWithAlert call passes isWait=TRUE. With false,
+// selectEvent skips `cy.wait("@events")` after creating the handler, so
+// addSupportCSAData types the alert message before the handler's POST /events has
+// resolved and the write is silently dropped — the handler keeps its DEFAULT message
+// and the toast reads "Hello world!". Confirmed by probe: an onSort AND an
+// onHeaderClick handler both toasted "Hello world!" instead of their configured text.
+//
+// back off the inspector — those DO resolve (verified: pageIndex reads back as `2`),
+// with strings rendered JSON-quoted (`"Liam"`) and numbers bare.
+// ---------------------------------------------------------------------------
+const tableWidget = (name) =>
+  `${commonWidgetSelector.draggableWidget(name)}:eq(0)`;
+
+describe(
+  "Table — selection, pagination, sort, filter & search",
+  { testIsolation: false },
+  () => {
+    const name = tableText.defaultWidgetName;
+
+    beforeEach(() => {
+      cy.apiLogin();
+      cy.apiCreateApp(`${fake.companyName}-table-interactions-App`);
+      cy.openApp();
+      cy.viewport(1400, 2200);
+      cy.dragAndDropWidget("Table", 250, 100);
+      cy.hideTooltip();
+      cy.modifyCanvasSize(900, 800);
+      cy.get("[data-cy='left-sidebar-settings-button']").click();
+      resizeTableWidget(name, 750, 600);
+      resizeQueryPanel("1");
+      openEditorSidebar(name);
+    });
+    afterEach(() => {
+      cy.apiDeleteApp();
+    });
+
+    // ---- selection ------------------------------------------------------
+
+    it("selects a row on click and fires onRowClicked", () => {
+      // allowSelection defaults to true (table.js:222-228); highlightSelectedRow
+      // defaults to FALSE (table.js:238-245) and is what puts the `.selected`
+      // class on the row (TableRow.jsx:46), so turn it on to get a DOM signal.
+      toggleTableProperty(tableText.toggleHighlightSelectedRow);
+      openEditorSidebar(name);
+      openAccordion(commonWidgetText.accordionEvents);
+      addMultiEventsWithAlert(
+        [{ event: tableText.eventRowClicked, message: tableText.toastRowClicked }],
+        true
+      );
+      cy.forceClickOnCanvas();
+      // Row 1 (Liam Patel), not row 0 — defaultSelectedRow is `{id: 1}`
+      // (table.js:256-265) so row 0 can already be selected on mount.
+      selectTableRow(1);
+      cy.verifyToastMessage(
+        commonSelectors.toastMessage,
+        tableText.toastRowClicked
+      );
+      cy.get(tableSelector.row(1)).should("have.class", "selected");
+    });
+
+    it("multi-selects individual rows while bulk selection is on", () => {
+      // showBulkSelector defaults FALSE (table.js:230-237); turning it on renders
+      // the per-row checkbox column AND the header select-all
+      // (buildTableColumn.js:74-92), and keeps multi-row selection enabled.
+      //
+      // Selection is driven by clicking the ROW, not the checkbox: a checkbox click
+      // fires both the input's own toggle handler and the row's handleRowClick, which
+      // toggles a second time and cancels it out (see toggleRowCheckbox). The
+      // checkboxes remain the ASSERTION surface — they reflect selection faithfully.
+      toggleTableProperty(tableText.toggleBulkSelection);
+      cy.forceClickOnCanvas();
+      // Use rows 1 and 3, never row 0: defaultSelectedRow is `{id: 1}`
+      // (initSlice.js:72) and selectRow('id', 1) runs on mount
+      // (TableExposedVariables.jsx:268-273), so row 0 arrives ALREADY selected and a
+      // click would toggle it off. Row 0's state is therefore left unasserted here.
+      toggleRowCheckbox(1, name);
+      toggleRowCheckbox(3, name);
+      cy.get(tableSelector.rowCheckbox(1, name)).should("be.checked");
+      cy.get(tableSelector.rowCheckbox(3, name)).should("be.checked");
+      cy.get(tableSelector.rowCheckbox(2, name)).should("not.be.checked");
+    });
+
+    it("selects and clears every row from the header select-all checkbox", () => {
+      toggleTableProperty(tableText.toggleBulkSelection);
+      cy.forceClickOnCanvas();
+      cy.get(tableSelector.selectAllRowsCheckbox)
+        .should("exist")
+        .click({ force: true });
+      verifySelectedRowCount(tableText.defaultInput.length, name);
+      cy.get(tableSelector.selectAllRowsCheckbox).click({ force: true });
+      verifySelectedRowCount(0, name);
+    });
+
+    // ---- pagination -----------------------------------------------------
+
+    it("pages forward and back and fires onPageChanged", () => {
+      // rowsPerPage defaults to 10 and the demo dataset is exactly 10 rows
+      // (table.js:65-73) -> one page, next/prev inert. Shrink it to 4 first.
+      setRowsPerPage(4);
+      openEditorSidebar(name);
+      openAccordion(commonWidgetText.accordionEvents);
+      addMultiEventsWithAlert(
+        [
+          {
+            event: tableText.eventPageChanged,
+            message: tableText.toastPageChanged,
+          },
+        ],
+        true
+      );
+      cy.forceClickOnCanvas();
+      verifyTableElements(tableText.defaultInput.slice(0, 4));
+      cy.get(tableSelector.paginationButtonToNext).click({ force: true });
+      cy.verifyToastMessage(
+        commonSelectors.toastMessage,
+        tableText.toastPageChanged
+      );
+      verifyTableElements(tableText.defaultInput.slice(4, 8));
+      cy.get(tableSelector.paginationButtonToPrevious).click({ force: true });
+      verifyTableElements(tableText.defaultInput.slice(0, 4));
+    });
+
+    // ---- sort -----------------------------------------------------------
+
+    it("sorts a column ascending then descending and fires onSort", () => {
+      // enabledSort defaults true (table.js:82-89). The sort arrow only renders
+      // once the column IS sorted (TableHeader.jsx:165-179), so its presence is
+      // the proof that the click applied a sort.
+      openAccordion(commonWidgetText.accordionEvents);
+      addMultiEventsWithAlert(
+        [
+          {
+            event: tableText.eventSortApplied,
+            message: tableText.toastSortApplied,
+          },
+        ],
+        true
+      );
+      cy.forceClickOnCanvas();
+      // Assert the SORT ITSELF first. A runtime probe confirmed a header click does
+      // apply the sort (asc icon present, first row "Alexander Vela"), so ordering the
+      // DOM assertions ahead of the toast keeps real sort coverage independent of the
+      // event assertion.
+      sortByColumn(tableText.name);
+      cy.get(tableSelector.sortIconAscending(tableText.name)).should("exist");
+      verifySingleValueOnTable(tableText.name, 0, "Alexander Vela");
+      // onSort fires unconditionally whenever sorting.length > 0
+      // (TableExposedVariables.jsx:164-174), so the sort above guarantees the event.
+      cy.verifyToastMessage(
+        commonSelectors.toastMessage,
+        tableText.toastSortApplied
+      );
+      sortByColumn(tableText.name);
+      cy.get(tableSelector.sortIconDescending(tableText.name)).should("exist");
+      verifySingleValueOnTable(tableText.name, 0, "William Sanchez");
+    });
+
+    // ---- filter ---------------------------------------------------------
+
+    it("filters rows and fires onFilterChanged", () => {
+      openAccordion(commonWidgetText.accordionEvents);
+      addMultiEventsWithAlert(
+        [
+          {
+            event: tableText.eventFilterChanged,
+            message: tableText.toastFilterChanged,
+          },
+        ],
+        true
+      );
+      cy.forceClickOnCanvas();
+      // "Reyes" matches Sophia Reyes (id 3) and Michael Reyes (id 10).
+      // freshFilter=true is REQUIRED: addFilter only clicks "+ add filter" (creating
+      // filter row 0) on that path. Without it `select-column-dropdown-0` never
+      // exists. Matches the proven usage in tableRegression.cy.js:168-206.
+      addFilter(
+        [{ column: tableText.name, operation: "contains", value: "Reyes" }],
+        true
+      );
+      cy.verifyToastMessage(
+        commonSelectors.toastMessage,
+        tableText.toastFilterChanged
+      );
+      verifyTableElements([
+        tableText.defaultInput[2],
+        tableText.defaultInput[9],
+      ]);
+    });
+
+    // ---- global search --------------------------------------------------
+
+    it("filters via the global search box and fires onSearch", () => {
+      openAccordion(commonWidgetText.accordionEvents);
+      addMultiEventsWithAlert(
+        [{ event: tableText.eventSearch, message: tableText.toastSearch }],
+        true
+      );
+      cy.forceClickOnCanvas();
+      searchOnTable("Liam", name);
+      cy.verifyToastMessage(commonSelectors.toastMessage, tableText.toastSearch);
+      verifyTableElements([tableText.defaultInput[1]]);
+    });
+
+    // ---- scalar exposed vars --------------------------------------------
+
+    it("exposes searchText and pageIndex on the inspector", () => {
+      setRowsPerPage(4);
+      cy.forceClickOnCanvas();
+      cy.get(tableSelector.paginationButtonToNext).click({ force: true });
+      verifyTableExposedVars(
+        [{ key: "pageIndex", type: "Number", value: "2" }],
+        name
+      );
+      cy.forceClickOnCanvas();
+      searchOnTable("Liam", name);
+      // The inspector detail panel renders string values JSON-quoted (`"Liam"`),
+      // while numbers render bare — confirmed by this run: the pageIndex assertion
+      // above passed and only searchText mismatched ('"Liam"' vs 'Liam').
+      verifyTableExposedVars(
+        [{ key: "searchText", type: "String", value: '"Liam"' }],
+        name
+      );
+    });
+  }
+);

--- a/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableStylesOptions.skip.js
+++ b/cypress-tests/cypress/e2e/happyPath/appbuilder/commonTestcases/newSuits/table/tableStylesOptions.skip.js
@@ -1,0 +1,87 @@
+import { fake } from "Fixtures/fake";
+import { commonWidgetSelector } from "Selectors/common";
+import { tableText } from "Texts/table";
+import { tableSelector } from "Selectors/table";
+import {
+  resizeTableWidget,
+  toggleTableProperty,
+  verifyAndModifyToggleFx,
+  dataCsvAssertionHelper,
+  dataPdfAssertionHelper,
+} from "Support/utils/table";
+import { openEditorSidebar, openAccordion } from "Support/utils/commonWidget";
+import { deleteDownloadsFolder } from "Support/utils/common";
+import { resizeQueryPanel } from "Support/utils/dataSource";
+
+// ---------------------------------------------------------------------------
+// Chunk 5 (DEFERRED STUB) — Table styles, table-option toggles and download menu.
+//
+// Scope when picked up:
+//   1. ~15 styles from WidgetManager/widgets/table.js:364-525, grouped by the
+//      `accordian` key — "Column Header" (columnTitleColor, columnHeaderWrap,
+//      headerCasing, header background/text), "Row" (selectedRowColor, rowStyle,
+//      cellHeight, maxRowHeight) and the container styles (actionButtonRadius,
+//      background, borderRadius, border, boxShadow, padding). NOTE several of these
+//      share the displayName "Background"/"Type" across accordions, so scope each
+//      swatch to its accordion body — the un-scoped selector collision is exactly
+//      what quarantined the modalHappyPath styles test (STATUS.md row #7).
+//   2. Table-option toggles: showSearch ("Show search"), showDownloadButton
+//      ("Show download button"), enableFiltering ("Enable filtering"),
+//      showUpdateButtons ("Show update buttons"), hideColumnSelectorButton,
+//      showRefreshButton, disabledState ("Disable"), visibility ("Visibility").
+//      Drive them with `toggleTableProperty(<displayName>)` (Support/utils/table.js)
+//      and assert the corresponding toolbar control appears/disappears.
+//   3. Download menu: `tableSelector.buttonDownloadDropdown(name)` opens the menu;
+//      `optionDownloadCSV` / `optionDownloadExcel` / `optionDownloadPdf` are the
+//      entries. `deleteDownloadsFolder()` (Support/utils/common) clears the folder
+//      first and `dataCsvAssertionHelper` / `dataPdfAssertionHelper`
+//      (Support/utils/table.js) build the expected file contents from
+//      tableText.defaultInput.
+//
+// Deferred because styles need a per-accordion scoping pass plus computed-CSS
+// assertions, which is independent research from the behavioural chunks.
+// ---------------------------------------------------------------------------
+const tableWidget = (name) =>
+  `${commonWidgetSelector.draggableWidget(name)}:eq(0)`;
+
+describe.skip(
+  "Table — styles, options & download",
+  { testIsolation: false },
+  () => {
+    const name = tableText.defaultWidgetName;
+
+    beforeEach(() => {
+      cy.apiLogin();
+      cy.apiCreateApp(`${fake.companyName}-table-styles-App`);
+      cy.openApp();
+      deleteDownloadsFolder();
+      cy.viewport(1400, 2200);
+      cy.dragAndDropWidget("Table", 250, 100);
+      cy.hideTooltip();
+      cy.modifyCanvasSize(900, 800);
+      cy.get("[data-cy='left-sidebar-settings-button']").click();
+      resizeTableWidget(name, 750, 600);
+      resizeQueryPanel("1");
+      openEditorSidebar(name);
+    });
+    afterEach(() => {
+      cy.apiDeleteApp();
+    });
+
+    it("applies the column-header and row styles", () => {
+      // TODO: scope each swatch to its accordion body before clicking — several
+      // styles share the displayName "Background"/"Type" across accordions.
+    });
+
+    it("shows and hides the toolbar controls via the table option toggles", () => {
+      // TODO: toggleTableProperty("Show search") -> assert
+      // tableSelector.searchInputField(name) no longer exists; repeat for the
+      // download / filter / update-button toggles.
+    });
+
+    it("downloads the table data as CSV and PDF", () => {
+      // TODO: buttonDownloadDropdown(name) -> optionDownloadCSV -> read the file
+      // and compare against dataCsvAssertionHelper(tableText.defaultInput).
+    });
+  }
+);

--- a/cypress-tests/cypress/support/utils/events.js
+++ b/cypress-tests/cypress/support/utils/events.js
@@ -1,3 +1,33 @@
+// ---------------------------------------------------------------------------
+// Shared primitives for the event-handler popover.
+// ---------------------------------------------------------------------------
+
+// Alias /events requests. Handlers save via POST (create) and PATCH (update), so the
+// pattern is method-agnostic; call before any `cy.wait("@events")`.
+const interceptEvents = () => cy.intercept(/\/events(\/|\?|$)/).as("events");
+
+// Blur the popover's active field so its value commits.
+const commitEventConfig = () =>
+  cy.get('[data-cy="event-label"]').click({ force: true });
+
+// Open a handler's config popover if it is closed. `index` is the card index, or
+// "last" for the most recently created handler. Force-click is required: an open Radix
+// popover sets `body { pointer-events: none }`.
+const ensureHandlerCardOpen = (index = 0) => {
+  const card = cy.get('[data-cy="event-handler-card"]');
+  return (index === "last" ? card.last() : card.eq(index)).then(($card) => {
+    if ($card.attr("data-state") !== "open") {
+      cy.wrap($card).click({ force: true });
+    }
+  });
+};
+
+// Add an event handler and set its action.
+//   event    — trigger label as shown in the UI, matched case-insensitively
+//              (callers may pass "On Click" while the UI shows "On click").
+//   needWait — pass TRUE whenever config is written straight after (an alert message,
+//              CSA params). With false that write races the handler's POST and is
+//              silently dropped, leaving the handler on its defaults.
 export const selectEvent = (
   event,
   action = "Show Alert",
@@ -6,17 +36,9 @@ export const selectEvent = (
   eventIndex = 0,
   needWait = true
 ) => {
-  // Event handlers save via POST `/events` (create) and PATCH `/events/:id`
-  // (update) — not PUT. Match the URL regardless of method so the waits below
-  // resolve on the real requests.
-  cy.intercept(/\/events(\/|\?|$)/).as("events");
-  // New popover-based add flow (EventManager.jsx): the "Add new event handler"
-  // button is a Popover trigger. Clicking it opens `add-event-menu`, whose
-  // options are `event-trigger-option-<value>` buttons labelled by displayName.
-  // Pick the trigger by its visible label (case-insensitive so callers can keep
-  // passing "On Click" while the UI shows "On click"). This single click both
-  // chooses the trigger AND creates the handler — the old `event-selection`
-  // step is gone.
+  interceptEvents();
+  // Popover add-flow: this single click on `event-trigger-option-<value>` both picks
+  // the trigger AND creates the handler (no separate `event-selection` step).
   cy.get(addEventhandlerSelector).eq(index).click();
   cy.get('[data-cy="add-event-menu"]').should("be.visible");
   cy.contains(
@@ -27,50 +49,23 @@ export const selectEvent = (
     cy.wait("@events");
   }
 
-  // Creating a handler auto-opens its config popover (`popover-card`); if it
-  // didn't, click the card to open it. The card IS the Radix popover trigger,
-  // so when it's already open it carries `data-state="open"` — gate on that
-  // rather than the popover's `:visible` (which flickers mid-animation and can
-  // wrongly trigger a re-click). When a re-click is needed, force it: an open
-  // Radix popover sets `body { pointer-events: none }` (scroll-lock), which
-  // would otherwise block the click even though the card is interactive.
-  cy.get('[data-cy="event-handler-card"]')
-    .eq(eventIndex)
-    .then(($card) => {
-      if ($card.attr("data-state") !== "open") {
-        cy.wrap($card).click({ force: true });
-      }
-    });
+  ensureHandlerCardOpen(eventIndex);
   cy.get('[data-cy="popover-card"]').should("be.visible");
 
-  // `action-selection` is now a RocketSelect (trigger + role=option items in a
-  // portal), not a searchable input. Open it (unless it auto-opened) and pick
-  // the action by its visible label.
-  chooseRocketOption('[data-cy="action-selection"]', action);
-  // A handler is created with `actionId: 'show-alert'` already set
-  // (EventManager.jsx:441), so re-picking "Show Alert" is a no-op that fires no
-  // PATCH /events — waiting for one would hang. Only wait when the action
-  // actually changes the saved handler.
+  selectListboxOption('[data-cy="action-selection"]', action);
+  
+  // A new handler already has actionId 'show-alert' (EventManager.jsx:441), so
+  // re-picking "Show Alert" fires no PATCH — waiting for one would hang.
   if (needWait && !/^\s*show alert\s*$/i.test(action)) {
     cy.wait("@events");
   }
 };
 
-// Pick an option (by visible label, case-insensitive) from a RocketSelect
-// identified by `triggerSelector` (a Radix UI Select).
-//
-// Opening it is the tricky part: the select's trigger lives inside the
-// `popover-card` (a Radix Popover) which scroll-locks `body{pointer-events:none}`,
-// so a pointer click — synthetic OR real — is swallowed; and EventManager can
-// control the select's `open` prop (autoOpenActionSelect), so clicking an
-// already-open listbox calls onOpenChange(false) and closes it. A force-click
-// therefore opened it only intermittently and timed out otherwise.
-//
-// Robust approach (mirrors selectRunQueryEvent in queries.js): focus the Radix
-// trigger and open via KEYBOARD (ArrowDown — unaffected by the pointer-events
-// lock), but only when it isn't already open, gating on the trigger's own
-// data-state so we never toggle a controlled-open select shut.
-const chooseRocketOption = (triggerSelector, label) => {
+// Pick an option from a Radix Select (RocketSelect) by visible label.
+// Opens via KEYBOARD {downarrow}: the trigger sits inside a scroll-locked popover
+// (`body { pointer-events: none }`) where pointer clicks are swallowed, and the select
+// may be controlled-open, so a click can toggle it shut. Gated on `data-state`.
+const selectListboxOption = (triggerSelector, label) => {
   cy.get(triggerSelector)
     .find('button[role="combobox"]')
     .should("be.visible")
@@ -86,11 +81,11 @@ const chooseRocketOption = (triggerSelector, label) => {
     .click({ force: true });
 };
 
-// Pick a value from an OptionCombobox (shared.jsx OptionCombobox → Rocket
-// Combobox). The field renders a searchable `ComboboxInput` (an InputGroup that
-// nests >1 <input>, so scope typing to the first/visible one) and a portalled
-// listbox of `role="option"` items. Type to filter, then click the exact match.
-const pickComboboxOption = (fieldSelector, label) => {
+// Pick a value from a searchable OptionCombobox by typing to filter, then clicking the
+// EXACT match (an inexact click can select a longer superset option).
+// The ComboboxInput nests more than one <input>, so typing is scoped to the first
+// visible one — `.find("input").type()` would throw "single element" here.
+const selectSearchableOption = (fieldSelector, label) => {
   cy.get(fieldSelector).scrollIntoView().click();
   cy.get(`${fieldSelector} input`)
     .filter(":visible")
@@ -103,21 +98,20 @@ const pickComboboxOption = (fieldSelector, label) => {
     .click({ force: true });
 };
 
+// Set a "Control Component" action's target and action name, plus its debounce.
+// Requires the handler popover to be open (selectEvent leaves it open).
 export const selectCSA = (
   component,
   componentAction,
   debounce = `{selectAll}{backspace}`
 ) => {
-  // Event handlers save via POST `/events` (create) and PATCH `/events/:id`
-  // (update) — not PUT. Match the URL regardless of method so the waits below
-  // resolve on the real requests.
-  cy.intercept(/\/events(\/|\?|$)/).as("events");
+  interceptEvents();
 
-  pickComboboxOption(
+  selectSearchableOption(
     '[data-cy="action-options-component-selection-field"]',
     component
   );
-  pickComboboxOption(
+  selectSearchableOption(
     '[data-cy="action-options-action-selection-field"]',
     componentAction
   );
@@ -126,71 +120,126 @@ export const selectCSA = (
   cy.get('[data-cy="debounce-input-field"]')
     .click()
     .type(`{selectAll}{backspace}${debounce}{enter}`);
-  cy.get('[data-cy="event-label"]').click({ force: true });
+  commitEventConfig();
   cy.wait("@events");
 };
 
+// Type into a config field of the open handler, e.g. addSupportCSAData("alert-message", msg)
+// or a CSA param via `event-<label>`. Reopens the handler card if a re-render closed it.
+// NOTE: the value is typed through clearAndTypeOnCodeMirror, which SILENTLY DROPS any
+// character outside [a-zA-Z0-9._-] — keep literals free of punctuation such as `!`.
 export const addSupportCSAData = (field, data) => {
-  // Event handlers save via POST `/events` (create) and PATCH `/events/:id`
-  // (update) — not PUT. Match the URL regardless of method so the waits below
-  // resolve on the real requests.
-  cy.intercept(/\/events(\/|\?|$)/).as("events");
+  interceptEvents();
   // The config field (e.g. alert-message) lives inside the event's `popover-card`.
   // Selecting the action via the RocketSelect can momentarily re-render the
   // popover; if it ended up closed, the field won't exist. Ensure the popover is
   // open (reopening the handler card when needed) before typing.
   cy.get("body").then(($body) => {
     if ($body.find(`[data-cy="${field}-input-field"]`).length === 0) {
-      // addSupportCSAData always runs right after selectEvent created/edited the
-      // most recent handler, so the relevant card is the last one.
-      cy.get('[data-cy="event-handler-card"]')
-        .last()
-        .then(($card) => {
-          if ($card.attr("data-state") !== "open") {
-            cy.wrap($card).click({ force: true });
-          }
-        });
+      // Runs right after selectEvent created/edited the most recent handler, so
+      // the relevant card is the last one.
+      ensureHandlerCardOpen("last");
     }
   });
   cy.get(`[data-cy="${field}-input-field"]`)
     .should("be.visible")
     .click({ force: true })
     .clearAndTypeOnCodeMirror(data);
-  cy.get('[data-cy="event-label"]').click({ force: true })
+  commitEventConfig();
 };
 
+// Set a CSA `select`-type parameter. Its combobox shares
+// `action-options-action-selection-field` with the action picker
+// (EventManager.jsx:1044), so the parameter's own control is `.eq(1)`.
 export const selectSupportCSAData = (option) => {
-  // Event handlers save via POST `/events` (create) and PATCH `/events/:id`
-  // (update) — not PUT. Match the URL regardless of method so the waits below
-  // resolve on the real requests.
-  cy.intercept(/\/events(\/|\?|$)/).as("events");
-  cy.get('[data-cy="action-options-action-selection-field"]')
-    .eq(1)
-    .click()
-    .find("input")
-    .type(`{selectAll}{backspace}${option}{enter}`);
-  cy.get('[data-cy="event-label"]').click({ force: true })
+  interceptEvents();
+  selectSearchableOption(
+    '[data-cy="action-options-action-selection-field"]:eq(1)',
+    option
+  );
+  commitEventConfig();
   cy.wait("@events");
 };
 
+// Change the trigger of an EXISTING handler at `eventIndex`.
 export const changeEventType = (event, eventIndex = 0) => {
-  // Event handlers save via POST `/events` (create) and PATCH `/events/:id`
-  // (update) — not PUT. Match the URL regardless of method so the waits below
-  // resolve on the real requests.
-  cy.intercept(/\/events(\/|\?|$)/).as("events");
+  interceptEvents();
   cy.get('[data-cy="event-handler"]').eq(eventIndex).click();
-  cy.get('[data-cy="event-selection"]')
-    .click()
-    .find("input")
-    .type(`{selectAll}{backspace}${event}{enter}`);
-  cy.get('[data-cy="event-label"]').click({ force: true })
+  // Same nested-<input> hazard as above — go through selectSearchableOption.
+  selectSearchableOption('[data-cy="event-selection"]', event);
+  commitEventConfig();
   cy.wait("@events");
 };
 
 
+// Wire several triggers to Show Alert in one call: [{ event, message }, ...].
+// Leave isWait TRUE — see selectEvent; false drops the alert message and the handler
+// falls back to its default "Hello world!".
 export const addMultiEventsWithAlert = (events, isWait = true) => {
   events.forEach((eventObj, index) => {
     selectEvent(eventObj.event, 'Show Alert', 0, '[data-cy="add-event-handler"]', index, isWait);
     addSupportCSAData("alert-message", eventObj.message);
   });
+};
+// ---------------------------------------------------------------------------
+// Component-specific action (CSA) configuration — widget agnostic.
+// ---------------------------------------------------------------------------
+
+// Set ONE parameter on the CSA of the currently-open event-handler popover.
+//
+// param = { label, type?, value }
+//   label — the param's displayName from the widget's WidgetManager config, verbatim
+//           (original casing and spaces, e.g. "Column key").
+//   type  — "toggle" | "select" | omitted (code field).
+//
+// Per type:
+//   toggle  — renders a checkbox `event-<label>-toggle-button`, NOT a code field.
+//             Toggle.jsx:23 sends `{{!value}}`, i.e. a click FLIPS. Pass an explicit
+//             `value: true|false`; the state is asserted after, so a missed click
+//             fails loudly instead of silently keeping the declared default.
+//   select  — see selectSupportCSAData.
+//   code    — field is `event-<label>-input-field` (SingleLineCodeEditor.jsx:559,685
+//             falls back to the raw cyLabel, hence the unslugified label).
+//
+//             *** CODE FIELDS ARE EVALUATED AS JAVASCRIPT. ***
+//             strings : {{"id"}}      — a bare `id` is an identifier -> undefined
+//             numbers : {{3}}
+//             arrays  : {{[1,2]}}
+//             Getting this wrong fails SILENTLY: the action runs, the param resolves
+//             to undefined, and nothing changes.
+export const setCSAParam = (param) => {
+  const { label, type, value } = param;
+
+  if (type === "toggle") {
+    const desired = value !== false;
+    const sel = `[data-cy="event-${label}-toggle-button"]`;
+    cy.get(sel)
+      .scrollIntoView()
+      .then(($el) => {
+        if ($el.prop("checked") !== desired) {
+          cy.wrap($el).click({ force: true });
+        }
+      });
+    cy.get(sel).should(desired ? "be.checked" : "not.be.checked");
+    return;
+  }
+
+  if (type === "select") {
+    selectSupportCSAData(value);
+    return;
+  }
+
+  addSupportCSAData(`event-${label}`, value);
+  // Defensive sync: addSupportCSAData never waits on its own intercept.
+  cy.wait("@events");
+};
+
+// Configure a "Control Component" action on the ALREADY-OPEN event handler: pick the
+// target component + action, set every param, then blur and wait for the app to save.
+// Call after selectEvent(<trigger>, "Control Component").
+export const configureCSA = (component, action, params = []) => {
+  selectCSA(component, action);
+  params.forEach(setCSAParam);
+  cy.forceClickOnCanvas();
+  cy.waitForAutoSave();
 };

--- a/cypress-tests/cypress/support/utils/queries.js
+++ b/cypress-tests/cypress/support/utils/queries.js
@@ -51,14 +51,16 @@ export const waitForQueryAction = (action) => {
 // Create an event handler (popover EventManager flow) and set its action to
 // "Run Query", picking the action from the `action-selection` RocketSelect.
 //
-// WHY THIS LIVES HERE (not via events.js `selectEvent`/`chooseRocketOption`):
+// WHY THIS LIVES HERE (not via events.js `selectEvent`/`selectListboxOption`):
 // `action-selection` is a Radix UI Select (frontend/.../shadcn/select.jsx:13
 // → @radix-ui/react-select Trigger). Its Trigger opens the portalled
 // `SelectContent` on a *pointer* gesture, not on a synthetic DOM click.
-// events.js `chooseRocketOption` opens it with `.click({ force:true })`, which
-// — when the EventManager auto-open (`open={true}` via autoOpenActionSelect,
-// EventManager.jsx:579) has NOT kicked in for this render — does not reliably
-// trigger Radix's pointerdown open handler. The portal never mounts, so
+// A synthetic `.click({ force:true })` on that Trigger — when the EventManager
+// auto-open (`open={true}` via autoOpenActionSelect, EventManager.jsx:579) has
+// NOT kicked in for this render — does not reliably trigger Radix's pointerdown
+// open handler. (events.js `selectListboxOption` was since changed to open via
+// KEYBOARD {downarrow} for this same reason; this local helper predates that and
+// is kept because it additionally gates on the trigger's data-state.) The portal never mounts, so
 // `[role="option"]` is never found and the step times out (30s). This was
 // intermittent: it passed whenever the auto-open had the listbox already
 // showing (guard short-circuits the trigger click), and failed when it didn't.

--- a/cypress-tests/cypress/support/utils/table.js
+++ b/cypress-tests/cypress/support/utils/table.js
@@ -1,5 +1,8 @@
 import { commonWidgetSelector, cyParamName } from "Selectors/common";
 import { tableSelector } from "Selectors/table";
+import { verifyNodeData } from "Support/utils/inspector";
+import { selectEvent, configureCSA } from "Support/utils/events";
+import { tableText } from "Texts/table";
 
 // Spec-local scoped resize. The shared `cy.resizeWidget` uses `[class="bottom-right"]`
 // which now matches 2 elements (commands.js:375 — forbidden to edit). We scope the
@@ -310,36 +313,221 @@ export const addFilter = (
   cy.wait(500);
 };
 
+// Open the LEFT inspector focused on the Table's live state, then verify exposed-var
+// rows. The shared openStateFromComponent hovers `draggable-widget-<name>`, which for
+// the Table matches TWO nodes (outer wrapper + inner <table>) and makes realHover throw
+// — so scope to the outer box (:eq(0)) and click the ConfigHandle's inspect button
+// (`<name>-inspect-button`, ConfigHandle.jsx:272). `nodes` is a [{key,type,value}] list
+// verified via verifyNodeData against the detail rows (inspector-<key>-label / -value).
+export const verifyTableExposedVars = (nodes, name = "table1") => {
+  cy.get(`[data-cy="draggable-widget-${name}"]`).eq(0).realHover().realHover();
+  cy.get(`[data-cy="draggable-widget-${name}"]`)
+    .eq(0)
+    .realHover()
+    .then(() => {
+      cy.get(`[data-cy="${name}-inspect-button"]`)
+        .realHover({ position: "topRight" })
+        .last()
+        .realClick();
+    });
+  nodes.forEach((node) => verifyNodeData(node.key, node.type, node.value));
+};
+
+// Toggle "Make all columns editable" (Inspector > Table). Single click, no column
+// popover — the low-flake way to make every column's cells editable for inline-edit
+// tests. Requires the right inspector to be open (openEditorSidebar first).
+export const makeAllColumnsEditable = () => {
+  cy.get(tableSelector.makeAllColumnsEditableToggle)
+    .scrollIntoView()
+    .click({ force: true });
+  cy.waitForAutoSave();
+};
+
+// Make a SINGLE column editable: open its column popover (column-<key>) then flip the
+// per-column "Make editable" toggle. Use when a test needs per-column granularity.
+export const makeColumnEditable = (columnKey = "name") => {
+  cy.get(tableSelector.columnItem(columnKey)).scrollIntoView().click();
+  cy.get(tableSelector.makeEditableToggle).scrollIntoView().click({ force: true });
+  cy.waitForAutoSave();
+};
+
+// Type into any NewTable editable cell, given the cell's own selector.
+//
+// An editable string cell is NOT an <input> and is NOT contenteditable at rest.
+// StringRenderer renders a plain display <div class="long-text-input" tabindex="0">
+// whose `onClick` is what flips it into edit mode (StringRenderer.jsx:150) — React then
+// swaps it for a `[contenteditable="true"]` div (StringRenderer.jsx:112). Edits commit
+// on blur, and Enter blurs (StringRenderer.jsx:130-140).
+//
+// The click MUST land on `.long-text-input` itself: the surrounding <td> carries no
+// such handler, so clicking the cell wrapper leaves the cell in display mode. Verified
+// by runtime probe — clicking the <td> gave `inputs=0 editable=0`.
+export const typeIntoEditableCell = (cellSelector, value) => {
+  cy.get(cellSelector).find(".long-text-input").click({ force: true });
+  cy.get(cellSelector)
+    .find('[contenteditable="true"]')
+    .type("{selectall}{backspace}", { force: true })
+    .type(`${value}{enter}`, { force: true });
+};
+
+// Inline-edit a cell of the rendered table body (`<name>-<column>-row-<i>`).
+export const editTableCell = (
+  column = "name",
+  rowIndex = 0,
+  value,
+  name = "table1"
+) => {
+  cy.forceClickOnCanvas();
+  typeIntoEditableCell(tableSelector.cell(column, rowIndex, name), value);
+  cy.forceClickOnCanvas();
+};
+
+// Open the add-new-row panel and fill the id / name / email cells of the first blank
+// row. Rewritten against AddNewRow.jsx — the previous version asserted the FILTER
+// panel's selectors (`filter-header`, `close-filters-button`) which belong to a
+// different popover, and reached the inputs through brittle `>>>` CSS chains.
+// Real hooks (AddNewRow.jsx:137-285):
+//   panel   .table-add-new-row      header  add-new-rows-header
+//   close   add-new-rows-close-button       table   add-new-row-table
+//   row     add-new-row-<index>     cell    `<columnHeader>-column-<rowIndex>`
+//   save    save-button             discard discard-button
+// NOTE: assert `exist`, NOT `be.visible`. The panel renders inside the table's
+// position:fixed container, so Cypress's visibility heuristic reports it "overflowed
+// by other elements" even though it is genuinely on screen — confirmed by a runtime
+// probe: rect 263x300 at (443,105), display:flex, visibility:visible, opacity:1.
+// Same false negative already documented for the search input and header toolbar.
 export const addNewRow = (name = "table1") => {
-  cy.get(tableSelector.addNewRowButton(name)).click();
-  cy.get(".table-add-new-row").should("be.visible");
-  cy.get(tableSelector.headerFilters).verifyVisibleElement(
-    "have.text",
-    "Add new rows"
-  );
-  cy.get(tableSelector.buttonCloseFilters).should("be.visible");
-  cy.get(tableSelector.addNewRowButton(name)).should("be.visible");
-  cy.contains("Save").should("be.visible");
-  cy.contains("Discard").should("be.visible");
-  cy.get(
-    ".table-add-new-row > .table-responsive > .table > thead > .tr > :nth-child(1)"
-  ).should("be.visible");
-  cy.get(
-    ".table-add-new-row > > .table > tbody > .table-row > :nth-child(1) >>> input"
-  )
-    .click()
-    .clear()
-    .type("5");
-  cy.get(
-    ".table-add-new-row > > .table > tbody > .table-row > :nth-child(2) >>> input"
-  )
-    .click()
-    .clear()
-    .type("Nick");
-  cy.get(
-    ".table-add-new-row > > .table > tbody > .table-row > :nth-child(3) >>> input"
-  )
-    .click()
-    .clear()
-    .type("nick@example.com");
+  cy.get(tableSelector.addNewRowButton(name)).click({ force: true });
+  cy.get(".table-add-new-row").should("exist");
+  cy.get(tableSelector.addNewRowsHeader).should("have.text", "Add new rows");
+  cy.get(tableSelector.addNewRowSaveButton).should("exist");
+  cy.get(tableSelector.addNewRowDiscardButton).should("exist");
+  // Row 0 is the blank row the panel opens with.
+  addNewRowCellInput("id", 0, "5");
+  addNewRowCellInput("name", 0, "Nick");
+  addNewRowCellInput("email", 0, "nick@example.com");
+};
+
+// Type into one cell of the add-new-row panel. Cells are `<column>-column-<rowIndex>`
+// (AddNewRow.jsx:215-217). AddNewRow re-renders the SAME column renderers with
+// `isEditable: true` (AddNewRow.jsx:243-246), so its cells are the identical
+// display-div -> contenteditable widgets used by the table body — there is no <input>
+// to type into. Confirmed by runtime probe: `inputs=0 editable=0 longText=1`.
+export const addNewRowCellInput = (column = "id", rowIndex = 0, value) => {
+  typeIntoEditableCell(`[data-cy="${column}-column-${rowIndex}"]`, value);
+};
+
+// ---------------------------------------------------------------------------
+// Chunk 3 — selection / pagination / sort helpers.
+// ---------------------------------------------------------------------------
+
+// Flip one of the Table's boolean properties from the right inspector. Every
+// `type: 'toggle'` property renders through ProgramaticallyHandleProperties, whose
+// data-cy is the displayName slugified + `-toggle-button`
+// (CodeBuilder/Elements/Toggle.jsx). Pass the displayName exactly as it appears in
+// WidgetManager/widgets/table.js (see tableText.toggle* constants).
+// force:true — the inspector panel virtualises and a toggle can be partially covered
+// by the sticky accordion header even after scrollIntoView.
+export const toggleTableProperty = (displayName) => {
+  cy.get(tableSelector.toggleButton(displayName))
+    .scrollIntoView()
+    .click({ force: true });
+  cy.waitForAutoSave();
+};
+
+// Set the Table's `rowsPerPage` (displayName 'Number of rows per page',
+// table.js:65-73). The default dataset is 10 rows and rowsPerPage defaults to 10 ->
+// exactly ONE page, which makes next/prev inert, so pagination tests must shrink it.
+//
+// The realPress(["Meta","a"]) + Backspace clear used by setTableData does NOT work on
+// this field: a runtime probe showed the editor still holding `{{10}{{4}}` afterwards
+// (select-all never took, so Backspace removed a single `}` and the new value was
+// appended), which left rowsPerPage unparseable and rendered ZERO rows while the
+// footer still read "10 Records". This field is SINGLE-line, so the shared
+// clearAndTypeOnCodeMirror — which computes the exact backspace count from the current
+// text — is the correct helper here. (The plan's warning against it applies only to
+// the multi-LINE `data` field, which it genuinely cannot clear.)
+export const setRowsPerPage = (rows) => {
+  cy.get('[data-cy="number-of-rows-per-page-input-field"]')
+    .filter(":visible")
+    .first()
+    .clearAndTypeOnCodeMirror(`{{${rows}}}`);
+  cy.forceClickOnCanvas();
+  cy.waitForAutoSave();
+};
+
+// Click a data row to select it. The row's onClick -> handleRowClick (TableRow.jsx:44-51)
+// which drives `selectedRow`/`selectedRowId` and fires onRowClicked. Click the row's
+// own cell rather than the <tr>: the <tr> is a flex container whose centre can land in
+// the gap between cells. force:true because the table body is position:fixed under the
+// canvas overlay.
+export const selectTableRow = (rowIndex = 0, column = "name", name = "table1") => {
+  cy.get(tableSelector.cell(column, rowIndex, name)).click({ force: true });
+  cy.wait(300);
+};
+
+// Toggle a row's selection by clicking the ROW, not its checkbox.
+//
+// Clicking the checkbox itself does NOT work: the <input>'s onChange is
+// `row.getToggleSelectedHandler()` (buildTableColumn.js:84-90) AND the enclosing <tr>'s
+// onClick runs handleRowClick, which ends in `row.toggleSelected()`
+// (TableData.jsx:132-145). One click therefore toggles the row TWICE and it lands back
+// unselected — confirmed by runtime probe (`afterInputClick=false`, and
+// `afterIconClick=false` for the SolidIcon overlay too). The header select-all is
+// unaffected because it has no row wrapper, which is why that path works.
+//
+// Clicking the row body runs handleRowClick exactly once, and with "Bulk selection" on
+// tanstack keeps multi-row selection, so successive row clicks accumulate.
+export const toggleRowCheckbox = (rowIndex = 0, name = "table1") => {
+  selectTableRow(rowIndex, "name", name);
+};
+
+// Assert exactly `count` row checkboxes are checked (excludes the thead select-all,
+// which is scoped out via the `<name>-selection-row-` prefix).
+export const verifySelectedRowCount = (count, name = "table1") => {
+  cy.get(`[data-cy^="${name}-selection-row-"] [data-cy="checkbox-input"]:checked`)
+    .should("have.length", count);
+};
+
+// Click a column header to sort it. Sorting must be enabled (enabledSort defaults true).
+// Returns nothing — assert with tableSelector.sortIconAscending/Descending, which only
+// render once the column IS sorted (TableHeader.jsx:165-179).
+export const sortByColumn = (column) => {
+  cy.get(tableSelector.columnHeader(column)).click({ force: true });
+  cy.wait(500);
+};
+
+// ---------------------------------------------------------------------------
+// Chunk 2 — CSA (component-specific action) driver.
+// ---------------------------------------------------------------------------
+
+// Wire one of the Table's CSAs onto its OWN `Row hovered` event, without firing it.
+// Fire it with triggerTableCSA.
+//
+// Hover is used as the trigger because it needs no second widget (hence no second drag)
+// and mutates no table state — unlike a row click, which changes selection and would
+// corrupt selection-CSA assertions. An onRowHovered handler is what arms TableRow's
+// onMouseEnter (_stores/slices/initSlice.js:170).
+//
+// `params` is a [{ label, type?, value }] list — see setCSAParam in Support/utils/events.js
+// for the per-type rules (string values MUST be quoted expressions: {{"id"}}).
+export const wireTableCSA = (action, params = [], name = "table1") => {
+  // Trigger choice only — the CSA mechanics live in Support/utils/events.js
+  // (configureCSA/setCSAParam) so any widget's spec can reuse them.
+  //
+  // isWait=true: skipping the post-create `cy.wait("@events")` races the handler's POST,
+  // which is what leaves a Show Alert handler on its default "Hello world!" message.
+  selectEvent(tableText.eventRowHovered, "Control Component", 0, undefined, 0, true);
+  configureCSA(name, action, params);
+};
+
+// Fire whatever CSA `wireTableCSA` armed, by hovering a data row.
+export const triggerTableCSA = (rowIndex = 0, name = "table1") => {
+  cy.forceClickOnCanvas();
+  // Synthetic mouseover, NOT realHover: the row can be covered (add-new-row panel, the
+  // position:fixed container) and a real pointer move would silently do nothing.
+  // Exactly ONE trigger — the CSA may re-render the table and detach the row, which
+  // breaks any chained .trigger(). React synthesises mouseenter from mouseover.
+  cy.get(tableSelector.row(rowIndex, name)).trigger("mouseover", { force: true });
+  cy.wait(800);
 };


### PR DESCRIPTION
## What

Refactors the Cypress event-handler support utilities and adds the **table Control Component action (CSA)** test suite that consumes them.

### 1. Event helpers — `cypress/support/utils/events.js`
- **Extract shared primitives** to remove duplication:
  - `interceptEvents()` — aliases `/events` (POST create / PATCH update, method-agnostic).
  - `commitEventConfig()` — blurs the active field to commit its value.
  - `ensureHandlerCardOpen(index)` — opens a handler's config popover if closed (`"last"` supported); force-clicks past the Radix `pointer-events: none` scroll-lock.
- **Rename option pickers** for clarity: `chooseRocketOption` → `selectListboxOption`, `pickComboboxOption` → `selectSearchableOption`.
- **Add `setCSAParam(param)`** — sets one CSA parameter (toggle / select / code field), documenting the two silent-failure traps: code fields are evaluated as JS (`{{"id"}}` vs bare `id`), and toggles *flip* on click so callers must pass an explicit `value`.
- **Add `configureCSA(component, action, params)`** — picks the target component + action, applies every param, then blurs and waits for auto-save.
- No exported helper signatures changed → existing specs unaffected; new exports are additive.

### 2. Table CSA suite (consumers of the new helpers)
- `cypress/support/utils/table.js` — `wireTableCSA` / `triggerTableCSA` built on `configureCSA`/`setCSAParam`.
- `cypress/e2e/.../newSuits/table/` — new specs: `tableCsa.cy.js`, `tableEditing.cy.js`, `tableInteractions.cy.js` (+ `tableColumnTypes.skip.js`, `tableStylesOptions.skip.js`).
- `cypress/constants/selectors/table.js`, `cypress/constants/texts/table.js` — additive selector/text keys used by the specs (insertions only).

### 3. Comment sync
- `cypress/support/utils/queries.js` and `newSuits/queries/chainingOfQueries.cy.js` — update inline comments referencing the renamed helper (`chooseRocketOption` → `selectListboxOption`).

## Why
Cuts repeated `cy.intercept` / card-reopen / blur boilerplate and gives table (and any other) specs a single, documented entry point for Control Component actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)