### PR TITLE
feat: allow workspace PATs to manage users

### DIFF
--- a/server/src/modules/organization-users/controller.ts
+++ b/server/src/modules/organization-users/controller.ts
@@ -79,7 +79,7 @@ export class OrganizationUsersController implements IOrganizationUsersController
   @InitFeature(FEATURE_KEY.USER_ARCHIVE)
   @Post(':id/archive')
   async archive(@User() user: UserEntity, @Param('id') id: string, @Body() body) {
-    const organizationId = body.organizationId ? body.organizationId : user.organizationId;
+    const organizationId = user.isPATLogin ? user.organizationId : body.organizationId || user.organizationId;
     await this.organizationUsersService.archive(id, organizationId, user);
     return;
   }
@@ -111,7 +111,7 @@ export class OrganizationUsersController implements IOrganizationUsersController
   @InitFeature(FEATURE_KEY.USER_UNARCHIVE)
   @Post(':id/unarchive')
   async unarchive(@User() user, @Param('id') id: string, @Body() body) {
-    const organizationId = body.organizationId ? body.organizationId : user.organizationId;
+    const organizationId = user.isPATLogin ? user.organizationId : body.organizationId || user.organizationId;
     await this.organizationUsersService.unarchive(user, id, organizationId);
     return;
   }

--- a/server/src/modules/personal-access-tokens/constants/scopes.ts
+++ b/server/src/modules/personal-access-tokens/constants/scopes.ts
@@ -1,4 +1,5 @@
 import { MODULES } from '@modules/app/constants/modules';
+import { FEATURE_KEY as ORGANIZATION_USER_FEATURE } from '@modules/organization-users/constants';
 
 /**
  * What a WORKSPACE personal access token may reach.
@@ -19,6 +20,7 @@ export enum PAT_BUNDLE {
   APPS = 'apps',
   DATA = 'data',
   WORKFLOWS = 'workflows',
+  WORKSPACE_USERS = 'workspace_users',
   WORKSPACE_ADMIN = 'workspace_admin',
   INSTANCE_ADMIN = 'instance_admin',
 }
@@ -48,9 +50,9 @@ export const PAT_BUNDLE_MODULES: Record<PAT_BUNDLE, MODULES[]> = {
     MODULES.APP_ENVIRONMENTS,
   ],
   [PAT_BUNDLE.WORKFLOWS]: [MODULES.WORKFLOWS],
+  [PAT_BUNDLE.WORKSPACE_USERS]: [MODULES.ORGANIZATION_USER],
   [PAT_BUNDLE.WORKSPACE_ADMIN]: [
     MODULES.ORGANIZATIONS,
-    MODULES.ORGANIZATION_USER,
     MODULES.USER,
     MODULES.GROUP_PERMISSIONS,
     MODULES.ORGANIZATION_CONSTANT,
@@ -111,11 +113,21 @@ export const PAT_UNASSIGNED_MODULES: MODULES[] = [
  * deliberately unassigned pending a decision — it builds apps, but its endpoints spend money on
  * model calls, so an app-scoped automation token should not reach it by default.
  */
-export const PAT_ALLOWED_BUNDLES: PAT_BUNDLE[] = [PAT_BUNDLE.APPS, PAT_BUNDLE.DATA];
+export const PAT_ALLOWED_BUNDLES: PAT_BUNDLE[] = [PAT_BUNDLE.APPS, PAT_BUNDLE.DATA, PAT_BUNDLE.WORKSPACE_USERS];
 
 const ALLOWED_MODULES: ReadonlySet<MODULES> = new Set(
   PAT_ALLOWED_BUNDLES.flatMap((bundle) => PAT_BUNDLE_MODULES[bundle])
 );
