### PR TITLE
Fix: default module version selection for unsynced and stub modules

### DIFF
--- a/.github/workflows/cypress-appbuilder.yml
+++ b/.github/workflows/cypress-appbuilder.yml
@@ -199,9 +199,9 @@ jobs:
 
       - name: Wait for the server to be ready
         run: |
-          echo "Waiting for ToolJet to start (timeout: 700 seconds)..."
+          echo "Waiting for ToolJet to start (timeout: 900 seconds)..."
           SUCCESS_FOUND=false
-          TIMEOUT=700
+          TIMEOUT=900
           ELAPSED=0
 
           while [ $ELAPSED -lt $TIMEOUT ]; do

--- a/.github/workflows/update-test-system.yml
+++ b/.github/workflows/update-test-system.yml
@@ -45,20 +45,16 @@ jobs:
       - name: ✅ Check user authorization
         run: |
           allowed_users=(
-            "${{ secrets.ALLOWED_USER1_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER2_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER3_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER4_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER5_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER6_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER7_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER8_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER9_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER10_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER11_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER12_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER13_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER14_TEST_SYSTEM }}"
+            "${{ secrets.PLATFORM_1 }}"
+            "${{ secrets.PLATFORM_2 }}"
+            "${{ secrets.MARKETPLACE_1 }}"
+            "${{ secrets.MARKETPLACE_2 }}"
+            "${{ secrets.AI_1 }}"
+            "${{ secrets.AI_2 }}"
+            "${{ secrets.APP_BUILDER_1 }}"
+            "${{ secrets.APP_BUILDER_2 }}"
+            "${{ secrets.DEVOPS_1 }}"
+            "${{ secrets.DEVOPS_2 }}"
           )
           current_user="${{ github.actor }}"
           authorized=false
@@ -275,20 +271,16 @@ jobs:
       - name: ✅ Check user authorization
         run: |
           allowed_users=(
-            "${{ secrets.ALLOWED_USER1_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER2_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER3_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER4_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER5_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER6_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER7_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER8_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER9_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER10_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER11_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER12_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER13_TEST_SYSTEM }}"
-            "${{ secrets.ALLOWED_USER14_TEST_SYSTEM }}"
+            "${{ secrets.PLATFORM_1 }}"
+            "${{ secrets.PLATFORM_2 }}"
+            "${{ secrets.MARKETPLACE_1 }}"
+            "${{ secrets.MARKETPLACE_2 }}"
+            "${{ secrets.AI_1 }}"
+            "${{ secrets.AI_2 }}"
+            "${{ secrets.APP_BUILDER_1 }}"
+            "${{ secrets.APP_BUILDER_2 }}"
+            "${{ secrets.DEVOPS_1 }}"
+            "${{ secrets.DEVOPS_2 }}"
           )
           current_user="${{ github.actor }}"
           authorized=false

--- a/frontend/src/AppBuilder/AppCanvas/Hooks/useCanvasDropHandler.js
+++ b/frontend/src/AppBuilder/AppCanvas/Hooks/useCanvasDropHandler.js
@@ -10,6 +10,7 @@ import toast from 'react-hot-toast';
 import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
 import { handleDeactivateTargets, hideGridLines } from '../Grid/gridUtils';
 import { appsService } from '@/_services';
+import { useGitSyncConfig } from '@/AppBuilder/_hooks/useGitSyncConfig';
 
 const BUFFER_OFFSET = 15;
 
