### PR TITLE
Page Switch batch issue fixed

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/AppCanvas.jsx
@@ -285,7 +285,10 @@ export const AppCanvas = ({ appId, switchDarkMode, darkMode }) => {
                 >
                   {environmentLoadingState !== 'loading' && !isCanvasReloading && (
                     <SuspenseCountProvider
-                      key={currentPageId}
+                      // Also keyed on pageKey — a same-page "switch page" CSA changes pageKey
+                      // but not currentPageId, so without this the provider wouldn't remount
+                      // and the batch that switch opens would never flush.
+                      key={`${currentPageId}-${pageKey}`}
                       disabled={pageLoader}
                       onAllResolved={handleAllSuspenseResolved}
                       deferCheck={isModuleMode || appType === 'module'}

--- a/frontend/src/AppBuilder/AppCanvas/__tests__/SuspenseTracker.spec.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/__tests__/SuspenseTracker.spec.jsx
@@ -1,0 +1,101 @@
+/**
+ * Unit coverage for SuspenseCountProvider's remount/key contract, which
+ * AppCanvas.jsx's page-switch fix depends on (AppCanvas.jsx:288).
+ *
+ * onAllResolved only ever fires once PER PROVIDER INSTANCE — hasResolved is a
+ * one-shot latch (SuspenseTracker.jsx:19-24) that never resets on its own.
+ * React only creates a fresh instance (fresh latch) when the `key` prop
+ * changes. AppCanvas.jsx used to key this provider on `currentPageId` alone.
+ * A "switch page" CSA targeting the CURRENT page mints a fresh `pageKey`
+ * (appSlice.js's isSamePage branch) but leaves `currentPageId` unchanged, so
+ * the provider never remounted, onAllResolved never fired again, and the
+ * exposed-value batch that switch opened never flushed. Fixed by keying on
+ * `${currentPageId}-${pageKey}` instead.
+ *
+ * This spec tests the underlying mechanism directly rather than through
+ * AppCanvas.jsx itself (a large, heavily-wired component) — it reproduces
+ * the same before/after key choice with a minimal harness.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SuspenseCountProvider, TrackedSuspense } from '../SuspenseTracker';
+
+/** A React.lazy component the test resolves on demand, instead of racing a real dynamic import. */
+function createLazyChild(label) {
+  let resolveImport;
+  const importPromise = new Promise((resolve) => {
+    resolveImport = resolve;
+  });
+  const LazyChild = React.lazy(() => importPromise.then(() => ({ default: () => <div>{label}</div> })));
+  return { LazyChild, resolveImport, label };
+}
+
+function Harness({ providerKey, onAllResolved, LazyChild }) {
+  return (
+    <SuspenseCountProvider key={providerKey} onAllResolved={onAllResolved}>
+      <TrackedSuspense fallback={<div>loading</div>}>
+        <LazyChild />
+      </TrackedSuspense>
+    </SuspenseCountProvider>
+  );
+}
+
+describe('SuspenseCountProvider', () => {
+  test('fires onAllResolved once its pending child resolves', async () => {
+    const onAllResolved = jest.fn();
+    const { LazyChild, resolveImport, label } = createLazyChild('loaded-1');
+
+    render(<Harness providerKey="page-a" onAllResolved={onAllResolved} LazyChild={LazyChild} />);
+    expect(onAllResolved).not.toHaveBeenCalled();
+
+    resolveImport();
+    await waitFor(() => expect(screen.getByText(label)).toBeInTheDocument());
+
+    expect(onAllResolved).toHaveBeenCalledTimes(1);
+  });
+
+  test('regression guard: re-rendering with the SAME key does not fire onAllResolved again — the bug from keying on currentPageId alone', async () => {
+    const onAllResolved = jest.fn();
+    const first = createLazyChild('loaded-1');
+
+    const { rerender } = render(
+      <Harness providerKey="page-a" onAllResolved={onAllResolved} LazyChild={first.LazyChild} />
+    );
+    first.resolveImport();
+    await waitFor(() => expect(screen.getByText(first.label)).toBeInTheDocument());
+    expect(onAllResolved).toHaveBeenCalledTimes(1);
+
+    // Simulate a same-page switch under the OLD (buggy) key: a new child
+    // suspends again (widgets remount, as AppCanvas's pageKey-driven inner
+    // layout does), but the provider's own key is unchanged, so it's the
+    // SAME instance — hasResolved is already latched true.
+    const second = createLazyChild('loaded-2');
+    rerender(<Harness providerKey="page-a" onAllResolved={onAllResolved} LazyChild={second.LazyChild} />);
+    second.resolveImport();
+    await waitFor(() => expect(screen.getByText(second.label)).toBeInTheDocument());
+
+    expect(onAllResolved).toHaveBeenCalledTimes(1);
+  });
+
+  test('fires onAllResolved again when the key changes — the fix (key includes pageKey)', async () => {
+    const onAllResolved = jest.fn();
+    const first = createLazyChild('loaded-1');
+
+    const { rerender } = render(
+      <Harness providerKey="page-a-pagekey1" onAllResolved={onAllResolved} LazyChild={first.LazyChild} />
+    );
+    first.resolveImport();
+    await waitFor(() => expect(screen.getByText(first.label)).toBeInTheDocument());
+    expect(onAllResolved).toHaveBeenCalledTimes(1);
+
+    // Simulate a same-page switch under the FIXED key: currentPageId is
+    // unchanged, but pageKey is fresh (a new uuid), so the combined key
+    // differs — React mounts a brand new provider instance with a fresh latch.
+    const second = createLazyChild('loaded-2');
+    rerender(<Harness providerKey="page-a-pagekey2" onAllResolved={onAllResolved} LazyChild={second.LazyChild} />);
+    second.resolveImport();
+    await waitFor(() => expect(screen.getByText(second.label)).toBeInTheDocument());
+
+    expect(onAllResolved).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -97,7 +97,6 @@ const useAppData = (
   const cleanUpStore = useStore((state) => state.cleanUpStore);
   const selectedEnvironment = useStore((state) => state.selectedEnvironment);
   const setIsEditorFreezed = useStore((state) => state.setIsEditorFreezed);
-  const setPageSwitchInProgress = useStore((state) => state.setPageSwitchInProgress);
   const selectedVersion = useStore((state) => state.selectedVersion);
   const setIsPublicAccess = useStore((state) => state.setIsPublicAccess);
   const setJsLibraryRegistry = useStore((state) => state.setJsLibraryRegistry);
@@ -224,10 +223,16 @@ const useAppData = (
     }
   };
 
+  // Only OBSERVES pageSwitchInProgress to remember (locally, in a ref) that a
+  // switch is under way, for the onPageLoad-vs-runOnLoadQueries branch further
+  // below. Must NOT reset the flag itself — that's appSlice.js's re-entrancy
+  // guard, and resetting it here as soon as this effect fires (essentially
+  // immediately after switchPage sets it) silently defeated the guard for
+  // virtually its entire intended lifetime, regardless of how long doSwitch
+  // actually takes to finish.
   useEffect(() => {
     if (pageSwitchInProgress && !moduleMode) {
       isPageSwitchRef.current = true;
-      setPageSwitchInProgress(false);
     }
   }, [pageSwitchInProgress, moduleMode]);
 
@@ -784,7 +789,7 @@ const useAppData = (
         setEnvironmentLoadingState('loading');
       }
       appVersionService.getAppVersionData(appId, selectedVersion?.id, mode).then(async (appData) => {
-        cleanUpStore(false);
+        cleanUpStore();
         const { should_freeze_editor } = appData;
         setIsEditorFreezed(should_freeze_editor);
 

--- a/frontend/src/AppBuilder/_stores/__tests__/integration/pageSwitch.spec.js
+++ b/frontend/src/AppBuilder/_stores/__tests__/integration/pageSwitch.spec.js
@@ -215,35 +215,24 @@ describe('switchPage — the re-entrancy guard', () => {
     expect(state().getCurrentPageId('canvas')).toBe('page-b');
   });
 
-  // BUG, still unfixed: the guard is released far too early.
+  // Regression guard: pageSwitchInProgress used to be cleared from inside
+  // cleanUpStore, called at the very START of doSwitch's body — leaving
+  // everything after that, including the `await yieldToMain()` further down,
+  // unguarded. A second switchPage landing in that window was accepted, and
+  // both doSwitch bodies reached `startExposedValueBatch()`. The batch is
+  // ref-counted (batchManager.ts:50-57), so depth became 2 while only one
+  // flush was ever issued for it — every exposed-value write in the app
+  // buffered forever and the canvas froze.
   //
-  // switchPage sets pageSwitchInProgress = true (appSlice.js:266), but
-  // cleanUpStore(true) sets it back to FALSE (appSlice.js:374-376) and is
-  // called at the very START of doSwitch's body (appSlice.js:299). Everything
-  // after that — including the `await yieldToMain()` at appSlice.js:351 — runs
-  // completely unguarded.
-  //
-  // A second switchPage landing in that window is accepted, and both doSwitch
-  // bodies reach `startExposedValueBatch()` (appSlice.js:353). The batch is
-  // ref-counted (batchManager.ts:50-57), so depth becomes 2 while only one
-  // flush will ever be issued for it. From then on every exposed-value write in
-  // the app is buffered and never applied: the canvas freezes.
-  //
-  // Right behaviour: pageSwitchInProgress must stay true until doSwitch
-  // finishes (or fails), so the second call is rejected like the same-tick one
-  // above. Fix = stop clearing the flag inside cleanUpStore and clear it at the
-  // end of doSwitch instead.
-  test.failing('BUG: a second call during the async window is accepted and leaks a batch', async () => {
+  // Fixed by never clearing the flag mid-doSwitch at all.
+  test('a second call during the async window is rejected, not accepted', async () => {
     seedModule();
 
     state().switchPage('page-b', 'b');
     // EXACTLY one hop, not settle(): it resolves the first `await yieldToMain()`
-    // and leaves doSwitch parked on the second, i.e. inside the unguarded
-    // window that cleanUpStore opened. settle() here would run the switch to
-    // completion and the call below would be a legitimate new switch, not a
-    // re-entrant one. NOTE: assert nothing about pageSwitchInProgress — an
-    // assertion on the defect itself would keep this test throwing even after
-    // the fix, so it could never be retired.
+    // and leaves doSwitch parked on the second — the window that used to be
+    // unguarded. settle() here would run the switch to completion and the call
+    // below would be a legitimate new switch, not a re-entrant one.
     await hop();
 
     state().switchPage('page-a', 'a');
@@ -251,8 +240,38 @@ describe('switchPage — the re-entrancy guard', () => {
 
     // The in-flight switch owns the destination; the late call must be rejected.
     expect(state().getCurrentPageId('canvas')).toBe('page-b');
-    // And a page switch owns exactly ONE bracket, so one flush must close it.
-    // Today depth is 2 and the canvas is frozen from here on.
+    // A page switch owns exactly ONE bracket, so one flush must close it.
+    state().flushExposedValueBatch();
+    expect(state().isExposedValueBatching()).toBe(false);
+  });
+
+  // Regression guard for the gap the fix above still left open: doSwitch opens
+  // its exposed-value batch as its very last step, but that batch is only
+  // flushed later, by the isComponentLayoutReady effect in useAppData.js once
+  // Suspense/layout settles for the new page — NOT by doSwitch itself. If the
+  // guard were released as soon as doSwitch's own synchronous work finished
+  // (rather than when the batch it opened actually flushes), two perfectly
+  // ordinary, non-racing clicks — switch to page B, then switch to page A a
+  // moment later, before B's layout has settled — would each open the batch,
+  // stacking depth to 2 with only one flush ever issued. No race window, no
+  // CPU throttling needed to hit it.
+  test('a second call after doSwitch finishes, but before its batch flushes, is rejected', async () => {
+    seedModule();
+
+    state().switchPage('page-b', 'b');
+    await settle();
+    // doSwitch has fully finished and opened its batch; nothing in this
+    // store-only test has flushed it yet (that's useAppData's job, not
+    // exercised here) — this is the ordinary post-switch state, not a defect.
+    expect(state().isExposedValueBatching()).toBe(true);
+
+    state().switchPage('page-a', 'a');
+    expect(toast).toHaveBeenCalledWith('Please wait, page switch in progress', { icon: '⚠️' });
+    await settle();
+
+    // The late call must be rejected — it must not have opened a second,
+    // never-to-be-closed nested batch.
+    expect(state().getCurrentPageId('canvas')).toBe('page-b');
     state().flushExposedValueBatch();
     expect(state().isExposedValueBatching()).toBe(false);
   });

--- a/frontend/src/AppBuilder/_stores/__tests__/integration/pageSwitch.spec.js
+++ b/frontend/src/AppBuilder/_stores/__tests__/integration/pageSwitch.spec.js
@@ -274,6 +274,11 @@ describe('switchPage — the re-entrancy guard', () => {
     expect(state().getCurrentPageId('canvas')).toBe('page-b');
     state().flushExposedValueBatch();
     expect(state().isExposedValueBatching()).toBe(false);
+    // The other half of the guard's lifecycle: the post-flush callback must
+    // actually release it. Without this assertion, a removed or broken
+    // callback would leave pageSwitchInProgress stuck true forever — every
+    // later switch permanently rejected — while this test still passed.
+    expect(state().pageSwitchInProgress).toBe(false);
   });
 });
 

--- a/frontend/src/AppBuilder/_stores/slices/appSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/appSlice.js
@@ -284,6 +284,8 @@ export const createAppSlice = (set, get) => ({
         },
         getCurrentMode,
         setPageLoader,
+        setPageSwitchInProgress,
+        bufferExposedValuePostFlush,
       } = get();
       const isPreview = getCurrentMode(moduleId) !== 'edit';
 
@@ -296,7 +298,7 @@ export const createAppSlice = (set, get) => ({
       const previousPageId = getCurrentPageId(moduleId);
       const isSamePage = previousPageId === pageId;
 
-      cleanUpStore(true);
+      cleanUpStore();
       clearTemporaryLayouts();
       setCurrentPageId(pageId, moduleId);
       setComponentNameIdMapping(moduleId);
@@ -352,6 +354,15 @@ export const createAppSlice = (set, get) => ({
 
       startExposedValueBatch();
       setPageLoader(false);
+      // Held until the batch this switch opened is actually flushed (by the
+      // isComponentLayoutReady effect in useAppData.js once Suspense/layout
+      // settles for the new page) — not merely until doSwitch's own
+      // synchronous work is done. Releasing it earlier let a second,
+      // perfectly legitimate switchPage (no race needed, just two normal
+      // clicks before the previous page finished settling) open a second
+      // nested batch that only one flush would ever close, freezing every
+      // exposed-value write in the app until reload.
+      bufferExposedValuePostFlush(() => setPageSwitchInProgress(false), `pageSwitchGuard|${moduleId}`);
     };
 
     doSwitch().catch((error) => {
@@ -365,15 +376,12 @@ export const createAppSlice = (set, get) => ({
     set(() => ({ pageSwitchInProgress: isInProgress }), false, 'setPageSwitchInProgress'),
   setPageLoader: (isInProgress) => set(() => ({ pageLoader: isInProgress }), false, 'setPageLoader'),
 
-  cleanUpStore: (isPageSwitch = false, moduleId) => {
+  cleanUpStore: (moduleId) => {
     const { resetUndoRedoStack, initModules, clearSelectedComponents } = get();
     resetUndoRedoStack();
     clearSelectedComponents();
     set((state) => {
       state.modules.canvas.componentNameIdMapping = {};
-      if (isPageSwitch) {
-        state.pageSwitchInProgress = false;
-      }
       state.containerChildrenMapping = {
         canvas: [],
       };


### PR DESCRIPTION
# page_switch_batch_issue: Page-switch exposed-value batch leak freezes app state

## Issue Description

Customer reported that app state stops updating reliably in the App Builder editor:

- A Table's `selectedRow` doesn't update consistently after clicking a row.
- The component Inspector doesn't always show all of a component's fields — some are missing intermittently.
- The "Open Modal" / "Close Modal" event action dropdown doesn't always work.

The issue was intermittent. It initially seemed tied to high memory usage (80-85%) on the customer's machine, but it came back later even under 50% memory usage. A full reload temporarily fixed it.

## Root Cause

### How a page switch is supposed to work

When you switch pages, ToolJet doesn't write every widget's data to the store one change at a time. Instead, it briefly "holds" all of it in memory, and only writes everything to the store in one go once the new page has fully finished loading (all its lazy-loaded components have resolved). This is just a performance optimization — apply a burst of changes together, and recompute anything that depends on them exactly once, instead of once per tiny update.

This "hold" period is tracked with a simple counter:
- Starting the hold adds 1 to the counter.
- Finishing (the new page has fully loaded) brings the counter back down by 1.
- While the counter is above 0, nothing gets written to the store — everything just sits in memory, waiting.

### What goes wrong

The bug happens when you switch pages quickly, before the previous page has finished loading.

Every switch adds 1 to the counter when it starts. But there's only **one** thing in the whole app watching "has the page finished loading?" — and it only ever watches the page you're *currently* on. If you switch away again before that watcher fires, it gets thrown away with the old page. It never fires, so its matching "-1" never happens either.

**Example:**
1. Switch to Page B → counter goes to 1. Page B starts loading.
2. Before Page B finishes, switch to Page A → counter goes to 2. Page B's "loading" watcher is discarded — abandoned mid-flight.
3. Only Page A eventually finishes loading, bringing the counter down to 1 — never back to 0.

Once the counter gets stuck above 0, it never recovers. From that moment on, **every write from every widget, anywhere in the app, on any page, gets held in memory and never actually applied.** There's no error, no warning, nothing visibly wrong — the app just silently stops updating state until you reload the whole page.

This explains everything the customer saw:
- **`selectedRow` never updated** — the click's write was being held, not applied.
- **Fields missing from the Inspector** — many of a widget's fields are set through a series of small updates right after it mounts. If the counter was already stuck, those updates got held and never landed.
- **Open Modal did nothing** — the modal's data was one of the writes stuck in limbo, so the code trying to open it found nothing there and failed silently.

### Why the safety check didn't catch this

There's a guard whose whole job is to block a second page switch while one is still in progress — that should have prevented this entirely. It failed for two separate reasons:

1. It was being turned off the moment a switch started its clean-up step — long before the switch had actually finished.
2. A second, unrelated piece of code was *also* turning it off almost immediately, for an entirely different reason (it just wanted to remember that a switch had happened, to decide whether to skip some startup queries afterward).

Because of these two bugs, the guard never actually stopped a second switch from starting — so nothing was in place to prevent the counter from stacking up.

## Fix

1. **`frontend/src/AppBuilder/_stores/slices/appSlice.js`** — the guard is no longer turned off during clean-up. It now only clears once the switch's held changes have actually been written to the store — not just once the switch's own code has finished running.
2. **`frontend/src/AppBuilder/_hooks/useAppData.js`** — the unrelated piece of code that was also turning off the guard now only *reads* it; it no longer changes it. Only the page-switch logic is allowed to release the guard.

### Known limitation

There's a second, separate way the "page finished loading" signal could theoretically fail to fire (a loading-tracker that's sensitive to timing under heavy load), which wasn't addressed here. Also, the counter itself is shared across four different features (app load, page switch, table/form row growth, hot reload) with no way to tell which one opened it — a more robust long-term fix would make each of them track its own handle instead of sharing one counter.

## Areas to Test

- Rapid/double-click page switching — `selectedRow`, Inspector field completeness, and Open/Close Modal should all stay correct afterward.
- Clicking the same page switch twice in the same instant still shows a "please wait" message and doesn't change the destination.
- Page switching combined with a table/form whose row count is still growing.
- A normal single page switch still behaves the same as before (startup queries/events on the new page still fire correctly).
- Full regression pass on `frontend/src/AppBuilder/_stores/__tests__/integration/pageSwitch.spec.js`, `exposedValueBatch.spec.js`, and `Widgets/NewTable/__tests__/integration/tableSelectedRow.spec.js`.
