### PR TITLE
Docs: add product and architecture maps under .agents/context

### DIFF
--- a/.agents/context/architecture-map.md
+++ b/.agents/context/architecture-map.md
@@ -1,0 +1,159 @@
+# ToolJet public architecture map
+
+## Scope
+
+This map covers the public repository and Community Edition paths. It does not inspect private code in `frontend/ee` or `server/ee`. Where public base classes are extended by other editions, the boundary is stated rather than inferred.
+
+## System summary
+
+ToolJet is a JavaScript/TypeScript monorepo. A React/Webpack frontend provides the administrative dashboard, App-Builder, ToolJet Database UI, and an isolated released-app viewer bundle. A NestJS server exposes REST and WebSocket endpoints, enforces authentication and CASL permissions, persists platform metadata with TypeORM/PostgreSQL, executes connector queries, and coordinates scheduled/background work through Redis and BullMQ. ToolJet Database uses a second PostgreSQL connection and PostgREST for workspace-scoped row operations.
+
+```mermaid
+graph LR
+  B[Browser] --> F[React frontend]
+  F -->|REST / WebSocket| N[NestJS server]
+  N --> M[(Main PostgreSQL)]
+  N --> T[(ToolJet DB PostgreSQL)]
+  N --> P[PostgREST]
+  P --> T
+  N --> R[(Redis / BullMQ)]
+  W[Worker process] --> R
+  W --> M
+  N --> PL[Connector plugins]
+  PL --> X[External databases, APIs and SaaS]
+  N --> O[SMTP / object storage / Git providers]
+```
+
+## Repository and runtime components
+
+| Path/component | Responsibility and entry point |
+|---|---|
+| `frontend/src/index.jsx` | Browser bootstrap and Sentry-wrapped React root. |
+| `frontend/src/RootRouter.jsx::RootRouter` | Root bundle split: `/applications/*` and `/embed-apps/*` load `ViewerApp`; other routes load the main app. |
+| `frontend/src/App/App.jsx::AppComponent` | Dashboard/editor/settings router and instance/workspace initialization. |
+| `frontend/src/AppBuilder/` | Zustand-based visual editor and viewer runtime: canvas, component rendering, expression resolution, events, actions, and query state. |
+| `frontend/src/ViewerApp.jsx` | Lightweight released/embedded-app router and app-scoped authentication routes. |
+| `server/src/main.ts::bootstrap` | Nest application bootstrap, middleware, `/api` prefix, validation, security headers, observability, and HTTP/WebSocket listener. |
+| `server/src/modules/app/module.ts::AppModule.register` | Composes platform infrastructure and approximately 50 feature modules. |
+| `server/src/modules/app/sub-module.ts::SubModule` | Dynamically selects the CE or edition-specific provider tree and caches DynamicModules. |
+| `server/src/modules/apps/` | App aggregate, versions/pages/components/events, release, viewer hydration, and import/export. |
+| `server/src/modules/data-sources/` + `data-queries/` | Connector configuration, environment-scoped credentials, template resolution, query execution, throttling, and result status. |
+| `plugins/packages/` | Built-in connector implementations for databases, APIs, storage, email, and SaaS systems. |
+| `server/src/modules/tooljet-db/` | Built-in database schema operations and authenticated PostgREST proxy. |
+| `server/src/modules/workflows/` | Workflow models, schedules, queues, execution records, and edition-extension points. Some CE controller methods are stubs. |
+| `docker/`, `deploy/` | Development/production images and Docker, Kubernetes, Helm, OpenShift deployment definitions. |
+
+## Boot and request processing
+
+`server/src/main.ts::bootstrap` creates `AppModule.register`, validates the selected edition, configures Pino logging, global validation/interceptors/exception handling, cookies/compression/body limits, CSRF-origin checks, security headers, URI versioning, static assets, and `WsAdapter`, then listens on `PORT` (default 3000). `GuardValidator.validateJwtGuard` fails startup validation for unguarded feature routes.
+
+`server/src/modules/app/loader.ts::AppModuleLoader.loadModules` initializes configuration, the event emitter, schedules, BullMQ, the main and ToolJet DB TypeORM connections, Redis, request context, logging, optional static frontend serving, Sentry, and optional OpenTelemetry.
+
+## Data stores
+
+| Store | Content | Access path |
+|---|---|---|
+| Main PostgreSQL | Workspaces, users/sessions, apps/versions, pages/components/layouts/events, data source metadata and encrypted options, queries, permissions, workflow records, audit and configuration metadata. | `server/ormconfig.ts::buildConnectionOptions`; entities in `server/src/entities/`; schema migrations in `server/migrations/`. |
+| ToolJet DB PostgreSQL | User-created workspace tables and rows, with per-workspace schema/user isolation unless SQL mode is disabled. | Named TypeORM connection from `buildToolJetDbConnectionOptions`; `TooljetDbTableOperationsService`. |
+| PostgREST | HTTP data plane over ToolJet DB; not a source of truth itself. | `PostgrestProxyService::{proxy,perform}` signs a database JWT, selects the workspace schema, and forwards requests. |
+| Redis | BullMQ queues and shared runtime coordination/cache facilities. | `AppModuleLoader` Bull/Redis configuration; `server/src/modules/workflows/module.ts`. |
+| Files/object storage | Uploaded assets/files through configurable storage providers. | `server/src/modules/files/`; deployment environment configuration. |
+
+Schema changes and data transformations are separated: `server/migrations/` contains TypeORM schema migrations, while `server/data-migrations/` contains deployment-time data migrations.
+
+## End-to-end flows
+
+### 1. Authentication and workspace authorization
+
+```mermaid
+sequenceDiagram
+  Browser->>AuthController: POST /api/authenticate
+  AuthController->>AuthService: login(...)
+  AuthService->>SessionUtilService: generateLoginResultPayload(...)
+  SessionUtilService-->>Browser: tj_auth_token cookie + session/permissions
+  Browser->>AuthController: GET /api/authorize
+  AuthController-->>Browser: active workspace context
+```
+
+`AuthController` supports global, super-admin, and workspace login. `SessionUtilService` signs the JWT cookie and builds the user/workspace permission payload. Subsequent controllers combine `JwtAuthGuard`, resource validation guards, and an `AbilityGuard`. Google/GitHub OAuth have CE implementations; OIDC/SAML/LDAP services are public stubs with private edition implementations (`server/src/modules/auth/AGENTS.md`).
+
+### 2. Author, release, and render an app
+
+1. `frontend/src/HomePage/HomePage.jsx::createApp` calls `frontend/src/_services/apps.service.js` and `AppsController.create`.
+2. `AppsService.create` wraps creation in `dbTransactionWrap`; `AppsUtilService.create` writes the App, initial Version, environment association, and default metadata.
+3. App-Builder operations persist pages, components, layouts, events, and queries under an App Version through `server/src/modules/apps/services/` and `server/src/modules/versions/`.
+4. `AppsController.releaseVersion` calls `AppsService.release`, which validates environment/version constraints and sets the released version.
+5. `RootRouter` loads the isolated `ViewerApp` bundle for `/applications/:slug`. Access guards resolve public/private access; `useAppData` hydrates the released definition; `Viewer` renders `AppCanvas`.
+
+### 3. Execute a connector query
+
+1. Builder or viewer calls `DataQueriesController.runQueryOnBuilder` or `runQuery`.
+2. Guards validate the App, Version, Data Source, ability, public/private access, and per-app throttle.
+3. `DataQueriesService.runAndGetResult` delegates to `DataQueriesUtilService.runQuery`.
+4. `AppEnvironmentUtilService.getOptions` selects environment- and branch-specific source options.
+5. `parseSourceOptions` decrypts credentials; `parseQueryOptions` resolves constants, secrets, and server globals.
+6. `PluginsServiceSelector.getService` chooses ToolJet DB, REST API, workflow, or a built-in/marketplace connector and executes it with a timeout.
+7. The result becomes `queries.<name>.data` in frontend state; dependency resolution updates bound components and query success/failure events run.
+
+### 4. Operate on ToolJet Database
+
+`TooljetDbController` exposes guarded table/column/foreign-key/bulk-upload operations. Row operations enter `/tooljet-db/proxy/*` or `PostgrestProxyService.perform`; the service maps opaque table IDs to workspace tables, creates a scoped Postgres JWT/profile header, validates JSONB input, and calls PostgREST. PostgREST performs the SQL against ToolJet DB PostgreSQL and returns representations/count metadata.
+
+### 5. Queue and execute background work
+
+Nest schedules and BullMQ share Redis configuration from `AppModuleLoader`. Workflow scheduling/execution queues are registered in `server/src/modules/workflows/module.ts`; processors and schedule bootstrap are registered only when `WORKER=true`. `npm run worker:prod` starts the same compiled server entry with that flag. The non-Cloud deployment also exposes Bull Board under `/jobs`, protected by configured basic authentication. **Boundary:** public workflow contracts are present, but some CE webhook methods throw `Method not implemented`, so full behavior is edition-dependent.
+
+## Authentication and authorization
+
+- JWT session: `server/src/modules/session/`, cookie `tj_auth_token`.
+- Feature authorization: module/feature metadata plus CASL in `server/src/modules/app/ability-factory.ts` and `guards/ability.guard.ts`.
+- Resource validation: App, Version, Data Source, workspace, public/private, and feature/license guards close to each controller.
+- Secrets: source options and workspace secrets are decrypted/resolved server-side during query execution.
+- Security middleware: CSRF-origin checks for custom domains, body validation/whitelisting, security headers, redacted request logging, parameterized-query rule, and throttling on app query runs.
+
+## External integrations
+
+Built-in plugins under `plugins/packages/` cover SQL/NoSQL databases, REST/GraphQL/OpenAPI/gRPC, object storage, messaging/email, and SaaS services. `PluginsServiceSelector` provides the runtime boundary. Other platform integrations include SMTP/email, Git providers for sync interfaces, S3/GCS/Azure-style storage providers, AI providers, Sentry, OTLP collectors, and PostHog in the frontend. Availability and credentials are environment/configuration dependent.
+
+## Deployment and observability
+
+- Development Compose runs frontend, server, plugin watcher, PostgreSQL, Redis, and PostgREST (`docker-compose.yaml`).
+- Production assets support CE images plus Docker Compose, Kubernetes, Helm, and OpenShift (`docker/`; `deploy/`). Nest can serve `frontend/build` or run with `SERVE_CLIENT=false`.
+- `/health` and `/api/health` are prefix-exempt health endpoints (`AppController.healthCheck`).
+- Pino supplies structured/redacted HTTP logs and transaction IDs (`AppModuleLoader`).
+- Optional Prometheus-format metrics use `ENABLE_METRICS`; optional Sentry uses `APM_VENDOR=sentry`. Public OTLP instrumentation is configured through `ENABLE_OTEL` and `server/src/otel/tracing.ts`, while `server/src/helpers/bootstrap.helper.ts::initializeOtel` currently limits initialization to EE/Cloud editions.
+- Recent history shows active work in viewer isolation, deployment certificates, connector validation, migrations, and agent context. Architecture claims should be revalidated as `main` evolves.
+
+## Tests and fixtures
+
+- Backend Jest unit/e2e tests mirror modules under `server/test/modules/`, with database transaction/savepoint isolation documented in `server/docs/testing.md`.
+- Frontend Jest/Testing Library tests live beside source; Storybook supports UI components (`frontend/.storybook/`).
+- Cypress end-to-end suites, fixtures, and plugin tests live in `cypress-tests/cypress/`.
+- Connector packages have Jest tests under `plugins/`; CI definitions are in `.github/workflows/`.
+
+## Expected failure modes
+
+| Failure | Handling/evidence |
+|---|---|
+| Invalid/expired session or insufficient permission | Guards return authorization errors before service execution. |
+| Public/private or unreleased app mismatch | App access guards and release validation prevent hydration. |
+| Query timeout, connector error, OAuth refresh requirement, or throttling | Data query services return structured failed/`needs_oauth` states; throttler limits per-app runs. |
+| PostgREST or ToolJet DB schema/data error | `PostgrestProxyService` translates failures to `QueryError`; ToolJet DB exception filters normalize responses. |
+| Redis/worker unavailable | Scheduled/queued work cannot progress; queue/worker gauges and Bull Board expose backlog when enabled. |
+| Stale frontend chunks after deployment | `RootRouter.jsx::ChunkErrorBoundary` reloads once, then presents a manual refresh action. |
+| Main DB, ToolJet DB, or PostgREST unavailable at boot/runtime | Health/startup or dependent requests fail; Compose/Kubernetes declare these service dependencies. |
+| Server/frontend component config drift | Existing saved apps may render incorrectly; repository instructions require synchronized config and migrations for key changes. |
+
+## Inferences
+
+- **Inference:** The architecture favors a modular monolith for control-plane/API behavior, with connector execution and background workers as extension/execution boundaries rather than independently deployed feature services.
+- **Inference:** App Version is the consistency boundary for editor/viewer behavior; environment-specific source options are deliberately resolved late so the same app definition can move between environments.
+
+## Unanswered questions
+
+- Which public modules are CE production paths versus shared contracts for private editions?
+- Is Redis used for any CE real-time collaboration path beyond BullMQ/cache, or is collaboration entirely edition-specific?
+- What is the supported production topology for splitting API and `WORKER=true` processes, including queue concurrency and failure recovery?
+- Which file/object-storage backend is the CE default in each supported deployment?
+- What formal SLOs, backup/restore guarantees, and disaster-recovery procedures apply to the two PostgreSQL databases and Redis?
+- Which API endpoints are considered stable public APIs versus internal frontend/backend contracts?

