### PR TITLE
[feat]: Hot reload the editor canvas without unmounting the editor

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
@@ -18,7 +18,7 @@ import { DeleteWidgetConfirmation } from './DeleteWidgetConfirmation';
 import useSidebarMargin from './Hooks/useSidebarMargin';
 import useAppPageSidebarHeight from './Hooks/useAppPageSidebarHeight';
 import { Container } from './Container';
-import { SuspenseCountProvider } from './SuspenseTracker';
+import { SuspenseCountProvider, SuspenseLoadingOverlay } from './SuspenseTracker';
 import { MobileLayout } from './MobileLayout';
 import { DesktopLayout } from './DesktopLayout';
 // Lazy load editor-only component to reduce viewer bundle size
@@ -64,6 +64,7 @@ export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
 
   const isMobileLayout = currentLayout === 'mobile';
   const pageLoader = useStore((state) => state.pageLoader, shallow);
+  const isCanvasReloading = useStore((state) => state.loaderStore.modules[moduleId].isCanvasReloading, shallow);
   const [isViewerSidebarPinned, setIsSidebarPinned] = useState(
     localStorage.getItem('isPagesSidebarPinned') === null
       ? false
@@ -253,6 +254,10 @@ export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
               })}
               style={{ minWidth: minCanvasWidth }}
             >
