### PR TITLE
Docs: add Copilot guardrails for frontend test specs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,33 @@
 - Zustand with Immer middleware only. No Redux/MobX/Recoil.
 - Use `shallow` comparison in `useStore` when selecting objects/arrays. Flag missing `shallow`.
 
+## Tests
+
+Rules: `.github/instructions/frontend-tests.instructions.md`. How to write one:
+`frontend/src/test/README.md`. Reject any spec that would still pass against broken
+production code. Specs are exempt from the TypeScript-only file rule.
+
+- **A spec must reach the code it covers.** The first check on any spec: it must reach
+  the changed production file by a direct import, by the real composed store (which
+  reaches every slice), or via `widgetHarness`. Reaching it through none of those —
+  because the spec stands up its own fake — is a reject however many assertions it has.
+  Going through the store or harness rather than naming the file is normal and correct.
+- **Never reimplement production logic in a spec** — not in a `jest.mock` factory, a
+  local `buildMockStore`/`createMockStore` helper, or a `createStore(...)` seeded with
+  hand-written state (`createStore` against a real slice factory is fine). Never mock
+  or hand-roll the App Builder store to test store behaviour — use the real composed
+  store via `seedApp()` / `AppBuilderTestSession` / `createWidgetHarness()`. "The real
+  store is too much setup" is not a reason.
+- **Fake HTTP only at the MSW boundary**; assert on the store, never on a mock.
+  Assertions must match the real signature — a void action returns `undefined`.
+- **Reject assertion-free specs and tautological assertions.** A bug fix ships with a
+  spec that was red before the fix.
+- **Name specs `*.spec.[jt]s(x)` inside a `__tests__/` directory** or jest never runs
+  them. Imports the real store → `__tests__/integration/`, else `__tests__/`. Placement
+  passing `test:layout` is not evidence a spec is correct.
+- **Widget specs use `createWidgetHarness()`** and may only assert on properties and
+  events the widget's schema declares.
+
 ## Icons & Assets
 
 - Use Tabler Icons (`@tabler/icons-react`) or Lucide React (`lucide-react`). Do NOT add new icon packages.
@@ -46,3 +73,11 @@
 - Missing `key` props in `.map()`
 - Missing `shallow` in `useStore` selectors
 - Direct DOM manipulation (except canvas drop calculations)
+- A spec that reaches the changed code through neither a direct import nor the real
+  store/harness, because it stands up its own fake
+- Production logic reimplemented in a spec — `jest.mock` factory, `buildMockStore`-style
+  helper, or a `createStore(...)` filled with hand-written state
+- A mocked or hand-rolled App Builder store in a spec
+- A spec asserting on a return value the production function does not have
+- A spec named `*.test.*` (never runs), or an integration spec outside `__tests__/integration/`
+- A bug fix touching `frontend/src/` with no spec added, or a spec that never reaches the changed line

