### PR TITLE
Fix: reject ToolJet DB update rows when the where filter is dropped

### DIFF
--- a/server/src/modules/tooljet-db/services/tooljet-db-data-operations.service.ts
+++ b/server/src/modules/tooljet-db/services/tooljet-db-data-operations.service.ts
@@ -215,6 +215,16 @@ export class TooljetDbDataOperationsService implements QueryService {
 
     const query = [];
     const whereQuery = buildPostgrestQuery(whereFilters);
+
+    // filter has conditions but none are usable - updating without it would hit every row
+    if (isEmpty(whereQuery) && !isEmpty(whereFilters)) {
+      throw new QueryError(
+        'Incomplete where filter.',
+        'Every filter condition needs a column and an operator. Remove the conditions to update all rows.',
+        {}
+      );
+    }
+
     const body = Object.values<{ column: string; value: any }>(columns).reduce((acc, colOpts) => {
       if (isEmpty(colOpts.column)) return acc;
       return Object.assign(acc, { [colOpts.column]: colOpts.value });


### PR DESCRIPTION
## 📝 What this does
An **Update rows** query whose conditions were incomplete sent a PATCH with no filter at all, so PostgREST rewrote every row in the table and the query still reported success. Incomplete conditions now fail with an error. Running with no conditions at all still updates every row — that stays supported.

## 🔀 Changes
- Rejected `update_rows` when filter conditions are authored but none produce a clause, throwing a `QueryError` like the existing limit and offset validation
- Left the deliberate no-conditions case alone, so update-all from the query manager keeps working

## 🧪 How to test
- [x] Create a ToolJet DB table with several rows
- [x] Add an Update rows query on it, pick a column and value, add a condition and leave the column or operator unset
- [x] Run it — the query fails with "Incomplete where filter." and no row changes
- [x] Remove the condition and run again — all rows update, as before
- [x] Fill the condition in properly and run — only the matching rows update

