### PR TITLE
fix: add background overlay to close color picker on clicking outside of the popover

### DIFF
--- a/frontend/src/AppBuilder/CodeBuilder/Elements/Color.jsx
+++ b/frontend/src/AppBuilder/CodeBuilder/Elements/Color.jsx
@@ -90,6 +90,9 @@ export const Color = ({
           <div>
             {/* <div style={coverStyles} onClick={() => setShowPicker(false)} /> */}
             <div style={pickerStyle}>
+              {/* Background overlay for closing the color picker */}
+              <div className="tw-fixed tw-inset-0" onClick={() => setShowPicker(false)} />
+
               <SketchPicker
                 onFocus={() => setShowPicker(true)}
                 color={value}


### PR DESCRIPTION
Resolves: https://github.com/ToolJet/ToolJet/issues/13918