### PR TITLE
Hide unavailable inline AI actions

### DIFF
--- a/frontend/src/AppBuilder/CodeEditor/PreviewBox.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/PreviewBox.jsx
@@ -19,6 +19,7 @@ import { useModuleContext } from '@/AppBuilder/_contexts/ModuleContext';
 import cx from 'classnames';
 import { findDefault } from '../_utils/component-properties-validation';
 import FixWithAi from './FixWithAi';
+import { INLINE_AI_FEATURES_ENABLED } from '@/_helpers/constants';
 
 const sanitizeLargeDataset = (data, callback) => {
   const SIZE_LIMIT_KB = 5 * 1024; // 5 KB in bytes
@@ -509,7 +510,7 @@ const PreviewContainer = ({
                   <div className="">{errorMsg !== 'null' ? errorMsg : 'Invalid'}</div>
                 </div>
 
-                {aiFeaturesEnabled && (
+                {aiFeaturesEnabled && INLINE_AI_FEATURES_ENABLED && (
                   <ToolTip
                     placement="left"
                     message={<FixIssueTooltipContent />}

--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerHeader.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerHeader.jsx
@@ -3,7 +3,7 @@ import RenameIcon from '../Icons/RenameIcon';
 import cx from 'classnames';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { DATA_SOURCE_TYPE } from '@/_helpers/constants';
+import { DATA_SOURCE_TYPE, INLINE_AI_FEATURES_ENABLED } from '@/_helpers/constants';
 import {
   ABORT_UNSUPPORTED_KINDS,
   AI_QUERY_SUPPORTED_KINDS,
@@ -155,7 +155,7 @@ export const QueryManagerHeader = forwardRef(({ darkMode, setActiveTab, activeTa
       <div className="query-header-buttons">
         {!(selectedQuery === null || showCreateQuery) && (
           <>
-            <GenerateQueryButton iconOnly={iconOnly} />
+            {INLINE_AI_FEATURES_ENABLED && <GenerateQueryButton iconOnly={iconOnly} />}
             <AbortButton />
             <RunButton buttonLoadingState={buttonLoadingState} iconOnly={iconOnly} />
             <PreviewButton

--- a/frontend/src/AppBuilder/QueryManager/Components/Transformation.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/Transformation.jsx
@@ -13,6 +13,7 @@ import AITripleSparkles from '@/_ui/Icon/solidIcons/AITripleSparkles';
 import { Button as ButtonComponent } from '@/components/ui/Button/Button';
 import { useWriteQueryEntry } from '@/AppBuilder/QueryManager/_hooks/useWriteQueryEntry';
 import { AI_QUERY_SUPPORTED_KINDS } from '@/AppBuilder/QueryManager/constants';
+import { INLINE_AI_FEATURES_ENABLED } from '@/_helpers/constants';
 
 const defaultValue = {
   javascript: `// write your code here
@@ -200,7 +201,7 @@ export const Transformation = ({ changeOption, options, darkMode, queryId, rende
                 {t('editor.queryManager.transformation.enableTransformation', 'Enable transformation')}
               </span>
             </OverlayTrigger>
-            <WriteTransformationButton />
+            {INLINE_AI_FEATURES_ENABLED && <WriteTransformationButton />}
           </div>
 
           <p className="tw-text-text-placeholder tw-mb-0" data-cy="transformation-info">

--- a/frontend/src/AppBuilder/QueryPanel/QueryDataPane.jsx
+++ b/frontend/src/AppBuilder/QueryPanel/QueryDataPane.jsx
@@ -21,6 +21,7 @@ import AppPermissionsModal from '@/modules/Appbuilder/components/AppPermissionsM
 import { shallow } from 'zustand/shallow';
 import { appPermissionService } from '@/_services';
 import AITripleSparkles from '@/_ui/Icon/solidIcons/AITripleSparkles';
+import { INLINE_AI_FEATURES_ENABLED } from '@/_helpers/constants';
 import QueryCardMenuBase from './QueryCardMenu';
 import { withEditionSpecificComponent } from '@/modules/common/helpers';
 
@@ -115,7 +116,7 @@ export const QueryDataPane = ({ darkMode }) => {
         <div className="queries-header">
           <AddDataSourceButton darkMode={darkMode} />
           <div className="queries-header-actions">
-            <AutoSortButton darkMode={darkMode} />
+            {INLINE_AI_FEATURES_ENABLED && <AutoSortButton darkMode={darkMode} />}
             <FilterandSortPopup
               onFilterDatasourcesChange={handleFilterDatasourcesChange}
               selectedDataSources={dataSourcesForFilters}

--- a/frontend/src/_helpers/constants.js
+++ b/frontend/src/_helpers/constants.js
@@ -18,6 +18,9 @@ export const USER_COLORS = [
 
 export const ON_BOARDING_SIZE = ['1-10', '11-50', '51-100', '101-500', '501-1000', '1000+'];
 
+// Temporarily hide inline AI actions that are not served by the standalone MCP agent.
+export const INLINE_AI_FEATURES_ENABLED = false;
+
 export const ON_BOARDING_ROLES = [
   'Head of engineering',
   'Head of product',


### PR DESCRIPTION
Temporarily hides these frontend actions while they are unavailable in the standalone MCP agent:

- Auto-sort queries
- Write Query / Write Custom Code
- Write Transformation
- Generate Code
- Fix Bug / Auto-fix

The main AI chat remains available, and the underlying implementations are preserved behind a single frontend flag.

Companion ee-frontend PR: https://github.com/ToolJet/ee-frontend/pull/618