### PR TITLE
fix: prevent infinite loading spinner for invalid workspace slug with no session

### DIFF
--- a/frontend/src/Routes/AuthRoute.jsx
+++ b/frontend/src/Routes/AuthRoute.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { RouteLoader } from './RouteLoader';
 import { useSessionManagement } from '@/_hooks/useSessionManagement';
 import { getPathname, getRedirectURL, isCustomDomain, redirectToMainHost } from '@/_helpers/routes';
+import { ERROR_TYPES } from '@/_helpers/constants';
 import { authenticationService, loginConfigsService, sessionService } from '@/_services';
 import { customDomainService } from '@/_services/custom-domain.service';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -100,7 +101,12 @@ export const AuthRoute = ({ children }) => {
         setGettingConfig(false);
       },
       async (response) => {
-        if (response.data.statusCode !== 404 && response.data.statusCode !== 422) {
+        // An archived workspace, looked up anonymously, should show the same
+        // invalid-link error as a nonexistent one (below, via LoginPage's own
+        // configs?.id check) instead of the generic "error while login" bounce.
+        const isArchivedWorkspace =
+          response.data.statusCode === 400 && response.data.message === ERROR_TYPES.WORKSPACE_ARCHIVED;
+        if (response.data.statusCode !== 404 && response.data.statusCode !== 422 && !isArchivedWorkspace) {
           return navigate({
             pathname: '/',
             state: { errorMessage: 'Error while login, please try again' },

--- a/frontend/src/Routes/AuthRoute.jsx
+++ b/frontend/src/Routes/AuthRoute.jsx
@@ -89,6 +89,12 @@ export const AuthRoute = ({ children }) => {
   const fetchOrganizationDetails = (resolvedSlug) => {
     loginConfigsService.getOrganizationConfigs(resolvedSlug || organizationSlug).then(
       (configs) => {
+        // Defensive guard: a malformed/empty success response should never leave the
+        // loading spinner stuck forever — fall through as if configs were unavailable.
+        if (!configs) {
+          setGettingConfig(false);
+          return;
+        }
         setOrganizationId(configs.id);
         setConfigs(configs);
         setGettingConfig(false);

--- a/frontend/src/_helpers/handle-response.js
+++ b/frontend/src/_helpers/handle-response.js
@@ -120,7 +120,14 @@ export function handleResponse(
           ReactDOM.render(modalEl, modalContainer);
         }
       } else if ([400].indexOf(response.status) !== -1) {
-        redirectToSwitchOrArchivedAppPage(data);
+        // Only hijack navigation for a signed-in visitor who landed on a workspace
+        // they no longer have access to. An anonymous lookup (e.g. AuthRoute checking
+        // an org slug before login) has no session to switch away from — let it reject
+        // normally so the caller's own error handling (e.g. the invalid-link page) runs.
+        const currentSession = authenticationService?.currentSessionValue;
+        if (currentSession?.authentication_status) {
+          redirectToSwitchOrArchivedAppPage(data);
+        }
       }
       const error = (data && data.message) || response.statusText;
       return Promise.reject({ error, data, statusCode: response?.status });

--- a/server/src/modules/login-configs/service.ts
+++ b/server/src/modules/login-configs/service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, HttpException, Injectable, NotFoundException } from '@nestjs/common';
 import { decamelizeKeys } from 'humps';
 import { ConfigService } from '@nestjs/config';
 import { LoginConfigsUtilService } from './util.service';
@@ -45,11 +45,19 @@ export class LoginConfigsService implements ILoginConfigsService {
         true,
         true
       );
+      if (!result) {
+        throw new NotFoundException('Organization not found');
+      }
       return this.loginConfigsUtilService.removeDisabledSsoConfigs(result);
     } catch (error) {
+      // Preserve any deliberate HTTP error (e.g. archived-workspace 400) thrown further down the stack.
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      // Any other failure (org not found, invalid slug/uuid, etc.) means the workspace doesn't exist.
       this.logger.error('Error fetching organization details', error);
+      throw new NotFoundException('Organization not found');
     }
-    return;
   }
 
   async getProcessedOrganizationConfigs(organizationId: string) {


### PR DESCRIPTION
server/ee : https://github.com/ToolJet/ee-server/pull/802

# Fix infinite loading spinner for invalid workspace URLs

## Issue

When a user without a valid session opens a workspace URL with an invalid slug/UUID, such as:

```text
https://app.tooljet.ai/<invalid-slug-or-uuid>
```

the application gets stuck on an infinite loading spinner instead of displaying the invalid-link error page.

## Root Cause

The issue was caused by an interaction between the backend login-config endpoint and the frontend auth flow.

### Backend

`GET /api/login-configs/:organizationId/public` did not return a `404` when the workspace did not exist or when the supplied workspace identifier was malformed.

`getProcessedOrganizationDetails` in:

* `server/src/modules/login-configs/service.ts`
* `server/ee/login-configs/service.ts`

wrapped the organization lookup in a `try/catch` that logged and silently swallowed lookup errors.

As a result, the controller returned `200 OK` with an effectively empty response:

```json
{
  "sso_configs": {}
}
```

This also occurred for malformed UUIDs, where the database lookup could otherwise throw a `QueryFailedError`.

### Frontend

`AuthRoute.jsx` assumed that a successful response always contained organization details and accessed:

```js
configs.id
```

without checking whether `configs` was defined. There was also no `.catch()` to handle the resulting error.

When the backend returned `200` with an empty response:

1. The success callback executed.
2. `configs` was `undefined`.
3. Accessing `configs.id` threw an uncaught `TypeError`.
4. Execution stopped before `setGettingConfig(false)` was called.
5. The loading state therefore remained `true`.
6. `RouteLoader` continued rendering `<TJLoader />` indefinitely.

## How to Reproduce Before the Fix

1. Clear the current session:

   * Open an incognito window, or
   * Delete the `tj_auth_token` cookie.
2. Navigate to a workspace URL containing an invalid slug:

   ```text
   https://app.tooljet.ai/<invalid-slug>
   ```

   Use the bare workspace URL format without `/applications/`.
3. Expected: an invalid-link/error page.
4. Actual: infinite `TJLoader` spinner.

### DevTools confirmation

**Network:**

```text
GET /api/login-configs/<invalid-slug>/public
→ 200 OK

{"sso_configs":{}}
```

**Console:**

```text
Uncaught TypeError:
Cannot read properties of undefined (reading 'id')
```

from `AuthRoute.jsx`.

The same issue can be reproduced locally at:

```text
http://localhost:8082/<invalid-slug>
```

with the backend running on port `3000`.

## Fix

### Backend

Updated `getProcessedOrganizationDetails` in both CE and EE implementations:

* `server/src/modules/login-configs/service.ts`
* `server/ee/login-configs/service.ts`

The organization lookup now:

* Throws `NotFoundException('Organization not found')` when the organization does not exist.
* Converts lookup failures, including malformed UUID cases, into the same `404` response instead of leaking a raw database error.
* Rethrows deliberate `HttpException` instances from downstream logic unchanged.

The last point preserves existing behavior for cases such as archived workspaces, which should continue returning their existing `400` response.

### Frontend

Updated:

```text
frontend/src/Routes/AuthRoute.jsx
```

with a defensive guard in the success branch.

If `configs` is unexpectedly falsy, the loading state is cleared instead of attempting to access `configs.id`.

This is a defensive safety net. The primary fix is the backend now correctly rejecting invalid workspace identifiers, which sends the request through the existing failure handling that redirects to the invalid-link page and clears the loading state.

## API / Schema Impact

* No schema changes.
* No migrations.
* No new endpoints.
* No API contract change for valid, well-formed requests.
* Invalid/nonexistent workspace identifiers now correctly return `404`.

## How to Test

### 1. Start the application locally

Backend:

```bash
cd server
npm run start:dev
```

Frontend:

```bash
cd frontend
npm start
```

Frontend runs on `8082` and backend on `3000`.

### 2. Invalid workspace slug

Clear cookies/localStorage for `localhost` and visit:

```text
http://localhost:8082/does-not-exist-xyz123
```

Expected:

* Redirects to `/error/invalid-link`.
* "Invalid link" card is displayed.
* No infinite loading spinner.
* No uncaught `TypeError`.

Verify the API request:

```text
GET /api/login-configs/does-not-exist-xyz123/public
→ 404

{
  "statusCode": 404,
  "message": "Organization not found"
}
```

### 3. Invalid UUID

Visit:

```text
http://localhost:8082/11111111-1111-1111-1111-111111111111
```

Expected:

* `404 Organization not found`.
* Redirects to `/error/invalid-link`.
* No infinite spinner.
* No raw Postgres/`QueryFailedError` exposed to the client.

### 4. Regression — normal instance-level login

Visit:

```text
http://localhost:8082/
```

Expected:

* `GET /api/login-configs/public` returns `200`.
* Normal "Sign in" form renders successfully.

### 5. Regression — archived workspace

If an archived workspace is available in the test environment, verify that it still returns:

```text
400 Organization is Archived
```

rather than being converted into a generic `404`.

## Summary

This change fixes the infinite loading state for invalid workspace URLs by ensuring nonexistent/malformed workspace identifiers are rejected by the backend and by adding a defensive loading-state guard in the frontend.

Valid login flows and existing archived-workspace behavior remain unchanged.
