### PR TITLE
fix: container widget header size should not reduce and if the config handle size is reduced then the container header should not overflow the handle

### DIFF
--- a/frontend/src/AppBuilder/Widgets/Container/Container.jsx
+++ b/frontend/src/AppBuilder/Widgets/Container/Container.jsx
@@ -59,7 +59,6 @@ export const Container = ({
   const setComponentProperty = useStore((state) => state.setComponentProperty, shallow);
   const activeSlot = useActiveSlot(id); // Track the active slot for this widget
   const { borderRadius, borderColor, boxShadow, headerDividerColor } = styles;
-  const headerMaxHeight = isDynamicHeightEnabled ? 10000 : parseInt(height, 10) - 100 - 10;
   const contentBgColor = useMemo(() => {
     return {
       backgroundColor:
@@ -92,7 +91,6 @@ export const Container = ({
   const containerHeaderStyles = {
     flexShrink: 0,
     padding: `${CONTAINER_FORM_CANVAS_PADDING}px ${CONTAINER_FORM_CANVAS_PADDING}px 3px ${CONTAINER_FORM_CANVAS_PADDING}px`,
-    maxHeight: `${headerMaxHeight}px`,
     borderTopLeftRadius: `${borderRadius}px`,
     borderTopRightRadius: `${borderRadius}px`,
     overflow: 'hidden',
@@ -116,7 +114,7 @@ export const Container = ({
   return (
     <div
       ref={containerRef}
-      className={`jet-container ${isLoading ? 'jet-container-loading' : ''}`}
+      className={`jet-container tw-overflow-hidden ${isLoading ? 'jet-container-loading' : ''}`}
       id={id}
       data-disabled={isDisabled}
       style={computedStyles}


### PR DESCRIPTION
Resolves: https://github.com/ToolJet/tj-ee/issues/4488

This PR resolves 2 issues:

1. Container header overflows out of its config handle on sudden shrink - Reduce the container size below the header size in one go and the header will overflow the config handle
2. Container header visibly shrinks while dragging container smaller - Reduce the container size slowly by one grid at a time at some point you will see the header size being reduced