--- a/.agents/context/architecture-map.md
+++ b/.agents/context/architecture-map.md
@@ -148,12 +148,3 @@ Built-in plugins under `plugins/packages/` cover SQL/NoSQL databases, REST/Graph
 
 - **Inference:** The architecture favors a modular monolith for control-plane/API behavior, with connector execution and background workers as extension/execution boundaries rather than independently deployed feature services.
 - **Inference:** App Version is the consistency boundary for editor/viewer behavior; environment-specific source options are deliberately resolved late so the same app definition can move between environments.
-
-## Unanswered questions
-
-- Which public modules are CE production paths versus shared contracts for private editions?
-- Is Redis used for any CE real-time collaboration path beyond BullMQ/cache, or is collaboration entirely edition-specific?
-- What is the supported production topology for splitting API and `WORKER=true` processes, including queue concurrency and failure recovery?
-- Which file/object-storage backend is the CE default in each supported deployment?
-- What formal SLOs, backup/restore guarantees, and disaster-recovery procedures apply to the two PostgreSQL databases and Redis?
-- Which API endpoints are considered stable public APIs versus internal frontend/backend contracts?

--- a/.agents/context/product-map.md
+++ b/.agents/context/product-map.md
@@ -1,0 +1,111 @@
+# ToolJet public product map
+
+## Scope and evidence
+
+This map describes the product represented by the public ToolJet repository, with emphasis on Community Edition (CE) code under `frontend/src/`, `server/src/`, and `plugins/`. Private edition implementations under the `frontend/ee` and `server/ee` submodules were not inspected. A capability appearing in the public interface does not by itself establish CE availability; edition- or license-dependent behavior is called out explicitly.
+
+Primary evidence: `README.md`, `UBIQUITOUS_LANGUAGE.md`, `docs/docs/`, root and nested `AGENTS.md` files, and the referenced implementation paths.
+
+## Product purpose
+
+ToolJet is a low-code platform for building and deploying internal applications. Builders assemble pages from components, connect them to data sources through queries, add events and actions, and release applications for end users. The repository also provides a built-in database, workspace/user administration, connector plugins, deployment assets, and an automation/workflow framework (`README.md`; `frontend/src/AppBuilder/`; `server/src/modules/app/module.ts::AppModule.register`).
+
+## Users and roles
+
+| User | Product responsibility | Evidence |
+|---|---|---|
+| Super Admin | Operates an instance and its workspaces and settings. | `UBIQUITOUS_LANGUAGE.md`; `server/src/modules/instance-settings/` |
+| Admin | Manages one workspace, its users, settings, and resources. | `UBIQUITOUS_LANGUAGE.md`; `server/src/modules/organizations/`; `server/src/modules/organization-users/` |
+| Builder | Creates apps, components, data sources, and queries, subject to permissions. | `UBIQUITOUS_LANGUAGE.md`; `frontend/src/AppBuilder/`; `server/src/modules/group-permissions/` |
+| End User | Views and interacts with released apps to which they have access. | `UBIQUITOUS_LANGUAGE.md`; `frontend/src/ViewerApp.jsx::ViewerApp` |
+| Application/API client | Opens a public or embedded app, or invokes an authorized outward-facing endpoint. | `server/src/modules/apps/controller.ts::AppsController`; `server/src/modules/external-apis/` |
+
+## Product model
+
+```mermaid
+graph TD
+  I[Instance] --> W[Workspace]
+  W --> U[Users and groups]
+  W --> A[Apps]
+  W --> DS[Data sources]
+  W --> DB[ToolJet Database]
+  W --> C[Constants and secrets]
+  A --> V[Versions]
+  V --> P[Pages]
+  P --> CP[Components and layouts]
+  V --> Q[Queries]
+  CP --> EH[Events and actions]
+  Q --> DS
+  A --> R[Released app]
+```
+
+`Organization` and `organizationId` in code mean Workspace in the product vocabulary (`UBIQUITOUS_LANGUAGE.md`).
+
+## Core capabilities
+
+| Capability | What users can do | Implementation evidence |
+|---|---|---|
+| Visual app building | Create multi-page apps, arrange components, configure properties/styles, bind dynamic values, and connect events to actions. | `frontend/src/AppBuilder/AppCanvas/`; `frontend/src/AppBuilder/WidgetManager/`; `server/src/modules/apps/services/{page,component,event}.service.ts` |
+| Components and runtime state | Use built-in UI components whose values can reference queries, components, globals, variables, constants, and secrets through `{{ }}` expressions. | `frontend/src/AppBuilder/_stores/`; `frontend/AGENTS.md` resolution pipeline; `server/src/modules/apps/services/widget-config/` |
+| Data sources and queries | Configure workspace- or app-level connectors, create parameterized queries, preview/run them, and bind results into apps. | `plugins/packages/`; `server/src/modules/data-sources/`; `server/src/modules/data-queries/`; `frontend/src/AppBuilder/QueryManager/` |
+| Built-in database | Create and alter tables, manage columns/foreign keys, upload CSV data, query and mutate rows, and join tables. | `server/src/modules/tooljet-db/controller.ts::TooljetDbController`; `frontend/src/TooljetDatabase/` |
+| App lifecycle | Create versions, edit in an environment, release a selected version, roll back by releasing an earlier version, and import/export app definitions. | `server/src/modules/versions/`; `server/src/modules/apps/service.ts::release`; `docs/docs/development-lifecycle/` |
+| Sharing and consumption | Access released apps by slug, make an app public, embed it, or require authenticated app access. | `frontend/src/ViewerApp.jsx`; `server/src/modules/apps/controller.ts::{validateReleasedAppAccess,appFromSlug}`; `docs/docs/app-builder/share.md` |
+| Workspace administration | Authenticate users, switch workspace, manage membership, roles/groups, folders, constants, environments, and settings. | `server/src/modules/auth/`; `server/src/modules/session/`; `server/src/modules/group-permissions/`; `frontend/src/modules/WorkspaceSettings/` |
+| Extensibility and deployment | Use built-in connector packages, marketplace plugins, and self-host through Docker, Kubernetes, Helm, or OpenShift assets. | `plugins/package.json`; `marketplace/`; `docker/`; `deploy/` |
+| Workflows and AI surfaces | Public base modules and UI/docs exist for workflow execution and AI-assisted building. Availability and concrete implementations vary by edition/license; several CE workflow webhook methods are stubs. | `server/src/modules/workflows/`; `server/src/modules/ai/`; `server/src/modules/workflows/controllers/workflow-webhooks.controller.ts` |
+
+## Important user journeys
+
+### 1. Sign in and enter a workspace
+
+1. A user signs in through password, Google, or GitHub flows implemented in CE; other SSO providers have public stubs and private implementations (`server/src/modules/auth/AGENTS.md`).
+2. `AuthController.login` calls `AuthService.login` (`server/src/modules/auth/controller.ts`, `service.ts`).
+3. `SessionUtilService.generateLoginResultPayload` signs the session and sets the `tj_auth_token` cookie (`server/src/modules/session/util.service.ts`).
+4. The frontend calls workspace authorization and loads role/permission context (`frontend/src/_helpers/authorizeWorkspace.js`; `frontend/src/App/App.jsx`).
+
+### 2. Build a data-backed app
+
+1. A Builder creates an app from the dashboard (`frontend/src/HomePage/HomePage.jsx::createApp`; `AppsController.create`).
+2. The backend transaction creates the App and initial Version/environment metadata (`AppsService.create`; `AppsUtilService.create`).
+3. The Builder adds Pages and Components through the App-Builder; the server persists version-scoped pages, components, layouts, and events (`frontend/src/AppBuilder/`; `server/src/modules/apps/services/`).
+4. The Builder configures a Data Source and Query (`server/src/modules/data-sources/`; `DataQueriesController.create`).
+5. A preview run resolves environment-specific credentials and templates and invokes the selected connector (`DataQueriesUtilService.runQuery`).
+
+### 3. Release and use an app
+
+1. The Builder selects a Version and releases it (`AppsController.releaseVersion` → `AppsService.release`).
+2. Release validates the target environment and applicable module/version rules, then updates the released version.
+3. An End User visits `/applications/:slug/:pageHandle?` (`frontend/src/RootRouter.jsx`; `ViewerApp.jsx`).
+4. Access guards allow the released public app anonymously or enforce private-app permissions (`server/src/modules/apps/guards/`).
+5. `Viewer` hydrates the released pages, components, events, and queries and renders `AppCanvas` (`frontend/src/AppBuilder/Viewer/Viewer.jsx`; `_hooks/useAppData.js`).
+
+### 4. Manage and use ToolJet Database
+
+1. An authorized user creates a workspace table through `TooljetDbController.createTable`.
+2. `TooljetDbTableOperationsService` applies schema operations to the ToolJet DB PostgreSQL connection and records table metadata through `InternalTable`.
+3. App queries use table IDs; `PostgrestProxyService` maps them to workspace-scoped tables, issues a scoped JWT, and forwards row operations to PostgREST.
+
+## Confirmed business rules
+
+- A Workspace is the tenant boundary for apps, users, data sources, constants, and ToolJet Database tables (`organizationId` across entities and guards).
+- Admin, Builder, and End User permissions are enforced server-side through CASL ability guards; UI visibility is not the authorization boundary (`server/src/modules/app/guards/ability.guard.ts`).
+- Every backend feature route must declare module/feature metadata and an ability guard; `GuardValidator` checks this at boot (`server/src/modules/app/validators/feature-guard.validator.ts`).
+- App content belongs to a Version; non-workflow app name, slug, icon, and public state are stored on version rows (`server/src/modules/apps/AGENTS.md`).
+- End users consume a released version. A public app can bypass login, but query execution remains guarded and throttled (`QueryAuthGuard`; `AppScopedThrottlerGuard`).
+- Query credentials and constants are resolved for the selected Environment on the server; secrets are decrypted there rather than exposed to the browser (`server/src/modules/data-queries/util.service.ts`).
+- Component configuration must remain backward compatible with previously saved apps, and server/frontend component defaults must change together (`frontend/AGENTS.md`; `server/AGENTS.md`).
+- Feature availability may be constrained by edition, license terms, and resource-count guards (`server/src/modules/licensing/`; `AbilityGuard`).
+
+## Inferences
+
+- **Inference:** The public repository is intentionally both the CE implementation and the stable contract/base layer extended by private editions. Evidence: dynamic module selection in `SubModule.getProviders` and the documented edition inheritance/composition patterns in `AGENTS.md`.
+- **Inference:** The App + Version aggregate is the dominant product boundary because pages, components, events, queries, release state, and most access checks converge on it.
+
+## Unanswered questions
+
+- Which capabilities in the public source are officially supported in CE today versus present only as shared interfaces, migrations, or gated UI?
+- Which user journeys and APIs carry backward-compatibility guarantees across minor and LTS releases?
+- Who owns each public module and connector, and what are their operational support boundaries?
+- Which telemetry paths are enabled by default in CE, and what exact data classification/redaction policy applies?
+- Are workflows intended to become a CE capability, or should their public base classes be documented solely as edition-extension contracts?

