### PR TITLE
Add data-cy attributes to File Button

### DIFF
--- a/cypress-tests/cypress/constants/selectors/fileButton.js
+++ b/cypress-tests/cypress/constants/selectors/fileButton.js
@@ -1,0 +1,46 @@
+// Selectors for the File Button widget.
+//
+// The widget builds most of its data-cy from `generateCypressDataCy(componentName)`
+// (frontend/src/modules/common/helpers/cypressHelpers.js), so names are derivable
+// rather than discovered. `cyBase` mirrors that helper exactly — keep the two in
+// step rather than adding another `cyParamName` variant.
+const cyBase = (widgetName) =>
+  String(widgetName)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export const fileButtonSelector = {
+  // NOTE: `widget` and `draggableWidget` take the name RAW. The widget root
+  // (`data-cy={dataCy}`) and RenderWidget's wrapper interpolate the component name
+  // unnormalised, so `btnUploadCSV` stays `btnUploadCSV` on these two nodes while
+  // every child below is lowercased. Do not "tidy" these into cyBase().
+  widget: (name) => `[data-cy="${name}"]`,
+  draggableWidget: (name) => `[data-cy="draggable-widget-${name}"]`,
+
+  // Always rendered
+  inputField: (name) => `[data-cy="${cyBase(name)}-input-field"]`,
+  button: (name) => `[data-cy="${cyBase(name)}-button"]`,
+
+  // Only while NOT loading — these live in the else-branch of `isLoading ? ... : ...`
+  label: (name) => `[data-cy="${cyBase(name)}-label"]`,
+  icon: (name) => `[data-cy="${cyBase(name)}-icon"]`, // + an icon must be configured
+  mandatoryIndicator: (name) => `[data-cy="${cyBase(name)}-mandatory-indicator"]`, // + mandatory on
+  // + a file is held and clear selection is enabled. Rendered as a SIBLING of the
+  // trigger (absolutely positioned), not nested inside it, so its disabled state
+  // does not cascade from the trigger.
+  clearButton: (name) => `[data-cy="${cyBase(name)}-clear-button"]`,
+
+  // Only while loading — mutually exclusive with label/icon/clear above
+  loader: (name) => `[data-cy="${cyBase(name)}-loader"]`,
+
+  // Only while a rejection is showing
+  invalidFeedback: (name) => `[data-cy="${cyBase(name)}-invalid-feedback"]`,
+
+  // Accessibility hooks on the file input. Usable as assertions, and as selectors
+  // for sibling file widgets that still lack a data-cy.
+  ariaRequired: (name) => `${fileButtonSelector.inputField(name)}[aria-required="true"]`,
+  ariaBusy: (name) => `${fileButtonSelector.inputField(name)}[aria-busy="true"]`,
+  // Tracks isPickerDisabled (disabled OR at the file limit), not just the disable property.
+  ariaDisabled: (name) => `${fileButtonSelector.inputField(name)}[aria-disabled="true"]`,
+};

--- a/frontend/src/AppBuilder/Widgets/FileButton/FileButton.jsx
+++ b/frontend/src/AppBuilder/Widgets/FileButton/FileButton.jsx
@@ -7,6 +7,7 @@ import TablerIcon from '@/_ui/Icon/TablerIcon';
 import { useFilePicker } from '@/AppBuilder/Widgets/FilePicker/hooks/useFilePicker';
 import { getModifiedColor, getCssVarValue } from '@/AppBuilder/Widgets/utils';
 import clsx from 'clsx';
+import { generateCypressDataCy } from '@/modules/common/helpers/cypressHelpers';
 
 // Alpha applied to the configured background to render the disabled state. Fading (rather than
 // lightening/darkening) keeps the chosen hue and reads as disabled on both light and dark surfaces.
@@ -37,6 +38,7 @@ export const FileButton = (props) => {
     dataCy,
     id,
   } = props;
