### PR TITLE
Fix: clone app with custom data source fails with 422

### DIFF
--- a/frontend/src/MarketplacePage/InstalledPlugins.jsx
+++ b/frontend/src/MarketplacePage/InstalledPlugins.jsx
@@ -227,8 +227,8 @@ const InstalledPluginCard = ({ plugin, marketplacePlugin, fetchPlugins, isDevMod
           <div className="card-body card-body-alignment">
             <div className="row align-items-center">
               <div className="col-auto">
-                <span className="text-white avatar">
-                  <img height="32" width="32" src={`data:image/svg+xml;base64,${plugin.iconFile.data}`} />
+                <span className="text-white app-icon-main">
+                  <img height="40" width="40" src={`data:image/svg+xml;base64,${plugin.iconFile.data}`} />
                 </span>
               </div>
               <div className="col">

--- a/frontend/src/_styles/license.scss
+++ b/frontend/src/_styles/license.scss
@@ -913,7 +913,7 @@
     text-overflow: ellipsis;
     width: auto;
     margin-left: auto;
-    color: var(--text-default, #1B1F24);    
+    color: var(--text-default, #1B1F24);
     max-height: 52px;
     box-shadow: none !important;
     padding: 8px 16px 8px 16px;
@@ -921,6 +921,29 @@
     border: 1px solid var(--border-weak, #E4E7EB);
     background: var(--button-secondary, #FFF);
     box-shadow: 0px 0px 1px 0px var(--dropshadow-100700-layer-1, rgba(48, 50, 51, 0.05)), 0px 1px 1px 0px var(--dropshadow-100400-layer-2, rgba(48, 50, 51, 0.10));
+
+    &:hover {
+        border: 1px solid var(--border-default, #CCD1D5);
+        color: var(--text-default, #1B1F24);
+        background: var(--button-outline-hover, rgba(136, 144, 153, 0.12));
+    }
+
+    &:focus {
+        border-radius: 8px;
+        border: 1px solid var(--border-default, #CCD1D5);
+        background: var(--button-outline-pressed, rgba(136, 144, 153, 0.18));
+    }
+
+    &:active {
+        border: 1px solid var(--border-weak, #E4E7EB);
+        background: var(--button-outline, #FFF);
+        box-shadow: 0px 0px 0px 2px var(--Interactive-focusActive, #4368E3);
+    }
+
+    &:disabled {
+        border: 1px solid var(--border-weak, #E4E7EB);
+        background: var(--button-outline-disabled, #FFF);
+    }
 }
 
 .modal-upgrade-btn {

--- a/server/src/modules/apps/services/app-import-export.service.ts
+++ b/server/src/modules/apps/services/app-import-export.service.ts
@@ -2152,8 +2152,9 @@ export class AppImportExportService {
         }
 
         // Ensure branch-scoped DSV exists so the DS appears on the global DS page
-        // for the active branch. This handles both newly created and existing DS.
-        if (!isDefaultDatasource) {
+        // for the active branch. Only needed for newly created data sources —
+        // existing ones (e.g. reused by name during clone) already have their DSVs.
+        if (!isDefaultDatasource && !this.isExistingDataSource(dataSourceForAppVersion)) {
           await this.ensureBranchDsvForDataSource(manager, dataSourceForAppVersion, user.organizationId, branchId);
         }
 

--- a/server/test/modules/apps/e2e/apps.spec.ts
+++ b/server/test/modules/apps/e2e/apps.spec.ts
@@ -857,6 +857,42 @@ describe('AppsController', () => {
 
         await logout(app, loggedUser.tokenCookie, anotherOrgAdminUserData.user.defaultOrganizationId);
       });
+
+      it('should clone an app with a custom data source in the same workspace', async () => {
+        const adminUserData = await createUser(app, {
+          email: 'admin@tooljet.io',
+          groups: ['all_users', 'admin'],
+        });
+
+        const loggedUser = await login(app);
+        adminUserData['tokenCookie'] = loggedUser.tokenCookie;
+
+        const { application } = await createAppWithDependencies(app, adminUserData.user, {
+          dsOptions: [{ key: 'host', value: 'localhost', encrypted: false }],
+          name: 'App with custom DS',
+          dsKind: 'restapi',
+        });
+
+        const payload = {
+          app: [{ id: application.id, name: 'App with custom DS (clone)' }],
+          organization_id: adminUserData.user.defaultOrganizationId,
+        };
+
+        const response = await request(app.getHttpServer())
+          .post('/api/v2/resources/clone')
+          .set('tj-workspace-id', adminUserData.user.defaultOrganizationId)
+          .set('Cookie', adminUserData['tokenCookie'])
+          .send(payload);
+
+        expect(response.statusCode).toBe(201);
+        expect(response.body.success).toBe(true);
+
+        const clonedAppId = response.body['imports']['app'][0]['id'];
+        const clonedApplication = await App.findOneOrFail({ where: { id: clonedAppId } });
+        expect(clonedApplication.name).toContain('App with custom DS');
+
+        await logout(app, adminUserData['tokenCookie'], adminUserData.user.defaultOrganizationId);
+      });
     });
 
     describe('PUT /api/apps/:id | Update application', () => {


### PR DESCRIPTION
## What this does

Fixes a 422 error (unique constraint violation on `idx_unique_active_name_branch`) when cloning an app with a custom data source in the same workspace.

## Root cause

`ensureBranchDsvForDataSource()` in `app-import-export.service.ts` was called unconditionally for all non-default data sources during import -- including ones reused by name during same-workspace clone. When the existing data source already had a branch DSV with the same name on the same branch, the insert violated the `idx_unique_active_name_branch` partial unique index.

## Fix

Skip `ensureBranchDsvForDataSource()` for existing (reused) data sources -- they already have their DSVs in place.

```diff
- if (!isDefaultDatasource) {
+ if (!isDefaultDatasource && !this.isExistingDataSource(dataSourceForAppVersion)) {
    await this.ensureBranchDsvForDataSource(...);
  }
```

## Test

Added e2e test case: "should clone an app with a custom data source in the same workspace" -- creates an app with a `restapi` data source, clones it in the same workspace, asserts 201 + success.

Closes #17679