--- a/.agents/context/product-map.md
+++ b/.agents/context/product-map.md
@@ -101,11 +101,3 @@ graph TD
 
 - **Inference:** The public repository is intentionally both the CE implementation and the stable contract/base layer extended by private editions. Evidence: dynamic module selection in `SubModule.getProviders` and the documented edition inheritance/composition patterns in `AGENTS.md`.
 - **Inference:** The App + Version aggregate is the dominant product boundary because pages, components, events, queries, release state, and most access checks converge on it.
-
-## Unanswered questions
-
-- Which capabilities in the public source are officially supported in CE today versus present only as shared interfaces, migrations, or gated UI?
-- Which user journeys and APIs carry backward-compatibility guarantees across minor and LTS releases?
-- Who owns each public module and connector, and what are their operational support boundaries?
-- Which telemetry paths are enabled by default in CE, and what exact data classification/redaction policy applies?
-- Are workflows intended to become a CE capability, or should their public base classes be documented solely as edition-extension contracts?

--- a/.agents/context/product-map.md
+++ b/.agents/context/product-map.md
@@ -4,7 +4,7 @@
 
 This map describes the product represented by the public ToolJet repository, with emphasis on Community Edition (CE) code under `frontend/src/`, `server/src/`, and `plugins/`. Private edition implementations under the `frontend/ee` and `server/ee` submodules were not inspected. A capability appearing in the public interface does not by itself establish CE availability; edition- or license-dependent behavior is called out explicitly.
 
