### PR TITLE
feat: Add Adanos market sentiment marketplace plugin

### DIFF
--- a/marketplace/package-lock.json
+++ b/marketplace/package-lock.json
@@ -5846,6 +5846,10 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tooljet-marketplace/adanos": {
+      "resolved": "plugins/adanos",
+      "link": true
+    },
     "node_modules/@tooljet-marketplace/aftership": {
       "resolved": "plugins/aftership",
       "link": true
@@ -19236,6 +19240,36 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "plugins/adanos": {
+      "name": "@tooljet-marketplace/adanos",
+      "version": "1.0.0",
+      "dependencies": {
+        "@tooljet-marketplace/common": "^1.0.0",
+        "axios": "^1.6.0"
+      },
+      "devDependencies": {
+        "@types/node": "^18.0.0",
+        "@vercel/ncc": "^0.34.0",
+        "typescript": "^4.7.4"
+      }
+    },
+    "plugins/adanos/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "plugins/adanos/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "plugins/aftership": {
       "name": "@tooljet-marketplace/aftership",
       "version": "1.0.0",
@@ -20877,6 +20911,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tooljet-marketplace/common": "^1.0.0",
+        "form-data": "^4.0.0",
         "got": "^11.8.6"
       },
       "devDependencies": {

--- a/marketplace/plugins/adanos/.gitignore
+++ b/marketplace/plugins/adanos/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+lib/*.d.*
+lib/*.js
+lib/*.js.map
+dist/*

--- a/marketplace/plugins/adanos/README.md
+++ b/marketplace/plugins/adanos/README.md
@@ -1,0 +1,18 @@
+# Adanos Marketplace Plugin for ToolJet
+
+Native connector for [Adanos](https://adanos.org) market and social media sentiment data.
+
+## Features
+
+- **Authentication**: Connect using your Adanos API key (`X-API-Key`).
+- **Data Sources**:
+  - Reddit stocks (`/reddit/stocks/v1`)
+  - X / FinTwit stocks (`/x/stocks/v1`)
+  - News stocks (`/news/stocks/v1`)
+  - Polymarket stocks (`/polymarket/stocks/v1`)
+  - Reddit crypto (`/reddit/crypto/v1`)
+- **Supported Operations**:
+  - `Get asset sentiment`: Sentiment metrics and score for a specific stock ticker or crypto token.
+  - `Get trending assets`: Real-time buzz and trending assets.
+  - `Compare assets`: Side-by-side sentiment comparison for up to 10 assets.
+  - `Get market sentiment`: Overall market sentiment score, buzz, and leading market drivers.

--- a/marketplace/plugins/adanos/__tests__/index.test.ts
+++ b/marketplace/plugins/adanos/__tests__/index.test.ts
@@ -1,0 +1,212 @@
+import AdanosService from '../lib/index';
+import axios from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('AdanosService', () => {
+  let service: AdanosService;
+  let mockAxiosInstance: any;
+
+  beforeEach(() => {
+    service = new AdanosService();
+    mockAxiosInstance = {
+      get: jest.fn(),
+    };
+    mockedAxios.create.mockReturnValue(mockAxiosInstance);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('testConnection', () => {
+    it('returns ok status when connection succeeds', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        status: 200,
+        data: { buzz_score: 55 },
+      });
+
+      const result = await service.testConnection({ api_key: 'sk_live_test123' });
+      expect(result.status).toBe('ok');
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/reddit/stocks/v1/market-sentiment');
+    });
+
+    it('returns failed status when connection fails', async () => {
+      mockAxiosInstance.get.mockRejectedValueOnce({
+        response: {
+          status: 401,
+          data: { detail: 'Invalid API key' },
+        },
+      });
+
+      const result = await service.testConnection({ api_key: 'sk_live_invalid' });
+      expect(result.status).toBe('failed');
+      expect(result.message).toBe('Invalid API key');
+    });
+  });
+
+  describe('run - get_asset_sentiment', () => {
+    it('fetches stock sentiment properly', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: { ticker: 'TSLA', sentiment_score: 0.45, buzz_score: 80 },
+      });
+
+      const result = await service.run(
+        { api_key: 'sk_live_test' },
+        {
+          operation: 'get_asset_sentiment',
+          source: 'reddit_stocks',
+          symbol: '$TSLA',
+          from: '2026-08-01',
+          to: '2026-08-28',
+        }
+      );
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/reddit/stocks/v1/stock/TSLA', {
+        params: { from: '2026-08-01', to: '2026-08-28' },
+      });
+      expect(result.status).toBe('ok');
+      expect(result.data).toEqual({ ticker: 'TSLA', sentiment_score: 0.45, buzz_score: 80 });
+    });
+
+    it('fetches crypto sentiment using token path', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: { symbol: 'BTC', sentiment_score: 0.65 },
+      });
+
+      const result = await service.run(
+        { api_key: 'sk_live_test' },
+        {
+          operation: 'get_asset_sentiment',
+          source: 'reddit_crypto',
+          symbol: 'BTC',
+        }
+      );
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/reddit/crypto/v1/token/BTC', {
+        params: {},
+      });
+      expect(result.status).toBe('ok');
+    });
+  });
+
+  describe('run - get_trending_assets', () => {
+    it('fetches trending assets with pagination and filters', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: [{ ticker: 'NVDA', buzz_score: 95 }],
+      });
+
+      const result = await service.run(
+        { api_key: 'sk_live_test' },
+        {
+          operation: 'get_trending_assets',
+          source: 'news_stocks',
+          limit: 10,
+          offset: 0,
+          type: 'stock',
+        }
+      );
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/news/stocks/v1/trending', {
+        params: { limit: 10, offset: 0, type: 'stock' },
+      });
+      expect(result.status).toBe('ok');
+    });
+  });
+
+  describe('run - compare_assets', () => {
+    it('fetches comparisons for stock tickers', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: { stocks: [{ ticker: 'AAPL' }, { ticker: 'MSFT' }] },
+      });
+
+      const result = await service.run(
+        { api_key: 'sk_live_test' },
+        {
+          operation: 'compare_assets',
+          source: 'x_stocks',
+          symbols: 'AAPL,MSFT',
+        }
+      );
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/x/stocks/v1/compare', {
+        params: { tickers: 'AAPL,MSFT' },
+      });
+      expect(result.status).toBe('ok');
+    });
+
+    it('fetches comparisons for crypto symbols', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: { tokens: [{ symbol: 'BTC' }, { symbol: 'ETH' }] },
+      });
+
+      const result = await service.run(
+        { api_key: 'sk_live_test' },
+        {
+          operation: 'compare_assets',
+          source: 'reddit_crypto',
+          symbols: 'BTC,ETH',
+        }
+      );
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/reddit/crypto/v1/compare', {
+        params: { symbols: 'BTC,ETH' },
+      });
+      expect(result.status).toBe('ok');
+    });
+  });
+
+  describe('run - query error handling', () => {
+    it('throws a QueryError with the API error message when a query fails', async () => {
+      mockAxiosInstance.get.mockRejectedValueOnce({
+        response: {
+          status: 422,
+          data: { detail: { message: 'Invalid ticker symbol' } },
+        },
+        name: 'Error',
+      });
+
+      await expect(
+        service.run(
+          { api_key: 'sk_live_test' },
+          { operation: 'get_asset_sentiment', source: 'reddit_stocks', symbol: 'TSLA' }
+        )
+      ).rejects.toMatchObject({
+        message: 'Query could not be completed',
+        description: 'Invalid ticker symbol',
+        data: { statusCode: 422, errorType: 'Error' },
+      });
+    });
+
+    it('throws an error when an operation is unsupported', async () => {
+      await expect(
+        service.run({ api_key: 'sk_live_test' }, { operation: 'bogus_operation', source: 'reddit_stocks' } as any)
+      ).rejects.toMatchObject({
+        message: 'Query could not be completed',
+        description: 'Unsupported operation: bogus_operation',
+      });
+    });
+  });
+
+  describe('run - get_market_sentiment', () => {
+    it('fetches market sentiment properly', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: { buzz_score: 60, trend: 'bullish' },
+      });
+
+      const result = await service.run(
+        { api_key: 'sk_live_test' },
+        {
+          operation: 'get_market_sentiment',
+          source: 'polymarket_stocks',
+        }
+      );
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/polymarket/stocks/v1/market-sentiment', {
+        params: {},
+      });
+      expect(result.status).toBe('ok');
+    });
+  });
+});

--- a/marketplace/plugins/adanos/lib/icon.svg
+++ b/marketplace/plugins/adanos/lib/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100%" height="100%">
+  <defs>
+    <linearGradient id="adanosGrad" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4F46E5"/>
+      <stop offset="100%" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" rx="20" fill="url(#adanosGrad)"/>
+  <path d="M50 20 L78 75 L62 75 L50 48 L38 75 L22 75 Z" fill="#FFFFFF"/>
+  <path d="M35 60 L65 60 L61 68 L39 68 Z" fill="#FFFFFF" opacity="0.9"/>
+</svg>

--- a/marketplace/plugins/adanos/lib/index.ts
+++ b/marketplace/plugins/adanos/lib/index.ts
@@ -1,0 +1,155 @@
+import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-marketplace/common';
+import { SourceOptions, QueryOptions } from './types';
+import axios, { AxiosInstance } from 'axios';
+
+const BASE_URL = 'https://api.adanos.org';
+
+const SOURCE_PREFIX_MAP: Record<string, string> = {
+  reddit_stocks: '/reddit/stocks/v1',
+  x_stocks: '/x/stocks/v1',
+  news_stocks: '/news/stocks/v1',
+  polymarket_stocks: '/polymarket/stocks/v1',
+  reddit_crypto: '/reddit/crypto/v1',
+};
+
+export default class AdanosService implements QueryService {
+  async run(sourceOptions: SourceOptions, queryOptions: QueryOptions, dataSourceId?: string): Promise<QueryResult> {
+    const client = await this.getConnection(sourceOptions);
+    const { operation, source = 'reddit_stocks', symbol, symbols, from, to, limit, offset, type } = queryOptions;
+
+    const basePrefix = SOURCE_PREFIX_MAP[source] || SOURCE_PREFIX_MAP.reddit_stocks;
+    const isCrypto = source === 'reddit_crypto';
+    let result = {};
+
+    try {
+      switch (operation) {
+        case 'get_asset_sentiment': {
+          const rawSymbol = (symbol || '').trim();
+          if (!rawSymbol) {
+            throw new Error('Ticker or Symbol is required for asset sentiment query');
+          }
+          const cleanSymbol = rawSymbol.replace(/^\$/, '');
+          const endpoint = isCrypto
+            ? `${basePrefix}/token/${encodeURIComponent(cleanSymbol)}`
+            : `${basePrefix}/stock/${encodeURIComponent(cleanSymbol)}`;
+
+          const params: Record<string, any> = {};
+          if (from) params.from = from.trim();
+          if (to) params.to = to.trim();
+
+          const response = await client.get(endpoint, { params });
+          result = response.data;
+          break;
+        }
+
+        case 'get_trending_assets': {
+          const endpoint = `${basePrefix}/trending`;
+          const params: Record<string, any> = {};
+          if (from) params.from = from.trim();
+          if (to) params.to = to.trim();
+          if (limit !== undefined && limit !== '') params.limit = Number(limit);
+          if (offset !== undefined && offset !== '') params.offset = Number(offset);
+          if (type && type !== 'all' && !isCrypto) params.type = type;
+
+          const response = await client.get(endpoint, { params });
+          result = response.data;
+          break;
+        }
+
+        case 'compare_assets': {
+          const rawSymbols = (symbols || '').trim();
+          if (!rawSymbols) {
+            throw new Error('Tickers or Symbols are required for comparison');
+          }
+          const endpoint = `${basePrefix}/compare`;
+          const params: Record<string, any> = {};
+          if (isCrypto) {
+            params.symbols = rawSymbols;
+          } else {
+            params.tickers = rawSymbols;
+          }
+          if (from) params.from = from.trim();
+          if (to) params.to = to.trim();
+
+          const response = await client.get(endpoint, { params });
+          result = response.data;
+          break;
+        }
+
+        case 'get_market_sentiment': {
+          const endpoint = `${basePrefix}/market-sentiment`;
+          const params: Record<string, any> = {};
+          if (from) params.from = from.trim();
+          if (to) params.to = to.trim();
+
+          const response = await client.get(endpoint, { params });
+          result = response.data;
+          break;
+        }
+
+        default:
+          throw new Error(`Unsupported operation: ${operation}`);
+      }
+    } catch (error: any) {
+      let errorMessage = 'An unknown error occurred';
+      const errorDetails: any = { errorType: error?.name || 'Error', raw: error };
+
+      if (error?.response?.data) {
+        const data = error.response.data;
+        errorMessage =
+          typeof data === 'string' ? data : data.detail?.message || data.detail || data.message || JSON.stringify(data);
+        errorDetails.statusCode = error.response.status;
+        errorDetails.response = data;
+      } else if (error?.message) {
+        errorMessage = error.message;
+      }
+
+      throw new QueryError('Query could not be completed', errorMessage, errorDetails);
+    }
+
+    return {
+      status: 'ok',
+      data: result,
+    };
+  }
+
+  async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
+    try {
+      const client = await this.getConnection(sourceOptions);
+      // Validate credentials against market-sentiment endpoint
+      const response = await client.get('/reddit/stocks/v1/market-sentiment');
+      if (response.status === 200) {
+        return {
+          status: 'ok',
+          message: 'Connection established successfully',
+        };
+      }
+      return {
+        status: 'failed',
+        message: 'Could not validate Adanos API connection',
+      };
+    } catch (error: any) {
+      const errorMsg =
+        error?.response?.data?.detail?.message ||
+        error?.response?.data?.detail ||
+        error?.message ||
+        'Could not connect to Adanos API';
+      return {
+        status: 'failed',
+        message: errorMsg,
+      };
+    }
+  }
+
+  async getConnection(sourceOptions: SourceOptions): Promise<AxiosInstance> {
+    const { api_key } = sourceOptions;
+    return axios.create({
+      baseURL: BASE_URL,
+      headers: {
+        'X-API-Key': api_key || '',
+        Accept: 'application/json',
+      },
+      timeout: 30000,
+    });
+  }
+}

--- a/marketplace/plugins/adanos/lib/manifest.json
+++ b/marketplace/plugins/adanos/lib/manifest.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/manifest.schema.json",
+  "title": "Adanos datasource",
+  "description": "A schema defining Adanos market sentiment datasource",
+  "type": "api",
+  "source": {
+    "name": "Adanos",
+    "kind": "adanos",
+    "exposedVariables": {
+      "isLoading": false,
+      "data": {},
+      "rawData": {}
+    },
+    "options": {
+      "api_key": {
+        "type": "string",
+        "encrypted": true
+      }
+    }
+  },
+  "defaults": {
+    "api_key": {
+      "value": ""
+    }
+  },
+  "properties": {
+    "api_key": {
+      "label": "API Key",
+      "key": "api_key",
+      "type": "password",
+      "description": "Enter your Adanos API key (X-API-Key)",
+      "placeholder": "sk_live_...",
+      "encrypted": true
+    }
+  },
+  "required": ["api_key"]
+}

--- a/marketplace/plugins/adanos/lib/operations.json
+++ b/marketplace/plugins/adanos/lib/operations.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/operations.schema.json",
+  "title": "Adanos Datasource",
+  "description": "A schema defining Adanos datasource operations",
+  "type": "api",
+  "defaults": {},
+  "properties": {
+    "operation": {
+      "label": "Operation",
+      "key": "operation",
+      "type": "dropdown-component-flip",
+      "description": "Select an operation",
+      "list": [
+        {
+          "value": "get_asset_sentiment",
+          "name": "Get asset sentiment"
+        },
+        {
+          "value": "get_trending_assets",
+          "name": "Get trending assets"
+        },
+        {
+          "value": "compare_assets",
+          "name": "Compare assets"
+        },
+        {
+          "value": "get_market_sentiment",
+          "name": "Get market sentiment"
+        }
+      ]
+    },
+    "get_asset_sentiment": {
+      "source": {
+        "label": "Data source",
+        "key": "source",
+        "type": "dropdown",
+        "description": "Select the platform source",
+        "list": [
+          { "value": "reddit_stocks", "name": "Reddit stocks" },
+          { "value": "x_stocks", "name": "X / FinTwit stocks" },
+          { "value": "news_stocks", "name": "News stocks" },
+          { "value": "polymarket_stocks", "name": "Polymarket stocks" },
+          { "value": "reddit_crypto", "name": "Reddit crypto" }
+        ],
+        "default": "reddit_stocks"
+      },
+      "symbol": {
+        "label": "Ticker / Symbol",
+        "key": "symbol",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Enter the stock ticker (e.g., TSLA, AAPL) or crypto symbol (e.g., BTC, ETH)",
+        "placeholder": "TSLA",
+        "height": "36px"
+      },
+      "from": {
+        "label": "From Date (YYYY-MM-DD)",
+        "key": "from",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Optional start date in YYYY-MM-DD (UTC)",
+        "placeholder": "2026-08-01",
+        "height": "36px"
+      },
+      "to": {
+        "label": "To Date (YYYY-MM-DD)",
+        "key": "to",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Optional end date in YYYY-MM-DD (UTC)",
+        "placeholder": "2026-08-28",
+        "height": "36px"
+      }
+    },
+    "get_trending_assets": {
+      "source": {
+        "label": "Data source",
+        "key": "source",
+        "type": "dropdown",
+        "description": "Select the platform source",
+        "list": [
+          { "value": "reddit_stocks", "name": "Reddit stocks" },
+          { "value": "x_stocks", "name": "X / FinTwit stocks" },
+          { "value": "news_stocks", "name": "News stocks" },
+          { "value": "polymarket_stocks", "name": "Polymarket stocks" },
+          { "value": "reddit_crypto", "name": "Reddit crypto" }
+        ],
+        "default": "reddit_stocks"
+      },
+      "from": {
+        "label": "From Date (YYYY-MM-DD)",
+        "key": "from",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Optional start date in YYYY-MM-DD (UTC)",
+        "placeholder": "2026-08-01",
+        "height": "36px"
+      },
+      "to": {
+        "label": "To Date (YYYY-MM-DD)",
+        "key": "to",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Optional end date in YYYY-MM-DD (UTC)",
+        "placeholder": "2026-08-28",
+        "height": "36px"
+      },
+      "limit": {
+        "label": "Limit",
+        "key": "limit",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Maximum number of items to return (1-100, default: 20)",
+        "placeholder": "20",
+        "height": "36px"
+      },
+      "offset": {
+        "label": "Offset",
+        "key": "offset",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Pagination offset (default: 0)",
+        "placeholder": "0",
+        "height": "36px"
+      },
+      "type": {
+        "label": "Asset Type",
+        "key": "type",
+        "type": "dropdown",
+        "description": "Filter by asset type (Stocks/X/Polymarket)",
+        "list": [
+          { "value": "all", "name": "All" },
+          { "value": "stock", "name": "Stocks" },
+          { "value": "etf", "name": "ETFs" }
+        ],
+        "default": "all"
+      }
+    },
+    "compare_assets": {
+      "source": {
+        "label": "Data source",
+        "key": "source",
+        "type": "dropdown",
+        "description": "Select the platform source",
+        "list": [
+          { "value": "reddit_stocks", "name": "Reddit stocks" },
+          { "value": "x_stocks", "name": "X / FinTwit stocks" },
+          { "value": "news_stocks", "name": "News stocks" },
+          { "value": "polymarket_stocks", "name": "Polymarket stocks" },
+          { "value": "reddit_crypto", "name": "Reddit crypto" }
+        ],
+        "default": "reddit_stocks"
+      },
+      "symbols": {
+        "label": "Tickers / Symbols (comma-separated, max 10)",
+        "key": "symbols",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Comma-separated asset symbols (e.g., TSLA,NVDA,AAPL or BTC,ETH)",
+        "placeholder": "TSLA,NVDA,AAPL",
+        "height": "36px"
+      },
+      "from": {
+        "label": "From Date (YYYY-MM-DD)",
+        "key": "from",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Optional start date in YYYY-MM-DD (UTC)",
+        "placeholder": "2026-08-01",
+        "height": "36px"
+      },
+      "to": {
+        "label": "To Date (YYYY-MM-DD)",
+        "key": "to",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Optional end date in YYYY-MM-DD (UTC)",
+        "placeholder": "2026-08-28",
+        "height": "36px"
+      }
+    },
+    "get_market_sentiment": {
+      "source": {
+        "label": "Data source",
+        "key": "source",
+        "type": "dropdown",
+        "description": "Select the platform source",
+        "list": [
+          { "value": "reddit_stocks", "name": "Reddit stocks" },
+          { "value": "x_stocks", "name": "X / FinTwit stocks" },
+          { "value": "news_stocks", "name": "News stocks" },
+          { "value": "polymarket_stocks", "name": "Polymarket stocks" },
+          { "value": "reddit_crypto", "name": "Reddit crypto" }
+        ],
+        "default": "reddit_stocks"
+      },
+      "from": {
+        "label": "From Date (YYYY-MM-DD)",
+        "key": "from",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Optional start date in YYYY-MM-DD (UTC)",
+        "placeholder": "2026-08-01",
+        "height": "36px"
+      },
+      "to": {
+        "label": "To Date (YYYY-MM-DD)",
+        "key": "to",
+        "type": "codehinter",
+        "className": "codehinter-plugins",
+        "width": "320px",
+        "description": "Optional end date in YYYY-MM-DD (UTC)",
+        "placeholder": "2026-08-28",
+        "height": "36px"
+      }
+    }
+  }
+}

--- a/marketplace/plugins/adanos/lib/types.ts
+++ b/marketplace/plugins/adanos/lib/types.ts
@@ -1,0 +1,15 @@
+export type SourceOptions = {
+  api_key: string;
+};
+
+export type QueryOptions = {
+  operation: 'get_asset_sentiment' | 'get_trending_assets' | 'compare_assets' | 'get_market_sentiment';
+  source?: 'reddit_stocks' | 'x_stocks' | 'news_stocks' | 'polymarket_stocks' | 'reddit_crypto';
+  symbol?: string;
+  symbols?: string;
+  from?: string;
+  to?: string;
+  limit?: string | number;
+  offset?: string | number;
+  type?: 'all' | 'stock' | 'etf';
+};

--- a/marketplace/plugins/adanos/package.json
+++ b/marketplace/plugins/adanos/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@tooljet-marketplace/adanos",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "build": "ncc build lib/index.ts -o dist",
+    "watch": "ncc build lib/index.ts -o dist --watch"
+  },
+  "homepage": "https://github.com/tooljet/tooljet#readme",
+  "dependencies": {
+    "@tooljet-marketplace/common": "^1.0.0",
+    "axios": "^1.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "@vercel/ncc": "^0.34.0",
+    "typescript": "^4.7.4"
+  }
+}

--- a/marketplace/plugins/adanos/tsconfig.json
+++ b/marketplace/plugins/adanos/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}

--- a/server/src/assets/marketplace/plugins.json
+++ b/server/src/assets/marketplace/plugins.json
@@ -381,5 +381,13 @@
     "timestamp": "Mon, 08 Jun 2026 14:10:00 GMT",
     "repo": "",
     "tags": ["IT Service Management"]
+  },
+  {
+    "name": "Adanos",
+    "description": "Plugin for Adanos market sentiment APIs",
+    "version": "1.0.0",
+    "id": "adanos",
+    "author": "Tooljet",
+    "timestamp": "Sat, 29 Aug 2026 00:00:00 GMT"
   }
 ]


### PR DESCRIPTION
## Summary
Adds an optional Adanos marketplace datasource for monitoring stock and
crypto market sentiment, addressing #17644.
- **Auth**: encrypted `X-API-Key`
- **Operations** (read-only): Get asset sentiment · Get trending assets · Compare assets · Get market sentiment
- **Data sources**: Reddit stocks, X / FinTwit stocks, News stocks, Polymarket stocks, Reddit crypto
- **Date windows**: `from`/`to` parameters only; deprecated `days` param not exposed
- No write operations; no changes to ToolJet trading logic
## Implementation
Follows the existing marketplace plugin structure: manifest, operation
schema, icon, registry entry (`server/src/assets/marketplace/plugins.json`),
focused unit tests for request construction and error handling, and a
README. Endpoint paths, query params, and auth header verified against
the Adanos OpenAPI spec.
## Testing
- `jest` — 10/10 unit tests pass (request construction + error handling)
- `eslint` — marketplace lint passes
- `npm ci` / `npm run build` — full marketplace build passes (incl. `ncc` bundle for `plugins/adanos`)
## Checklist
- [x] I have read the [contributing guide](https://docs.tooljet.ai/docs/contributing-guide/marketplace/creating-a-plugin)
- [x] Plugin conforms to the marketplace plugin structure
- [x] API key stored encrypted
- [x] No secrets committed
