### PR TITLE
deps: bump mariadb to 3.5.3 in plugin (GHSA-42r5-vhpq-m858, GHSA-cqhc-2h57-wpxf, GHSA-g5xc-5w98-jfvm)

### DIFF
--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -4903,7 +4903,6 @@
       "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.28.17.tgz",
       "integrity": "sha512-1sFtTiNAPTdCVb1EcKlDxIO9qF0lxWh0wKtIxNShOVmFuWN7r37ZDNY5IZaqKDD1NtbZe45W9isKx/JscgfQLg==",
       "hasInstallScript": true,
-      "hasShrinkwrap": true,
       "license": "SEE LICENSE IN developer-license-3_2.txt",
       "dependencies": {
         "debug": "3.1.0"
@@ -14329,19 +14328,19 @@
       }
     },
     "node_modules/mariadb": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/mariadb/-/mariadb-3.5.2.tgz",
-      "integrity": "sha512-9rztrI4nouxAY/82a+RlzzZ5ie2vxu2eYclkBvTy1ATXH1B9cnvZ0O71Pzsy/mlfDb5P3HhOg0JzQKkDRhctyA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mariadb/-/mariadb-3.5.3.tgz",
+      "integrity": "sha512-i053Kc0MgdUv/hu9mCyq67TYfPXFj3/MV8I7ZW5wvJNixIyXC0VztMPUjIVj/449nQo+BsxFD4Fdk/sA/uqKPQ==",
       "license": "LGPL-2.1-or-later",
       "dependencies": {
         "@types/geojson": "^7946.0.16",
-        "@types/node": ">=18",
+        "@types/node": ">=20",
         "denque": "^2.1.0",
         "iconv-lite": "^0.7.2",
-        "lru-cache": "^10.4.3"
+        "lru-cache": "^11.5.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/mariadb/node_modules/denque": {
@@ -14354,10 +14353,13 @@
       }
     },
     "node_modules/mariadb/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -21123,7 +21125,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tooljet-plugins/common": "file:../common",
-        "mariadb": "^3.2.3",
+        "mariadb": "^3.5.3",
         "react": "^17.0.2"
       }
     },

--- a/plugins/packages/mariadb/package.json
+++ b/plugins/packages/mariadb/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/tooljet/tooljet#readme",
   "dependencies": {
     "@tooljet-plugins/common": "file:../common",
-    "mariadb": "^3.2.3",
+    "mariadb": "^3.5.3",
     "react": "^17.0.2"
   }
 }


### PR DESCRIPTION
Updates the mariadb connector in the MariaDB plugin to address GHSA-42r5-vhpq-m858 (cleartext transmission of credentials), GHSA-cqhc-2h57-wpxf (password leak to a MITM despite ssl: true), and GHSA-g5xc-5w98-jfvm (SQL injection in Buffer parameter escaping under big5 and similar charsets).

Evidence:
- plugins/packages/mariadb/package.json referenced mariadb ^3.2.3, plugins/package-lock.json pinned 3.5.2
- osv-scanner reported all three advisories for mariadb@3.5.2 before the update
- updated version: 3.5.3

Validation:
- osv-scanner no longer reports any advisory for mariadb after the update
- npm run lint (plugins) passes
- npm run build (plugins) passes, using node 22 per .nvmrc

Note: mariadb 3.5.3 requires node 20 or later, matching the repo node 22 pin.

Scope: plugins/packages/mariadb/package.json and plugins/package-lock.json only.
