### PR TITLE
Fix: Widget inspector consistency and minor component fixes

### DIFF
--- a/frontend/src/AppBuilder/LeftSidebar/LeftSidebar.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/LeftSidebar.jsx
@@ -272,7 +272,8 @@ export const BaseLeftSidebar = ({
       <Popover
         onInteractOutside={(e) => {
           // if tooljetai is open don't close
-          if (['tooljetai', 'inspect', 'debugger', 'settings', 'libraries'].includes(selectedSidebarItem)) return;
+          if (['tooljetai', 'inspect', 'debugger', 'settings', 'libraries', 'apphistory'].includes(selectedSidebarItem))
+            return;
           const isWithinSidebar = e.target.closest('.left-sidebar');
           const isClickOnInspect = e.target.closest('.config-handle-inspect');
           if (pinned || isWithinSidebar || isClickOnInspect) return;

--- a/frontend/src/AppBuilder/WidgetManager/widgets/__tests__/widgetConfigOrdering.spec.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/__tests__/widgetConfigOrdering.spec.js
@@ -1,0 +1,48 @@
+/**
+ * Layer 1 unit tests — pure config object assertions. No store, no DOM.
+ *
+ * Validates that widget config key ordering is consistent across widgets:
+ *   - `mandatory` is the FIRST key in the `validation` block
+ *   - `tooltipFormat` and `tooltip` are the LAST keys in the
+ *     `additionalActions` section of `properties`
+ *
+ * These are the key-order invariants the inspector relies on (it iterates
+ * `Object.keys()` over the config), so a reorder in a config file silently
+ * breaks the UI. Catching it here is cheaper than a Cypress test.
+ */
+import { datePickerV2Config } from '../datepickerV2';
+import { timePickerConfig } from '../timepicker';
+import { datetimePickerV2Config } from '../datetimepickerV2';
+import { circularProgressbarConfig } from '../circularProgressbar';
+import { progressbarConfig } from '../progressbar';
+
+/** Returns only the property keys whose config has `section: 'additionalActions'`. */
+function additionalActionKeys(config) {
+  return Object.entries(config.properties)
+    .filter(([, v]) => v.section === 'additionalActions')
+    .map(([k]) => k);
+}
+
+describe('widget config ordering', () => {
+  describe('mandatory is the first validation key', () => {
+    test.each([
+      ['DatePickerV2', datePickerV2Config],
+      ['TimePicker', timePickerConfig],
+      ['DateTimePickerV2', datetimePickerV2Config],
+    ])('%s has mandatory as the first validation key', (_name, config) => {
+      const keys = Object.keys(config.validation);
+      expect(keys[0]).toBe('mandatory');
+    });
+  });
+
+  describe('tooltip fields are the last additionalActions entries', () => {
+    test.each([
+      ['CircularProgressbar', circularProgressbarConfig],
+      ['Progressbar', progressbarConfig],
+    ])('%s has tooltipFormat and tooltip as the last two additionalActions keys', (_name, config) => {
+      const keys = additionalActionKeys(config);
+      expect(keys.at(-2)).toBe('tooltipFormat');
+      expect(keys.at(-1)).toBe('tooltip');
+    });
+  });
+});

--- a/frontend/src/AppBuilder/WidgetManager/widgets/circularProgressbar.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/circularProgressbar.js
@@ -52,30 +52,6 @@ export const circularProgressbarConfig = {
       },
       accordian: 'Data',
     },
-    // Renders first in the Additional Actions section. Its displayName is the
-    // visible "Tooltip" label for the whole pair; the `tooltip` code field below
-    // hides its own label via showLabel:false so we don't get a duplicate.
-    tooltipFormat: {
-      type: 'switch',
-      displayName: 'Tooltip',
-      options: [
-        { displayName: 'Plain text', value: 'plainText' },
-        { displayName: 'Markdown', value: 'markdown' },
-        { displayName: 'HTML', value: 'html' },
-      ],
-      isFxNotRequired: true,
-      defaultValue: { value: 'plainText' },
-      fullWidth: true,
-      newLine: true, // render the switch on its own line below the "Tooltip" label
-      section: 'additionalActions',
-    },
-    tooltip: {
-      type: 'code',
-      displayName: 'Tooltip',
-      validation: { schema: { type: 'string' } },
-      section: 'additionalActions',
-      showLabel: false,
-    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -87,6 +63,27 @@ export const circularProgressbarConfig = {
       displayName: 'Visibility',
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
+    },
+    tooltipFormat: {
+      type: 'switch',
+      displayName: 'Tooltip',
+      options: [
+        { displayName: 'Plain text', value: 'plainText' },
+        { displayName: 'Markdown', value: 'markdown' },
+        { displayName: 'HTML', value: 'html' },
+      ],
+      isFxNotRequired: true,
+      defaultValue: { value: 'plainText' },
+      fullWidth: true,
+      newLine: true,
+      section: 'additionalActions',
+    },
+    tooltip: {
+      type: 'code',
+      displayName: 'Tooltip',
+      validation: { schema: { type: 'string' } },
+      section: 'additionalActions',
+      showLabel: false,
     },
   },
   events: {},

--- a/frontend/src/AppBuilder/WidgetManager/widgets/datepickerV2.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/datepickerV2.js
@@ -8,6 +8,10 @@ export const datePickerV2Config = {
     height: 40,
   },
   validation: {
+    mandatory: {
+      type: 'toggle',
+      displayName: 'Make this field mandatory',
+    },
     minDate: {
       type: 'code',
       placeholder: 'DD/MM/YYYY',
@@ -32,10 +36,6 @@ export const datePickerV2Config = {
     customRule: {
       type: 'code',
       displayName: 'Custom validation',
-    },
-    mandatory: {
-      type: 'toggle',
-      displayName: 'Make this field mandatory',
     },
   },
   others: {

--- a/frontend/src/AppBuilder/WidgetManager/widgets/datetimepickerV2.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/datetimepickerV2.js
@@ -9,6 +9,10 @@ export const datetimePickerV2Config = {
     height: 40,
   },
   validation: {
+    mandatory: {
+      type: 'toggle',
+      displayName: 'Make this field mandatory',
+    },
     minDate: {
       type: 'code',
       placeholder: 'DD/MM/YYYY',
@@ -45,10 +49,6 @@ export const datetimePickerV2Config = {
     customRule: {
       type: 'code',
       displayName: 'Custom validation',
-    },
-    mandatory: {
-      type: 'toggle',
-      displayName: 'Make this field mandatory',
     },
   },
   others: {

--- a/frontend/src/AppBuilder/WidgetManager/widgets/divider.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/divider.js
@@ -99,6 +99,12 @@ export const dividerConfig = {
       },
       accordian: 'Divider',
     },
+    labelFontSize: {
+      type: 'numberInput',
+      displayName: 'Label size',
+      validation: { schema: { type: 'number' }, defaultValue: 12 },
+      accordian: 'Divider',
+    },
     textWrap: {
       type: 'switch',
       displayName: 'Text wrap',
@@ -155,6 +161,7 @@ export const dividerConfig = {
       labelAlignment: { value: 'center' },
       dividerStyle: { value: 'solid' },
       labelColor: { value: 'var(--cc-placeholder-text)' },
+      labelFontSize: { value: '{{12}}' },
       textWrap: { value: 'wrap' },
       padding: { value: 'default' },
       boxShadow: { value: '0px 0px 0px 0px #00000040' },

--- a/frontend/src/AppBuilder/WidgetManager/widgets/progressbar.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/progressbar.js
@@ -46,30 +46,6 @@ export const progressbarConfig = {
       },
       accordian: 'Data',
     },
-    // Renders first in the Additional Actions section. Its displayName is the
-    // visible "Tooltip" label for the whole pair; the `tooltip` code field below
-    // hides its own label via showLabel:false so we don't get a duplicate.
-    tooltipFormat: {
-      type: 'switch',
-      displayName: 'Tooltip',
-      options: [
-        { displayName: 'Plain text', value: 'plainText' },
-        { displayName: 'Markdown', value: 'markdown' },
-        { displayName: 'HTML', value: 'html' },
-      ],
-      isFxNotRequired: true,
-      defaultValue: { value: 'plainText' },
-      fullWidth: true,
-      newLine: true, // render the switch on its own line below the "Tooltip" label
-      section: 'additionalActions',
-    },
-    tooltip: {
-      type: 'code',
-      displayName: 'Tooltip',
-      validation: { schema: { type: 'string' } },
-      section: 'additionalActions',
-      showLabel: false,
-    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -81,6 +57,27 @@ export const progressbarConfig = {
       displayName: 'Visibility',
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
+    },
+    tooltipFormat: {
+      type: 'switch',
+      displayName: 'Tooltip',
+      options: [
+        { displayName: 'Plain text', value: 'plainText' },
+        { displayName: 'Markdown', value: 'markdown' },
+        { displayName: 'HTML', value: 'html' },
+      ],
+      isFxNotRequired: true,
+      defaultValue: { value: 'plainText' },
+      fullWidth: true,
+      newLine: true,
+      section: 'additionalActions',
+    },
+    tooltip: {
+      type: 'code',
+      displayName: 'Tooltip',
+      validation: { schema: { type: 'string' } },
+      section: 'additionalActions',
+      showLabel: false,
     },
   },
   events: {},

--- a/frontend/src/AppBuilder/WidgetManager/widgets/timepicker.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/timepicker.js
@@ -8,6 +8,10 @@ export const timePickerConfig = {
     height: 40,
   },
   validation: {
+    mandatory: {
+      type: 'toggle',
+      displayName: 'Make this field mandatory',
+    },
     minTime: {
       type: 'code',
       placeholder: 'HH:mm',
@@ -23,10 +27,6 @@ export const timePickerConfig = {
     customRule: {
       type: 'code',
       displayName: 'Custom validation',
-    },
-    mandatory: {
-      type: 'toggle',
-      displayName: 'Make this field mandatory',
     },
   },
   others: {

--- a/frontend/src/AppBuilder/WidgetManager/widgets/timer.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/timer.js
@@ -32,6 +32,14 @@ export const timerConfig = {
         defaultValue: 'countUp',
       },
     },
+    format: {
+      type: 'code',
+      displayName: 'Time format',
+      validation: {
+        schema: { type: 'string' },
+        defaultValue: 'hh:mm:ss:SSS',
+      },
+    },
     collapseWhenHidden: {
       type: 'toggle',
       displayName: 'Collapse when hidden',
@@ -80,6 +88,9 @@ export const timerConfig = {
       },
       type: {
         value: 'countUp',
+      },
+      format: {
+        value: 'hh:mm:ss:SSS',
       },
       collapseWhenHidden: { value: '{{false}}' },
     },

--- a/frontend/src/AppBuilder/Widgets/Divider.jsx
+++ b/frontend/src/AppBuilder/Widgets/Divider.jsx
@@ -5,7 +5,8 @@ const DASH_WIDTH = 4;
 const DASH_GAP = 4;
 
 export const Divider = function Divider({ dataCy, height, width, darkMode, styles, properties }) {
-  const { labelAlignment, labelColor, dividerColor, boxShadow, dividerStyle, padding, textWrap } = styles;
+  const { labelAlignment, labelColor, labelFontSize, dividerColor, boxShadow, dividerStyle, padding, textWrap } =
+    styles;
   const { label, visibility } = properties;
   const color =
     dividerColor === '' || ['#000', '#000000'].includes(dividerColor) ? (darkMode ? '#fff' : '#000') : dividerColor;
@@ -37,7 +38,7 @@ export const Divider = function Divider({ dataCy, height, width, darkMode, style
   const labelStyles = {
     color: labelColor,
     boxShadow,
-    fontSize: '11px',
+    fontSize: `${labelFontSize ?? 12}px`,
     fontWeight: '500',
     lineHeight: '16px',
     ...(shouldWrap

--- a/frontend/src/AppBuilder/Widgets/PasswordInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/PasswordInput.jsx
@@ -10,7 +10,7 @@ export const PasswordInput = (props) => {
     inputLogic.setIconVisibility(!inputLogic.iconVisibility);
   };
 
-  const TogglePasswordVisibilityIcon = !inputLogic.iconVisibility ? IconEye : IconEyeClosed;
+  const TogglePasswordVisibilityIcon = inputLogic.iconVisibility ? IconEye : IconEyeClosed;
 
   const passwordIcon = (
     <div onClick={toggleVisibility} data-cy={`password-visibility-icon`}>

--- a/frontend/src/AppBuilder/Widgets/Statistics.jsx
+++ b/frontend/src/AppBuilder/Widgets/Statistics.jsx
@@ -254,6 +254,7 @@ export const Statistics = function Statistics({
               size={(primaryValueSize ?? 34) * 1.3}
               stroke={1.5}
               color={iconColor}
+              style={{ color: iconColor }}
             />
           )}
 

--- a/frontend/src/AppBuilder/Widgets/Timer.jsx
+++ b/frontend/src/AppBuilder/Widgets/Timer.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { formatTimerValue } from './utils';
 
 export const Timer = function Timer({ height, properties = {}, styles, setExposedVariable, fireEvent, dataCy }) {
   const getTimeObj = ({ HH, MM, SS, MS }) => {
@@ -129,17 +130,6 @@ export const Timer = function Timer({ height, properties = {}, styles, setExpose
     onStart(true);
   };
 
-  const prependZero = (value, count = 1) => {
-    if (!value) {
-      return count === 2 ? '000' : '00';
-    }
-    if (count === 2) {
-      return `${value.toString().length === 1 ? `00${value}` : value.toString().length === 2 ? `0${value}` : value}`;
-    } else {
-      return `${value.toString().length === 1 ? `0${value}` : value}`;
-    }
-  };
-
   const isCountDownFinished = () => {
     return time.hour === 0 && time.minute === 0 && time.second === 0 && time.mSecond === 0;
   };
@@ -160,12 +150,7 @@ export const Timer = function Timer({ height, properties = {}, styles, setExpose
       data-cy={dataCy}
     >
       <div className="timer-wrapper">
-        <div className="counter-container">
-          {`${prependZero(time.hour)}:${prependZero(time.minute)}:${prependZero(time.second)}:${prependZero(
-            time.mSecond,
-            2
-          )}`}
-        </div>
+        <div className="counter-container">{formatTimerValue(time, properties.format)}</div>
         <div className="btn-list justify-content-end">
           {state === 'initial' && (
             <a

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/divider.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/divider.spec.jsx
@@ -149,6 +149,25 @@ describe('Divider widget', () => {
       const label = await screen.findByText('A very long section heading');
       expect(label).toHaveStyle({ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' });
     });
+
+    test('applies the labelFontSize style to the label text', async () => {
+      divider.render({
+        properties: { label: binding('Sized') },
+        styles: { labelFontSize: binding('{{20}}') },
+      });
+
+      const label = await screen.findByText('Sized');
+      expect(label).toHaveStyle({ fontSize: '20px' });
+    });
+
+    test('defaults the label font size to 12px when labelFontSize is not set', async () => {
+      divider.render({
+        properties: { label: binding('Default') },
+      });
+
+      const label = await screen.findByText('Default');
+      expect(label).toHaveStyle({ fontSize: '12px' });
+    });
   });
 
   describe('visibility', () => {

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/passwordInput.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/passwordInput.spec.jsx
@@ -1,0 +1,103 @@
+/**
+ * PasswordInput — behaviour spec against the real store. Nothing about the
+ * widget is mocked. Shared setup lives in ./widgetHarness.js.
+ *
+ * Scope covers the password-specific behaviour that PasswordInput.jsx adds on
+ * top of BaseInput: the eye-icon visibility toggle that switches the input
+ * between `type="password"` (hidden) and `type="text"` (visible), and the icon
+ * state that tracks it.
+ *
+ * The fix under test: the eye icon must reflect the CURRENT state of the
+ * password — `IconEyeClosed` when hidden, `IconEye` when visible — not the
+ * action that clicking will perform.
+ */
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { createWidgetHarness, binding } from './widgetHarness';
+
+const widget = createWidgetHarness({
+  componentType: 'PasswordInput',
+  handle: 'passwordinput1',
+  id: 'pw1',
+  defaultProperties: {
+    label: binding('Password'),
+    placeholder: binding('Enter password'),
+    value: binding(''),
+    visibility: binding('{{true}}'),
+    disabledState: binding('{{false}}'),
+    loadingState: binding('{{false}}'),
+  },
+  defaultStyles: {
+    alignment: binding('side'),
+    direction: binding('left'),
+    auto: binding('{{true}}'),
+    width: binding('{{33}}'),
+    widthType: binding('ofComponent'),
+    labelFontSize: binding('{{12}}'),
+    borderRadius: binding('{{6}}'),
+    icon: binding('IconLock'),
+    iconVisibility: binding('{{true}}'),
+  },
+});
+
+/** The password <input> element. */
+const input = (container) => container.querySelector('input');
+/** The eye-icon toggle button. */
+const toggle = (container) => container.querySelector('[data-cy="password-visibility-icon"]');
+
+describe('PasswordInput', () => {
+  beforeEach(widget.setup);
+  afterEach(widget.teardown);
+
+  describe('eye icon visibility toggle', () => {
+    test('the input starts as type="password" (hidden)', async () => {
+      const { container } = widget.render();
+
+      await waitFor(() => expect(input(container)).toBeInTheDocument());
+      expect(input(container)).toHaveAttribute('type', 'password');
+    });
+
+    test('clicking the eye icon switches the input to type="text" (visible)', async () => {
+      const { container } = widget.render();
+
+      await waitFor(() => expect(toggle(container)).toBeInTheDocument());
+      fireEvent.click(toggle(container));
+
+      await waitFor(() => expect(input(container)).toHaveAttribute('type', 'text'));
+    });
+
+    test('clicking the eye icon a second time switches back to type="password"', async () => {
+      const { container } = widget.render();
+
+      await waitFor(() => expect(toggle(container)).toBeInTheDocument());
+      // First click: password → text
+      fireEvent.click(toggle(container));
+      await waitFor(() => expect(input(container)).toHaveAttribute('type', 'text'));
+
+      // Second click: text → password
+      fireEvent.click(toggle(container));
+      await waitFor(() => expect(input(container)).toHaveAttribute('type', 'password'));
+    });
+
+    test('the icon is IconEyeClosed when the password is hidden (default state)', async () => {
+      const { container } = widget.render();
+
+      await waitFor(() => expect(toggle(container)).toBeInTheDocument());
+      // Tabler icons add a class `tabler-icon-eye-closed` for IconEyeClosed
+      const svg = toggle(container).querySelector('svg');
+      await waitFor(() => expect(svg).toBeInTheDocument());
+      expect(svg).toHaveClass('tabler-icon-eye-closed');
+    });
+
+    test('the icon switches to IconEye when the password is revealed', async () => {
+      const { container } = widget.render();
+
+      await waitFor(() => expect(toggle(container)).toBeInTheDocument());
+      fireEvent.click(toggle(container));
+
+      // After toggle, the icon should be the open eye
+      const svg = toggle(container).querySelector('svg');
+      await waitFor(() => expect(svg).toHaveClass('tabler-icon-eye'));
+      expect(svg).not.toHaveClass('tabler-icon-eye-closed');
+    });
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/statistics.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/statistics.spec.jsx
@@ -135,6 +135,22 @@ describe('Statistics widget', () => {
       // absence is `Boolean(iconVisibility)` and not just a pending dynamic import.
       expect(statRoot(container).querySelector(':scope > svg, :scope > span')).not.toBeInTheDocument();
     });
+
+    test('the icon SVG carries an inline color style so filled icons pick up iconColor via currentColor', async () => {
+      // @tabler/icons-react v2.x maps the `color` prop to SVG `stroke`, not CSS
+      // `color`. Filled icons use `fill="currentColor"` on their paths, so CSS
+      // `color` must also be set for them to obey iconColor.
+      const { container } = widget.render({
+        properties: { icon: binding('IconDatabaseDollar') },
+        styles: { iconVisibility: binding('{{true}}'), iconColor: binding('#e74c3c') },
+      });
+
+      await waitFor(() => expect(statRoot(container).querySelector(':scope > svg')).toBeInTheDocument(), {
+        timeout: 30000,
+      });
+      const svg = statRoot(container).querySelector(':scope > svg');
+      expect(svg).toHaveStyle({ color: '#e74c3c' });
+    });
   });
 
   describe('formatting numeric values that come back from a query', () => {

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/timer.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/timer.spec.jsx
@@ -1,0 +1,70 @@
+/**
+ * Behaviour spec for the real Timer widget (AppBuilder/Widgets/Timer.jsx),
+ * rendered through the real RenderWidget against the real composed store.
+ * Nothing about the widget is mocked. Shared setup lives in ./widgetHarness.js.
+ *
+ * Scope here is the `format` property (WidgetManager/widgets/timer.js): the
+ * displayed value honours the configured time format, defaults to
+ * hh:mm:ss:SSS, and an empty format falls back to that same default. The
+ * millisecond-accurate tick loop and the Start/Pause/Reset events are owned by
+ * the Cypress suite (see src/test/README.md "What NOT to unit test"); the pure
+ * token replacement is proven in isolation by
+ * ../utils.formatTimerValue.spec.js. What this spec adds is that the format
+ * reaches the DOM through the real resolver, from a `{{ }}` binding travelling
+ * the live dependency graph — the thing a mocked store cannot express.
+ *
+ * The widget sits at state `initial` on mount (no interval is started), so the
+ * rendered counter is a stable projection of `properties.value` through
+ * `properties.format` — exactly what these assertions read.
+ */
+import { screen } from '@testing-library/react';
+import { createWidgetHarness, binding } from './widgetHarness';
+
+const TIMER = 'timer';
+
+const widget = createWidgetHarness({
+  componentType: 'Timer',
+  handle: 'timer1',
+  id: TIMER,
+  defaultProperties: {
+    value: binding('01:02:03:456'),
+    type: binding('countUp'),
+    format: binding('hh:mm:ss:SSS'),
+  },
+  defaultStyles: {
+    visibility: binding('{{true}}'),
+    disabledState: binding('{{false}}'),
+  },
+  widgetHeight: 128,
+  widgetWidth: 300,
+});
+
+describe('Timer widget', () => {
+  beforeEach(widget.setup);
+  afterEach(widget.teardown);
+
+  test('renders the default value using the full hh:mm:ss:SSS format', async () => {
+    widget.render();
+
+    expect(await screen.findByText('01:02:03:456')).toBeInTheDocument();
+  });
+
+  test('hides milliseconds when the format omits SSS', async () => {
+    widget.render({ properties: { format: binding('hh:mm:ss') } });
+
+    expect(await screen.findByText('01:02:03')).toBeInTheDocument();
+    expect(screen.queryByText('01:02:03:456')).not.toBeInTheDocument();
+  });
+
+  test('renders only minutes and seconds with a mm:ss format', async () => {
+    widget.render({ properties: { format: binding('mm:ss') } });
+
+    expect(await screen.findByText('02:03')).toBeInTheDocument();
+  });
+
+  test('falls back to hh:mm:ss:SSS when the format is blank', async () => {
+    widget.render({ properties: { format: binding('') } });
+
+    expect(await screen.findByText('01:02:03:456')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/__tests__/utils.formatTimerValue.spec.js
+++ b/frontend/src/AppBuilder/Widgets/__tests__/utils.formatTimerValue.spec.js
@@ -1,0 +1,78 @@
+/**
+ * Unit spec for the pure timer formatting helpers in AppBuilder/Widgets/utils.js.
+ *
+ * `formatTimerValue`/`padTimeUnit` are pure token replacers — no store, no DOM,
+ * zero mocks — so this is a Layer 1 spec (see src/test/README.md "Where a test
+ * goes"). It does NOT import the composed store, which is what keeps it a unit
+ * spec rather than an integration one.
+ */
+import { formatTimerValue, padTimeUnit, DEFAULT_TIMER_FORMAT } from '../utils';
+
+const time = { hour: 1, minute: 2, second: 3, mSecond: 45 };
+
+describe('padTimeUnit', () => {
+  test('pads to two digits by default', () => {
+    expect(padTimeUnit(3)).toBe('03');
+  });
+
+  test('pads to three digits when asked, for milliseconds', () => {
+    expect(padTimeUnit(45, 3)).toBe('045');
+  });
+
+  test('treats 0 as a zero-padded value, not a blank', () => {
+    expect(padTimeUnit(0)).toBe('00');
+    expect(padTimeUnit(0, 3)).toBe('000');
+  });
+
+  test('coerces non-numeric input to zero', () => {
+    expect(padTimeUnit(undefined)).toBe('00');
+    expect(padTimeUnit(NaN, 3)).toBe('000');
+  });
+
+  test('leaves an already-wide value untouched', () => {
+    expect(padTimeUnit(123, 3)).toBe('123');
+  });
+});
+
+describe('formatTimerValue', () => {
+  test('renders the full default format hh:mm:ss:SSS', () => {
+    expect(formatTimerValue(time)).toBe('01:02:03:045');
+  });
+
+  test('hides milliseconds when the format omits SSS', () => {
+    expect(formatTimerValue(time, 'hh:mm:ss')).toBe('01:02:03');
+  });
+
+  test('renders only minutes and seconds with mm:ss', () => {
+    expect(formatTimerValue(time, 'mm:ss')).toBe('02:03');
+  });
+
+  test('renders only hours and minutes with hh:mm', () => {
+    expect(formatTimerValue(time, 'hh:mm')).toBe('01:02');
+  });
+
+  test('matches SSS before SS, so milliseconds never collide with seconds', () => {
+    expect(formatTimerValue({ hour: 0, minute: 0, second: 7, mSecond: 8 }, 'ss:SSS')).toBe('07:008');
+  });
+
+  test('supports the uppercase HH/MM tokens too', () => {
+    expect(formatTimerValue(time, 'HH:MM')).toBe('01:02');
+  });
+
+  test('falls back to the default format when given a blank or missing format', () => {
+    expect(formatTimerValue(time, '')).toBe('01:02:03:045');
+    expect(formatTimerValue(time, undefined)).toBe('01:02:03:045');
+  });
+
+  test('preserves separators and literal characters between tokens', () => {
+    expect(formatTimerValue(time, 'hh-mm')).toBe('01-02');
+  });
+
+  test('defaults every unit to zero when the time object is empty', () => {
+    expect(formatTimerValue({})).toBe('00:00:00:000');
+  });
+
+  test('DEFAULT_TIMER_FORMAT is hh:mm:ss:SSS', () => {
+    expect(DEFAULT_TIMER_FORMAT).toBe('hh:mm:ss:SSS');
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/utils.js
+++ b/frontend/src/AppBuilder/Widgets/utils.js
@@ -59,6 +59,34 @@ export function getSafeRenderableValue(value) {
       })();
 }
 
+export const DEFAULT_TIMER_FORMAT = 'hh:mm:ss:SSS';
+
+export function padTimeUnit(value, digits = 2) {
+  const numeric = Number(value);
+  return String(Number.isFinite(numeric) ? numeric : 0).padStart(digits, '0');
+}
+
+/**
+ * Formats a timer's {hour, minute, second, mSecond} into a display string using
+ * a token-based format. Supported tokens: hh/HH (hours), mm/MM (minutes),
+ * ss/SS (seconds) padded to 2 digits, and SSS (milliseconds) padded to 3.
+ * SSS is matched before SS so milliseconds never collide with seconds.
+ * Falsy/blank formats fall back to DEFAULT_TIMER_FORMAT.
+ */
+export function formatTimerValue(time = {}, format = DEFAULT_TIMER_FORMAT) {
+  const safeFormat = format || DEFAULT_TIMER_FORMAT;
+  const tokens = {
+    HH: padTimeUnit(time.hour, 2),
+    hh: padTimeUnit(time.hour, 2),
+    MM: padTimeUnit(time.minute, 2),
+    mm: padTimeUnit(time.minute, 2),
+    SSS: padTimeUnit(time.mSecond, 3),
+    SS: padTimeUnit(time.second, 2),
+    ss: padTimeUnit(time.second, 2),
+  };
+  return safeFormat.replace(/SSS|hh|HH|mm|MM|ss|SS/g, (match) => tokens[match]);
+}
+
 export const getFormattedSteps = (steps) => {
   if (Array.isArray(steps)) return steps;
   if (typeof steps === 'string') {

--- a/server/src/modules/apps/services/widget-config/circularProgressbar.js
+++ b/server/src/modules/apps/services/widget-config/circularProgressbar.js
@@ -52,30 +52,6 @@ export const circularProgressbarConfig = {
       },
       accordian: 'Data',
     },
-    // Renders first in the Additional Actions section. Its displayName is the
-    // visible "Tooltip" label for the whole pair; the `tooltip` code field below
-    // hides its own label via showLabel:false so we don't get a duplicate.
-    tooltipFormat: {
-      type: 'switch',
-      displayName: 'Tooltip',
-      options: [
-        { displayName: 'Plain text', value: 'plainText' },
-        { displayName: 'Markdown', value: 'markdown' },
-        { displayName: 'HTML', value: 'html' },
-      ],
-      isFxNotRequired: true,
-      defaultValue: { value: 'plainText' },
-      fullWidth: true,
-      newLine: true, // render the switch on its own line below the "Tooltip" label
-      section: 'additionalActions',
-    },
-    tooltip: {
-      type: 'code',
-      displayName: 'Tooltip',
-      validation: { schema: { type: 'string' } },
-      section: 'additionalActions',
-      showLabel: false,
-    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -87,6 +63,27 @@ export const circularProgressbarConfig = {
       displayName: 'Visibility',
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
+    },
+    tooltipFormat: {
+      type: 'switch',
+      displayName: 'Tooltip',
+      options: [
+        { displayName: 'Plain text', value: 'plainText' },
+        { displayName: 'Markdown', value: 'markdown' },
+        { displayName: 'HTML', value: 'html' },
+      ],
+      isFxNotRequired: true,
+      defaultValue: { value: 'plainText' },
+      fullWidth: true,
+      newLine: true,
+      section: 'additionalActions',
+    },
+    tooltip: {
+      type: 'code',
+      displayName: 'Tooltip',
+      validation: { schema: { type: 'string' } },
+      section: 'additionalActions',
+      showLabel: false,
     },
   },
   events: {},

--- a/server/src/modules/apps/services/widget-config/datepickerV2.js
+++ b/server/src/modules/apps/services/widget-config/datepickerV2.js
@@ -8,6 +8,10 @@ export const datePickerV2Config = {
     height: 40,
   },
   validation: {
+    mandatory: {
+      type: 'toggle',
+      displayName: 'Make this field mandatory',
+    },
     minDate: {
       type: 'code',
       placeholder: 'DD/MM/YYYY',
@@ -32,10 +36,6 @@ export const datePickerV2Config = {
     customRule: {
       type: 'code',
       displayName: 'Custom validation',
-    },
-    mandatory: {
-      type: 'toggle',
-      displayName: 'Make this field mandatory',
     },
   },
   others: {

--- a/server/src/modules/apps/services/widget-config/datetimepickerV2.js
+++ b/server/src/modules/apps/services/widget-config/datetimepickerV2.js
@@ -9,6 +9,10 @@ export const datetimePickerV2Config = {
     height: 40,
   },
   validation: {
+    mandatory: {
+      type: 'toggle',
+      displayName: 'Make this field mandatory',
+    },
     minDate: {
       type: 'code',
       placeholder: 'DD/MM/YYYY',
@@ -45,10 +49,6 @@ export const datetimePickerV2Config = {
     customRule: {
       type: 'code',
       displayName: 'Custom validation',
-    },
-    mandatory: {
-      type: 'toggle',
-      displayName: 'Make this field mandatory',
     },
   },
   others: {

--- a/server/src/modules/apps/services/widget-config/divider.js
+++ b/server/src/modules/apps/services/widget-config/divider.js
@@ -125,6 +125,12 @@ export const dividerConfig = {
       },
       accordian: 'Divider',
     },
+    labelFontSize: {
+      type: 'numberInput',
+      displayName: 'Label size',
+      validation: { schema: { type: 'number' }, defaultValue: 12 },
+      accordian: 'Divider',
+    },
     textWrap: {
       type: 'switch',
       displayName: 'Text wrap',
@@ -181,6 +187,7 @@ export const dividerConfig = {
       labelAlignment: { value: 'center' },
       dividerStyle: { value: 'solid' },
       labelColor: { value: 'var(--cc-placeholder-text)' },
+      labelFontSize: { value: '{{12}}' },
       textWrap: { value: 'wrap' },
       padding: { value: 'default' },
       boxShadow: { value: '0px 0px 0px 0px #00000040' },

--- a/server/src/modules/apps/services/widget-config/progressbar.js
+++ b/server/src/modules/apps/services/widget-config/progressbar.js
@@ -46,30 +46,6 @@ export const progressbarConfig = {
       },
       accordian: 'Data',
     },
-    // Renders first in the Additional Actions section. Its displayName is the
-    // visible "Tooltip" label for the whole pair; the `tooltip` code field below
-    // hides its own label via showLabel:false so we don't get a duplicate.
-    tooltipFormat: {
-      type: 'switch',
-      displayName: 'Tooltip',
-      options: [
-        { displayName: 'Plain text', value: 'plainText' },
-        { displayName: 'Markdown', value: 'markdown' },
-        { displayName: 'HTML', value: 'html' },
-      ],
-      isFxNotRequired: true,
-      defaultValue: { value: 'plainText' },
-      fullWidth: true,
-      newLine: true, // render the switch on its own line below the "Tooltip" label
-      section: 'additionalActions',
-    },
-    tooltip: {
-      type: 'code',
-      displayName: 'Tooltip',
-      validation: { schema: { type: 'string' } },
-      section: 'additionalActions',
-      showLabel: false,
-    },
     loadingState: {
       type: 'toggle',
       displayName: 'Loading state',
@@ -81,6 +57,27 @@ export const progressbarConfig = {
       displayName: 'Visibility',
       validation: { schema: { type: 'boolean' }, defaultValue: true },
       section: 'additionalActions',
+    },
+    tooltipFormat: {
+      type: 'switch',
+      displayName: 'Tooltip',
+      options: [
+        { displayName: 'Plain text', value: 'plainText' },
+        { displayName: 'Markdown', value: 'markdown' },
+        { displayName: 'HTML', value: 'html' },
+      ],
+      isFxNotRequired: true,
+      defaultValue: { value: 'plainText' },
+      fullWidth: true,
+      newLine: true,
+      section: 'additionalActions',
+    },
+    tooltip: {
+      type: 'code',
+      displayName: 'Tooltip',
+      validation: { schema: { type: 'string' } },
+      section: 'additionalActions',
+      showLabel: false,
     },
   },
   events: {},

--- a/server/src/modules/apps/services/widget-config/timepicker.js
+++ b/server/src/modules/apps/services/widget-config/timepicker.js
@@ -8,6 +8,10 @@ export const timePickerConfig = {
     height: 40,
   },
   validation: {
+    mandatory: {
+      type: 'toggle',
+      displayName: 'Make this field mandatory',
+    },
     minTime: {
       type: 'code',
       placeholder: 'HH:mm',
@@ -23,10 +27,6 @@ export const timePickerConfig = {
     customRule: {
       type: 'code',
       displayName: 'Custom validation',
-    },
-    mandatory: {
-      type: 'toggle',
-      displayName: 'Make this field mandatory',
     },
   },
   others: {

--- a/server/src/modules/apps/services/widget-config/timer.js
+++ b/server/src/modules/apps/services/widget-config/timer.js
@@ -32,6 +32,14 @@ export const timerConfig = {
         defaultValue: 'countUp',
       },
     },
+    format: {
+      type: 'code',
+      displayName: 'Time format',
+      validation: {
+        schema: { type: 'string' },
+        defaultValue: 'hh:mm:ss:SSS',
+      },
+    },
     collapseWhenHidden: {
       type: 'toggle',
       displayName: 'Collapse when hidden',
@@ -80,6 +88,9 @@ export const timerConfig = {
       },
       type: {
         value: 'countUp',
+      },
+      format: {
+        value: 'hh:mm:ss:SSS',
       },
       collapseWhenHidden: { value: '{{false}}' },
     },


### PR DESCRIPTION
## 📝 What this does
Fixes several widget inspector inconsistencies and minor component bugs to align behavior across all widgets.

## 🔀 Changes
- Fixed PasswordInput eye icon showing opposite visibility state for filled vs outline icons
- Moved "Make this field mandatory" to top of Validation section for DatePickerV2, TimePicker, DateTimePickerV2
- Moved Tooltip to end of Additional Actions section for CircularProgressbar and Progressbar
- Added label size style attribute to Divider component (was hardcoded to 11px)
- Fixed filled Tabler icons not respecting icon color in Statistics component

## 🧪 How to test
- [ ] Drop a PasswordInput — toggle eye icon, verify closed eye = hidden, open eye = visible
- [ ] Drop DatePickerV2, TimePicker, DateTimePickerV2 — verify "Make this field mandatory" appears first under Validation
- [ ] Drop CircularProgressbar and Progressbar — verify Tooltip appears last in Additional Actions
- [ ] Drop a Divider with a label — verify "Label size" appears in Styles and changing it updates the label font size
- [ ] Drop a Statistics component — set a filled icon (e.g. IconAlertCircleFilled), change Icon color, verify it applies