--- a/.github/instructions/frontend-tests.instructions.md
+++ b/.github/instructions/frontend-tests.instructions.md
@@ -1,0 +1,120 @@
+---
+applyTo: "frontend/src/**/__tests__/**,frontend/src/**/*.spec.js,frontend/src/**/*.spec.jsx,frontend/src/**/*.spec.ts,frontend/src/**/*.spec.tsx,frontend/src/**/*.test.js,frontend/src/**/*.test.jsx,frontend/src/**/*.test.ts,frontend/src/**/*.test.tsx,frontend/src/test/**"
+---
+
+# Frontend Tests — Rules
+
+How to write a spec: `frontend/src/test/README.md`. These are the rules a spec must
+not break. Scope is the frontend jest suite, not `cypress-tests/`.
+
+The thing to catch: **a spec that passes against broken production code.** It
+certifies nothing while implying the behaviour is safe. One "spec" here had 6 tests,
+zero `expect()` calls, and passed.
+
+Specs are exempt from the TypeScript-only rule in `frontend-typescript.instructions.md`
+— a `.spec.js` matches its `.js` source. Do not ask for a spec to be converted.
+
+## 1. Mocking
+
+- **Never reimplement production logic inside a spec.** `jest.mock` is only the most
+  obvious form. It counts equally when the copy lives in a local helper
+  (`buildMockStore`, `createMockStore`, `makeFakeSlice`), in a `createStore(...)`
+  seeded with hand-written state, or inline in the test body. `createStore` itself is
+  fine against a **real** slice factory — `createStore(immer(createXSlice))` is the
+  endorsed layer-2 pattern, see `_stores/__tests__/appVersionSlice.readOnly.spec.js`.
+  The defect is the hand-written copy, not the helper.
+  A comment saying the copy "mirrors" production is a confession, not a mitigation:
+  the copy asserts nothing about production, and it drifts on the next edit to the
+  real function.
+- **Never mock or hand-roll the App Builder store to test store behaviour.**
+  `jest.mock('@/AppBuilder/_stores/store')`, `createMockStore`, a `createStore(...)`
+  filled with hand-written state, or a fake `useStore` object cannot
+  observe a cascade, ordering, or timing. Anything about a slice, a
+  resolved value, an exposed value, or an event uses the real composed store via
+  `seedApp()` / `AppBuilderTestSession` / `createWidgetHarness()`. A pure helper
+  reading only a state shape is the one exception.
+- **"The real store needs too much setup" is not a reason.** `seedApp()` gets a page,
+  components and a live dependency graph in three lines — see
+  `_stores/slices/__tests__/integration/validateWidget.spec.js`. A spec that opens by
+  justifying a fake store because the composed store is expensive has the cost
+  backwards.
+- **Fake HTTP only at the MSW boundary** — no `jest.mock` of `@/_services/**`, no
+  `global.fetch = jest.fn()`.
+- **Assert on the store, never on a mock.** A spec whose only assertion is
+  `expect(spy).toHaveBeenCalled()` is testing its own mock.
+- Only these may be mocked: **time, IDs, geometry, observers, media, storage,
+  edition, and external package adapters.**
+
+## 2. The test must be able to fail
+
+- **A spec must reach the code it covers.** If a spec cannot reach the changed
+  production file, it cannot fail when that file breaks, however many assertions it
+  carries. Reaching counts three ways — a direct import; importing the real composed
+  store `@/AppBuilder/_stores/store`, which reaches every slice; or importing
+  `widgetHarness`, which reaches the widget under test. A spec that reaches the changed
+  code through **none** of those, because it stands up its own fake instead, is an
+  automatic reject. Do not flag an integration or widget spec merely for not naming the
+  changed file among its imports — going through the store or the harness is the
+  normal, correct shape.
+- **Assertions must match the real signature.** Check what the production function
+  actually returns before asserting on a return value. A void store action returns
+  `undefined`, so `expect(result).toEqual([...])` proves only that some fake in the
+  spec returned what the spec told it to. Same for arguments: call the function the way
+  the code path under test calls it, or the spec exercises a different branch. **A
+  default value on the parameter is not an excuse** — if the call site under test
+  passes an argument, the spec must pass it too. Omitting it is correct only where that
+  call site itself omits it — or where the spec's subject *is* the function, in which
+  case its own default path is a valid case to test.
+- **No assertion-free specs.** Zero `expect()` calls in a test body is an automatic reject.
+- **No tautological assertions** — `expect(x).toBeDefined()`, asserting a value the
+  test itself just set, or asserting only that render did not throw. Each passes
+  against arbitrarily broken code.
+- **A bug fix ships with a spec that was red before the fix.** If the new spec never
+  reaches the changed production line, it was green before the fix too.
+- **`.only` must never merge.** A `.skip` needs a rationale at the skip or in the
+  file header.
+- **`test.failing` is only for a bug deliberately left unfixed**, and must name the
+  bug and cite the source location. Never for a bug the same PR fixes. One that goes
+  red means the bug is fixed — flip it to `test`.
+
+## 3. Naming and placement (CI-enforced, silently fatal if wrong)
+
+- **Name specs `*.spec.[jt]s(x)`, inside a `__tests__/` directory.** A `*.test.*`
+  file, or a `*.spec.*` outside `__tests__/`, is invisible to jest and never runs.
+- **Does the spec import the real composed store, `@/AppBuilder/_stores/store`?**
+  No → `__tests__/`. Yes → `__tests__/integration/`. Both directions are enforced,
+  including a spec in `integration/` that never touches the store.
+- Importing `./widgetHarness` counts as importing the store, so **all widget specs
+  are integration specs**.
+- **The placement question presumes the spec imports what it covers.** A spec about
+  store behaviour that imports no store is not a unit spec — it is a broken spec, and
+  the layout check cannot see the difference. `npm run test:layout` passing is never
+  evidence that a spec is correct; it only proves the file will be collected by jest.
+  Check §2's reach rule first, then placement.
+
+## 4. Layer
+
+Write at the lowest layer that can observe the behaviour: pure function → one slice
+→ real store + `seedApp()` → RTL. **All timing and ordering behaviour needs the real
+store** — that bug class lives between slices, and a mocked store has no timing.
+Flag an RTL spec that exists only to reach a pure helper.
+
+## 5. Widget specs
+
+- **Use `createWidgetHarness`** from
+  `src/AppBuilder/Widgets/__tests__/integration/widgetHarness.js`. A hand-rolled
+  setup silently misses what it handles — most importantly `setEditorLoading(false)`,
+  without which `fireEvent` hard-returns (`eventsSlice.js:104`) and every event
+  silently does nothing while the spec passes.
+- **Assert only on properties and events the widget's schema in
+  `src/AppBuilder/WidgetManager/widgets/` actually declares.** A test for a property
+  the widget does not have passes while asserting nothing.
+- Cover, in priority order: exposed values published; events firing **and the handler
+  seeing the new value, not the previous one**; falsy values (`false`, `0`, `''`)
+  surviving intact; `{{ }}` bindings.
+
+## 6. Out of scope for unit tests
+
+Cypress owns canvas drag/resize/drop, full Editor/Viewer route flows, multiplayer/yjs,
+CodeMirror internals, chart rendering, and pixel layout. Test the math and helpers
+behind them instead — do not ask for unit tests of those surfaces.