-Primary evidence: `README.md`, `UBIQUITOUS_LANGUAGE.md`, `docs/docs/`, root and nested `AGENTS.md` files, and the referenced implementation paths.
+Primary evidence: `README.md`, `UBIQUITOUS_LANGUAGE.md`, root and nested `AGENTS.md` files, and the referenced implementation paths.
 
 ## Product purpose
 
@@ -49,8 +49,8 @@ graph TD
 | Components and runtime state | Use built-in UI components whose values can reference queries, components, globals, variables, constants, and secrets through `{{ }}` expressions. | `frontend/src/AppBuilder/_stores/`; `frontend/AGENTS.md` resolution pipeline; `server/src/modules/apps/services/widget-config/` |
 | Data sources and queries | Configure workspace- or app-level connectors, create parameterized queries, preview/run them, and bind results into apps. | `plugins/packages/`; `server/src/modules/data-sources/`; `server/src/modules/data-queries/`; `frontend/src/AppBuilder/QueryManager/` |
 | Built-in database | Create and alter tables, manage columns/foreign keys, upload CSV data, query and mutate rows, and join tables. | `server/src/modules/tooljet-db/controller.ts::TooljetDbController`; `frontend/src/TooljetDatabase/` |
-| App lifecycle | Create versions, edit in an environment, release a selected version, roll back by releasing an earlier version, and import/export app definitions. | `server/src/modules/versions/`; `server/src/modules/apps/service.ts::release`; `docs/docs/development-lifecycle/` |
-| Sharing and consumption | Access released apps by slug, make an app public, embed it, or require authenticated app access. | `frontend/src/ViewerApp.jsx`; `server/src/modules/apps/controller.ts::{validateReleasedAppAccess,appFromSlug}`; `docs/docs/app-builder/share.md` |
+| App lifecycle | Create versions, edit in an environment, release a selected version, roll back by releasing an earlier version, and import/export app definitions. | `server/src/modules/versions/`; `server/src/modules/apps/service.ts::release`; `server/src/modules/apps/services/app-import-export.service.ts` |
+| Sharing and consumption | Access released apps by slug, make an app public, embed it, or require authenticated app access. | `frontend/src/ViewerApp.jsx`; `server/src/modules/apps/controller.ts::{validateReleasedAppAccess,appFromSlug}` |
 | Workspace administration | Authenticate users, switch workspace, manage membership, roles/groups, folders, constants, environments, and settings. | `server/src/modules/auth/`; `server/src/modules/session/`; `server/src/modules/group-permissions/`; `frontend/src/modules/WorkspaceSettings/` |
 | Extensibility and deployment | Use built-in connector packages, marketplace plugins, and self-host through Docker, Kubernetes, Helm, or OpenShift assets. | `plugins/package.json`; `marketplace/`; `docker/`; `deploy/` |
 | Workflows and AI surfaces | Public base modules and UI/docs exist for workflow execution and AI-assisted building. Availability and concrete implementations vary by edition/license; several CE workflow webhook methods are stubs. | `server/src/modules/workflows/`; `server/src/modules/ai/`; `server/src/modules/workflows/controllers/workflow-webhooks.controller.ts` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ cd plugins && npm install && npm run build
 ## Key conventions
 
 - Database name convention: `tooljet_{edition}` (see `PG_DB` in `.env`)
