### PR TITLE
Fix: harden SSRF protection across data-source connectors and OAuth

### DIFF
--- a/marketplace/plugins/common/lib/ssrf-protection.ts
+++ b/marketplace/plugins/common/lib/ssrf-protection.ts
@@ -448,8 +448,12 @@ export async function resolvesToPrivateIP(hostname: string, config?: SSRFProtect
     const ipCheckFn = config?.allowPrivateNetworks ? isDangerousPrivateIP : isPrivateIP;
     return addresses.some(addr => ipCheckFn(addr));
   } catch (error) {
-    console.warn(`DNS resolution error for ${hostname}:`, error.message);
-    return false;
+    // Fail-closed here too: a resolver error is exactly as unverifiable as an
+    // empty answer above, and shouldn't be treated as "safe" (was previously
+    // `return false`, the opposite of the empty-address case's intentional
+    // fail-closed default — part of GHSA-9gjw-8vc2-fjcv).
+    console.warn(`DNS resolution error for ${hostname}, blocking as precaution:`, error.message);
+    return true;
   }
 }
 
@@ -692,8 +696,11 @@ export function getSSRFProtectionOptions(options?: SSRFProtectionOptions, existi
 
   const ssrfOptions: any = {
     ...existingOptions,
-    // Custom DNS lookup function to validate resolved IPs
-    dnsLookup: createSSRFSafeLookup(config),
+    // Custom DNS lookup function to validate resolved IPs.
+    // got's option is `lookup` (see CacheableLookup['lookup'] in its types) — NOT
+    // `dnsLookup`. That key doesn't exist on got's Options type, so got silently
+    // ignored it and this resolver was never actually invoked (GHSA-9gjw-8vc2-fjcv).
+    lookup: createSSRFSafeLookup(config),
   };
 
   // Redirect validation hook - prevents SSRF bypass via open redirects

--- a/plugins/packages/baserow/lib/index.ts
+++ b/plugins/packages/baserow/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, validateUrlForSSRF } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import got, { Headers } from 'got';
 const JSON5 = require('json5');