+              {/* The same overlay the viewer uses for lazy-loading. It has to sit here rather than
+                  deeper in the canvas: the wrappers below collapse to zero height while the widget
+                  tree is unmounted, and this is the nearest full-height positioned ancestor. */}
+              {isCanvasReloading && <SuspenseLoadingOverlay darkMode={isAppDarkMode} pageLoader />}
               <div
                 ref={canvasContentRef}
                 className={cx(
@@ -278,7 +283,7 @@ export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
                   currentLayout={currentLayout}
                   isModuleMode={isModuleMode}
                 >
-                  {environmentLoadingState !== 'loading' && (
+                  {environmentLoadingState !== 'loading' && !isCanvasReloading && (
                     <SuspenseCountProvider
                       key={currentPageId}
                       disabled={pageLoader}

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -758,9 +758,9 @@ const useAppData = (
     const isEnvChanged =
       selectedEnvironment?.id && previousEnvironmentId && previousEnvironmentId != selectedEnvironment?.id;
     const isVersionChanged = currentVersionId && previousVersion && currentVersionId != previousVersion;
-    const isAppHistoryChanged = restoreTimestamp != previousRestoreTimestamp;
+    const isForceRefreshTriggered = restoreTimestamp != previousRestoreTimestamp;
 
-    if (isEnvChanged || isVersionChanged || isAppHistoryChanged) {
+    if (isEnvChanged || isVersionChanged || isForceRefreshTriggered) {
       setEditorLoading(true, moduleId);
       clearSelectedComponents();
       if (isEnvChanged) {

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -181,6 +181,11 @@ const useAppData = (
   // Used to trigger app refresh flow after restoring app history
   const restoreTimestamp = useStore((state) => state.restoreTimestamp);
   const previousRestoreTimestamp = usePrevious(restoreTimestamp);
+  // Used to trigger the same refresh in place, without unmounting the editor chrome
+  const hotReloadTimestamp = useStore((state) => state.hotReloadTimestamp);
+  const previousHotReloadTimestamp = usePrevious(hotReloadTimestamp);
+  const setCanvasReloading = useStore((state) => state.setCanvasReloading);
+  const setIsComponentLayoutReady = useStore((state) => state.setIsComponentLayoutReady);
 
   const location = useRouter().location;
 
@@ -759,9 +764,21 @@ const useAppData = (
       selectedEnvironment?.id && previousEnvironmentId && previousEnvironmentId != selectedEnvironment?.id;
     const isVersionChanged = currentVersionId && previousVersion && currentVersionId != previousVersion;
     const isForceRefreshTriggered = restoreTimestamp != previousRestoreTimestamp;
+    // A hot reload runs this same pipeline but swaps only the canvas, so the editor chrome
+    // (and the AI chat mid-conversation) stays mounted and we stay on the current page.
+    const isHotReload = hotReloadTimestamp != previousHotReloadTimestamp;
 
-    if (isEnvChanged || isVersionChanged || isForceRefreshTriggered) {
-      setEditorLoading(true, moduleId);
+    if (isEnvChanged || isVersionChanged || isForceRefreshTriggered || isHotReload) {
+      if (isHotReload) {
+        setCanvasReloading(true, moduleId);
+        // The canvas subtree unmounts while reloading (AppCanvas), but AppCanvas itself stays
+        // mounted, so its unmount cleanup won't clear this. Clear it here so it can flip back to
+        // true once the rebuilt canvas settles — that transition is what re-runs the on-load
+        // queries, onPageLoad events and JS libraries.
+        setIsComponentLayoutReady(false, moduleId);
+      } else {
+        setEditorLoading(true, moduleId);
+      }
       clearSelectedComponents();
       if (isEnvChanged) {
         setEnvironmentLoadingState('loading');
@@ -811,7 +828,19 @@ const useAppData = (
         let startingPage = appData.pages.find(
           (page) => page.id === appData.editing_version.home_page_id || appData.editing_version.homePageId
         );
-        setCurrentPageId(startingPage.id, moduleId);
+        // A hot reload keeps the user where they are; everything else lands on the home page
+        const pageToLoad = (isHotReload && appData.pages.find((page) => page.id === currentPageId)) || startingPage;
+        setCurrentPageId(pageToLoad.id, moduleId);
+        if (isHotReload) {
+          // We're staying on the same page, and the refresh may have renamed it — so refresh the
+          // handle and the {{page.*}} constants, which this effect otherwise never sets. Scoped to
+          // hot reload to leave the version/env/history flows behaving exactly as before.
+          setCurrentPageHandle(pageToLoad?.handle, moduleId);
+          setResolvedPageConstants(
+            { id: pageToLoad?.id, handle: pageToLoad?.handle, name: pageToLoad?.name },
+            moduleId
+          );
+        }
         setComponentNameIdMapping(moduleId);
         updateEventsField('events', appData.events, moduleId);
         // const queryData = await dataqueryService.getAll(currentVersionId);
@@ -884,10 +913,20 @@ const useAppData = (
 
         setQueryMapping(moduleId);
         initDependencyGraph(moduleId);
+        if (isHotReload) {
+          // The canvas stayed mounted, so pair the batch the same way initial load does: open it
+          // before the rebuilt canvas settles and let the layout-ready effect flush it.
+          startExposedValueBatch();
+          // Datasources/modules may be new in this definition (the env branch above only covers
+          // datasources, and only when the environment changed).
+          getAllGlobalDataSourceList(appData.organizationId || appData.organization_id);
+          if (appData.modules) setModuleDefinition(appData.modules);
+        }
+        setCanvasReloading(false, moduleId);
         setEditorLoading(false, moduleId);
       });
     }
-  }, [selectedEnvironment?.id, currentVersionId, moduleMode, moduleId, restoreTimestamp]);
+  }, [selectedEnvironment?.id, currentVersionId, moduleMode, moduleId, restoreTimestamp, hotReloadTimestamp]);
 
   useEffect(() => {
     if (moduleMode) return;

--- a/frontend/src/AppBuilder/_stores/slices/appVersionSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/appVersionSlice.js
@@ -11,6 +11,7 @@ const initialState = {
   restoredAppHistoryId: null, // Used to trigger app refresh flow after restoring app history
   restoreTimestamp: null, // Timestamp to ensure re-fetch even when restoring to same entry twice
   isEditorReadOnly: false, // module opened in Build-with (view-only) mode
+  hotReloadTimestamp: null, // Timestamp to re-fetch the app in place (canvas-only loader, stays on current page)
 };
 
 export const createAppVersionSlice = (set, get) => ({
@@ -90,10 +91,19 @@ export const createAppVersionSlice = (set, get) => ({
     );
   },
 
+  /**
+   * Re-fetches the current app version and rebuilds the canvas in place. Runs the same refresh
+   * pipeline as a version switch (see useAppData), except the editor chrome — header, sidebars,
+   * and the AI chat with its conversation and streaming response — stays mounted, and the user
+   * stays on the page they were on.
+   *
+   * Use it when something outside the editor changed the app wholesale (e.g. the AI builder
+   * editing pages/queries/global settings) and an incremental store update won't cover it.
+   */
   triggerHotReload: () => {
     set(
       (state) => {
-        state.restoreTimestamp = Date.now();
+        state.hotReloadTimestamp = Date.now();
       },
       false,
       'triggerHotReload'

--- a/frontend/src/AppBuilder/_stores/slices/appVersionSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/appVersionSlice.js
@@ -89,4 +89,14 @@ export const createAppVersionSlice = (set, get) => ({
       'setRestoredAppHistoryId'
     );
   },
+
+  triggerHotReload: () => {
+    set(
+      (state) => {
+        state.restoreTimestamp = Date.now();
+      },
+      false,
+      'triggerHotReload'
+    );
+  },
 });

--- a/frontend/src/AppBuilder/_stores/slices/loaderSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/loaderSlice.js
@@ -3,6 +3,9 @@ const initialState = {
     modules: {
       canvas: {
         isEditorLoading: true,
+        // Scoped to the canvas widget tree only — keeps the editor chrome (header,
+        // sidebars, AI chat) mounted while the app definition is re-fetched.
+        isCanvasReloading: false,
       },
     },
   },
@@ -28,6 +31,14 @@ export const createLoaderSlice = (set, get) => ({
       },
       false,
       'setEditorLoading'
+    ),
+  setCanvasReloading: (status, moduleId = 'canvas') =>
+    set(
+      (state) => {
+        state.loaderStore.modules[moduleId].isCanvasReloading = status;
+      },
+      false,
+      'setCanvasReloading'
     ),
   setIsLoaderLoading: (status, moduleId = 'canvas') =>
     set(


### PR DESCRIPTION
## 📝 What this does
Adds a `triggerHotReload` store action that re-fetches the current app version and rebuilds the canvas in place — the editor header, sidebars and AI chat stay mounted, so an in-progress conversation and any streaming response survive the refresh, and the user stays on the page they were on.

Needed for the AI builder: a chat turn can now change the app wholesale (pages, queries, global settings, background colour), which the incremental store updates in the SSE `diff` handler don't cover.

## 🔀 Changes
- Added `triggerHotReload`, which drives the existing version-switch refresh pipeline via its own `hotReloadTimestamp` signal
- Added a canvas-scoped `isCanvasReloading` loader flag, so the reload no longer trips the full-editor loader that unmounts the whole tree
- Reused the viewer's existing lazy-loading overlay for the canvas-only loader instead of adding another one
- Kept the user on the current page across a reload, refreshing the page handle and `{{page.*}}` constants in case it was renamed
- Re-pulled datasources and module definitions, which a refreshed definition may reference for the first time

## 🧪 How to test
This PR adds the capability but no caller — the AI-side wiring lands separately — so testing needs a temporary trigger. The store is a module import, not a global, so it can't be reached from the console directly.

Add this inside the `Editor` component in `frontend/src/AppBuilder/AppBuilder.jsx` (`useEffect` and `useStore` are already imported there), and remove it when done:

```js
useEffect(() => {
  window.tjRefresh = () => useStore.getState().triggerHotReload();
}, []);
```

Then, in the editor with the dev server running, call `window.tjRefresh()` from the devtools console and check:

- [ ] The loader appears only over the canvas — header, sidebars and AI chat stay mounted
- [ ] Open the AI chat, send a message, then hot reload — the conversation survives
- [ ] Navigate to a non-home page, then hot reload — you stay on that page
- [ ] Change the app background colour or rename a page from another session, then hot reload — the change appears
- [ ] On-load queries re-run and `onPageLoad` fires after the canvas settles
- [ ] Toggle the left sidebar while reloading — the loader stays centred over the canvas area
- [ ] Regression: version switch, environment change and app-history restore behave as before (these still use the full-editor loader and still land on the home page)
- [ ] Regression: the viewer's lazy-loading overlay still works
