### PR TITLE
fix(server): return null from findAppFromVersion so version guards answer 404

### DIFF
--- a/server/src/modules/versions/repository.ts
+++ b/server/src/modules/versions/repository.ts
@@ -255,17 +255,22 @@ export class VersionRepository extends Repository<AppVersion> {
     return m.delete(AppVersion, { id: versionId });
   }
 
-  async findAppFromVersion(id: string, organizationId: string, manager?: EntityManager): Promise<App> {
+  async findAppFromVersion(id: string, organizationId: string, manager?: EntityManager): Promise<App | null> {
     const m = manager ?? this.manager;
-    const appVersion = await m.findOneOrFail(AppVersion, {
+    // Null-returning contract: every guard checks for a falsy app to throw
+    // its own NotFoundException (404). findOneOrFail would throw a raw
+    // EntityNotFoundError first, turning a cross-org or unknown versionId
+    // into an unhandled 500 and leaving those guards' checks dead.
+    const appVersion = await m.findOne(AppVersion, {
       where: { id, app: { organizationId } },
       relations: ['app'],
     });
-    const app = appVersion.app;
+    const app = appVersion?.app;
+    if (!app) return null;
     // Workflows keep metadata on apps.*; non-workflows must overlay from the
     // canonical version row resolved by git-sync state. Forward the loaded
     // version's branchId so the overlay picks that branch's row directly.
-    if (app && app.type !== APP_TYPES.WORKFLOW) {
+    if (app.type !== APP_TYPES.WORKFLOW) {
       const metadataVersion = await this.resolveMetadataVersion(m, app, {
         branchId: appVersion.branchId ?? undefined,
       });

--- a/server/test/modules/versions/unit/version-repository.find-app-from-version.spec.ts
+++ b/server/test/modules/versions/unit/version-repository.find-app-from-version.spec.ts
@@ -1,0 +1,70 @@
+/// <reference types="jest" />
+import { EntityManager } from 'typeorm';
+import { App } from '@entities/app.entity';
+import { AppVersion } from '@entities/app_version.entity';
+import { VersionRepository } from '@modules/versions/repository';
+import { APP_TYPES } from '@modules/apps/constants';
+
+type Row = { where: unknown; payload: unknown };
+
+/**
+ * A faithful-enough EntityManager stub: `findOne` mirrors TypeORM's
+ * null-returning lookup and `findOneOrFail` mirrors its throwing one, so a
+ * regression back to findOneOrFail fails these tests the same way the live
+ * API regressed to a 500.
+ */
+const makeManager = (rows: Row[]) => {
+  const match = (options: { where: unknown }) =>
+    rows.find((row) => JSON.stringify(row.where) === JSON.stringify(options.where))?.payload ?? null;
+  const manager = {
+    findOne: jest.fn(async (_entity: unknown, options: { where: unknown }) => match(options)),
+    findOneOrFail: jest.fn(async (_entity: unknown, options: { where: unknown }) => {
+      const found = match(options);
+      if (found === null) {
+        throw new Error(`Could not find any entity matching: ${JSON.stringify(options.where)}`);
+      }
+      return found;
+    }),
+  };
+  return manager as unknown as EntityManager & typeof manager;
+};
+
+const makeRepository = () => {
+  const dataSource = { createEntityManager: () => ({}) } as never;
+  return new VersionRepository(dataSource) as unknown as {
+    findAppFromVersion: (id: string, orgId: string, manager?: EntityManager) => Promise<App | null>;
+  };
+};
+
+describe('VersionRepository.findAppFromVersion', () => {
+  const orgA = 'org-a';
+  const orgB = 'org-b';
+  const workflowApp = { id: 'app-2', type: APP_TYPES.WORKFLOW } as unknown as App;
+
+  it('returns null for a versionId that does not resolve in the caller org, instead of throwing', async () => {
+    const repo = makeRepository();
+    const manager = makeManager([]);
+    await expect(repo.findAppFromVersion('version-1', orgA, manager)).resolves.toBeNull();
+  });
+
+  it('scopes the lookup to the organization, so a cross-org version id is a 404, not a leak or a 500', async () => {
+    const repo = makeRepository();
+    // A workflow app keeps the test on the no-overlay path; the metadata
+    // overlay itself is e2e territory.
+    const manager = makeManager([
+      { where: { id: 'version-1', app: { organizationId: orgA } }, payload: { id: 'version-1', branchId: null, app: workflowApp } },
+    ]);
+
+    await expect(repo.findAppFromVersion('version-1', orgA, manager)).resolves.toBe(workflowApp);
+    await expect(repo.findAppFromVersion('version-1', orgB, manager)).resolves.toBeNull();
+  });
+
+  it('returns the workflow app without the non-workflow metadata overlay', async () => {
+    const repo = makeRepository();
+    const manager = makeManager([
+      { where: { id: 'version-2', app: { organizationId: orgA } }, payload: { id: 'version-2', branchId: null, app: workflowApp } },
+    ]);
+
+    await expect(repo.findAppFromVersion('version-2', orgA, manager)).resolves.toBe(workflowApp);
+  });
+});


### PR DESCRIPTION
## Summary

`VersionRepository.findAppFromVersion` resolved the app with `findOneOrFail`, so an unresolvable `versionId` threw a raw `EntityNotFoundError` before any guard could act — the `if (!app) throw new NotFoundException(...)` checks in `validate-app-version.guard`, `validate-query-app.guard` and `workflow-access.guard` were dead code, and a cross-org or unknown versionId surfaced as an unhandled **500** with the TypeORM message in the body instead of the intended **404** (#17395).

## Change

The method now uses the null-returning `findOne` contract its callers were already written against (return type `Promise<App | null>`). The workflow-type fast path and the git-sync metadata overlay are unchanged; only the not-found behavior changes — from a throw to the null every caller already handles.

## Testing

- New unit spec `version-repository.find-app-from-version.spec.ts` with a faithful manager stub (its `findOneOrFail` throws exactly like TypeORM's, so a regression back to it fails the suite the same way the live API 500'd):
  - unknown versionId → resolves `null` instead of throwing;
  - org scoping: the same versionId resolves for its org and `null` for another org (404, not a cross-org 500/leak);
  - workflow app returned without the metadata overlay.
- Differential: with the source change stashed, 2 of 3 tests fail with the issue's exact `Could not find any entity matching` error; with the fix, 3/3 pass. The neighboring `app-version.ability.spec.ts` suite stays 35/35.

Fixes #17395