+  const cyBase = generateCypressDataCy(dataCy);
   const browseButtonRef = useRef(null);
 
   const {
@@ -179,6 +181,7 @@ export const FileButton = (props) => {
           aria-disabled={isPickerDisabled}
           aria-busy={isLoading}
           aria-labelledby={`${id}-label`}
+          data-cy={`${cyBase}-input-field`}
           className="tw-hidden"
         />
         <div className="tw-relative tw-w-full tw-h-full">
@@ -202,14 +205,20 @@ export const FileButton = (props) => {
             disabled={disabledState}
             aria-disabled={isPickerDisabled}
             onClick={openFilePicker}
+            data-cy={`${cyBase}-button`}
           >
             {isLoading ? (
-              <div className="tw-w-full tw-flex-1 tw-h-full tw-flex tw-items-center tw-justify-center">
+              <div
+                className="tw-w-full tw-flex-1 tw-h-full tw-flex tw-items-center tw-justify-center"
+                data-cy={`${cyBase}-loader`}
+              >
                 <Loader color={computedLoaderColor} width="16" />
               </div>
             ) : (
               <>
-                {iconVisibility && <TablerIcon iconName={icon} size={16} color={computedIconColor} />}
+                {iconVisibility && (
+                  <TablerIcon iconName={icon} size={16} color={computedIconColor} data-cy={`${cyBase}-icon`} />
+                )}
                 <span
                   className={clsx(
                     'tw-flex tw-items-center tw-gap-1.5 tw-min-w-0 tw-overflow-hidden',
@@ -219,11 +228,16 @@ export const FileButton = (props) => {
                 >
                   <span
                     id={`${id}-label`}
+                    data-cy={`${cyBase}-label`}
                     style={{ fontSize: `${labelSize}px`, color: computedLabelColor }}
                     className={clsx('tw-truncate', fontWeightClass[labelWeight] ?? 'tw-font-medium')}
                   >
                     {selectedFiles.length === 0 ? buttonText : selectedSummary}
-                    {isMandatory && <span style={{ color: 'var(--cc-error-systemStatus)' }}>*</span>}
+                    {isMandatory && (
+                      <span style={{ color: 'var(--cc-error-systemStatus)' }} data-cy={`${cyBase}-mandatory-indicator`}>
+                        *
+                      </span>
+                    )}
                   </span>
                 </span>
               </>
@@ -238,6 +252,7 @@ export const FileButton = (props) => {
               disabled={disabledState}
               className="tw-shrink-0"
               style={{ position: 'absolute', top: '50%', right: '8px', transform: 'translateY(-50%)' }}
+              data-cy={`${cyBase}-clear-button`}
               onClick={(e) => {
                 e.stopPropagation();
                 e.preventDefault();
@@ -250,7 +265,10 @@ export const FileButton = (props) => {
         </div>
       </div>
       {uiErrorMessage && (
-        <div className="tw-text-[11px] tw-font-normal tw-leading-4 tw-mt-0.5 tw-text-[color:var(--cc-error-systemStatus)]">
+        <div
+          className="tw-text-[11px] tw-font-normal tw-leading-4 tw-mt-0.5 tw-text-[color:var(--cc-error-systemStatus)]"
+          data-cy={`${cyBase}-invalid-feedback`}
+        >
           {uiErrorMessage}
         </div>
       )}


### PR DESCRIPTION
File Button exposed a single `data-cy` on its root, leaving the trigger, file input, icon, label, clear control and error message unreachable from Cypress. That blocked most of its planned spec coverage.

## What this adds

Every addressable part is tagged, each routed through `generateCypressDataCy` so a renamed component still yields a derivable selector:

| selector | element | renders when |
| --- | --- | --- |
| `<name>-input-field` | hidden file input | always |
| `<name>-button` | trigger | always |
| `<name>-label` | label / selected-file summary | always |
| `<name>-icon` | icon | an icon is configured |
| `<name>-mandatory-indicator` | required marker | mandatory is on |
| `<name>-clear-button` | clear control | a file is held + clear enabled |
| `<name>-invalid-feedback` | validation message | a rejection is showing |
| `<name>-loader` | loading spinner | Loading state is on |

The mandatory asterisk is worth calling out: it had no attribute on any widget and is nested *inside* the label, so the label's text read `"Upload file*"` rather than `"Upload file"`, and the required marker could not be asserted on its own.

Non-interactive structure is intentionally left untagged, per the naming contract: two layout wrappers, the `path` nodes inside icons, and the `svg` inside the clear button (its parent button is tagged).

## Verification

All eight confirmed against the live DOM by dumping the full widget subtree in each state it renders in — resting, mandatory, file selected, and rejection — rather than inferred from source. `-loader` was confirmed by toggling Loading state on and back off.

## Two conventions for the reviewer to confirm

This sets precedent, so both are worth a deliberate decision rather than being inherited:

1. **`-mandatory-indicator` and `-loader` are new names.** No widget tagged either before. The asterisk in particular is bare on `Checkbox.jsx:265`, `ToggleV2.jsx:282` and `FilePicker.jsx:235` too, so whatever name lands here is the one those should adopt.
2. **Normalisation is now inconsistent between widgets.** File Button routes label and icon through `generateCypressDataCy`; `Button.jsx` passes `dataCy` raw for the same two (`:260`, `:277`) while normalising only the button (`:217`). Both widgets also keep their root raw. Identical for default names like `filebutton1`; they diverge the moment a component is renamed to camelCase. Worth picking one rule and applying it to both.

## Related

The mandatory `*` sitting inside the `aria-labelledby` target also pollutes the accessible name (it computes as "Evidence*"). Marking that span `aria-hidden="true"` would fix it, since `aria-required` already conveys the state — left out here to keep this change to selectors only.