-- TypeORM schema migrations in `server/migrations/` (and `server/ee/migrations/` for EE); data migrations in `server/data-migrations/`
+- TypeORM schema migrations in `server/migrations/`; data migrations in `server/data-migrations/`
 - Never import `@ee/` or `@cloud/` from CE code — webpack enforces this at compile time
 - Backend port reads from `PORT` in `.env`; frontend port via `npm start -- --port <port>`
 - Lint before committing. Pre-commit hooks are in the repo (husky + lint-staged, activated by root `npm install`); the hook only lint-fixes frontend files — backend needs `cd server && npm run lint` manually. CI lints all three folders and blocks the PR on failure. Never `--no-verify` unless the user explicitly asks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,24 @@ Edition pattern: **composition** via registries + webpack module replacement.
 
 Frontend conventions, App Builder architecture and glossary: `frontend/AGENTS.md`.
 
+## Product and system orientation
+
+Use these maps to get oriented before tracing unfamiliar behavior:
+
+- `.agents/context/product-map.md` — users, capabilities, user journeys, confirmed business rules, inferences, and open product questions
+- `.agents/context/architecture-map.md` — runtime components, data stores, authentication/authorization, integrations, deployment, failure modes, and end-to-end technical flows
+
+The maps are indexes, not substitutes for current code. Follow their path and symbol references, then verify the relevant implementation, tests, migrations, and recent history. Treat sections labeled **Inference** as hypotheses and **Unanswered questions** as unresolved; never silently promote either to fact.
+
+### Public/private boundary
+
+This root repository is public; `server/ee/` and `frontend/ee/` are separate private submodules. For public issues, PRs, documentation, and support responses:
+
+- Base claims and reproduction steps only on public-repository evidence.
+- Do not disclose private source, repository links, customer data, internal deployment details, or private issue/Slack context.
+- If private context motivates a public fix, restate the problem as a publicly reproducible invariant and add a public regression test.
+- Do not inspect or modify private submodules unless the task explicitly includes them and the current user is authorized.
+
 ## Project structure
 
 ```
@@ -57,6 +75,20 @@ deploy/          # K8s, Helm, Docker deploy configs
 - **Widget** (legacy) = **Component**.
 - **Module** is overloaded: NestJS module (backend) vs reusable app building block (frontend/EE feature). Qualify which you mean.
 - Never abbreviate `data_source` as `ds`.
+
+## Evidence-first investigation
+
+For product questions, bug reports, regressions, and root-cause analysis:
+
+1. Normalize the report: expected behavior, observed behavior, edition, version/commit, environment, role, app state, and reproducible inputs. State what is missing.
+2. Locate the capability and user journey in `.agents/context/product-map.md`; use `UBIQUITOUS_LANGUAGE.md` for canonical terms.
+3. Trace the complete path using `.agents/context/architecture-map.md`: frontend route/state → API controller and guards → service/repository → data store, queue, or connector → response and UI update.
+4. Read the closest applicable `AGENTS.md` before reasoning about a module. Inspect relevant tests, migrations, configuration, and recent git history; do not diagnose from filenames or symptoms alone.
+5. Write down competing hypotheses and try to falsify them. Distinguish **Confirmed**, **Inference**, and **Unknown** conclusions.
+6. Cite concrete repository paths and symbols for technical claims. Include commands, test results, logs, and commit SHAs when they materially support the conclusion.
+7. Do not modify code for an analysis-only request. When a fix is requested, reproduce first where feasible, add a regression test, implement the smallest fix, and run the narrowest relevant checks before broader suites.
+
+An investigation handoff should contain: problem statement, scope/impact, reproduction status, evidence, root cause or ranked hypotheses, owning module, recommended next action, and confidence/unknowns.
 
 ## Node version
 
@@ -83,7 +115,7 @@ cd plugins && npm install && npm run build
 ## Key conventions
 
 - Database name convention: `tooljet_{edition}` (see `PG_DB` in `.env`)
-- TypeORM schema migrations in `server/src/migrations/` (and `server/ee/migrations/` for EE); data migrations in `server/data-migrations/`
+- TypeORM schema migrations in `server/migrations/` (and `server/ee/migrations/` for EE); data migrations in `server/data-migrations/`
 - Never import `@ee/` or `@cloud/` from CE code — webpack enforces this at compile time
 - Backend port reads from `PORT` in `.env`; frontend port via `npm start -- --port <port>`
 - Lint before committing. Pre-commit hooks are in the repo (husky + lint-staged, activated by root `npm install`); the hook only lint-fixes frontend files — backend needs `cd server && npm run lint` manually. CI lints all three folders and blocks the PR on failure. Never `--no-verify` unless the user explicitly asks
@@ -105,6 +137,8 @@ Context is layered — the closest file to the code you're changing wins:
 | File | Scope |
 |---|---|
 | `AGENTS.md` (this file) | Repo-wide architecture, editions, structure |
+| `.agents/context/product-map.md` | Public product capabilities, users, journeys, and business rules |
+| `.agents/context/architecture-map.md` | Public system components, data flows, integrations, and failure modes |
 | `UBIQUITOUS_LANGUAGE.md` | Canonical domain glossary |
 | `server/AGENTS.md` | Backend + testing conventions |
 | `server/src/modules/<module>/AGENTS.md` | Per-module purpose, key files, invariants |
@@ -112,4 +146,6 @@ Context is layered — the closest file to the code you're changing wins:
 | `frontend/AGENTS.md` | Frontend conventions, App Builder architecture, glossary |
 | `server/docs/testing.md` | Backend testing — what to test, then how to write it |
 
-**Living-docs rule:** when you meaningfully change a module (new service, changed invariant, renamed concept, new gotcha discovered), update its `AGENTS.md` in the same PR. If the module has none yet, create one from `server/docs/agents-module-template.md`. Introducing or renaming a domain term means updating `UBIQUITOUS_LANGUAGE.md` in the same PR — every glossary term should map to a real code identifier or user-facing feature. Stale context is worse than no context.
+**Living-docs rule:** when you meaningfully change a module (new service, changed invariant, renamed concept, new gotcha discovered), update its `AGENTS.md` in the same PR. If the module has none yet, create one from `server/docs/agents-module-template.md`. Introducing or renaming a domain term means updating `UBIQUITOUS_LANGUAGE.md` in the same PR — every glossary term should map to a real code identifier or user-facing feature.
+
+Update `.agents/context/product-map.md` when a public capability, user journey, role, or business rule changes. Update `.agents/context/architecture-map.md` when a runtime component, data store, integration boundary, authentication path, deployment topology, or major failure mode changes. Keep evidence links current, preserve explicit inference/unknown labels, and review map changes with the same owners as the code. Stale context is worse than no context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,10 @@ Frontend conventions, App Builder architecture and glossary: `frontend/AGENTS.md
 
 Use these maps to get oriented before tracing unfamiliar behavior:
 
