### PR TITLE
Dropdown label issue resolved in module

### DIFF
--- a/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import Select, { components } from 'react-select';
 import { IconX } from '@tabler/icons-react';
 
@@ -334,7 +334,19 @@ export const DropdownV2 = ({
 
   useFormClear(() => setInputValue(null));
 
-  const triggerWidth = ref?.current?.getBoundingClientRect?.()?.width;
+  const [measuredTriggerWidth, setMeasuredTriggerWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(([entry]) => {
+      setMeasuredTriggerWidth(entry.contentRect.width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const triggerWidth = measuredTriggerWidth || ref?.current?.getBoundingClientRect?.()?.width;
 
   const menuContentWidth = useMemo(() => {
     if (menuWidthMode !== 'matchContent') return null;
@@ -426,9 +438,9 @@ export const DropdownV2 = ({
           : isDropdownDisabled || isDropdownLoading
           ? 'var(--text-disabled)'
           : 'var(--text-primary)',
-      maxWidth:
-        ref?.current?.offsetWidth -
-        (iconVisibility ? INDICATOR_CONTAINER_WIDTH + ICON_WIDTH : INDICATOR_CONTAINER_WIDTH),
+      maxWidth: triggerWidth
+        ? triggerWidth - (iconVisibility ? INDICATOR_CONTAINER_WIDTH + ICON_WIDTH : INDICATOR_CONTAINER_WIDTH)
+        : undefined,
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/dropdownV2.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/dropdownV2.spec.jsx
@@ -27,7 +27,7 @@
  * shape rather than the post-resolution one, so these tests would catch a
  * regression in that flattening too.
  */
-import { screen, waitFor, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import { createWidgetHarness, binding, store, MODULE_ID } from './widgetHarness';
 
 const ID = 'dd1';
@@ -570,6 +570,64 @@ describe('DropdownV2', () => {
       // flips true from a selection/clear through the Select's onChange
       // (:558-570) — never from mounting empty, however invalid that is.
       expect(within(container).queryByText('Field cannot be empty')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('closed-value label width (module first-paint race)', () => {
+    // Bug: inside a Module, the closed label's `maxWidth` was read from a
+    // stale ref (`ref.current.offsetWidth`) that never triggers a
+    // re-render, so it stuck too small on first paint (e.g. "Option 1"
+    // rendered as "o.") until an unrelated click forced one. Fix: track
+    // the width via `ResizeObserver` state instead. jsdom does no real
+    // layout, so the race is simulated directly: `getBoundingClientRect`
+    // is stubbed small, then the captured `ResizeObserver` callback is
+    // fired with the "real" width — no click involved.
+    const OPTIONS = { value: [option('Option 1', 'a', { isDefault: true })] };
+    const singleValue = (container) => container.querySelector('[class*="-singleValue"]');
+    let restoreRect;
+    let restoreResizeObserver;
+
+    beforeEach(() => {
+      const rectDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'getBoundingClientRect');
+      Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ width: 70, height: 40, top: 0, left: 0, right: 70, bottom: 40 }),
+      });
+      restoreRect = () => Object.defineProperty(Element.prototype, 'getBoundingClientRect', rectDescriptor);
+
+      const originalResizeObserver = window.ResizeObserver;
+      restoreResizeObserver = () => {
+        window.ResizeObserver = originalResizeObserver;
+      };
+    });
+
+    afterEach(() => {
+      restoreRect();
+      restoreResizeObserver();
+    });
+
+    test('the label width constraint corrects itself once the trigger is measured, with no interaction', async () => {
+      let resizeCallback;
+      window.ResizeObserver = class {
+        constructor(callback) {
+          resizeCallback = callback;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+
+      const { container } = widget.render({ properties: { options: OPTIONS } });
+
+      await waitFor(() => expect(singleValue(container)).toBeInTheDocument());
+      // First paint: still reading the small stale width.
+      expect(getComputedStyle(singleValue(container)).maxWidth).toBe('10px');
+
+      // Must have registered an observer to ever learn the real size.
+      expect(resizeCallback).toBeInstanceOf(Function);
+      act(() => resizeCallback([{ contentRect: { width: 300 } }]));
+
+      await waitFor(() => expect(getComputedStyle(singleValue(container)).maxWidth).toBe('240px'));
     });
   });
 });


### PR DESCRIPTION
# Module Dropdown: Option Label Renders as Truncated Text

## Issue Description

When a Select/Dropdown component is added inside a Module and that Module is used in an app, the selected option's label renders incorrectly on first load (e.g. showing as `o.` instead of `Option 1`). Clicking the dropdown to open it fixes the label, and it remains correct afterward.

## Root Cause

`frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx` computed the closed-select label's `maxWidth` directly from `ref?.current?.offsetWidth`, read synchronously during render (not from React state):

```js
maxWidth:
  ref?.current?.offsetWidth -
  (iconVisibility ? INDICATOR_CONTAINER_WIDTH + ICON_WIDTH : INDICATOR_CONTAINER_WIDTH),
```

A ref's underlying DOM measurement can change without triggering a React re-render. In a normal app, the canvas grid width is already final by the component's first paint. Inside a Module, the component mounts through an extra resolution/layout pass before the module's container reaches its final width, so on first paint `ref.current.offsetWidth` is smaller than the eventual layout size. Combined with `overflow: hidden; text-overflow: ellipsis` on the label, this produces a `maxWidth` too small to fit the real label, truncating it down to essentially one character (e.g. `Option 1` → `o.`).

Nothing forces a re-render after that until an unrelated state update happens — clicking the dropdown calls `setIsMenuOpen(true)`, which re-renders the component and recomputes `maxWidth` against the by-then-correct `ref.current.offsetWidth`, which is why the label "fixes itself" on interaction and stays fixed.

The sibling `MultiselectV2` widget had already solved this same problem via a `ResizeObserver`-backed width state (`frontend/src/AppBuilder/Widgets/MultiselectV2/CustomValueContainer.jsx:9-40`); `DropdownV2` had not been updated to match.

## Fix

`frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx`:
- Added a `measuredTriggerWidth` state variable updated via a `ResizeObserver` observing the trigger element (`useLayoutEffect`, lines ~337-347).
- `triggerWidth` now prefers `measuredTriggerWidth`, falling back to the old ref read only if `ResizeObserver` is unavailable.
- The `singleValue` style's `maxWidth` now derives from this state-tracked `triggerWidth` instead of reading `ref.current.offsetWidth` inline.

This ensures the label re-renders and self-corrects the moment the container reaches its true size, without requiring user interaction, and keeps working correctly across future resizes (e.g. sidebar toggle, column resize).

## Areas to Test

- Add a Select/Dropdown inside a Module, use the module in an app, and confirm the default/selected option label renders correctly on first load without needing to click the dropdown.
- Test with the module placed in different column widths/layouts to confirm the label truncates correctly via ellipsis only when genuinely too long, not prematurely.
- Resize the app builder sidebar or the component's container after load and confirm the label width adjusts correctly.
- Regression: verify normal (non-module) Select/Dropdown components still render and truncate labels correctly, including with `iconVisibility` on and off.
- Regression: verify `matchField`/`matchContent` menu width modes (which also depend on `triggerWidth`) still behave correctly for both module and non-module dropdowns.