@@ -57,6 +58,7 @@ export const useCanvasDropHandler = () => {
   const setRightSidebarOpen = useStore((state) => state.setRightSidebarOpen, shallow);
   const setModulesList = useStore((state) => state.setModulesList, shallow) || noop;
   const setFlexContainerDropTarget = useStore((state) => state.setFlexContainerDropTarget, shallow);
+  const { isGitSyncEnabled } = useGitSyncConfig();
 
   const handleDrop = async ({ componentType: draggedComponentType, component }, canvasId) => {
     const realCanvasRef =
@@ -122,11 +124,16 @@ export const useCanvasDropHandler = () => {
             toast.error('Module is still not ready. Please try again.', { id: toastId });
             return;
           }
+          const isModuleSynced = (hydratedVersion.is_synced ?? hydratedVersion.isSynced) === true;
+          const isDraft = hydratedVersion.status === 'DRAFT';
+          const shouldUnpin = isGitSyncEnabled && isModuleSynced && isDraft;
           dropComponent = {
             ...dropComponent,
             isStub: false,
-            versionId: hydratedVersion.module_reference_id ?? hydratedVersion.moduleReferenceId,
-            versionName: hydratedVersion.name ?? '',
+            versionId: shouldUnpin
+              ? ''
+              : (hydratedVersion.module_reference_id ?? hydratedVersion.moduleReferenceId ?? ''),
+            versionName: shouldUnpin ? '' : (hydratedVersion.name ?? ''),
             environmentId: hydratedVersion.current_environment_id,
             moduleContainer: hydrated.module_container,
             defaultSize: {

--- a/frontend/src/AppBuilder/AppCanvas/Hooks/useCanvasDropHandler.js
+++ b/frontend/src/AppBuilder/AppCanvas/Hooks/useCanvasDropHandler.js
@@ -47,6 +47,17 @@ const pickDefaultVersion = (appVersions = []) => {
   );
 };
 
+// Mirrors modules/Modules/utils.js#getIsModuleSynced (ee). Duplicated locally because CE code
+// can't import from @ee/ — keep both in sync if the sync rule changes. A module is "synced"
+// only when EVERY draft it has (main-branch AND branch-type) is in git; checking a single
+// picked version here would miss an unsynced sibling draft and unpin a module that isn't
+// actually fully synced.
+const isModuleSynced = (appVersions = []) => {
+  const draftVersions = appVersions.filter((v) => v.status === 'DRAFT');
+  if (draftVersions.length === 0) return appVersions.some((v) => (v.is_synced ?? v.isSynced) === true);
+  return draftVersions.every((v) => (v.is_synced ?? v.isSynced) === true);
+};
+
 export const useCanvasDropHandler = () => {
   const { isModuleEditor } = useModuleContext();
 
@@ -124,9 +135,8 @@ export const useCanvasDropHandler = () => {
             toast.error('Module is still not ready. Please try again.', { id: toastId });
             return;
           }
-          const isModuleSynced = (hydratedVersion.is_synced ?? hydratedVersion.isSynced) === true;
           const isDraft = hydratedVersion.status === 'DRAFT';
-          const shouldUnpin = isGitSyncEnabled && isModuleSynced && isDraft;
+          const shouldUnpin = isGitSyncEnabled && isDraft && isModuleSynced(hydrated.app_versions);
           dropComponent = {
             ...dropComponent,
             isStub: false,


### PR DESCRIPTION
## 📝 What this does
A module dropped onto the canvas could get pinned or unpinned inconsistently with how the Inspector reports its sync status — this aligns the two, and removes a duplicated sync-status check along the way.
- [ee-server](no changes)
- [ee-frontend](https://github.com/ToolJet/ee-frontend/pull/612)

## 🔀 Changes
- Unpin module version on drop only when the dropped draft is git-synced, otherwise pin to the version's reference id
- Checked sync status across all of a module's versions instead of just the one version picked on drop, so a module with an unsynced sibling draft no longer gets incorrectly unpinned
- Extracted the duplicated "is module synced" check (ee) into a shared `getIsModuleSynced` helper used by both `ModuleManager` and `ModuleViewerInspector`

## 🧪 How to test
- [ ] Enable git sync (single branching) in a workspace, pull a module that has an unsynced feature-branch draft alongside a synced main draft
- [ ] Drag that module onto a canvas and confirm it's pinned (not unpinned) to a version, matching what the module's Inspector shows as its sync state
- [ ] Drag a fully-synced module onto a canvas and confirm it drops unpinned (follows current branch)