-- `.agents/context/product-map.md` — users, capabilities, user journeys, confirmed business rules, inferences, and open product questions
+- `.agents/context/product-map.md` — users, capabilities, user journeys, confirmed business rules, and inferences
 - `.agents/context/architecture-map.md` — runtime components, data stores, authentication/authorization, integrations, deployment, failure modes, and end-to-end technical flows
 
-The maps are indexes, not substitutes for current code. Follow their path and symbol references, then verify the relevant implementation, tests, migrations, and recent history. Treat sections labeled **Inference** as hypotheses and **Unanswered questions** as unresolved; never silently promote either to fact.
+The maps are indexes, not substitutes for current code. Follow their path and symbol references, then verify the relevant implementation, tests, migrations, and recent history. Treat sections labeled **Inference** as hypotheses; never silently promote them to fact.
 
 ### Public/private boundary
 
@@ -148,4 +148,4 @@ Context is layered — the closest file to the code you're changing wins:
 
 **Living-docs rule:** when you meaningfully change a module (new service, changed invariant, renamed concept, new gotcha discovered), update its `AGENTS.md` in the same PR. If the module has none yet, create one from `server/docs/agents-module-template.md`. Introducing or renaming a domain term means updating `UBIQUITOUS_LANGUAGE.md` in the same PR — every glossary term should map to a real code identifier or user-facing feature.
 
