### PR TITLE
TagsInput: onSearch event and searchText added

### DIFF
--- a/frontend/src/AppBuilder/WidgetManager/widgets/TagsInput.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/TagsInput.js
@@ -228,6 +228,7 @@ export const tagsInputConfig = {
   events: {
     onTagAdded: { displayName: 'On tag added' },
     onTagDeleted: { displayName: 'On tag deleted' },
+    onSearch: { displayName: 'On search' },
     onFocus: { displayName: 'On focus' },
     onBlur: { displayName: 'On blur' },
   },
@@ -405,6 +406,7 @@ export const tagsInputConfig = {
     tags: [],
     newTagsAdded: [],
     selectedTags: [],
+    searchText: '',
   },
 
   definition: {

--- a/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/TagsInput/TagsInput.jsx
@@ -331,6 +331,13 @@ const TagsInput = ({
 
     setInputValue(value);
     setFocusedOptionIndex(-1);
+
+    // searchText only updates for a new, non-empty search - clearing the
+    // input keeps the last searched text exposed until a new search starts
+    if (value) {
+      setExposedVariable('searchText', value);
+    }
+    fireEvent('onSearch');
   };
 
   // Handle keyboard events
@@ -558,6 +565,7 @@ const TagsInput = ({
       selectedTags: Array.isArray(defaultItems) ? defaultItems.map(({ label, value }) => ({ label, value })) : [],
       tags: Array.isArray(selectOptions) ? selectOptions.map(({ label, value }) => ({ label, value })) : [],
       newTagsAdded: [],
+      searchText: '',
     };
     setExposedVariables(exposedVariables);
     isInitialRender.current = false;

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/tagsInput.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/tagsInput.spec.jsx
@@ -1,0 +1,87 @@
+/**
+ * TagsInput — `onSearch` event and `searchText` exposed variable (PR #17672).
+ * Shared setup lives in ./widgetHarness.js.
+ *
+ * Scope, stated up front: this file covers only the search-text behaviour
+ * added by that PR — `onSearch` firing as the user types, and `searchText`
+ * retaining the last typed value across a clear instead of resetting to ''.
+ * Tag creation/selection, validation, and the widget's other lifecycle
+ * events are exercised elsewhere and not repeated here.
+ */
+import { waitFor } from '@testing-library/react';
+import { createWidgetHarness, binding, setVariableOn, store, MODULE_ID } from './widgetHarness';
+
+const ID = 'tags1';
+const NAME = 'tagsinput1';
+
+const widget = createWidgetHarness({
+  componentType: 'TagsInput',
+  handle: NAME,
+  id: ID,
+  defaultProperties: { visibility: binding('{{true}}') },
+});
+
+/** The CreatableSelect's own text input — the only `<input>` TagsInput renders. */
+const input = (container) => container.querySelector('.tags-input-widget input');
+
+/**
+ * TagsInput is lazy-loaded, so on the first render in a file the input isn't
+ * in the DOM yet — waiting for it here mirrors DropdownV2's `openMenu`.
+ */
+async function getInput(container) {
+  await waitFor(() => expect(input(container)).toBeInTheDocument());
+  return input(container);
+}
+
+/**
+ * Registers a real `set-custom-variable` action on onSearch whose value is a
+ * binding into this component's own exposed `searchText`. The variable it
+ * writes is the probe: a stale read leaves the PREVIOUS search text there,
+ * which is exactly the ordering bug this event's firing point could hide.
+ */
+function attachOnSearchCapture() {
+  return setVariableOn(ID, 'onSearch', { key: 'seenByHandler', value: `{{components.${NAME}.searchText}}` });
+}
+
+describe('TagsInput', () => {
+  beforeEach(widget.setup);
+  afterEach(widget.teardown);
+
+  describe('search', () => {
+    test('typing in the search box fires onSearch and exposes the freshly typed searchText', async () => {
+      const { container } = widget.render({ events: attachOnSearchCapture() });
+
+      await widget.session.user.type(await getInput(container), 'ga');
+
+      await waitFor(() => expect(widget.exposed().searchText).toBe('ga'));
+      expect(store().getVariable('seenByHandler', MODULE_ID)).toBe('ga');
+    });
+
+    test('clearing the search box keeps the last searched text exposed instead of resetting it', async () => {
+      const { container } = widget.render({});
+      const el = await getInput(container);
+
+      await widget.session.user.type(el, 'ga');
+      await waitFor(() => expect(widget.exposed().searchText).toBe('ga'));
+
+      await widget.session.user.clear(el);
+
+      expect(el).toHaveValue('');
+      expect(widget.exposed().searchText).toBe('ga');
+    });
+
+    test('starting a new search after a clear overwrites the retained searchText', async () => {
+      const { container } = widget.render({});
+      const el = await getInput(container);
+
+      await widget.session.user.type(el, 'ga');
+      await waitFor(() => expect(widget.exposed().searchText).toBe('ga'));
+      await widget.session.user.clear(el);
+      expect(widget.exposed().searchText).toBe('ga');
+
+      await widget.session.user.type(el, 'zzz');
+
+      await waitFor(() => expect(widget.exposed().searchText).toBe('zzz'));
+    });
+  });
+});

--- a/server/src/modules/apps/services/widget-config/TagsInput.js
+++ b/server/src/modules/apps/services/widget-config/TagsInput.js
@@ -228,6 +228,7 @@ export const tagsInputConfig = {
   events: {
     onTagAdded: { displayName: 'On tag added' },
     onTagDeleted: { displayName: 'On tag deleted' },
+    onSearch: { displayName: 'On search' },
     onFocus: { displayName: 'On focus' },
     onBlur: { displayName: 'On blur' },
   },
@@ -405,6 +406,7 @@ export const tagsInputConfig = {
     tags: [],
     newTagsAdded: [],
     selectedTags: [],
+    searchText: '',
   },
 
   definition: {


### PR DESCRIPTION
# tags_input_on_search_fix: Add `onSearch` event and `searchText` exposed variable to TagsInput

## Summary

The TagsInput widget now exposes an `onSearch` event and a `searchText` variable, so apps can react to what a user types in the tags search box and read the current/last search query.

## What's Implemented

- `onSearch` fires on every keystroke in the TagsInput search box, alongside the existing `onTagAdded`/`onTagDeleted`/`onFocus`/`onBlur` events.
- `searchText` is exposed in the inspector and updates on every non-empty keystroke.
- When the search box is cleared, `searchText` is **not** reset to empty — it keeps the last searched value until the user starts typing a new search, at which point it updates to the new text.
- Programmatic clears (tag creation, comma/semicolon paste splitting, Escape key) don't touch `searchText`, since they clear the internal input box directly rather than going through the search-change path.

## Areas to Test

- Typing in the TagsInput search box fires `onSearch` per keystroke and updates `{{tagsInput1.searchText}}` live.
- Clearing the box (backspace to empty) leaves `searchText` at its last non-empty value.
- Starting a new search after clearing correctly overwrites `searchText` with the new text.
- Creating a tag (Enter/comma/semicolon) clears the visible input box but does not reset `searchText`.
- Existing events (`onTagAdded`, `onTagDeleted`, `onFocus`, `onBlur`) and the `clear` action still work unchanged.
