### PR TITLE
added curl health check in platform and marketplace cypress workflows

### DIFF
--- a/.github/workflows/cypress-marketplace.yml
+++ b/.github/workflows/cypress-marketplace.yml
@@ -205,20 +205,28 @@ jobs:
           ELAPSED=0
 
           while [ $ELAPSED -lt $TIMEOUT ]; do
-            # Check for success message in logs
+            # Check 1: success message in logs
             if docker-compose logs tooljet 2>/dev/null | grep -qE "TOOLJET APPLICATION STARTED SUCCESSFULLY|Ready to use at http://localhost:82|Ready to use at http://localhost:80"; then
               echo "Found success message in logs!"
               SUCCESS_FOUND=true
               break
             fi
 
-            echo "Still waiting... (${ELAPSED}s elapsed)"
+            # Check 2: health endpoint returns HTTP 200
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health || echo "000")
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "Health check passed (HTTP $HTTP_STATUS)!"
+              SUCCESS_FOUND=true
+              break
+            fi
+
+            echo "Still waiting... (${ELAPSED}s elapsed, last health check: HTTP ${HTTP_STATUS})"
             sleep 10
             ELAPSED=$((ELAPSED + 10))
           done
 
           if [ "$SUCCESS_FOUND" = false ]; then
-            echo "Timeout reached without finding success logs"
+            echo "Timeout reached without finding success logs or healthy endpoint"
             echo "Showing current logs for troubleshooting..."
             docker-compose logs --tail=100 tooljet
             exit 1

--- a/.github/workflows/cypress-platform.yml
+++ b/.github/workflows/cypress-platform.yml
@@ -223,20 +223,28 @@ jobs:
           ELAPSED=0
 
           while [ $ELAPSED -lt $TIMEOUT ]; do
-            # Check for success message in logs
+            # Check 1: success message in logs
             if docker-compose logs tooljet 2>/dev/null | grep -qE "🚀 TOOLJET APPLICATION STARTED SUCCESSFULLY|Ready to use at http://localhost:82 🚀|Ready to use at http://localhost:80"; then
               echo "✅ Found success message in logs!"
               SUCCESS_FOUND=true
               break
             fi
 
-            echo "⏳ Still waiting... (${ELAPSED}s elapsed)"
+            # Check 2: health endpoint returns HTTP 200
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health || echo "000")
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "✅ Health check passed (HTTP $HTTP_STATUS)!"
+              SUCCESS_FOUND=true
+              break
+            fi
+
+            echo "⏳ Still waiting... (${ELAPSED}s elapsed, last health check: HTTP ${HTTP_STATUS})"
             sleep 10
             ELAPSED=$((ELAPSED + 10))
           done
 
           if [ "$SUCCESS_FOUND" = false ]; then
-            echo "❌ Timeout reached without finding success logs"
+            echo "❌ Timeout reached without finding success logs or healthy endpoint"
             echo "📄 Showing current logs for troubleshooting..."
             docker-compose logs --tail=100 tooljet
             exit 1
@@ -624,18 +632,25 @@ jobs:
           TIMEOUT=700
           ELAPSED=0
           while [ $ELAPSED -lt $TIMEOUT ]; do
-            # Check for success message in logs
+            # Check 1: success message in logs
             if docker-compose logs tooljet 2>/dev/null | grep -qE "🚀 TOOLJET APPLICATION STARTED SUCCESSFULLY"; then
               echo "✅ Found success message in logs!"
               SUCCESS_FOUND=true
               break
             fi
-            echo "⏳ Still waiting... (${ELAPSED}s elapsed)"
+            # Check 2: health endpoint returns HTTP 200
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health || echo "000")
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "✅ Health check passed (HTTP $HTTP_STATUS)!"
+              SUCCESS_FOUND=true
+              break
+            fi
+            echo "⏳ Still waiting... (${ELAPSED}s elapsed, last health check: HTTP ${HTTP_STATUS})"
             sleep 10
             ELAPSED=$((ELAPSED + 10))
           done
           if [ "$SUCCESS_FOUND" = false ]; then
