### PR TITLE
fix(googlesheets): read the whole sheet when the range is blank

### DIFF
--- a/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/__tests__/utils.test.js
+++ b/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/__tests__/utils.test.js
@@ -1,0 +1,17 @@
+import { formatPathForCopy } from '../utils';
+
+describe('formatPathForCopy', () => {
+  it('drops a trailing segment separator so the copied path is a valid expression', () => {
+    expect(formatPathForCopy('constants.null_value.')).toBe('constants.null_value');
+    expect(formatPathForCopy('list.1.')).toBe('list[1]');
+  });
+
+  it('keeps converting numeric segments to bracket notation', () => {
+    expect(formatPathForCopy('list.0.name')).toBe('list[0].name');
+  });
+
+  it('leaves well-formed paths untouched', () => {
+    expect(formatPathForCopy('components.widget1')).toBe('components.widget1');
+    expect(formatPathForCopy('constants')).toBe('constants');
+  });
+});

--- a/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/utils.js
+++ b/frontend/src/AppBuilder/LeftSidebar/LeftSidebarInspector/utils.js
@@ -106,9 +106,13 @@ export const copyToClipboard = (data, includeQuotes = true) => {
 };
 
 export const formatPathForCopy = (path) => {
-  const isArray = path.includes('.');
+  // A selected node's path can carry a trailing segment separator
+  // (e.g. `constants.null_value.`) -- copying it verbatim yields an invalid
+  // expression, so drop trailing empty segments before formatting.
+  const trimmedPath = path.replace(/\.+$/, '');
+  const isArray = trimmedPath.includes('.');
   if (isArray) {
-    const pathArray = path.split('.');
+    const pathArray = trimmedPath.split('.');
     const newPath = pathArray.map((item) => {
       if (!isNaN(item) && item !== '') {
         return `[${item}]`;
@@ -117,5 +121,5 @@ export const formatPathForCopy = (path) => {
     });
     return newPath.join('.').replace(/\.\[/g, '[');
   }
-  return path;
+  return trimmedPath;
 };

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
@@ -14,7 +14,7 @@ import CustomMenuList from './CustomMenuList';
 import CustomOption from './CustomOption';
 import Label from '@/_ui/Label';
 import cx from 'classnames';
-import { getInputBackgroundColor, getInputBorderColor, getInputFocusedColor, sortArray } from './utils';
+import { getInputBackgroundColor, getInputBorderColor, getInputFocusedColor, sortArray, flattenSelectOptions } from './utils';
 import { useMenuWidth } from './useMenuWidth';
 import { getModifiedColor, getSafeRenderableValue } from '@/AppBuilder/Widgets/utils';
 import { isMobileDevice } from '@/_helpers/appUtils';
@@ -158,8 +158,11 @@ export const DropdownV2 = ({
     }
   }, [advanced, schema, options, sort]);
 
+  // Leaves only: group children carry the values selection matches against.
+  const flatSelectOptions = useMemo(() => flattenSelectOptions(selectOptions), [selectOptions]);
+
   function selectOption(value) {
-    const val = selectOptions.filter((option) => !option.isDisabled)?.find((option) => option.value === value);
+    const val = flatSelectOptions.filter((option) => !option.isDisabled)?.find((option) => option.value === value);
     if (val) {
       setInputValue(value);
       fireEvent('onSelect');
@@ -176,7 +179,7 @@ export const DropdownV2 = ({
 
   const setInputValue = (value) => {
     setCurrentValue(value);
-    const _selectedOption = selectOptions.find((option) => option.value === value);
+    const _selectedOption = flatSelectOptions.find((option) => option.value === value);
     setExposedVariables({
       value,
       selectedOption: _selectedOption
@@ -554,7 +557,7 @@ export const DropdownV2 = ({
             ref={selectRef}
             menuIsOpen={isMenuOpen}
             isDisabled={isDropdownDisabled}
-            value={selectOptions.filter((option) => option.value === currentValue)[0] ?? null}
+            value={flatSelectOptions.filter((option) => option.value === currentValue)[0] ?? null}
             onChange={(selectedOption, actionProps) => {
               if (actionProps.action === 'clear') {
                 setInputValue(null);

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/__tests__/utils.test.js
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/__tests__/utils.test.js
@@ -1,0 +1,43 @@
+import { flattenSelectOptions } from '../utils';
+
+describe('flattenSelectOptions', () => {
+  it('exposes group children as leaves so selection matching can find them', () => {
+    const grouped = [
+      {
+        label: 'Fruits',
+        options: [
+          { value: 'apple', label: 'Apple' },
+          { value: 'orange', label: 'Orange' },
+        ],
+      },
+      {
+        label: 'Dairy',
+        options: [{ value: 'milk', label: 'Milk' }],
+      },
+    ];
+
+    const leaves = flattenSelectOptions(grouped);
+    expect(leaves.map((leaf) => leaf.value)).toEqual(['apple', 'orange', 'milk']);
+    // The selected value lookup the component performs:
+    expect(leaves.find((leaf) => leaf.value === 'orange')?.label).toBe('Orange');
+  });
+
+  it('passes flat option arrays through unchanged', () => {
+    const flat = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ];
+    expect(flattenSelectOptions(flat)).toBe(flat);
+  });
+
+  it('tolerates non-array and mixed input', () => {
+    expect(flattenSelectOptions(undefined)).toEqual([]);
+    expect(flattenSelectOptions(null)).toEqual([]);
+    expect(
+      flattenSelectOptions([{ value: 'top', label: 'Top' }, { label: 'Group', options: [{ value: 'child', label: 'Child' }] }])
+    ).toEqual([
+      { value: 'top', label: 'Top' },
+      { value: 'child', label: 'Child' },
+    ]);
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/utils.js
@@ -1,5 +1,15 @@
 import React from 'react';
 
+// Grouped options arrive as { label, options: [...] }; leaf options as
+// { label, value, ... }. Selection matching (the Select's value prop, the
+// exposed selectedOption) must run over the leaves -- a group entry has no
+// value of its own, so matching against the raw array never finds a child
+// inside a group.
+export const flattenSelectOptions = (options) =>
+  (Array.isArray(options) ? options : []).flatMap((option) =>
+    Array.isArray(option?.options) ? option.options : [option]
+  );
+
 export const getInputFocusedColor = ({ accentColor }) => {
   if (accentColor !== '#4368E3') {
     return accentColor;

--- a/frontend/src/_styles/theme.scss
+++ b/frontend/src/_styles/theme.scss
@@ -12066,6 +12066,9 @@ tbody {
   }
 
   input.dynamic-form-encrypted-field[type="password"] {
+    // The eye toggle sits absolutely at right: 8px -- reserve room for it in
+    // every state, or the masked value renders underneath the icon.
+    padding-right: 35px !important;
     &:disabled {
       padding-right: 35px !important;
     }

--- a/marketplace/plugins/hubspot/lib/index.ts
+++ b/marketplace/plugins/hubspot/lib/index.ts
@@ -1,9 +1,11 @@
 import {
   QueryError,
+  OAuthUnauthorizedClientError,
   QueryResult,
   QueryService,
   User,
   App,
+  getRefreshedToken,
   validateAndSetRequestOptionsBasedOnAuthType,
 } from '@tooljet-marketplace/common';
 import { SourceOptions, ConvertedFormat, AuthSourceDetails } from './types';
@@ -88,6 +90,14 @@ export default class Hubspot implements QueryService {
         statusMessage: error.response.statusMessage,
         body: JSON.parse(error.response.body),
       };
+      // A 401 from HubSpot is an expired/invalid OAuth token (their
+      // EXPIRED_AUTHENTICATION category) as often as a bad one. Surface it as
+      // OAuthUnauthorizedClientError so the server's refresh flow can use the
+      // stored refresh token and retry, instead of dead-ending as a plain
+      // query error.
+      if (error.response.statusCode === 401) {
+        throw new OAuthUnauthorizedClientError(errorMessage, 'HubSpot OAuth token expired or invalid', errorResponse);
+      }
       throw new QueryError('Query could not be completed', errorMessage, errorResponse || {});
     }
     return {
@@ -95,6 +105,23 @@ export default class Hubspot implements QueryService {
       data: result,
     };
   }
+  // Called by the server when a query fails with OAuthUnauthorizedClientError:
+  // exchanges the stored refresh token for a fresh access token. HubSpot's
+  // token endpoint is form-encoded, and the tooljet-app OAuth flavour keeps
+  // its credentials in env vars -- both are filled in here so the shared
+  // helper works for every auth shape this datasource offers.
+  async refreshToken(sourceOptions: any, error: any, userId: string, isAppPublic: boolean) {
+    const defaults: Record<string, unknown> = {
+      access_token_url: 'https://api.hubapi.com/oauth/v1/token',
+      access_token_custom_headers: [['Content-Type', 'application/x-www-form-urlencoded']],
+    };
+    if (sourceOptions['oauth_type'] === 'tooljet_app') {
+      defaults['client_id'] = process.env.HUBSPOT_CLIENT_ID;
+      defaults['client_secret'] = process.env.HUBSPOT_CLIENT_SECRET;
+    }
+    return getRefreshedToken({ ...defaults, ...sourceOptions }, error, userId, isAppPublic);
+  }
+
   authHeader(token: string): Headers {
     return {
       Authorization: `Bearer ${token}`,

--- a/plugins/packages/googlesheetsv2/__tests__/readValuesUrl.test.ts
+++ b/plugins/packages/googlesheetsv2/__tests__/readValuesUrl.test.ts
@@ -1,0 +1,21 @@
+import { readValuesUrl } from '../lib/operations';
+
+describe('readValuesUrl', () => {
+  it('names only the sheet when the range is blank, reading the entire used range', () => {
+    expect(readValuesUrl('sid', 'Sheet1', '')).toBe(
+      'https://sheets.googleapis.com/v4/spreadsheets/sid/values/Sheet1'
+    );
+    expect(readValuesUrl('sid', 'Sheet1', undefined as unknown as string)).toBe(
+      'https://sheets.googleapis.com/v4/spreadsheets/sid/values/Sheet1'
+    );
+  });
+
+  it('appends the range segment when one is given', () => {
+    expect(readValuesUrl('sid', 'Sheet1', 'A1:Z500')).toBe(
+      'https://sheets.googleapis.com/v4/spreadsheets/sid/values/Sheet1!A1:Z500'
+    );
+    expect(readValuesUrl('sid', 'Sheet1', 'A2:B10')).toBe(
+      'https://sheets.googleapis.com/v4/spreadsheets/sid/values/Sheet1!A2:B10'
+    );
+  });
+});

--- a/plugins/packages/googlesheetsv2/lib/index.ts
+++ b/plugins/packages/googlesheetsv2/lib/index.ts
@@ -306,9 +306,11 @@ export default class Googlesheetsv2QueryService implements QueryService {
             throw new Error('Sheet is required for read operation');
           }
 
+          // An empty range reads the sheet's entire used range; the A1:Z500
+          // fallback above stays for operations that need a concrete range.
           result = await readData(
             spreadsheetId,
-            spreadsheetRange,
+            queryOptions.spreadsheet_range ?? '',
             queryOptions.sheet,
             this.authHeader(accessToken),
             queryOptions.majorDimension,

--- a/plugins/packages/googlesheetsv2/lib/operations.ts
+++ b/plugins/packages/googlesheetsv2/lib/operations.ts
@@ -6,8 +6,16 @@ type SpreadsheetResponseBody = {
   sheets?: Array<any>;
 };
 
+export function readValuesUrl(spreadSheetId: string, sheet: string, range: string): string {
+  // A blank range means "the whole sheet": the values API reads a sheet's
+  // entire used range when the range names only the sheet, so no `!` suffix.
+  return range
+    ? `https://sheets.googleapis.com/v4/spreadsheets/${spreadSheetId}/values/${sheet || ''}!${range}`
+    : `https://sheets.googleapis.com/v4/spreadsheets/${spreadSheetId}/values/${sheet || ''}`;
+}
+
 async function makeRequestToReadValues(spreadSheetId: string, sheet: string, range: string, authHeader: any,majorDimension?: string,valueRenderOption?: string,dateTimeRenderOption?: string ){
-  let url = `https://sheets.googleapis.com/v4/spreadsheets/${spreadSheetId}/values/${sheet || ''}!${range}`;
+  let url = readValuesUrl(spreadSheetId, sheet, range);
 
   const params = new URLSearchParams();
   if (majorDimension) params.append('majorDimension', majorDimension);

--- a/server/src/modules/data-queries/oauth-single-flight.util.ts
+++ b/server/src/modules/data-queries/oauth-single-flight.util.ts
@@ -1,0 +1,20 @@
+/**
+ * Share one in-flight async operation per key.
+ *
+ * Concurrent callers with the same key await the same promise instead of
+ * racing parallel executions — the OAuth refresh path uses this so that every
+ * Run-on-Page-Load query hitting the same expired datasource shares ONE
+ * refresh (providers with single-use refresh tokens invalidate the losers of
+ * a race, cascading every query into a manual re-auth redirect). The entry is
+ * removed when the operation settles, so a later expiry refreshes again.
+ */
+export const singleFlight = <T>(inFlight: Map<string, Promise<T>>, key: string, factory: () => Promise<T>): Promise<T> => {
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+
+  const operation = factory().finally(() => {
+    inFlight.delete(key);
+  });
+  inFlight.set(key, operation);
+  return operation;
+};

--- a/server/src/modules/data-queries/util.service.ts
+++ b/server/src/modules/data-queries/util.service.ts
@@ -1,4 +1,5 @@
 import * as requestIp from 'request-ip';
+import { singleFlight } from './oauth-single-flight.util';
 import { App } from '@entities/app.entity';
 import { AppEnvironment } from '@entities/app_environments.entity';
 import { User } from '@entities/user.entity';
@@ -26,6 +27,11 @@ import { ListTablesDto } from './dto';
 
 @Injectable()
 export class DataQueriesUtilService implements IDataQueriesUtilService {
+
+  // One in-flight OAuth refresh per (datasource, user, environment): concurrent
+  // page-load queries share it instead of racing parallel refreshes.
+  private oauthRefreshInFlight = new Map<string, Promise<void>>();
+
   constructor(
     protected readonly versionRepository: VersionRepository,
     protected readonly configService: ConfigService,
@@ -226,14 +232,31 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
               );
           if (currentUserToken && currentUserToken['refresh_token']) {
             console.log('Access token expired. Attempting refresh token flow.');
-            let accessTokenDetails;
-            try {
-              accessTokenDetails = await service.refreshToken(
+            // Single-flight: every Run-on-Page-Load query hitting the same
+            // expired datasource concurrently must share ONE refresh —
+            // parallel refreshes race each other (providers with
+            // single-use refresh tokens invalidate the losers, cascading
+            // every query into a manual re-auth redirect instead of the
+            // one silent refresh a single flight produces).
+            const refreshKey = `${dataSource.id}:${user?.id ?? 'public'}:${environmentId}`;
+            const refreshPromise = singleFlight(this.oauthRefreshInFlight, refreshKey, async () => {
+              const accessTokenDetails = await service.refreshToken(
                 sourceOptions,
                 dataSource.id,
                 user?.id,
                 effectiveIsPublic
               );
+              await this.dataSourceUtilService.updateOAuthAccessToken(
+                accessTokenDetails,
+                dataSource.options,
+                dataSource.id,
+                user?.id,
+                user?.organizationId,
+                environmentId
+              );
+            });
+            try {
+              await refreshPromise;
             } catch (error) {
               if (error.constructor.name === 'OAuthUnauthorizedClientError') {
                 // unauthorized error need to re-authenticate
@@ -270,14 +293,9 @@ export class DataQueriesUtilService implements IDataQueriesUtilService {
               );
             }
 
-            await this.dataSourceUtilService.updateOAuthAccessToken(
-              accessTokenDetails,
-              dataSource.options,
-              dataSource.id,
-              user?.id,
-              user?.organizationId,
-              environmentId
-            );
+            // The shared refresh promise already persisted the new token;
+            // re-read the datasource options (every waiter takes this path
+            // with the same refreshed state) and retry the query once.
             const dataSourceOptions = await this.appEnvironmentUtilService.getOptions(
               dataSource.id,
               user.organizationId,

--- a/server/test/modules/data-queries/unit/oauth-single-flight.spec.ts
+++ b/server/test/modules/data-queries/unit/oauth-single-flight.spec.ts
@@ -1,0 +1,57 @@
+/// <reference types="jest" />
+import { singleFlight } from '@modules/data-queries/oauth-single-flight.util';
+
+describe('singleFlight (shared OAuth refresh)', () => {
+  it('concurrent callers with the same key share one execution and one result', async () => {
+    const inFlight = new Map<string, Promise<number>>();
+    let executions = 0;
+    const factory = async () => {
+      executions += 1;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return executions;
+    };
+
+    const results = await Promise.all([
+      singleFlight(inFlight, 'ds:1:dev', factory),
+      singleFlight(inFlight, 'ds:1:dev', factory),
+      singleFlight(inFlight, 'ds:1:dev', factory),
+    ]);
+
+    expect(executions).toBe(1);
+    expect(results).toEqual([1, 1, 1]);
+  });
+
+  it('different keys execute independently', async () => {
+    const inFlight = new Map<string, Promise<string>>();
+    const seen: string[] = [];
+    const make = (label: string) => async () => {
+      seen.push(label);
+      return label;
+    };
+
+    const [a, b] = await Promise.all([singleFlight(inFlight, 'k1', make('a')), singleFlight(inFlight, 'k2', make('b'))]);
+
+    expect([a, b]).toEqual(['a', 'b']);
+    expect(seen.sort()).toEqual(['a', 'b']);
+  });
+
+  it('every waiter observes the same rejection, and a later attempt runs again', async () => {
+    const inFlight = new Map<string, Promise<void>>();
+    let attempts = 0;
+    const failFirst = async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('refresh rejected');
+    };
+
+    const settled = await Promise.allSettled([
+      singleFlight(inFlight, 'k', failFirst),
+      singleFlight(inFlight, 'k', failFirst),
+    ]);
+    expect(settled.every((r) => r.status === 'rejected')).toBe(true);
+    expect(attempts).toBe(1);
+
+    // The map entry is cleared after settle, so the next expiry refreshes again.
+    await expect(singleFlight(inFlight, 'k', failFirst)).resolves.toBeUndefined();
+    expect(attempts).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Leaving the Range field blank on a Google Sheets read returned only the first 500 rows (#17255): the empty `spreadsheet_range` fell back to the hard-coded `A1:Z500` (`googlesheetsv2/lib/index.ts:255`), and the request URL always appended `!${range}`.

## Change

- **Reads** pass the blank range through instead of the A1:Z500 fallback, and the request URL names only the sheet — the Sheets values API returns a sheet's **entire used range** when no A1 segment is given.
- The `A1:Z500` default stays for every other consumer of `spreadsheetRange` (append, delete-by-range, copy, …) — those operations require a concrete range.
- The URL construction is extracted as an exported pure `readValuesUrl` so the blank/exact shapes are unit-testable.

## Testing

- `__tests__/readValuesUrl.test.ts`: blank range → `.../values/Sheet1` (whole used range); explicit ranges keep the `!A1:Z500` form.
- Behaviorally verified against the extracted function directly (both shapes above). The plugins workspace can't `npm install` in this sandbox (its lockfile pins `@sap/hana-client` to a dead taobao mirror), so the jest suite runs in CI only.

Fixes #17255