+
+const PAT_ALLOWED_FEATURES: Partial<Record<MODULES, ReadonlySet<string>>> = {
+  [MODULES.ORGANIZATION_USER]: new Set([
+    ORGANIZATION_USER_FEATURE.VIEW_ALL_USERS,
+    ORGANIZATION_USER_FEATURE.USER_INVITE,
+    ORGANIZATION_USER_FEATURE.USER_UPDATE,
+    ORGANIZATION_USER_FEATURE.USER_ARCHIVE,
+    ORGANIZATION_USER_FEATURE.USER_UNARCHIVE,
+  ]),
+};
 
 /** Which bundle a module belongs to, for the denial message. Undefined if unassigned. */
 export function patBundleOf(module: MODULES): PAT_BUNDLE | undefined {
@@ -126,7 +138,9 @@ export function patBundleOf(module: MODULES): PAT_BUNDLE | undefined {
  * Fails CLOSED: a route whose controller carries no @InitModule is denied rather than exempt, so a
  * new endpoint is locked down by default instead of silently escaping the allowlist.
  */
-export function patCanAccess(module: MODULES | undefined): boolean {
+export function patCanAccess(module: MODULES | undefined, feature?: string): boolean {
   if (!module) return false;
-  return ALLOWED_MODULES.has(module);
+  if (!ALLOWED_MODULES.has(module)) return false;
+  const allowedFeatures = PAT_ALLOWED_FEATURES[module];
+  return !allowedFeatures || (!!feature && allowedFeatures.has(feature));
 }

--- a/server/src/modules/personal-access-tokens/interceptors/pat-scope.interceptor.ts
+++ b/server/src/modules/personal-access-tokens/interceptors/pat-scope.interceptor.ts
@@ -38,9 +38,10 @@ export class PatScopeInterceptor implements NestInterceptor {
     }
 
     const module = this.reflector.get<MODULES>('tjModuleId', context.getClass());
-    if (!patCanAccess(module)) {
+    const feature = this.reflector.get<string>('tjFeatureId', context.getHandler());
+    if (!patCanAccess(module, feature)) {
       throw new ForbiddenException(
-        `This personal access token cannot access ${module ?? 'this resource'}. ` +
+        `This personal access token cannot access ${feature ?? module ?? 'this resource'}. ` +
           `Workspace tokens are limited to: ${PAT_ALLOWED_BUNDLES.join(', ')}.`
       );
     }

--- a/server/test/modules/personal-access-tokens/e2e/pat-session.spec.ts
+++ b/server/test/modules/personal-access-tokens/e2e/pat-session.spec.ts
@@ -207,6 +207,13 @@ describe('Personal access token session exchange', () => {
         .set('Cookie', `tj_auth_token=${body.authToken}`)
         .set('tj-workspace-id', orgId)
         .expect(200);
+
+      await request
+        .agent(app.getHttpServer())
+        .get('/api/organization-users')
+        .set('Cookie', `tj_auth_token=${body.authToken}`)
+        .set('tj-workspace-id', orgId)
+        .expect(200);
     });
 
     it('should be refused on a module outside the allowlist', async () => {
@@ -217,12 +224,19 @@ describe('Personal access token session exchange', () => {
       // which is the whole point of the allowlist.
       const res = await request
         .agent(app.getHttpServer())
-        .get('/api/organization-users')
+        .get('/api/v2/group-permissions')
         .set('Cookie', `tj_auth_token=${body.authToken}`)
         .set('tj-workspace-id', orgId)
         .expect(403);
 
       expect(res.body.message).toMatch(/personal access token cannot access/i);
+
+      await request
+        .agent(app.getHttpServer())
+        .post('/api/organization-users/random-id/archive-all')
+        .set('Cookie', `tj_auth_token=${body.authToken}`)
+        .set('tj-workspace-id', orgId)
+        .expect(403);
     });
 
     it('should not be able to mint another token', async () => {

--- a/server/test/modules/personal-access-tokens/e2e/pat-session.spec.ts
+++ b/server/test/modules/personal-access-tokens/e2e/pat-session.spec.ts
@@ -216,6 +216,38 @@ describe('Personal access token session exchange', () => {
         .expect(200);
     });
 
+    it('should ignore a body workspace override for archive and unarchive', async () => {
+      const outsider = await createUser(app, {
+        email: 'pat-scope-outsider@tooljet.io',
+        firstName: 'other',
+        lastName: 'user',
+      });
+      const { token } = await createPat('workspace-user-pinning');
+      const { body } = await exchange(token).expect(201);
+      const agent = request.agent(app.getHttpServer());
+
+      const archive = await agent
+        .post(`/api/organization-users/${outsider.orgUser.id}/archive`)
+        .set('Cookie', `tj_auth_token=${body.authToken}`)
+        .set('tj-workspace-id', orgId)
+        .send({ organizationId: outsider.organization.id });
+      expect(archive.status).toBeGreaterThanOrEqual(400);
+      await outsider.orgUser.reload();
+      expect(outsider.orgUser.status).toBe('active');
+
+      await getDefaultDataSource()
+        .getRepository(OrganizationUser)
+        .update({ id: outsider.orgUser.id }, { status: 'archived' });
+      const unarchive = await agent
+        .post(`/api/organization-users/${outsider.orgUser.id}/unarchive`)
+        .set('Cookie', `tj_auth_token=${body.authToken}`)
+        .set('tj-workspace-id', orgId)
+        .send({ organizationId: outsider.organization.id });
+      expect(unarchive.status).toBeGreaterThanOrEqual(400);
+      await outsider.orgUser.reload();
+      expect(outsider.orgUser.status).toBe('archived');
+    });
+
     it('should be refused on a module outside the allowlist', async () => {
       const { token } = await createPat('outside-allowlist');
       const { body } = await exchange(token).expect(201);

--- a/server/test/modules/personal-access-tokens/unit/pat-scopes.spec.ts
+++ b/server/test/modules/personal-access-tokens/unit/pat-scopes.spec.ts
@@ -8,6 +8,7 @@ import {
   patCanAccess,
 } from '@modules/personal-access-tokens/constants/scopes';
 import { PatScopeInterceptor } from '@modules/personal-access-tokens/interceptors/pat-scope.interceptor';
+import { FEATURE_KEY as ORGANIZATION_USER_FEATURE } from '@modules/organization-users/constants';
 
 /**
  * Tagged `security` because CI's unit step runs only --group=working|workflows|security, and
@@ -49,12 +50,21 @@ describe('PAT scope definition', () => {
     ]) {
       expect(patCanAccess(module)).toBe(true);
     }
+    for (const feature of [
+      ORGANIZATION_USER_FEATURE.VIEW_ALL_USERS,
+      ORGANIZATION_USER_FEATURE.USER_INVITE,
+      ORGANIZATION_USER_FEATURE.USER_UPDATE,
+      ORGANIZATION_USER_FEATURE.USER_ARCHIVE,
+      ORGANIZATION_USER_FEATURE.USER_UNARCHIVE,
+    ]) {
+      expect(patCanAccess(MODULES.ORGANIZATION_USER, feature)).toBe(true);
+    }
+    expect(patCanAccess(MODULES.ORGANIZATION_USER, ORGANIZATION_USER_FEATURE.USER_ARCHIVE_ALL)).toBe(false);
   });
 
   it('denies workspace and instance administration', () => {
     for (const module of [
       MODULES.ORGANIZATIONS,
-      MODULES.ORGANIZATION_USER,
       MODULES.GROUP_PERMISSIONS,
       MODULES.LOGIN_CONFIGS,
       MODULES.INSTANCE_SETTINGS,


### PR DESCRIPTION
## Summary

- Allow workspace PATs to access only the approved organization-user features: list, invite, update, archive, and unarchive.
- Keep ToolJet RBAC as the final permission check.
- Pin archive and unarchive operations to the workspace encoded in the PAT session.
- Keep all other organization-user and workspace-admin features denied by default.

## Testing

- Verified PAT session exchange against the local backend.
- Verified app listing and the full invite, list, update, archive, and unarchive lifecycle through a real workspace PAT.
- Independently confirmed the final archived state in PostgreSQL.

## Impact

- Speed: no additional network or model calls; only a constant-time feature allowlist check on PAT requests.
- Quality: enables the required user-management flow while preserving workspace isolation and existing role checks.
- Token usage: no LLM token impact in ToolJet.

Companion PRs will expose these endpoints through MCP and route supported requests through the agent.