### PR TITLE
Canvas margin adjustment issue due to hidden scrollbar fixed

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/appCanvas.scss
+++ b/frontend/src/AppBuilder/AppCanvas/appCanvas.scss
@@ -161,6 +161,11 @@
     // }
 }
 
+.canvas-content {
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+}
+
 #main-editor-canvas.disable-moveable-line #real-canvas {
     transform: none !important;
     position: relative;
@@ -190,14 +195,16 @@
 }
 
 .scrollbar-hidden {
-    scrollbar-width: none;
-    /* Firefox */
-    -ms-overflow-style: none;
-    /* IE and Edge */
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
 
     &::-webkit-scrollbar {
-        width: 0;
-        height: 0;
+        width: 6px;
+    }
+
+    &::-webkit-scrollbar-thumb,
+    &::-webkit-scrollbar-track {
+        background: transparent;
     }
 }
 


### PR DESCRIPTION
# scrollbar_margin_issue: Canvas shifts left/right when its vertical scrollbar toggles

## Issue Description

When a custom canvas width is set, the canvas is centered on the page via `margin: 0 auto`. Whenever the vertical scrollbar for the canvas appears or disappears, the canvas visibly shifts horizontally — margins shrink and the canvas moves left when the scrollbar shows, and it moves back right when the scrollbar hides.

## Root Cause

The canvas is centered by [`HotkeyProvider.jsx:152-154`](../../../ToolJet/frontend/src/AppBuilder/AppCanvas/HotkeyProvider.jsx):

```js
style={{
  width: '100%',
  maxWidth: canvasMaxWidth,
  margin: '0 auto',
  ...
}}
```

This wrapper's `width: 100%` resolves against its scrolling parent, `.canvas-content` (the ref set up in `AppCanvas.jsx`, the main vertical scroll container). `useEnableMainCanvasScroll.js` toggles a `scrollbar-hidden` class on `.canvas-content` to show the scrollbar only while the user is actively scrolling, hiding it ~600ms after scrolling stops.

Previously, `.scrollbar-hidden` (in `appCanvas.scss`) hid the scrollbar by literally collapsing its width to 0 (`scrollbar-width: none`, `::-webkit-scrollbar { width: 0 }`). Since a classic (non-overlay) vertical scrollbar only eats into space on the right edge, toggling its width between `0` and the browser's default (~15–17px) changed `.canvas-content`'s content-box width asymmetrically — shrinking/growing space only on the right — which shifted the `margin: 0 auto`-centered canvas left/right each time the scrollbar appeared or disappeared.

The same class of bug was already fixed once in this codebase for sub-canvases, at `appCanvas.scss:138-162` (`.real-canvas.flex-container-canvas`), with a comment: *"Flex children reflow when scrollbar width changes, so keep the gutter stable and only reveal colors on hover."* The main canvas scroll container (`.canvas-content`) had not received the same treatment.

## Fix

`frontend/src/AppBuilder/AppCanvas/appCanvas.scss`:

- Added a `.canvas-content` rule that always reserves a constant scrollbar gutter (`scrollbar-gutter: stable; scrollbar-width: thin;`), independent of whether content actually overflows.
- Changed `.scrollbar-hidden` from collapsing scrollbar width to 0 down to only toggling color/visibility (`scrollbar-width: thin; scrollbar-color: transparent transparent;` plus transparent `::-webkit-scrollbar-thumb`/`::-webkit-scrollbar-track`), so the reserved gutter width never changes — only whether the thumb/track are painted.

Net effect: the scrollbar's presence/visibility can still toggle for the "hide while idle" UX, but the space it occupies is now constant, so `.canvas-content`'s content-box width — and therefore the centered canvas's position — no longer shifts.

## Areas to Test

- Toggle scroll state on the main canvas (scroll, then let it idle ~600ms) with a custom canvas width set — canvas should stay visually still, not drift left/right.
- Switch between pages/apps where one has content tall enough to require vertical scrolling and another does not — canvas position should stay constant across the switch.
- Re-check the existing sub-canvas (`flex-container-canvas`) scrollbar behavior is unaffected — its own rule was left untouched.
- Cross-browser: Chrome, Firefox, and Safari (specifically Safari 18.2+ — `scrollbar-gutter` support landed there in late 2024; earlier Safari won't get the "always reserve gutter" behavior, only the constant-width color-toggle part).
