### PR TITLE
Nav Enhancement: itemId and group expand behaviour updated

### DIFF
--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/Navigation.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/Navigation.jsx
@@ -34,6 +34,7 @@ export const Navigation = ({ componentMeta, darkMode, ...restProps }) => {
     handleAddItemToGroup,
     handleReorder,
     getResolvedValue,
+    validateItemId,
   } = useMenuItemsManager(component, paramUpdated);
 
   // Property organization
@@ -60,6 +61,7 @@ export const Navigation = ({ componentMeta, darkMode, ...restProps }) => {
         onMouseLeave={() => setHoveredItemIndex(null)}
         onDeleteItem={handleDeleteItem}
         onItemChange={handleItemChange}
+        validateItemId={validateItemId}
         onAddItem={handleAddItem}
         onAddGroup={handleAddGroup}
         onAddItemToGroup={handleAddItemToGroup}

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/GroupMenuItem.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/GroupMenuItem.jsx
@@ -6,7 +6,15 @@ import { getSafeRenderableValue } from '@/AppBuilder/Widgets/utils';
 import OverflowTooltip from '@/_components/OverflowTooltip';
 import NavItemPopover from './NavItemPopover';
 
-export const GroupMenuItem = ({ darkMode, item, highlight, onDeleteItem, onItemChange, getResolvedValue }) => {
+export const GroupMenuItem = ({
+  darkMode,
+  item,
+  highlight,
+  onDeleteItem,
+  onItemChange,
+  validateItemId,
+  getResolvedValue,
+}) => {
   const [showActionsPopover, setShowActionsPopover] = useState(false);
   const [showEditPopover, setShowEditPopover] = useState(false);
   const optionsBtnRef = useRef(null);
@@ -107,6 +115,7 @@ export const GroupMenuItem = ({ darkMode, item, highlight, onDeleteItem, onItemC
                 darkMode={darkMode}
                 onItemChange={onItemChange}
                 onDeleteItem={onDeleteItem}
+                validateItemId={validateItemId}
                 getResolvedValue={getResolvedValue}
               />
             </Overlay>

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/MenuItem.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/MenuItem.jsx
@@ -7,7 +7,15 @@ import { getSafeRenderableValue } from '@/AppBuilder/Widgets/utils';
 import OverflowTooltip from '@/_components/OverflowTooltip';
 import NavItemPopover from './NavItemPopover';
 
-export const MenuItem = ({ componentId, darkMode, item, onDeleteItem, onItemChange, getResolvedValue }) => {
+export const MenuItem = ({
+  componentId,
+  darkMode,
+  item,
+  onDeleteItem,
+  onItemChange,
+  validateItemId,
+  getResolvedValue,
+}) => {
   const [showActionsPopover, setShowActionsPopover] = useState(false);
   const [showEditPopover, setShowEditPopover] = useState(false);
   const optionBtnRef = useRef(null);
@@ -113,6 +121,7 @@ export const MenuItem = ({ componentId, darkMode, item, onDeleteItem, onItemChan
                 darkMode={darkMode}
                 onItemChange={onItemChange}
                 onDeleteItem={onDeleteItem}
+                validateItemId={validateItemId}
                 getResolvedValue={getResolvedValue}
                 parentId={item.parentId}
               />

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/NavItemPopover.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/NavItemPopover.jsx
@@ -14,6 +14,7 @@ const NavItemPopover = forwardRef(
       onItemChange,
       onDeleteItem,
       onDuplicateItem,
+      validateItemId,
       getResolvedValue,
       parentId = null,
       ...restProps
@@ -108,6 +109,24 @@ const NavItemPopover = forwardRef(
                   data-cy="inspector-nav-item-details-label-input"
                   initialValue={item?.label}
                   onChange={(value) => handleChange('label', value)}
+                />
+              </div>
+
+              {/* Id field */}
+              <div data-cy="inspector-nav-item-details-id-field" className="nav-item-popover-field">
+                <label data-cy="inspector-nav-item-details-id-label" className="nav-item-popover-field-label">
+                  Id
+                </label>
+                <CodeHinter
+                  {...basicCodeHinterProps}
+                  data-cy="inspector-nav-item-details-id-input"
+                  initialValue={item?.id}
+                  placeholder={'Item ID'}
+                  onChange={(value) => handleChange('id', value)}
+                  validationFn={(value) => validateItemId(value, item?.id)}
+                  componentId={componentId}
+                  paramName="id"
+                  fieldMeta={{ type: 'string', validation: { schema: { type: 'string' }, defaultValue: 'itemId' } }}
                 />
               </div>
 

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/NavItemsList.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/NavItemsList.jsx
@@ -46,6 +46,7 @@ const NavItemsList = ({
   darkMode,
   onDeleteItem,
   onItemChange,
+  validateItemId,
   onAddItem,
   onAddGroup,
   onReorder,
@@ -73,6 +74,7 @@ const NavItemsList = ({
         darkMode={darkMode}
         onDeleteItem={onDeleteItem}
         onItemChange={onItemChange}
+        validateItemId={validateItemId}
         onReorder={onReorder}
         getResolvedValue={getResolvedValue}
       />

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/Tree/SortableTree.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/components/Tree/SortableTree.jsx
@@ -15,6 +15,7 @@ export function SortableTree({
   onReorder,
   onDeleteItem,
   onItemChange,
+  validateItemId,
   getResolvedValue,
   collapsible = true,
   indicator = true,
@@ -30,6 +31,7 @@ export function SortableTree({
           item={item}
           onDeleteItem={onDeleteItem}
           onItemChange={onItemChange}
+          validateItemId={validateItemId}
           getResolvedValue={getResolvedValue}
         />
       );
@@ -43,6 +45,7 @@ export function SortableTree({
         onCollapse={props.onCollapse}
         onDeleteItem={onDeleteItem}
         onItemChange={onItemChange}
+        validateItemId={validateItemId}
         getResolvedValue={getResolvedValue}
       />
     );

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/hooks/useMenuItemsManager.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Navigation/hooks/useMenuItemsManager.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { shallow } from 'zustand/shallow';
 import useStore from '@/AppBuilder/_stores/store';
+import { validateStaticId } from '../../../Utils';
 
 export const useMenuItemsManager = (component, paramUpdated) => {
   const [menuItems, setMenuItems] = useState([]);
@@ -107,6 +108,33 @@ export const useMenuItemsManager = (component, paramUpdated) => {
     return baseItem;
   };
 
+  // Validate a candidate item id against every other id in the tree (top-level + children)
+  const validateItemId = (value, currentItemId) => {
+    const existingIds = [];
+    const collectIds = (items) => {
+      items.forEach((item) => {
+        existingIds.push(item.id);
+        if (item.children) collectIds(item.children);
+      });
+    };
+    collectIds(menuItems);
+
+    return validateStaticId(value, existingIds, currentItemId);
+  };
+
+  // Rename the `ref` on any events bound to this item so they follow the item's new id
+  const renameItemEventRefs = (oldId, newId) => {
+    const { getModuleEvents, updateAppVersionEventHandlers } = useStore.getState().eventsSlice;
+    const events = getModuleEvents('canvas').filter((e) => e.sourceId === component?.id && e.event?.ref === oldId);
+    if (events.length === 0) return;
+
+    const updatedEvents = events.map((e) => ({ ...e, event: { ...e.event, ref: newId } }));
+    updateAppVersionEventHandlers(
+      updatedEvents.map((e) => ({ event_id: e.id, diff: e })),
+      'update'
+    );
+  };
+
   // Event handlers
   const handleItemChange = (propertyPath, value, itemId, parentId = null) => {
     const newItems = menuItems.map((item) => {
@@ -126,6 +154,16 @@ export const useMenuItemsManager = (component, paramUpdated) => {
       }
       return item;
     });
+
+    if (propertyPath === 'id') {
+      const [isValid] = validateItemId(value, itemId);
+      // Always reflect what the user is typing locally, but only persist + rename event
+      // refs once the new id is valid (non-empty, unique)
+      setMenuItems(newItems);
+      if (!isValid) return;
+      renameItemEventRefs(itemId, value);
+    }
+
     updateMenuItems(newItems);
   };
 
@@ -278,5 +316,6 @@ export const useMenuItemsManager = (component, paramUpdated) => {
     handleAddItemToGroup,
     handleReorder,
     getResolvedValue,
+    validateItemId,
   };
 };

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/TabComponent.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/TabComponent.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Accordion from '@/AppBuilder/RightSideBar/Inspector/InspectorAccordion';
 import { ADDITIONAL_ACTIONS_ACCORDION_ID } from '../inspectorConstants';
 import { EventManager } from '../EventManager';
-import { renderElement } from '../Utils';
+import { renderElement, validateStaticId } from '../Utils';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';
 import List from '@/ToolJetUI/List/List';
@@ -238,26 +238,17 @@ export function TabsLayout({ componentMeta, darkMode, ...restProps }) {
     updateAllTabItemsParams(updatedTabItems);
   };
 
-  const validateTabId = (value, currentItemId) => {
-    if (value === null || value === undefined || value === '') {
-      return [false, 'Tab ID cannot be empty'];
-    }
-
-    const stringValue = String(value);
-    const trimmedValue = stringValue.trim();
-
-    if (!trimmedValue) {
-      return [false, 'Tab ID cannot be empty'];
-    }
-
-    const duplicateTab = tabItems.find((tabItem) => tabItem.id === trimmedValue && tabItem.id !== currentItemId);
-
-    if (duplicateTab) {
-      return [false, 'Tab ID must be unique. This ID is already used by another tab.'];
-    }
-
-    return [true, null];
-  };
+  const validateTabId = (value, currentItemId) =>
+    validateStaticId(
+      value,
+      tabItems.map((tab) => tab.id),
+      currentItemId,
+      {
+        emptyMessage: 'Tab ID cannot be empty',
+        bindingMessage: 'Tab ID cannot contain a dynamic binding ({{ }}). Use a plain, static value.',
+        duplicateMessage: 'Tab ID must be unique. This ID is already used by another tab.',
+      }
+    );
 
   const areAllTabIdsValid = () => {
     const ids = tabItems.map((tab) => tab.id);

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Utils.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Utils.js
@@ -258,6 +258,32 @@ export function renderElement(
   );
 }
 
+// Validate a candidate static id (Tabs' tab id, Nav item id, etc). Ids are compared with
+// plain equality everywhere at runtime (never resolved), so a `{{ }}` binding can never work
+// as an id and must be rejected outright rather than accepted and silently broken.
+export const validateStaticId = (value, existingIds = [], currentId = null, messages = {}) => {
+  const {
+    emptyMessage = 'ID cannot be empty',
+    bindingMessage = 'ID cannot contain a dynamic binding ({{ }}). Use a plain, static value.',
+    duplicateMessage = 'ID must be unique. This ID is already used by another item.',
+  } = messages;
+
+  if (value === null || value === undefined || String(value).trim() === '') {
+    return [false, emptyMessage];
+  }
+  const trimmedValue = String(value).trim();
+
+  if (trimmedValue.includes('{{') || trimmedValue.includes('}}')) {
+    return [false, bindingMessage];
+  }
+
+  if (existingIds.some((id) => id === trimmedValue && id !== currentId)) {
+    return [false, duplicateMessage];
+  }
+
+  return [true, null];
+};
+
 export const goToModule = (moduleAppId) => {
   const subpath = getSubpath();
   const slug =

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/__tests__/Utils.spec.js
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/__tests__/Utils.spec.js
@@ -1,0 +1,103 @@
+/**
+ * Pure unit tests for `validateStaticId` (src/AppBuilder/RightSideBar/Inspector/Utils.js).
+ *
+ * `validateStaticId` is the shared validator behind both the Navigation
+ * widget's item ids (useMenuItemsManager.validateItemId) and the Tabs
+ * widget's tab ids (TabComponent.validateTabId) — see the header comment on
+ * the source function for why a `{{ }}` binding must be rejected outright
+ * (ids are compared with plain equality at runtime, never resolved).
+ *
+ * No store import, zero mocks — a plain function in, tuple out.
+ */
+// Utils.js's other exports (renderElement/renderCustomStyles/renderQuerySelector) pull in the
+// full CodeHinter -> ee AiBuilder -> @mdxeditor/editor chain, which Jest isn't set up to
+// transform (ESM-only). `validateStaticId` never touches any of that, so this stubs the one
+// heavy, unrelated import just to let the module load — it does not touch the logic under test.
+jest.mock('../Elements/Code', () => ({ Code: () => null }));
+jest.mock('../Components/Form/_components', () => ({ LabeledDivider: () => null }));
+
+import { validateStaticId } from '../Utils';
+
+describe('validateStaticId', () => {
+  describe('empty/blank values', () => {
+    test('null is invalid with the default empty message', () => {
+      expect(validateStaticId(null)).toEqual([false, 'ID cannot be empty']);
+    });
+
+    test('undefined is invalid with the default empty message', () => {
+      expect(validateStaticId(undefined)).toEqual([false, 'ID cannot be empty']);
+    });
+
+    test('an empty string is invalid', () => {
+      expect(validateStaticId('')).toEqual([false, 'ID cannot be empty']);
+    });
+
+    test('a whitespace-only string is invalid', () => {
+      expect(validateStaticId('   ')).toEqual([false, 'ID cannot be empty']);
+    });
+
+    test('a custom emptyMessage override is used instead of the default', () => {
+      const [isValid, message] = validateStaticId('', [], null, { emptyMessage: 'Tab ID cannot be empty' });
+      expect(isValid).toBe(false);
+      expect(message).toBe('Tab ID cannot be empty');
+    });
+  });
+
+  describe('dynamic bindings', () => {
+    test('a full binding like {{foo}} is invalid with the default binding message', () => {
+      expect(validateStaticId('{{foo}}')).toEqual([
+        false,
+        'ID cannot contain a dynamic binding ({{ }}). Use a plain, static value.',
+      ]);
+    });
+
+    test('a malformed/partial binding is still rejected', () => {
+      const [isValid, message] = validateStaticId('{{components.codeeditor1.}}');
+      expect(isValid).toBe(false);
+      expect(message).toBe('ID cannot contain a dynamic binding ({{ }}). Use a plain, static value.');
+    });
+
+    test('a custom bindingMessage override is used instead of the default', () => {
+      const [isValid, message] = validateStaticId('{{foo}}', [], null, {
+        bindingMessage: 'Tab ID cannot contain a dynamic binding ({{ }}). Use a plain, static value.',
+      });
+      expect(isValid).toBe(false);
+      expect(message).toBe('Tab ID cannot contain a dynamic binding ({{ }}). Use a plain, static value.');
+    });
+  });
+
+  describe('duplicates', () => {
+    test('a value equal to another id in existingIds is invalid', () => {
+      const [isValid, message] = validateStaticId('item2', ['item1', 'item2', 'item3'], 'item1');
+      expect(isValid).toBe(false);
+      expect(message).toBe('ID must be unique. This ID is already used by another item.');
+    });
+
+    test('a custom duplicateMessage override is used instead of the default', () => {
+      const [isValid, message] = validateStaticId('t1', ['t0', 't1'], 't0', {
+        duplicateMessage: 'Tab ID must be unique. This ID is already used by another tab.',
+      });
+      expect(isValid).toBe(false);
+      expect(message).toBe('Tab ID must be unique. This ID is already used by another tab.');
+    });
+
+    test('a value equal to currentId itself is valid — not flagged as a duplicate of itself', () => {
+      // currentId is the item's OWN (unchanged) id, which is naturally also present
+      // in existingIds. Renaming an item to its own current name must not error.
+      expect(validateStaticId('item1', ['item1', 'item2'], 'item1')).toEqual([true, null]);
+    });
+  });
+
+  describe('valid values', () => {
+    test('a unique, non-empty, non-binding value is valid', () => {
+      expect(validateStaticId('newItem', ['item1', 'item2'], 'item3')).toEqual([true, null]);
+    });
+
+    test('leading/trailing whitespace is trimmed before the duplicate check', () => {
+      expect(validateStaticId('  item2  ', ['item1', 'item2'], 'item1')).toEqual([
+        false,
+        'ID must be unique. This ID is already used by another item.',
+      ]);
+    });
+  });
+});

--- a/frontend/src/AppBuilder/WidgetManager/widgets/navigation.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/navigation.js
@@ -209,6 +209,22 @@ export const navigationConfig = {
       displayName: 'Select item',
       params: [{ handle: 'id', displayName: 'Item ID', defaultValue: '', type: 'code' }],
     },
+    {
+      handle: 'setItemVisibility',
+      displayName: 'Set item visibility',
+      params: [
+        { handle: 'id', displayName: 'Item ID', defaultValue: '', type: 'code' },
+        { handle: 'value', displayName: 'Value', defaultValue: '{{true}}', type: 'toggle' },
+      ],
+    },
+    {
+      handle: 'setItemDisable',
+      displayName: 'Set item disable',
+      params: [
+        { handle: 'id', displayName: 'Item ID', defaultValue: '', type: 'code' },
+        { handle: 'value', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' },
+      ],
+    },
   ],
   definition: {
     others: {

--- a/frontend/src/AppBuilder/Widgets/Navigation/Navigation.jsx
+++ b/frontend/src/AppBuilder/Widgets/Navigation/Navigation.jsx
@@ -7,7 +7,15 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { ToolTip } from '@/_components';
 import OverflowTooltip from '@/_components/OverflowTooltip';
 import { useCalculateOverflow } from './hooks/useCalculateOverflow';
-import { findItemById, findParentGroup, isItemVisible, isItemDisabled } from './utils';
+import {
+  findItemById,
+  findParentGroup,
+  isItemVisible,
+  isItemDisabled,
+  isGroupVisible,
+  isMenuItemVisible,
+  updateItemById,
+} from './utils';
 import { shallow } from 'zustand/shallow';
 import useStore from '@/AppBuilder/_stores/store';
 import { NO_OF_GRIDS } from '@/AppBuilder/AppCanvas/appCanvasConstants';
@@ -86,10 +94,10 @@ const RenderNavGroup = ({
   orientation,
   darkMode,
   childAlignment,
+  isExpanded,
+  onToggleExpand,
 }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  if (!isItemVisible(group)) return null;
+  if (!isGroupVisible(group)) return null;
 
   const isDisabled = isItemDisabled(group);
 
@@ -195,7 +203,7 @@ const RenderNavGroup = ({
         })}
         onClick={(e) => {
           e.stopPropagation();
-          if (!isDisabled) setIsExpanded(!isExpanded);
+          if (!isDisabled) onToggleExpand(group.id);
         }}
         disabled={isDisabled}
         data-state={isExpanded ? 'open' : 'closed'}
@@ -268,8 +276,17 @@ export const Navigation = function Navigation(props) {
   const verticalAlignment = verticalAlignmentStyle ?? properties?.verticalAlignment ?? 'top';
   const childAlignment = subMenuAlignment;
 
-  // Get menu items from component definition
-  const menuItems = properties.menuItems || [];
+  // Menu items — kept as local state so setItemVisibility/setItemDisable actions can mutate
+  // individual items by id, while still resyncing when the definition changes (e.g. inspector edits)
+  const [menuItems, setMenuItems] = useState(properties.menuItems || []);
+  const menuItemsRef = useRef(menuItems);
+
+  useEffect(() => {
+    if (JSON.stringify(menuItemsRef.current) !== JSON.stringify(properties.menuItems)) {
+      setMenuItems(properties.menuItems || []);
+      menuItemsRef.current = properties.menuItems || [];
+    }
+  }, [properties.menuItems]);
 
   // Refs for overflow calculation
   const containerRef = useRef(null);
@@ -279,6 +296,14 @@ export const Navigation = function Navigation(props) {
   const [selectedItemId, setSelectedItemId] = useState(null);
   const selectedItemRef = useRef(null);
   const selectItemRef = useRef(null);
+
+  // Which groups are expanded (vertical/accordion mode). Manual header clicks toggle a
+  // group independently; selecting an item collapses every group except the selected
+  // item's parent (or all of them, if the selection is a top-level item) — see applySelection.
+  const [expandedGroups, setExpandedGroups] = useState({});
+  const toggleGroupExpanded = (groupId) => {
+    setExpandedGroups((prev) => ({ ...prev, [groupId]: !prev[groupId] }));
+  };
 
   // Local state bridge for exposed variables — allows both prop changes (sidebar)
   // and action calls (setVisibility/setLoading) to drive rendering
@@ -307,8 +332,8 @@ export const Navigation = function Navigation(props) {
       }
     }
 
-    // Then filter by visibility
-    return deduplicatedItems.filter(isItemVisible);
+    // Then filter by visibility (a group also needs at least one visible, enabled child)
+    return deduplicatedItems.filter(isMenuItemVisible);
   }, [menuItems]);
 
   // Overflow calculation for horizontal orientation
@@ -338,6 +363,16 @@ export const Navigation = function Navigation(props) {
     setSelectedItemId(item.id);
     setExposedVariable('selectedItem', clickData);
     setExposedVariable('previousSelectedItem', previousSelected);
+
+    // Collapse every other group; keep the selected item's own group (if any) open.
+    // Selecting a top-level item collapses all groups.
+    setExpandedGroups(() => {
+      const next = {};
+      menuItems.forEach((menuItem) => {
+        if (menuItem.isGroup) next[menuItem.id] = menuItem.id === parentGroup?.id;
+      });
+      return next;
+    });
   };
 
   // Handle item click
@@ -404,6 +439,12 @@ export const Navigation = function Navigation(props) {
       },
       selectItem: async function (itemId) {
         selectItemRef.current(itemId);
+      },
+      setItemVisibility: async function (itemId, value) {
+        setMenuItems((prev) => updateItemById(prev, itemId, (item) => ({ ...item, visible: !value })));
+      },
+      setItemDisable: async function (itemId, value) {
+        setMenuItems((prev) => updateItemById(prev, itemId, (item) => ({ ...item, disable: !!value })));
       },
     };
 
@@ -600,6 +641,8 @@ export const Navigation = function Navigation(props) {
                             darkMode={darkMode}
                             isInOverflow={true}
                             childAlignment={childAlignment}
+                            isExpanded={!!expandedGroups[item.id]}
+                            onToggleExpand={toggleGroupExpanded}
                           />
                         );
                       }
@@ -652,6 +695,8 @@ export const Navigation = function Navigation(props) {
                 orientation={orientation}
                 darkMode={darkMode}
                 childAlignment={childAlignment}
+                isExpanded={!!expandedGroups[item.id]}
+                onToggleExpand={toggleGroupExpanded}
               />
             );
           }

--- a/frontend/src/AppBuilder/Widgets/Navigation/__tests__/utils.spec.js
+++ b/frontend/src/AppBuilder/Widgets/Navigation/__tests__/utils.spec.js
@@ -1,0 +1,87 @@
+/**
+ * Pure unit tests for the group-visibility helpers in
+ * src/AppBuilder/Widgets/Navigation/utils.js.
+ *
+ * `item.visible` stores a "hidden" flag (visible.value === '{{true}}', or the
+ * raw boolean `true`, means the item IS HIDDEN — visible-by-default), while
+ * `item.disable` stores a normal "disabled" flag (disable.value === '{{true}}',
+ * or raw `true`, means disabled). See isItemVisible/isItemDisabled above these
+ * helpers in the source file.
+ *
+ * No store import, zero mocks.
+ */
+import { isGroupVisible, isMenuItemVisible } from '../utils';
+
+const visibleChild = (id) => ({ id, isGroup: false, visible: false, disable: false });
+const hiddenChild = (id) => ({ id, isGroup: false, visible: true, disable: false });
+const disabledChild = (id) => ({ id, isGroup: false, visible: false, disable: true });
+
+describe('isGroupVisible', () => {
+  test('a group whose own visible flag marks it hidden is not visible, regardless of children', () => {
+    const group = { id: 'g1', isGroup: true, visible: true, disable: false, children: [visibleChild('c1')] };
+    expect(isGroupVisible(group)).toBe(false);
+  });
+
+  test('a group with an empty children array is not visible', () => {
+    const group = { id: 'g1', isGroup: true, visible: false, disable: false, children: [] };
+    expect(isGroupVisible(group)).toBe(false);
+  });
+
+  test('a group with children where ALL are hidden is not visible', () => {
+    const group = {
+      id: 'g1',
+      isGroup: true,
+      visible: false,
+      disable: false,
+      children: [hiddenChild('c1'), hiddenChild('c2')],
+    };
+    expect(isGroupVisible(group)).toBe(false);
+  });
+
+  test('a group with children where ALL are disabled (but not hidden) is not visible', () => {
+    const group = {
+      id: 'g1',
+      isGroup: true,
+      visible: false,
+      disable: false,
+      children: [disabledChild('c1'), disabledChild('c2')],
+    };
+    expect(isGroupVisible(group)).toBe(false);
+  });
+
+  test('a group with at least one child that is both visible and enabled is visible', () => {
+    const group = {
+      id: 'g1',
+      isGroup: true,
+      visible: false,
+      disable: false,
+      children: [hiddenChild('c1'), disabledChild('c2'), visibleChild('c3')],
+    };
+    expect(isGroupVisible(group)).toBe(true);
+  });
+});
+
+describe('isMenuItemVisible', () => {
+  test('dispatches to isGroupVisible for a group item', () => {
+    const invisibleGroup = { id: 'g1', isGroup: true, visible: false, disable: false, children: [] };
+    expect(isMenuItemVisible(invisibleGroup)).toBe(isGroupVisible(invisibleGroup));
+    expect(isMenuItemVisible(invisibleGroup)).toBe(false);
+
+    const visibleGroup = {
+      id: 'g2',
+      isGroup: true,
+      visible: false,
+      disable: false,
+      children: [visibleChild('c1')],
+    };
+    expect(isMenuItemVisible(visibleGroup)).toBe(true);
+  });
+
+  test('dispatches to isItemVisible for a non-group item', () => {
+    const visibleItem = { id: 'i1', isGroup: false, visible: false, disable: false };
+    expect(isMenuItemVisible(visibleItem)).toBe(true);
+
+    const hiddenItem = { id: 'i2', isGroup: false, visible: true, disable: false };
+    expect(isMenuItemVisible(hiddenItem)).toBe(false);
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/Navigation/utils.js
+++ b/frontend/src/AppBuilder/Widgets/Navigation/utils.js
@@ -6,6 +6,27 @@ export const isItemDisabled = (item) =>
     ? item.disable.value === '{{true}}' || item.disable.value === true
     : item.disable === true;
 
+// A group is only visible if it isn't hidden itself AND at least one of its children
+// is both visible and enabled (mirrors the page/navigation group logic)
+export const isGroupVisible = (group) => {
+  if (!isItemVisible(group)) return false;
+  return (
+    Array.isArray(group.children) && group.children.some((child) => isItemVisible(child) && !isItemDisabled(child))
+  );
+};
+
+export const isMenuItemVisible = (item) => (item.isGroup ? isGroupVisible(item) : isItemVisible(item));
+
+// Recursively replace an item (by id) anywhere in the tree, including inside group children
+export const updateItemById = (items, targetId, updater) =>
+  items.map((item) => {
+    if (item.id === targetId) return updater(item);
+    if (item.isGroup && item.children) {
+      return { ...item, children: updateItemById(item.children, targetId, updater) };
+    }
+    return item;
+  });
+
 // Helper to find item by ID (including nested items)
 export const findItemById = (items, targetId) => {
   for (const item of items) {

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/navigation.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/navigation.spec.jsx
@@ -1,0 +1,136 @@
+/**
+ * Behaviour spec for the real Navigation widget
+ * (src/AppBuilder/Widgets/Navigation/Navigation.jsx), vertical orientation.
+ *
+ * Nothing is mocked: the real composed store resolves `menuItems`, and the
+ * real Navigation component renders the accordion-style groups. Covers the
+ * two behaviours added by the nav-enhancement change:
+ *   1. isGroupVisible/isMenuItemVisible gate which groups render at all
+ *      (RenderNavGroup returns null for a group with no visible+enabled child).
+ *   2. applySelection's expandedGroups bookkeeping — selecting a leaf item
+ *      expands its own parent group and collapses every other group;
+ *      selecting a top-level item collapses all groups; manually toggling one
+ *      group's header via onToggleExpand does not touch any other group.
+ *
+ * `item.visible`/`item.disable` here use the raw-boolean (non-object) form
+ * of isItemVisible/isItemDisabled — `visible: true` means HIDDEN,
+ * `disable: true` means DISABLED — see Navigation/utils.js.
+ *
+ * Lives in __tests__/integration/ because it imports @/AppBuilder/_stores/store
+ * via ./widgetHarness (scripts/validate-test-layout.js). Setup shared across
+ * widgets lives in ./widgetHarness.js.
+ */
+import { screen } from '@testing-library/react';
+import { createWidgetHarness, binding } from './widgetHarness';
+
+const NAV = 'nav1';
+
+const child = (id, label, { hidden = false, disabled = false } = {}) => ({
+  id,
+  label,
+  icon: { value: 'IconFile' },
+  iconVisibility: true,
+  visible: hidden,
+  disable: disabled,
+  isGroup: false,
+});
+
+const group = (id, label, children) => ({
+  id,
+  label,
+  icon: { value: 'IconFolder' },
+  iconVisibility: true,
+  visible: false, // the group itself is not hidden
+  disable: false,
+  isGroup: true,
+  children,
+});
+
+const menuItems = [
+  { ...child('top1', 'Top Item') },
+  group('groupA', 'Group A', [child('a1', 'A Child 1')]),
+  group('groupB', 'Group B', [child('b1', 'B Child 1')]),
+  // Every child is hidden, so the group itself must not render at all.
+  group('groupHidden', 'Group Hidden', [child('h1', 'Hidden Child', { hidden: true })]),
+];
+
+const widget = createWidgetHarness({
+  componentType: 'Navigation',
+  handle: 'nav1',
+  id: NAV,
+  defaultProperties: {
+    menuItems: { value: menuItems },
+    visibility: binding('{{true}}'),
+    disabledState: binding('{{false}}'),
+  },
+  defaultStyles: {
+    orientation: binding('vertical'),
+  },
+});
+
+const groupWrapper = (container, id) => container.querySelector(`[data-cy="nav-group-${id}"]`);
+const groupHeader = (container, id) => groupWrapper(container, id)?.querySelector('button');
+const groupBody = (container, id) => groupWrapper(container, id)?.querySelector('.accordion-body');
+const itemButton = (container, id) => container.querySelector(`[data-cy="nav-item-${id}"]`);
+
+const isExpanded = (container, id) => groupBody(container, id)?.classList.contains('expanded');
+
+describe('Navigation widget (vertical orientation)', () => {
+  beforeEach(widget.setup);
+  afterEach(widget.teardown);
+
+  test('a group whose every child is hidden does not render at all', async () => {
+    const { container } = widget.render();
+
+    expect(await screen.findByText('Group A')).toBeInTheDocument();
+    expect(groupWrapper(container, 'groupHidden')).not.toBeInTheDocument();
+    expect(screen.queryByText('Group Hidden')).not.toBeInTheDocument();
+  });
+
+  test('selecting an item inside Group A collapses a manually-expanded Group B and expands Group A', async () => {
+    const { container } = widget.render();
+    await screen.findByText('Group A');
+
+    // Manually expand Group B via its own header.
+    await widget.session.user.click(groupHeader(container, 'groupB'));
+    expect(isExpanded(container, 'groupB')).toBe(true);
+    expect(isExpanded(container, 'groupA')).toBe(false);
+
+    // Now select a leaf item that lives inside Group A.
+    await widget.session.user.click(itemButton(container, 'a1'));
+
+    expect(isExpanded(container, 'groupA')).toBe(true);
+    expect(isExpanded(container, 'groupB')).toBe(false);
+  });
+
+  test('selecting a top-level item collapses every previously-expanded group', async () => {
+    const { container } = widget.render();
+    await screen.findByText('Group A');
+
+    await widget.session.user.click(groupHeader(container, 'groupA'));
+    await widget.session.user.click(groupHeader(container, 'groupB'));
+    expect(isExpanded(container, 'groupA')).toBe(true);
+    expect(isExpanded(container, 'groupB')).toBe(true);
+
+    await widget.session.user.click(itemButton(container, 'top1'));
+
+    expect(isExpanded(container, 'groupA')).toBe(false);
+    expect(isExpanded(container, 'groupB')).toBe(false);
+  });
+
+  test('manually clicking a group header toggles only that group, leaving others untouched', async () => {
+    const { container } = widget.render();
+    await screen.findByText('Group A');
+
+    await widget.session.user.click(groupHeader(container, 'groupA'));
+    await widget.session.user.click(groupHeader(container, 'groupB'));
+    expect(isExpanded(container, 'groupA')).toBe(true);
+    expect(isExpanded(container, 'groupB')).toBe(true);
+
+    // Toggle Group A closed again — Group B's already-expanded state must not change.
+    await widget.session.user.click(groupHeader(container, 'groupA'));
+
+    expect(isExpanded(container, 'groupA')).toBe(false);
+    expect(isExpanded(container, 'groupB')).toBe(true);
+  });
+});


### PR DESCRIPTION
# nav_enhancement: Nav widget parity with Tabs and Page/Navigation

## Summary

Three enhancements to the Nav (Navigation) widget, bringing it closer in behavior to the Tabs widget and the app's Page/Navigation menu: editable/accessible item ids, auto-hiding empty groups, and accordion-style group collapse on selection.

## What's Implemented

- **Item ids are now editable and addressable.** Nav items already had internal `id`s, but they weren't user-editable or usable from actions. The item edit popover now has an "Id" field (validated for emptiness/uniqueness/no dynamic bindings). Two new actions, `Set item visibility` and `Set item disable`, take an item id and mutate that specific item at runtime.
- **A group auto-hides when it has no visible, enabled children.** Mirrors Page/Navigation's rule: a group is rendered only if it isn't itself hidden AND at least one child is both visible and enabled.
- **Selecting an item collapses other open groups (vertical/accordion mode).** Selecting an item inside a group collapses every other group, leaving that item's parent group open. Selecting a top-level item collapses all groups. Manually clicking a group header to expand/collapse it is unaffected — that stays independent per group.
- **Id validation now rejects `{{ }}` dynamic bindings.** Item/tab ids are compared with plain equality everywhere at runtime (dnd, event refs, action params) and are never resolved, so a binding can never work as an id — it's now rejected outright instead of being silently accepted and breaking downstream lookups. Applied to both the Nav widget and the Tabs widget (which had the identical gap) via a shared validator.

## Areas to Test

- Add/edit/delete nav items and groups; edit an item's id and confirm click events still fire correctly after the rename.
- Try setting a duplicate id, an empty id, and an id containing `{{ }}` in both the Nav item popover and the Tabs tab-id field — all three should be rejected with a clear message.
- Call `setItemVisibility`/`setItemDisable` from another component's action and confirm the targeted item (including a child inside a group) updates without affecting siblings.
- Hide all children of a group (individually, or via the new actions) and confirm the group itself disappears from both horizontal and vertical layouts, including the overflow "More" menu.
- In vertical orientation: select an item inside Group A while Group B is open — confirm Group B collapses and Group A stays open; then select a top-level item and confirm all groups collapse.
- Regression: horizontal orientation's dropdown-style groups (unaffected by the collapse logic) still open/close normally via click and outside-click.