@@ -21,6 +21,9 @@ export default class Baserow implements QueryService {
     const apiToken = sourceOptions.api_token;
     const host = sourceOptions.baserow_host;
     const baseURL = host === 'baserow_cloud' ? 'https://api.baserow.io' : sourceOptions.base_url;
+
+    // SSRF Protection: Validate the data source URL before making any request.
+    await validateUrlForSSRF(baseURL);
 
     try {
       switch (operation) {

--- a/plugins/packages/common/lib/ssrf-protection.ts
+++ b/plugins/packages/common/lib/ssrf-protection.ts
@@ -448,8 +448,12 @@ export async function resolvesToPrivateIP(hostname: string, config?: SSRFProtect
     const ipCheckFn = config?.allowPrivateNetworks ? isDangerousPrivateIP : isPrivateIP;
     return addresses.some(addr => ipCheckFn(addr));
   } catch (error) {
-    console.warn(`DNS resolution error for ${hostname}:`, error.message);
-    return false;
+    // Fail-closed here too: a resolver error is exactly as unverifiable as an
+    // empty answer above, and shouldn't be treated as "safe" (was previously
+    // `return false`, the opposite of the empty-address case's intentional
+    // fail-closed default — part of GHSA-9gjw-8vc2-fjcv).
+    console.warn(`DNS resolution error for ${hostname}, blocking as precaution:`, error.message);
+    return true;
   }
 }
 
@@ -692,8 +696,11 @@ export function getSSRFProtectionOptions(options?: SSRFProtectionOptions, existi
 
   const ssrfOptions: any = {
     ...existingOptions,
-    // Custom DNS lookup function to validate resolved IPs
-    dnsLookup: createSSRFSafeLookup(config),
+    // Custom DNS lookup function to validate resolved IPs.
+    // got's option is `lookup` (see CacheableLookup['lookup'] in its types) — NOT
+    // `dnsLookup`. That key doesn't exist on got's Options type, so got silently
+    // ignored it and this resolver was never actually invoked (GHSA-9gjw-8vc2-fjcv).
+    lookup: createSSRFSafeLookup(config),
   };
 
   // Redirect validation hook - prevents SSRF bypass via open redirects

--- a/plugins/packages/couchdb/lib/index.ts
+++ b/plugins/packages/couchdb/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, ConnectionTestResult, validateUrlForSSRF } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import got from 'got';
 const JSON5 = require('json5');
@@ -15,6 +15,13 @@ export default class Couchdb implements QueryService {
       const key = Buffer.from(combined).toString('base64');
       return { Authorization: `Basic ${key}` };
     };
+
+    // SSRF Protection: the data source's host/port covers every operation except
+    // get_view, which fetches a fully separate caller-supplied view_url instead.
+    await validateUrlForSSRF(`${protocol}://${host}:${port}`);
+    if (operation === 'get_view') {
+      await validateUrlForSSRF(view_url);
+    }
 
     try {
       switch (operation) {
@@ -119,6 +126,7 @@ export default class Couchdb implements QueryService {
   async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { username, password, port, host, database, protocol } = sourceOptions;
+    await validateUrlForSSRF(`${protocol}://${host}:${port}`);
     const combined = `${username}:${password}`;
     const key = Buffer.from(combined).toString('base64');
     const client = await got(`${protocol}://${host}:${port}/_all_dbs`, {

--- a/plugins/packages/databricks/lib/index.ts
+++ b/plugins/packages/databricks/lib/index.ts
@@ -8,6 +8,7 @@ import {
   ConnectionTestResult,
   getCurrentToken,
   createQueryBuilder,
+  validateUrlForSSRF,
 } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import { DBSQLClient } from '@databricks/sql';
@@ -102,6 +103,10 @@ export default class Databricks implements QueryService {
     const redirectUri = `${fullUrl}oauth2/authorize`;
     const tokenUrl = `https://${workspaceHost}/oidc/v1/token`;
 
+    // SSRF Protection: workspaceHost is data-source config, same shape as
+    // access_token_url elsewhere — validate before sending client_id/client_secret.
+    await validateUrlForSSRF(tokenUrl);
+
     const data = {
       client_id: clientId,
       client_secret: clientSecret,
@@ -184,6 +189,9 @@ export default class Databricks implements QueryService {
     const clientId = sourceOptions['client_id'];
     const clientSecret = sourceOptions['client_secret'];
     const tokenUrl = `https://${workspaceHost}/oidc/v1/token`;
+
+    // SSRF Protection: same token-refresh sink as the code exchange above.
+    await validateUrlForSSRF(tokenUrl);
 
     const data = {
       client_id: clientId,
@@ -316,6 +324,10 @@ export default class Databricks implements QueryService {
       socketTimeout: 60 * 1000,
     };
 
+    // SSRF Protection: DBSQLClient opens its own Thrift/HTTP connection to this
+    // host with no filtering of its own.
+    await validateUrlForSSRF(`https://${credentials.host}`);
+
     try {
       const client = new DBSQLClient();
       await client.connect(credentials);
@@ -445,6 +457,10 @@ export default class Databricks implements QueryService {
 
     const warehouseId = this.extractWarehouseId(httpPath);
     const host = sourceOptions.host;
+
+    // SSRF Protection: validate before this host is used for the statements
+    // request below, and reused for the poll requests in pollStatementResult().
+    await validateUrlForSSRF(`https://${host}`);
 
     const sqlText = queryOptions.query || queryOptions.sql_query;
     const finalSql = this.isSqlParametersUsed(queryOptions)
@@ -1145,6 +1161,9 @@ export default class Databricks implements QueryService {
 
       const warehouseId = this.extractWarehouseId(httpPath);
       const host = sourceOptions.host;
+
+      // SSRF Protection: same host validation as the single-auth path above.
+      await validateUrlForSSRF(`https://${host}`);
 
       const response = await got(`https://${host}/api/2.0/sql/statements`, {
         method: 'POST',

--- a/plugins/packages/elasticsearch/lib/index.ts
+++ b/plugins/packages/elasticsearch/lib/index.ts
@@ -1,4 +1,4 @@
-import { ConnectionTestResult, QueryService, QueryResult, QueryError } from '@tooljet-plugins/common';
+import { ConnectionTestResult, QueryService, QueryResult, QueryError, validateUrlForSSRF } from '@tooljet-plugins/common';
 import {
   getDocument,
   updateDocument,
@@ -107,6 +107,11 @@ export default class ElasticsearchService implements QueryService {
   async getConnection(sourceOptions: SourceOptions): Promise<Client> {
     const host = sourceOptions.host;
     const port = sourceOptions.port;
+
+    // SSRF Protection: Validate the data source host before connecting. Covers both
+    // run() and testConnection(), which both go through this method.
+    await validateUrlForSSRF(`${this.determineProtocol(sourceOptions)}://${host}:${port}`);
+
     const username = encodeURIComponent(sourceOptions.username);
     const password = encodeURIComponent(sourceOptions.password);
     const sslEnabled = sourceOptions.ssl_enabled;

--- a/plugins/packages/grpcv2/lib/operations.ts
+++ b/plugins/packages/grpcv2/lib/operations.ts
@@ -1,4 +1,5 @@
 import { SourceOptions, QueryOptions, GrpcService, GrpcMethod, GrpcClient, GrpcOperationError, toError, isRecord } from './types';
+import { validateUrlForSSRF } from '@tooljet-plugins/common';
 import got from 'got';
 import { GrpcReflection, serviceHelper, ServiceHelperOptionsType } from 'grpc-js-reflection-client';
 import type { ListMethodsType } from 'grpc-js-reflection-client/dist/Types/ListMethodsType';
@@ -581,6 +582,9 @@ export const extractMethodsFromService = (
 };
 
 export const loadProtoFromRemoteUrl = async (url: string): Promise<protoLoader.PackageDefinition> => {
+  // SSRF Protection: Validate URL before fetching the proto file.
+  await validateUrlForSSRF(url);
+
   try {
     const response = await got(url, {
       timeout: {

--- a/plugins/packages/influxdb/lib/index.ts
+++ b/plugins/packages/influxdb/lib/index.ts
@@ -1,4 +1,4 @@
-import { ConnectionTestResult, QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { ConnectionTestResult, QueryError, QueryResult, QueryService, validateUrlForSSRF } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import got, { Headers } from 'got';
 const JSON5 = require('json5');
@@ -16,6 +16,9 @@ export default class influxdb implements QueryService {
         'Content-Type': 'application/json',
       };
     };
+
+    // SSRF Protection: Validate the data source host before making any request.
+    await validateUrlForSSRF(`${protocol}://${host}:${port}`);
 
     try {
       switch (operation) {
@@ -148,6 +151,7 @@ export default class influxdb implements QueryService {
   }
   async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
     const { port, host, protocol, api_token } = sourceOptions;
+    await validateUrlForSSRF(`${protocol}://${host}:${port}`);
     const client = await got(`${protocol}://${host}:${port}/influxdb/cloud/api//ping`, {
       method: 'get',
       headers: { Authorization: `Token ${api_token}` },

--- a/plugins/packages/n8n/lib/index.ts
+++ b/plugins/packages/n8n/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, validateUrlForSSRF, getSSRFProtectionOptions } from '@tooljet-plugins/common';
 import { QueryOptions, SourceOptions } from './types';
 import got, { HTTPError, OptionsOfTextResponseBody } from 'got';
 
@@ -33,7 +33,7 @@ export default class N8n implements QueryService {
     const bodyContent = body ? extractJsonData(body) : '';
 
     const constructPayload = (method: string): OptionsOfTextResponseBody => {
-      return {
+      const base: OptionsOfTextResponseBody = {
         method: method === 'post' ? 'POST' : 'GET',
         headers: headers,
         username: authType === 'basic' && sourceOptions.username,
@@ -41,7 +41,13 @@ export default class N8n implements QueryService {
         searchParams: paramsContent,
         json: method === 'post' ? bodyContent : undefined,
       };
+      // Apply SSRF protection options (custom DNS lookup + redirect validation)
+      return getSSRFProtectionOptions(undefined, base);
     };
+
+    // SSRF Protection: Validate URL before making request. GHSA-4cp2-4g48-grwr —
+    // this connector had no check at all, unlike restapi/graphql/openapi.
+    await validateUrlForSSRF(url);
 
     try {
       switch (operation) {

--- a/plugins/packages/nocodb/lib/index.ts
+++ b/plugins/packages/nocodb/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, validateUrlForSSRF } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import got, { Headers } from 'got';
 const JSON5 = require('json5');
@@ -21,6 +21,9 @@ export default class Nocodb implements QueryService {
     const apiToken = sourceOptions.api_token;
     const host = sourceOptions.nocodb_host;
     const baseURL = host === 'nocodb_cloud' ? 'https://app.nocodb.com' : sourceOptions.base_url;
+
+    // SSRF Protection: Validate the data source URL before making any request.
+    await validateUrlForSSRF(baseURL);
 
     let query_string = queryOptions.query_string || '';
     if (query_string[0] === '?') {

--- a/plugins/packages/smtp/lib/index.ts
+++ b/plugins/packages/smtp/lib/index.ts
@@ -1,4 +1,4 @@
-import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-plugins/common';
+import { QueryError, QueryResult, QueryService, ConnectionTestResult, validateUrlForSSRF } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import nodemailer, { Transporter } from 'nodemailer';
 import type { Attachment } from 'nodemailer/lib/mailer';
@@ -66,6 +66,12 @@ export default class Smtp implements QueryService {
   async getConnection(sourceOptions: SourceOptions, _options?: object): Promise<Transporter> {
     const { host, user, password } = sourceOptions;
     const port = Number(sourceOptions.port);
+
+    // SSRF Protection: this opens a real socket to an arbitrary internal host/port
+    // via the SMTP protocol. Not an HTTP request, so we validate the host through
+    // the same IP/hostname checks as any other sink (scheme is irrelevant here).
+    // Covers both run() and testConnection(), which both go through this method.
+    await validateUrlForSSRF(`https://${host}:${port}`);
 
     const transport: Transporter = nodemailer.createTransport({
       port,

--- a/plugins/packages/snowflake/lib/index.ts
+++ b/plugins/packages/snowflake/lib/index.ts
@@ -13,6 +13,7 @@ import {
   validateAndSetRequestOptionsBasedOnAuthType,
   getCurrentToken,
   createQueryBuilder,
+  validateUrlForSSRF,
 } from '@tooljet-plugins/common';
 import { SourceOptions, QueryOptions } from './types';
 import * as snowflake from 'snowflake-sdk';
@@ -633,6 +634,9 @@ export default class Snowflake implements QueryService {
     }
 
     const access_token_url = getOptionValue('access_token_url');
+    // SSRF Protection: same shape as the server-core OAuth token exchange
+    // (GHSA-gfwc-3frw-hp8v) — client_id/client_secret go out in this request.
+    await validateUrlForSSRF(access_token_url);
     const client_auth = getOptionValue('client_auth');
     const custom_auth_params = sanitizeParams(getOptionValue('custom_auth_params'));
 
@@ -736,6 +740,9 @@ export default class Snowflake implements QueryService {
     if (!access_token_url) {
       throw new QueryError('Access token URL missing', 'access_token_url is required for token refresh', {});
     }
+
+    // SSRF Protection: same token-refresh sink as fetchOAuthToken's code exchange.
+    await validateUrlForSSRF(access_token_url);
 
     const client_auth = sourceOptions['client_auth'];
     const custom_auth_params = sanitizeParams(sourceOptions['custom_auth_params']);

--- a/plugins/packages/typesense/lib/index.ts
+++ b/plugins/packages/typesense/lib/index.ts
@@ -1,4 +1,4 @@
-import { ConnectionTestResult, QueryService, QueryResult } from '@tooljet-plugins/common';
+import { ConnectionTestResult, QueryService, QueryResult, validateUrlForSSRF } from '@tooljet-plugins/common';
 import { createCollection, getDocument, updateDocument, deleteDocument, indexDocument, search } from './operations';
 import { Client } from 'typesense';
 import { SourceOptions, QueryOptions } from './types';
@@ -50,6 +50,10 @@ export default class TypeSenseService implements QueryService {
   }
 
   async getConnection(sourceOptions: SourceOptions): Promise<any> {
+    // SSRF Protection: Validate the data source host before connecting. Covers both
+    // run() and testConnection(), which both go through this method.
+    await validateUrlForSSRF(`${sourceOptions.protocol}://${sourceOptions.host}:${sourceOptions.port}`);
+
     const client = new Client({
       nodes: [
         {

--- a/server/src/helpers/ssrf-protection.helper.ts
+++ b/server/src/helpers/ssrf-protection.helper.ts
@@ -1,0 +1,150 @@
+import { URL } from 'url';
+import * as dns from 'dns/promises';
+import * as net from 'net';
+import { BadRequestException } from '@nestjs/common';
+import { getTooljetEdition } from './utils.helper';
+
+/**
+ * Server-core SSRF guard for outbound requests built from user-supplied URLs
+ * (e.g. OAuth access_token_url on a data source, or body-controlled options on
+ * the test-connection endpoint).
+ *
+ * Mirrors the policy already enforced on the plugin side
+ * (plugins/packages/common/lib/ssrf-protection.ts) so a request behaves the
+ * same whether it's issued by a plugin or by server-core — including the
+ * edition split: Cloud is multi-tenant and always enforces this; EE customers
+ * are frequently deployed air-gapped/on-prem and need it off by default
+ * (opt in); CE defaults on but can opt out. Kept as a smaller, server-local
+ * port rather than a cross-package import because server has no build-time
+ * dependency on @tooljet-plugins/common.
+ *
+ * ponytail: DNS-rebinding-as-a-service hostnames (nip.io, sslip.io, ...) and
+ * the got-level `lookup` TOCTOU guard from the plugin version are not ported
+ * here — these call sites are single request-response exchanges, not a
+ * general-purpose HTTP client with redirects. Add them if this helper grows
+ * more callers.
+ */
+
+const CLOUD_METADATA_ENDPOINTS = [/^169\.254\.169\.25[34]$/, /^metadata\.google\.internal$/i, /^100\.100\.100\.200$/];
+
+const ALLOWED_SCHEMES = ['http:', 'https:'];
+
+// Self-hosted (EE/CE) only: hostnames that always mean "this box" and are safe to
+// exempt outright, matching the plugin-side allowlist. Not extended to literal
+// 127.0.0.1 — same gap the plugin side has, kept for parity rather than guessed at.
+const LOOPBACK_HOSTNAME_ALLOWLIST = new Set(['localhost', 'ip6-localhost', 'ip6-loopback']);
+
+function isSSRFProtectionEnabled(): boolean {
+  const edition = getTooljetEdition();
+  if (edition === 'cloud') return true; // multi-tenant — not configurable
+  if (edition === 'ee') return process.env.SSRF_PROTECTION_ENABLED === 'true'; // off by default: on-prem/air-gapped
+  return process.env.SSRF_PROTECTION_ENABLED !== 'false'; // ce: on by default
+}
+
+function isCloudMetadataEndpoint(hostname: string): boolean {
+  return CLOUD_METADATA_ENDPOINTS.some((pattern) => pattern.test(hostname));
+}
+
+/**
+ * Dangerous ranges that stay blocked even on self-hosted deployments:
+ * loopback, link-local/cloud metadata, CGNAT, unspecified, multicast, reserved.
+ * RFC1918 (10.x, 172.16.x, 192.168.x) is intentionally NOT blocked — self-hosted
+ * customers legitimately run internal services (OAuth providers, databases, etc.)
+ * on their own private network.
+ */
+function isDangerousPrivateIP(ip: string): boolean {
+  if (isCloudMetadataEndpoint(ip)) return true;
+
+  const match = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (match) {
+    const [a, b, c, d] = match.slice(1).map(Number);
+    if ([a, b, c, d].some((o) => o < 0 || o > 255)) return false;
+    if (a === 127) return true; // loopback
+    if (a === 169 && b === 254) return true; // link-local / cloud metadata
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+    if (a === 0) return true; // unspecified
+    if (a === 255 && b === 255 && c === 255 && d === 255) return true; // broadcast
+    if (a >= 224 && a <= 239) return true; // multicast
+    if (a >= 240) return true; // reserved
+    return false;
+  }
+
+  const normalized = ip.toLowerCase();
+  if (normalized === '::1') return true; // loopback
+  if (normalized.startsWith('fe80:')) return true; // link-local
+  return false;
+}
+
+async function resolvesToPrivateIP(hostname: string): Promise<boolean> {
+  if (net.isIP(hostname)) return false; // raw IPs are checked by the caller before DNS
+
+  const addresses: string[] = [];
+  await Promise.all([
+    dns
+      .resolve4(hostname)
+      .then((a) => addresses.push(...a))
+      .catch(() => undefined),
+    dns
+      .resolve6(hostname)
+      .then((a) => addresses.push(...a))
+      .catch(() => undefined),
+  ]);
+
+  // Fail closed: an unresolvable host can't be verified safe.
+  if (addresses.length === 0) return true;
+
+  return addresses.some((addr) => isDangerousPrivateIP(addr));
+}
+
+/**
+ * Validates a user-supplied URL is safe to send a server-side request to.
+ * Throws BadRequestException if the URL is malformed, uses a disallowed
+ * scheme, or points at a loopback/link-local/cloud-metadata address.
+ *
+ * Edition-aware: off by default on EE (air-gapped/on-prem, opt in via
+ * SSRF_PROTECTION_ENABLED=true), on by default on CE (opt out via
+ * SSRF_PROTECTION_ENABLED=false), always on for Cloud. RFC1918 ranges
+ * (10.x/172.16.x/192.168.x) are never blocked — only loopback, link-local /
+ * cloud metadata, CGNAT, and reserved ranges are, on every edition.
+ */
+export async function validateUrlForSSRF(urlString: string): Promise<void> {
+  if (!isSSRFProtectionEnabled()) return;
+
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new BadRequestException('Invalid URL');
+  }
+
+  if (!ALLOWED_SCHEMES.includes(url.protocol)) {
+    throw new BadRequestException(`URL scheme '${url.protocol}' is not allowed`);
+  }
+
+  const hostname = url.hostname.toLowerCase();
+
+  if (getTooljetEdition() !== 'cloud' && LOOPBACK_HOSTNAME_ALLOWLIST.has(hostname)) return;
+
+  const isRawIP = net.isIP(hostname) !== 0;
+
+  if (isRawIP && isDangerousPrivateIP(hostname)) {
+    throw new BadRequestException('URL points to a blocked private/internal address');
+  }
+
+  if (!isRawIP && (await resolvesToPrivateIP(hostname))) {
+    throw new BadRequestException('URL resolves to a blocked private/internal address');
+  }
+}
+
+/**
+ * Same check as validateUrlForSSRF, but built from separate host/port/protocol
+ * fields instead of a single URL string — the shape most data-source `options`
+ * come in (host, port, protocol as three distinct config values). Throws the
+ * same way; returns silently if any part is missing (the caller's own
+ * required-field validation should catch that separately).
+ */
+export async function validateHostForSSRF(host: string, protocol?: string): Promise<void> {
+  if (!host) return;
+  const scheme = protocol ? `${protocol.replace(/:$/, '')}:` : 'https:';
+  await validateUrlForSSRF(`${scheme}//${host}`);
+}

--- a/server/src/modules/data-sources/util.service.ts
+++ b/server/src/modules/data-sources/util.service.ts
@@ -14,6 +14,7 @@ import { DataSourcesRepository } from './repository';
 import { LICENSE_FIELD } from '@modules/licensing/constants';
 import { LicenseTermsService } from '@modules/licensing/interfaces/IService';
 import { cleanObject, resolveOptionsArrayForOAuth, resolveSourceOptionsForOAuth } from '@helpers/utils.helper';
+import { validateUrlForSSRF, validateHostForSSRF } from '@helpers/ssrf-protection.helper';
 import { decode } from 'js-base64';
 import { EncryptionService } from '@modules/encryption/service';
 import { OrganizationConstantType } from '@modules/organization-constants/constants';
@@ -611,6 +612,15 @@ export class DataSourcesUtilService implements IDataSourcesUtilService {
         }
       }
 
+      // SSRF Protection: `kind`, `plugin_id`, and every value in `sourceOptions` above
+      // come straight from the request body — not the data source `:id` in the URL,
+      // which the guard chain only checks belongs to the caller's org. Individual
+      // plugins protect their own run()/testConnection() paths for the fields they
+      // know about; this is a blanket check across every plugin kind reachable here,
+      // covering the ones that haven't had a plugin-level fix applied yet.
+      // GHSA-v64h-hqhj-2h7r.
+      await this.validateTestConnectionOptionsForSSRF(sourceOptions);
+
       const service = await this.pluginsServiceSelector.getService(plugin_id, kind);
       if (!service?.testConnection) {
         throw new NotImplementedException('testConnection method not implemented');
@@ -767,6 +777,39 @@ export class DataSourcesUtilService implements IDataSourcesUtilService {
     return params;
   }
 
+  // Field names observed across data-source plugin `sourceOptions` shapes that carry
+  // a raw, user-controlled destination — kept as a flat list rather than a per-kind
+  // map since testConnection() only has `kind` as a string, no compile-time plugin
+  // type to switch on. ponytail: heuristic, not exhaustive — new plugins should also
+  // add their own validateUrlForSSRF() call at the point they build a request, same
+  // as the plugins fixed alongside this change.
+  private static readonly SSRF_SENSITIVE_OPTION_KEYS = [
+    'url',
+    'base_url',
+    'view_url',
+    'access_token_url',
+    'endpoint',
+    'node',
+    'workspaceHost',
+  ];
+
+  private async validateTestConnectionOptionsForSSRF(sourceOptions: Record<string, any>): Promise<void> {
+    for (const key of DataSourcesUtilService.SSRF_SENSITIVE_OPTION_KEYS) {
+      const value = sourceOptions?.[key];
+      if (typeof value === 'string' && value.length > 0) {
+        await validateUrlForSSRF(value);
+      }
+    }
+
+    // host/port/protocol travel as separate fields on most plugins rather than one
+    // URL string — validate the same way the fixed connectors do.
+    if (typeof sourceOptions?.host === 'string' && sourceOptions.host.length > 0) {
+      const protocol = typeof sourceOptions?.protocol === 'string' ? sourceOptions.protocol : 'https';
+      const port = sourceOptions?.port ? `:${sourceOptions.port}` : '';
+      await validateHostForSSRF(`${sourceOptions.host}${port}`, protocol);
+    }
+  }
+
   private fetchEnvVariables(pluginKind: string, keyAppend: string): string {
     const dataSourcePrefix = {
       googlecalendar: 'GOOGLE',
@@ -802,6 +845,13 @@ export class DataSourcesUtilService implements IDataSourcesUtilService {
     if (!sourceOptions['client_id']) {
       throw new BadRequestException('Missing client_id');
     }
+
+    // Block SSRF before client_id/client_secret ever leave the server: without this,
+    // a malicious access_token_url both exfiltrates the OAuth credentials in the POST
+    // and lets the attacker's response be trusted back as the active access_token.
+    // GHSA-gfwc-3frw-hp8v.
+    await validateUrlForSSRF(accessTokenUrl);
+
     const customParams = this.sanitizeCustomParams(sourceOptions['custom_auth_params']);
     const customAccessTokenHeaders = this.sanitizeCustomParams(sourceOptions['access_token_custom_headers']);
 


### PR DESCRIPTION
## 📝 What this does

ToolJet has one real SSRF guard (`validateUrlForSSRF()` / `getSSRFProtectionOptions()`), and it was only wired into three connectors (restapi, graphql, openapi). Everything else that builds a server-side request from a user-supplied URL — the OAuth token exchange, 11 more connectors, the test-connection endpoint — had none. Separately, the guard those three connectors do have has a dead connect-time check: the DNS-rebinding resolver was attached under `dnsLookup`, a key `got` doesn't recognize (it's `lookup`), so it silently never ran.

This closes both: applies the existing guard everywhere the same shape of bug exists, and fixes the guard itself. Branched off `lts-3.16` per convention.

## 🔒 Closes

| Advisory | Severity | Root cause fixed here |
|---|---|---|
| [GHSA-gfwc-3frw-hp8v](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-gfwc-3frw-hp8v) | Critical | OAuth token exchange |
| [GHSA-4cp2-4g48-grwr](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-4cp2-4g48-grwr) | High | n8n connector |
| [GHSA-9gjw-8vc2-fjcv](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-9gjw-8vc2-fjcv) | High | DNS-rebinding key mismatch |
| [GHSA-v64h-hqhj-2h7r](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-v64h-hqhj-2h7r) | High | test-connection body-controlled SSRF |
| [GHSA-qmm2-755w-926f](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-qmm2-755w-926f) | High | gRPC v2 `proto_file_url` |
| [GHSA-f2q2-vqvc-x5fj](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-f2q2-vqvc-x5fj) | High | couchdb / influxdb / nocodb / baserow |
| [GHSA-wm89-9qp9-fmp8](https://github.com/ToolJet/ToolJet/security/advisories/GHSA-wm89-9qp9-fmp8) | High | SMTP unguarded host (partial — see note below) |

Duplicates of the above, closed as the same root cause once this merges: `GHSA-mg4v-7xvj-cmr3`, `GHSA-qp57-2c66-5m54`, `GHSA-v93v-c4v6-cqw9`, `GHSA-j7h9-6898-9x42`, `GHSA-4ph2-rjxp-hg3q`, `GHSA-q683-w237-6cwh`, `GHSA-ff84-p74f-qf2v`, `GHSA-qvvc-g4pc-2cw4`, `GHSA-f79m-hwqg-ph9w`, `GHSA-qw9q-v8f8-v2pj`, `GHSA-3wxv-px6c-4mqr`, `GHSA-wm8x-g37h-g66v`. Also closes the reachability angle in `GHSA-wf9x-p9qr-gc7h` and `GHSA-7vr2-4qvh-9582` (public-app queries against n8n/couchdb) as a side effect of fixing those connectors — the unauthenticated public-app path itself is intended product behavior, not something this PR changes.

**Not closed by this PR:** `GHSA-cpfv-xw32-mqj7` and the credential-decrypt angle in `GHSA-j3wq-4286-9hqq` — those are IDOR-shaped secret-exfiltration bugs on the same test-connection endpoint, not SSRF, and need a separate fix. `GHSA-wm89-9qp9-fmp8`'s "arbitrary file read via Nodemailer type confusion" claim didn't hold up against this source (checked directly — attachments are always base64-decoded into a Buffer, never a raw path); only its host/port SSRF portion is fixed here.

## 🏗️ Architecture

```mermaid
flowchart LR
    subgraph before["Before"]
        B1["Builder-controlled\nURL / host"] -->|no check| B2["got() / SDK client /\nSMTP transport"]
        B2 --> B3["Internal network,\ncloud metadata,\nor credential exfil"]
    end
    subgraph after["After"]
        A1["Builder-controlled\nURL / host"] --> A2{validateUrlForSSRF}
        A2 -->|blocked| A3["400 — loopback / link-local /\ncloud metadata / bad scheme"]
        A2 -->|allowed| A4["got() / SDK client /\nSMTP transport"]
    end
```

```mermaid
sequenceDiagram
    participant P as got (request lib)
    participant H as ssrf-protection.ts
    Note over P,H: Connect-time rebinding check — was dead
    H->>P: dnsLookup: createSSRFSafeLookup()
    P--xH: unknown option, ignored
    Note over P,H: Fixed
    H->>P: lookup: createSSRFSafeLookup()
    P->>H: called on every connect, resolved IP re-checked
```

## Design considerations

- **Why a new server-side helper instead of importing the plugin one?** `server/` has no build-time dependency on `@tooljet-plugins/common`, and two call sites (OAuth exchange, test-connection) didn't justify wiring a cross-package dependency just for this. Ported only the policy server-core needs.
- **Why per-plugin fixes instead of one central gate for everything?** Protection already lives at the point of the outbound request in every connector's `run()` — matching that for `testConnection()` too means both entry points share the same guarded code path, no drift between them. Added a central heuristic gate in the test-connection orchestrator on top, as defense-in-depth for the ~27 plugins not individually touched in this pass.
- **Why does EE still default SSRF protection off?** Matches the existing plugin-side policy, unchanged: EE deployments are typically air-gapped/on-prem and need full internal reach. RFC1918 stays allowed on every edition regardless of this flag — only loopback/link-local/cloud-metadata/CGNAT are blocked unconditionally.
- **Why fix the marketplace copy too?** `marketplace/plugins/common/lib/ssrf-protection.ts` is a byte-identical duplicate of the same file, same bug — found by checking sibling implementations before assuming one file was the whole fix.

## 🔀 Changes

- Added SSRF validation to the server-core OAuth token exchange and the test-connection endpoint's body-controlled options, plus a new server-side helper
- Wired the existing SSRF helper into 11 connectors that had no protection at all (n8n, couchdb, influxdb, nocodb, baserow, elasticsearch, typesense, databricks, snowflake, SMTP, gRPC v2)
- Fixed the shared helper's dead connect-time DNS-rebinding check (wrong `got` option key) and a fail-open DNS-error path, in both live copies of the file
- Closed a second, previously unlisted Databricks sink (`DBSQLClient.connect()`'s PAT/Thrift path) found while auditing sibling code paths

## 🧪 How to test

- [ ] Set a data source's `access_token_url` to `http://127.0.0.1:<port>/token`, trigger `authorize_oauth2` → rejected before the request goes out
- [ ] Create a couchdb/influxdb/n8n/etc. data source with `host` pointed at `169.254.169.254` → both `run()` and test-connection reject it
- [ ] `POST /data-sources/:id/test-connection` with body `{kind: "influxdb", options: {host: "127.0.0.1", ...}}` against an unrelated saved data source → rejected by the central gate, no need to save a malicious data source first
- [ ] `SSRF_PROTECTION_ENABLED=false` on CE → previously-blocked internal host now allowed (kill switch verified, opt-out intact)
- [ ] `tsc --noEmit` clean on `server/` and all 13 touched plugin packages, checked individually — 0 new errors
