### PR TITLE
Fix: Install page plugin card size and upgrade button hover visibility

### DIFF
--- a/frontend/src/MarketplacePage/InstalledPlugins.jsx
+++ b/frontend/src/MarketplacePage/InstalledPlugins.jsx
@@ -227,8 +227,8 @@ const InstalledPluginCard = ({ plugin, marketplacePlugin, fetchPlugins, isDevMod
           <div className="card-body card-body-alignment">
             <div className="row align-items-center">
               <div className="col-auto">
-                <span className="text-white avatar">
-                  <img height="32" width="32" src={`data:image/svg+xml;base64,${plugin.iconFile.data}`} />
+                <span className="text-white app-icon-main">
+                  <img height="40" width="40" src={`data:image/svg+xml;base64,${plugin.iconFile.data}`} />
                 </span>
               </div>
               <div className="col">

--- a/frontend/src/_styles/license.scss
+++ b/frontend/src/_styles/license.scss
@@ -913,7 +913,7 @@
     text-overflow: ellipsis;
     width: auto;
     margin-left: auto;
-    color: var(--text-default, #1B1F24);    
+    color: var(--text-default, #1B1F24);
     max-height: 52px;
     box-shadow: none !important;
     padding: 8px 16px 8px 16px;
@@ -921,6 +921,29 @@
     border: 1px solid var(--border-weak, #E4E7EB);
     background: var(--button-secondary, #FFF);
     box-shadow: 0px 0px 1px 0px var(--dropshadow-100700-layer-1, rgba(48, 50, 51, 0.05)), 0px 1px 1px 0px var(--dropshadow-100400-layer-2, rgba(48, 50, 51, 0.10));
+
+    &:hover {
+        border: 1px solid var(--border-default, #CCD1D5);
+        color: var(--text-default, #1B1F24);
+        background: var(--button-outline-hover, rgba(136, 144, 153, 0.12));
+    }
+
+    &:focus {
+        border-radius: 8px;
+        border: 1px solid var(--border-default, #CCD1D5);
+        background: var(--button-outline-pressed, rgba(136, 144, 153, 0.18));
+    }
+
+    &:active {
+        border: 1px solid var(--border-weak, #E4E7EB);
+        background: var(--button-outline, #FFF);
+        box-shadow: 0px 0px 0px 2px var(--Interactive-focusActive, #4368E3);
+    }
+
+    &:disabled {
+        border: 1px solid var(--border-weak, #E4E7EB);
+        background: var(--button-outline-disabled, #FFF);
+    }
 }
 
 .modal-upgrade-btn {


### PR DESCRIPTION
## 📝 What this does
Fixes two UI bugs on the Marketplace and License pages: plugin cards on the Installed page now render at the correct size with proper icon dimensions, and the Upgrade button text remains visible on hover in dark mode.

## 🔀 Changes
- Replaced the `avatar` CSS class with `app-icon-main` on the installed plugin card icon wrapper and increased icon dimensions from 32px to 40px to match the MarketplaceCard layout
- Added `:hover`, `:focus`, `:active`, and `:disabled` pseudo-class styles to `.upgrade-btn` in the license SCSS using design tokens, preventing text from becoming invisible on hover in dark mode

Closes #17095
Closes #14939

## 🧪 How to test
- [ ] Navigate to the Marketplace > Installed page and verify plugin icons are properly sized and aligned
- [ ] Hover over the Upgrade button on the License page in dark mode and verify text remains visible
- [ ] Test Upgrade button states: hover, focus, active, and disabled