-Update `.agents/context/product-map.md` when a public capability, user journey, role, or business rule changes. Update `.agents/context/architecture-map.md` when a runtime component, data store, integration boundary, authentication path, deployment topology, or major failure mode changes. Keep evidence links current, preserve explicit inference/unknown labels, and review map changes with the same owners as the code. Stale context is worse than no context.
+Update `.agents/context/product-map.md` when a public capability, user journey, role, or business rule changes. Update `.agents/context/architecture-map.md` when a runtime component, data store, integration boundary, authentication path, deployment topology, or major failure mode changes. Keep evidence links current, preserve explicit inference labels, and review map changes with the same owners as the code. Stale context is worse than no context.


### PR DESCRIPTION
## 📝 What this does
Adds a public orientation layer — product and architecture maps — so contributors and agents can get their bearings before tracing unfamiliar behaviour, and documents the public/private submodule boundary.
- [ee-server](no changes)
- [ee-frontend](https://github.com/ToolJet/ee-frontend/pull/608)

## 🔀 Changes
- Added public product and architecture maps with explicit Inference sections
- Placed them under `.agents/context/` rather than `docs/`, which is the Docusaurus site and its own npm package
- Documented the public/private submodule boundary and an evidence-first investigation flow
- Corrected the schema migrations path to `server/migrations/`

## 🧪 How to test
- [ ] Confirm both maps render and their path and symbol references resolve
- [ ] Confirm `docs/` builds unaffected, with no stray `agent/` folder
- [ ] Confirm migrations run from the documented path