--- a/.github/instructions/frontend-typescript.instructions.md
+++ b/.github/instructions/frontend-typescript.instructions.md
@@ -9,6 +9,9 @@ applyTo: "frontend/src/**/*"
 - All new files created under `frontend/src/` MUST use `.tsx` or `.ts` extensions.
 - `.jsx` and `.js` files are legacy and must NOT be added.
 - If a file contains JSX, use `.tsx`. If it is logic-only with no JSX, use `.ts`.
+- **Exception — test specs.** A `*.spec.*` file matches the extension of the module
+  it covers (`.spec.js` for a `.js` source). Do not flag a new `.spec.js`/`.spec.jsx`.
+  See `frontend-tests.instructions.md`.
 
 ## Enforcement
 

--- a/frontend/src/test/README.md
+++ b/frontend/src/test/README.md
@@ -54,7 +54,7 @@ npm run test:app-builder:cypress # requires the normal Cypress app/server setup
   boundary; only time, IDs, geometry, observers, media, storage, edition, and
   external package adapters may be controlled.
 - **Store reset**: zustand stores are reset automatically after every test
-  (`__mocks__/zustand.js` + `resetAllStores()` in `setupTests.js`). Do not
+  (`__mocks__/zustand.js`'s `__resetAllStores()`, called from `setupTests.js`). Do not
   hand-roll `setState({}, true)` cleanup in tests.
 - **ESM packages**: if a test fails with `SyntaxError: Cannot use import
   statement outside a module`, add the offending package to `esmPackages` in
@@ -145,7 +145,7 @@ untestable by construction.
 | --------------------------- | ----------------------------------------------------------- |
 | Pure functions/helpers      | plain jest, no DOM (consider `@jest-environment node`)      |
 | App Builder store behavior  | `AppBuilderTestSession.store.act/read` against the real composed store |
-| `src/_services/**`          | MSW: `import '@/test/setupMsw'`, add handlers with `server.use()`, seed auth with `seedSession()` |
+| `src/_services/**`          | MSW: `import '@/test/setupMsw'`, add handlers with `server.use()` |
 | Components                  | `render` from `@/test/test-utils` when routing is needed; add feature providers explicitly |
 
 Shared pieces:


### PR DESCRIPTION
## 📝 What this does

Teaches Copilot review the frontend testing contract, so specs that look like coverage but assert nothing get flagged instead of merged. Recent PRs have shipped specs built on hand-rolled mock stores, or placed where jest never collects them — both report green while testing nothing.

## 🔀 Changes

- Added `.github/instructions/frontend-tests.instructions.md`, auto-applied to specs and `__tests__/`, codifying the rules in `frontend/src/test/README.md`
- Covered the fake-coverage patterns seen in review: fake stores, specs that never reach the code they claim to test, assertions on a mock or on a signature production does not have, and misnamed or misplaced specs
- Summarised the same rules in the shared Copilot instructions, with new entries in Common Review Flags
- Carved specs out of the TypeScript-only file rule, which otherwise flags every new `.spec.js`
- Fixed three stale references in the test README — `infra.spec.js`, `__resetAllStores`, and a `seedSession()` helper that does not exist

## 🧪 How to test

- [ ] Open a PR adding a spec with a hand-rolled mock store — Copilot should flag it
- [ ] Open a PR adding a spec named `*.test.*`, or a `*.spec.*` outside `__tests__/` — Copilot should flag that it never runs
- [ ] Open a PR adding a new `.spec.js` — Copilot should NOT ask for it to be converted to TypeScript