### PR TITLE
Dropdown v2: Allow Deselection property added and multiselect v2 accent color issue fixed

### DIFF
--- a/frontend/src/AppBuilder/WidgetManager/widgets/dropdownV2.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/dropdownV2.js
@@ -81,6 +81,12 @@ export const dropdownV2Config = {
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
     },
+    allowDeselection: {
+      type: 'toggle',
+      displayName: 'Allow deselection',
+      validation: { schema: { type: 'boolean' }, defaultValue: true },
+      section: 'additionalActions',
+    },
     showSearchInput: {
       type: 'toggle',
       displayName: 'Show search in options',
@@ -438,6 +444,7 @@ export const dropdownV2Config = {
       sort: { value: 'none' },
       placeholder: { value: 'Select an option' },
       showClearBtn: { value: '{{true}}' },
+      allowDeselection: { value: '{{true}}' },
       showSearchInput: { value: '{{true}}' },
       serverSideSearch: { value: '{{false}}' },
       visibility: { value: '{{true}}' },

--- a/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropdownV2/DropdownV2.jsx
@@ -78,6 +78,7 @@ export const DropdownV2 = ({
     optionsLoadingState,
     sort,
     showClearBtn,
+    allowDeselection,
     showSearchInput,
     serverSideSearch,
   } = properties;
@@ -571,7 +572,7 @@ export const DropdownV2 = ({
                 setInputValue(null);
               }
               if (actionProps.action === 'select-option') {
-                if (currentValue === selectedOption.value) {
+                if (allowDeselection !== false && currentValue === selectedOption.value) {
                   setInputValue(null);
                 } else setInputValue(selectedOption.value);
               }

--- a/frontend/src/AppBuilder/Widgets/MultiselectV2/CustomOption.jsx
+++ b/frontend/src/AppBuilder/Widgets/MultiselectV2/CustomOption.jsx
@@ -11,6 +11,7 @@ const CustomOption = (props) => {
   const hasCaption = caption !== null && caption !== undefined && caption !== '';
   const captionText = hasCaption ? String(caption) : '';
   const isSelectAll = labelText.includes('Select all');
+  const accentColor = props.selectProps.accentColor;
   // Server-side search: results come pre-filtered from the backend, so skip client-side highlighting.
   const serverSideSearch = props.selectProps.serverSideSearch === true;
   const renderWithHighlight = (text) => (serverSideSearch ? text : highlightText(text, props.selectProps.inputValue));
@@ -23,7 +24,13 @@ const CustomOption = (props) => {
       }}
     >
       <div className="d-flex multiselct-widget-option" style={{ alignItems: 'flex-start' }}>
-        <FormCheck checked={props.isSelected} disabled={props?.isDisabled} />
+        <FormCheck.Input
+          checked={props.isSelected}
+          disabled={props?.isDisabled}
+          style={
+            props.isSelected && accentColor ? { backgroundColor: accentColor, borderColor: accentColor } : undefined
+          }
+        />
         <div className="tw-min-w-0 tw-flex-1 tw-flex tw-flex-col" style={{ marginLeft: '5px' }}>
           <span className="tw-truncate" title={labelText}>
             {isSelectAll ? 'Select all' : renderWithHighlight(labelText)}

--- a/frontend/src/AppBuilder/Widgets/MultiselectV2/MultiselectV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/MultiselectV2/MultiselectV2.jsx
@@ -633,6 +633,7 @@ export const MultiselectV2 = ({
             containerRef={valueContainerRef}
             showAllSelectedLabel={showAllSelectedLabel}
             iconColor={iconColor}
+            accentColor={accentColor}
             optionsLoadingState={optionsLoadingState && advanced}
             darkMode={darkMode}
             menuBackgroundColor={menuBackgroundColor}

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/dropdownV2.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/dropdownV2.spec.jsx
@@ -261,6 +261,23 @@ describe('DropdownV2', () => {
       expect(widget.exposed().selectedOption).toBeNull();
     });
 
+    test('picking the already-selected option again keeps it selected when allowDeselection is off', async () => {
+      const { container } = widget.render({
+        properties: { options: OPTIONS, allowDeselection: binding('{{false}}') },
+      });
+
+      await openMenu(container);
+      await widget.session.user.click(await screen.findByText('Beta'));
+      expect(widget.exposed().value).toBe('b');
+
+      await widget.session.user.click(trigger(container));
+      const options = await screen.findAllByRole('option');
+      await widget.session.user.click(options.find((el) => el.textContent === 'Beta'));
+
+      expect(widget.exposed().value).toBe('b');
+      expect(widget.exposed().selectedOption).toEqual({ label: 'Beta', value: 'b', caption: null });
+    });
+
     test('the placeholder is what shows while nothing is selected', async () => {
       const { container } = widget.render({ properties: { options: OPTIONS, placeholder: binding('Pick a letter') } });
 

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/multiselectV2.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/multiselectV2.spec.jsx
@@ -1,0 +1,95 @@
+/**
+ * MultiselectV2 — accent color on an option's checkbox. Shared setup lives in
+ * ./widgetHarness.js.
+ *
+ * Same jsdom virtualizer problem as DropdownV2 (see dropdownV2.spec.jsx's
+ * header for the full explanation): CustomMenuList is shared between the two
+ * widgets and measures offsetHeight, which jsdom hard-codes to 0, so the
+ * option list renders empty unless it's stubbed per-test below.
+ */
+import { screen, waitFor, within } from '@testing-library/react';
+import { createWidgetHarness, binding } from './widgetHarness';
+
+const ID = 'ms1';
+const NAME = 'multiselect1';
+
+const widget = createWidgetHarness({
+  componentType: 'MultiselectV2',
+  handle: NAME,
+  id: ID,
+  defaultProperties: { visibility: binding('{{true}}') },
+  defaultStyles: {
+    auto: binding('{{true}}'),
+    labelWidth: binding('33'),
+    widthType: binding('ofComponent'),
+    alignment: binding('side'),
+    direction: binding('left'),
+  },
+});
+
+function option(label, value, { visible = true, disable = false, caption = null } = {}) {
+  return {
+    label,
+    value,
+    caption,
+    visible: { value: `{{${visible}}}` },
+    disable: { value: `{{${disable}}}` },
+  };
+}
+
+const trigger = (container) => container.querySelector('.multiselect-widget .px-0.h-100');
+
+async function openMenu(container) {
+  await waitFor(() => expect(trigger(container)).toBeInTheDocument());
+  await widget.session.user.click(trigger(container));
+}
+
+describe('MultiselectV2', () => {
+  let restoreOffsetHeight;
+
+  beforeEach(() => {
+    const descriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 300 });
+    restoreOffsetHeight = () => Object.defineProperty(HTMLElement.prototype, 'offsetHeight', descriptor);
+    widget.setup();
+  });
+
+  afterEach(() => {
+    restoreOffsetHeight();
+    widget.teardown();
+  });
+
+  describe('accent color', () => {
+    const OPTIONS = { value: [option('Alpha', '1'), option('Beta', '2')] };
+
+    test('a selected option renders its checkbox with the configured accent color', async () => {
+      const { container } = widget.render({
+        properties: { options: OPTIONS, values: { value: ['1'] } },
+        styles: { accentColor: binding('#008000') },
+      });
+
+      await openMenu(container);
+
+      const alpha = (await screen.findAllByRole('option')).find((el) => el.textContent.includes('Alpha'));
+      const checkbox = within(alpha).getByRole('checkbox');
+
+      expect(checkbox).toBeChecked();
+      expect(checkbox).toHaveStyle({ backgroundColor: '#008000', borderColor: '#008000' });
+    });
+
+    test('an unselected option does not get the accent color applied', async () => {
+      const { container } = widget.render({
+        properties: { options: OPTIONS, values: { value: ['1'] } },
+        styles: { accentColor: binding('#008000') },
+      });
+
+      await openMenu(container);
+
+      const beta = (await screen.findAllByRole('option')).find((el) => el.textContent.includes('Beta'));
+      const checkbox = within(beta).getByRole('checkbox');
+
+      expect(checkbox).not.toBeChecked();
+      expect(checkbox.style.backgroundColor).toBe('');
+    });
+  });
+});

--- a/server/src/modules/apps/services/widget-config/dropdownV2.js
+++ b/server/src/modules/apps/services/widget-config/dropdownV2.js
@@ -81,6 +81,12 @@ export const dropdownV2Config = {
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
     },
+    allowDeselection: {
+      type: 'toggle',
+      displayName: 'Allow deselection',
+      validation: { schema: { type: 'boolean' }, defaultValue: true },
+      section: 'additionalActions',
+    },
     showSearchInput: {
       type: 'toggle',
       displayName: 'Show search in options',
@@ -438,6 +444,7 @@ export const dropdownV2Config = {
       sort: { value: 'none' },
       placeholder: { value: 'Select an option' },
       showClearBtn: { value: '{{true}}' },
+      allowDeselection: { value: '{{true}}' },
       showSearchInput: { value: '{{true}}' },
       serverSideSearch: { value: '{{false}}' },
       visibility: { value: '{{true}}' },


### PR DESCRIPTION
# dropdown_deselection_fix: Dropdown "Allow Deselection" toggle + Multiselect accent color fix

## Summary

Adds an "Allow Deselection" toggle to the Dropdown V2 widget (control whether reclicking the selected option clears it) and fixes Multiselect V2's checkbox color not following the widget's configured Accent color.

## What's Implemented

- **Dropdown V2**: new "Allow Deselection" toggle under Additional Actions, default `true` (preserves existing behavior — clicking the currently selected option clears the value). When turned off, reclicking the selected option leaves it selected.
- **Multiselect V2**: option checkboxes now render with the widget's configured Accent color when checked, instead of always showing Tabler's default blue.

## Areas to Test

- Dropdown V2: toggle "Allow Deselection" off, click the selected option — value should stay selected. Toggle it back on — reclicking should clear the value (original behavior).
- Dropdown V2: apps saved before this change (no `allowDeselection` in their definition) should still clear on reclick by default.
- Multiselect V2: change Accent color and confirm checked checkboxes reflect it; confirm unchecked checkboxes and the checkmark icon still render correctly; confirm disabled options still look disabled.
- Regression: Dropdown V2's own checkmark accent color (unaffected by this change) still works.