-            echo "❌ Timeout reached without finding success logs"
+            echo "❌ Timeout reached without finding success logs or healthy endpoint"
             echo "📄 Showing current logs for troubleshooting..."
             docker-compose logs --tail=100 tooljet
             exit 1
@@ -1057,18 +1072,25 @@ jobs:
           TIMEOUT=700
           ELAPSED=0
           while [ $ELAPSED -lt $TIMEOUT ]; do
-            # Check for success message in logs
+            # Check 1: success message in logs
             if docker-compose logs tooljet 2>/dev/null | grep -qE "🚀 TOOLJET APPLICATION STARTED SUCCESSFULLY"; then
               echo "✅ Found success message in logs!"
               SUCCESS_FOUND=true
               break
             fi
-            echo "⏳ Still waiting... (${ELAPSED}s elapsed)"
+            # Check 2: health endpoint returns HTTP 200
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health || echo "000")
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "✅ Health check passed (HTTP $HTTP_STATUS)!"
+              SUCCESS_FOUND=true
+              break
+            fi
+            echo "⏳ Still waiting... (${ELAPSED}s elapsed, last health check: HTTP ${HTTP_STATUS})"
             sleep 10
             ELAPSED=$((ELAPSED + 10))
           done
           if [ "$SUCCESS_FOUND" = false ]; then
-            echo "❌ Timeout reached without finding success logs"
+            echo "❌ Timeout reached without finding success logs or healthy endpoint"
             echo "📄 Showing current logs for troubleshooting..."
             docker-compose logs --tail=100 tooljet
             exit 1
@@ -1492,18 +1514,25 @@ jobs:
           TIMEOUT=700
           ELAPSED=0
           while [ $ELAPSED -lt $TIMEOUT ]; do
-            # Check for success message in logs
+            # Check 1: success message in logs
             if docker-compose logs tooljet 2>/dev/null | grep -qE "🚀 TOOLJET APPLICATION STARTED SUCCESSFULLY"; then
               echo "✅ Found success message in logs!"
               SUCCESS_FOUND=true
               break
             fi
-            echo "⏳ Still waiting... (${ELAPSED}s elapsed)"
+            # Check 2: health endpoint returns HTTP 200
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health || echo "000")
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "✅ Health check passed (HTTP $HTTP_STATUS)!"
+              SUCCESS_FOUND=true
+              break
+            fi
+            echo "⏳ Still waiting... (${ELAPSED}s elapsed, last health check: HTTP ${HTTP_STATUS})"
             sleep 10
             ELAPSED=$((ELAPSED + 10))
           done
           if [ "$SUCCESS_FOUND" = false ]; then
-            echo "❌ Timeout reached without finding success logs"
+            echo "❌ Timeout reached without finding success logs or healthy endpoint"
             echo "📄 Showing current logs for troubleshooting..."
             docker-compose logs --tail=100 tooljet
             exit 1


### PR DESCRIPTION
## Summary
- Applies the same fix from #17613 (commit 59647be4c0a33454b77deff8df4ea98859ff6a5d, "added curl check in lts") to `cypress-platform.yml` and `cypress-marketplace.yml`
- Adds a secondary health check (`curl` against `http://localhost:3000/api/health`) alongside the existing log-based success check in the "Wait for the server to be ready" step, so the workflow doesn't fail purely because the expected log line wasn't matched while the server is actually up
- Applied to all 4 occurrences of the wait-for-server block in `cypress-platform.yml` and the 1 occurrence in `cypress-marketplace.yml`

## Test plan
- [ ] Confirm YAML is valid (validated locally with `yaml.safe_load`)
- [ ] Trigger the platform and marketplace Cypress workflows on lts-3.16 and confirm the "Wait for the server to be ready" step passes via either the log match or the health check