### PR TITLE
Add tab navigation functions: setNextTab and setPreviousTab

### DIFF
--- a/frontend/src/AppBuilder/WidgetManager/widgets/tabs.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/tabs.js
@@ -318,6 +318,16 @@ export const tabsConfig = {
       ],
     },
     {
+      handle: 'setNextTab',
+      displayName: 'Go to next tab',
+      params: [],
+    },
+    {
+      handle: 'setPreviousTab',
+      displayName: 'Go to previous tab',
+      params: [],
+    },
+    {
       handle: 'setVisibility',
       displayName: 'Set visibility',
       params: [{ handle: 'setVisibility', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],

--- a/frontend/src/AppBuilder/Widgets/Tabs/Tabs.jsx
+++ b/frontend/src/AppBuilder/Widgets/Tabs/Tabs.jsx
@@ -13,6 +13,7 @@ import { useDynamicHeight } from '@/_hooks/useDynamicHeight';
 import { useTabsNavScrollArrows } from '@/AppBuilder/Widgets/Tabs/useTabsNavScrollArrows';
 import { shallow } from 'zustand/shallow';
 import { getCssVarValue, getSafeRenderableValue } from '@/AppBuilder/Widgets/utils';
+import { resolveAdjacentTab } from './adjacentTab';
 import './tabs.scss';
 const tinycolor = require('tinycolor2');
 const TAB_HEADER_HEIGHT = 49.5;
@@ -90,10 +91,14 @@ export const Tabs = function Tabs({
     parsedTabs = resolveWidgetFieldValue(parsedTabs);
   }
 
-  parsedTabs = parsedTabs?.map((parsedTab, index) => ({
-    ...parsedTab,
-    id: parsedTab.id ? parsedTab.id : index,
-  }));
+  parsedTabs = Array.isArray(parsedTabs)
+    ? parsedTabs
+        .filter((parsedTab) => parsedTab && typeof parsedTab === 'object')
+        .map((parsedTab, index) => ({
+          ...parsedTab,
+          id: parsedTab.id ? parsedTab.id : index,
+        }))
+    : [];
   const highlightColor = styles?.highlightColor ?? '#f44336';
   let parsedHighlightColor = highlightColor;
   parsedHighlightColor = resolveWidgetFieldValue(highlightColor);
@@ -150,6 +155,7 @@ export const Tabs = function Tabs({
     shallow
   );
   const [tabItems, setTabItems] = useState(parsedTabs);
+  const parsedTabsRef = useRef(parsedTabs);
   const tabItemsRef = useRef(tabItems);
 
   useDynamicHeight({
@@ -170,11 +176,16 @@ export const Tabs = function Tabs({
   }, [parsedDefaultTab]);
 
   useEffect(() => {
-    if (JSON.stringify(tabItemsRef.current) !== JSON.stringify(parsedTabs)) {
-      setTabItems(parsedTabs);
+    if (JSON.stringify(parsedTabsRef.current) !== JSON.stringify(parsedTabs)) {
+      parsedTabsRef.current = parsedTabs;
       tabItemsRef.current = parsedTabs;
+      setTabItems(parsedTabs);
     }
   }, [parsedTabs]);
+
+  useEffect(() => {
+    tabItemsRef.current = tabItems;
+  }, [tabItems]);
 
   useEffect(() => {
     if (!parsedScrollToTopOnTabSwitch) return;
@@ -187,6 +198,21 @@ export const Tabs = function Tabs({
   }, [currentTab, parsedScrollToTopOnTabSwitch]);
 
   useEffect(() => {
+    // Reads the live tab list rather than this effect's closure: the effect does
+    // not re-run on tabItems, so setTabVisibility/setTabDisable would otherwise
+    // be invisible to these actions.
+    const switchToTab = (id) => {
+      if (id === null || id === undefined || currentTab == id) return;
+      setCurrentTab(id);
+      setExposedVariables({
+        currentTab: id,
+        // eslint-disable-next-line eqeqeq
+        currentTabTitle: tabItemsRef.current?.find((tab) => tab.id == id)?.title,
+      });
+      fireEvent('onTabSwitch');
+      setSelectedComponents([]);
+    };
+
     const exposedVariables = {
       setTab: async function (id) {
         if (currentTab != id) {
@@ -198,6 +224,15 @@ export const Tabs = function Tabs({
           fireEvent('onTabSwitch');
           setSelectedComponents([]);
         }
+      },
+      // Skip hidden and disabled tabs, clamp at the ends. A clamped move
+      // resolves to null and switchToTab treats that as a no-op, so
+      // onTabSwitch does not fire for a switch that did not happen.
+      setNextTab: async function () {
+        switchToTab(resolveAdjacentTab(tabItemsRef.current, currentTab, 'next'));
+      },
+      setPreviousTab: async function () {
+        switchToTab(resolveAdjacentTab(tabItemsRef.current, currentTab, 'previous'));
       },
       setTabDisable: async function (id, value) {
         setTabItems((prevTabItems) => {

--- a/frontend/src/AppBuilder/Widgets/Tabs/__tests__/adjacentTab.spec.js
+++ b/frontend/src/AppBuilder/Widgets/Tabs/__tests__/adjacentTab.spec.js
@@ -1,0 +1,88 @@
+/** @jest-environment node */
+import { resolveAdjacentTab } from '../adjacentTab';
+
+// Semantics chosen deliberately, since nothing in the widget implied them and
+// Retool has no equivalent action to copy (its Tabs exposes only setValue):
+//
+//   - hidden (`visible === false`) and disabled (`disable` is truthy) tabs are
+//     skipped, so an action can never land the user somewhere they cannot see
+//     or reach. Note `setTab` does NOT check `disable`, so this is stricter.
+//   - the ends CLAMP rather than wrap. The dominant use is a wizard's Next/Back
+//     button, where wrapping from the last step to the first is a bug. Adding an
+//     opt-in `wrap` later stays backwards compatible; removing it would not.
+//   - a clamped move returns null so the caller can skip firing onTabSwitch.
+const tabs = (...specs) => specs.map(({ id, ...rest }) => ({ id, title: `Tab ${id}`, ...rest }));
+
+describe('resolveAdjacentTab', () => {
+  const three = tabs({ id: 't0' }, { id: 't1' }, { id: 't2' });
+
+  it('moves to the following tab', () => {
+    expect(resolveAdjacentTab(three, 't0', 'next')).toBe('t1');
+    expect(resolveAdjacentTab(three, 't1', 'next')).toBe('t2');
+  });
+
+  it('moves to the preceding tab', () => {
+    expect(resolveAdjacentTab(three, 't2', 'previous')).toBe('t1');
+    expect(resolveAdjacentTab(three, 't1', 'previous')).toBe('t0');
+  });
+
+  it('clamps at both ends instead of wrapping', () => {
+    expect(resolveAdjacentTab(three, 't2', 'next')).toBeNull();
+    expect(resolveAdjacentTab(three, 't0', 'previous')).toBeNull();
+  });
+
+  it('skips hidden tabs', () => {
+    const withHidden = tabs({ id: 't0' }, { id: 't1', visible: false }, { id: 't2' });
+
+    expect(resolveAdjacentTab(withHidden, 't0', 'next')).toBe('t2');
+    expect(resolveAdjacentTab(withHidden, 't2', 'previous')).toBe('t0');
+  });
+
+  it('skips disabled tabs', () => {
+    const withDisabled = tabs({ id: 't0' }, { id: 't1', disable: true }, { id: 't2' });
+
+    expect(resolveAdjacentTab(withDisabled, 't0', 'next')).toBe('t2');
+    expect(resolveAdjacentTab(withDisabled, 't2', 'previous')).toBe('t0');
+  });
+
+  it('matches the UI by skipping any tab with a truthy disable value', () => {
+    const withDynamicDisable = tabs({ id: 't0' }, { id: 't1', disable: 'dynamic-value' }, { id: 't2' });
+
+    expect(resolveAdjacentTab(withDynamicDisable, 't0', 'next')).toBe('t2');
+  });
+
+  it('clamps when every remaining tab is skippable', () => {
+    const trailingHidden = tabs({ id: 't0' }, { id: 't1', visible: false }, { id: 't2', disable: true });
+
+    expect(resolveAdjacentTab(trailingHidden, 't0', 'next')).toBeNull();
+  });
+
+  it('matches ids loosely, because a dynamic tab list yields numeric ids', () => {
+    // Tabs.jsx assigns `id: parsedTab.id ? parsedTab.id : index`, so a tab list
+    // built from code can carry numbers while the configured list carries
+    // strings, and the widget compares with == nearly everywhere.
+    const numeric = tabs({ id: 0 }, { id: 1 }, { id: 2 });
+
+    expect(resolveAdjacentTab(numeric, '0', 'next')).toBe(1);
+    expect(resolveAdjacentTab(numeric, 1, 'next')).toBe(2);
+  });
+
+  it('moves on from a tab that has since been hidden', () => {
+    // setTabVisibility can hide the tab the user is currently on.
+    const currentHidden = tabs({ id: 't0', visible: false }, { id: 't1' }, { id: 't2' });
+
+    expect(resolveAdjacentTab(currentHidden, 't0', 'next')).toBe('t1');
+  });
+
+  it('falls back to the first or last navigable tab when the current id is unknown', () => {
+    // setTab does no validation, so currentTab can hold an id that is not in the list.
+    expect(resolveAdjacentTab(three, 'nope', 'next')).toBe('t0');
+    expect(resolveAdjacentTab(three, 'nope', 'previous')).toBe('t2');
+  });
+
+  it('returns null for an empty or unusable tab list', () => {
+    expect(resolveAdjacentTab([], 't0', 'next')).toBeNull();
+    expect(resolveAdjacentTab(undefined, 't0', 'next')).toBeNull();
+    expect(resolveAdjacentTab(tabs({ id: 't0', visible: false }), 't0', 'next')).toBeNull();
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/Tabs/__tests__/integration/tabsActions.spec.jsx
+++ b/frontend/src/AppBuilder/Widgets/Tabs/__tests__/integration/tabsActions.spec.jsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { waitFor } from '@testing-library/react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import useStore from '@/AppBuilder/_stores/store';
+import { createWidgetHarness, drain, setVariableOn } from '../../../__tests__/integration/widgetHarness';
+
+const TABS_ID = 'tabs-1';
+const DndWrapper = ({ children }) => <DndProvider backend={HTML5Backend}>{children}</DndProvider>;
+const store = () => useStore.getState();
+const tabItems = [
+  { id: 'first', title: 'First', visible: true, disable: false },
+  { id: 'middle', title: 'Middle', visible: true, disable: false },
+  { id: 'last', title: 'Last', visible: true, disable: false },
+];
+
+const widget = createWidgetHarness({
+  componentType: 'Tabs',
+  handle: 'tabs1',
+  id: TABS_ID,
+  widgetHeight: 450,
+  wrapper: DndWrapper,
+  defaultProperties: {
+    useDynamicOptions: { value: false },
+    tabItems: { value: tabItems },
+    defaultTab: { value: 'first' },
+    hideTabs: { value: false },
+    renderOnlyActiveTab: { value: false },
+    scrollToTopOnTabSwitch: { value: false },
+    dynamicHeight: { value: false },
+    loadingState: { value: false },
+    visibility: { value: true },
+    disabledState: { value: false },
+  },
+  defaultStyles: {
+    visibility: { value: true },
+    disabledState: { value: false },
+    tabWidth: { value: 'auto' },
+    transition: { value: 'none' },
+    padding: { value: 'default' },
+  },
+});
+
+describe('Tabs adjacent component-specific actions', () => {
+  beforeEach(widget.setup);
+  afterEach(widget.teardown);
+
+  test('Next skips a tab hidden through the public Tabs action and publishes the destination before onTabSwitch', async () => {
+    const { queryByText } = widget.render({
+      events: setVariableOn(TABS_ID, 'onTabSwitch', {
+        key: 'tabSeenByHandler',
+        value: '{{components.tabs1.currentTab}}',
+      }),
+    });
+
+    await waitFor(() => expect(widget.exposed().setNextTab).toBeInstanceOf(Function));
+    store().setSelectedComponents([TABS_ID]);
+
+    await widget.session.store.act(async () => {
+      await widget.exposed().setTabVisibility('middle', false);
+    });
+    await waitFor(() => expect(queryByText('Middle')).not.toBeInTheDocument());
+
+    await widget.session.store.act(async () => {
+      await widget.exposed().setNextTab();
+    });
+    await drain();
+
+    expect(widget.exposed().currentTab).toBe('last');
+    expect(widget.exposed().currentTabTitle).toBe('Last');
+    expect(widget.variables().tabSeenByHandler).toBe('last');
+    expect(store().selectedComponents).toEqual([]);
+  });
+
+  test('Previous skips a tab disabled through the public Tabs action', async () => {
+    widget.render({ properties: { defaultTab: { value: 'last' } } });
+
+    await waitFor(() => expect(widget.exposed().setPreviousTab).toBeInstanceOf(Function));
+    await widget.session.store.act(async () => {
+      await widget.exposed().setTabDisable('middle', true);
+    });
+    await waitFor(() => expect(widget.exposed().currentTab).toBe('last'));
+
+    await widget.session.store.act(async () => {
+      await widget.exposed().setPreviousTab();
+    });
+
+    expect(widget.exposed().currentTab).toBe('first');
+    expect(widget.exposed().currentTabTitle).toBe('First');
+  });
+
+  test('a boundary action preserves selection and does not fire onTabSwitch', async () => {
+    widget.render({
+      events: setVariableOn(TABS_ID, 'onTabSwitch', {
+        key: 'boundaryEvent',
+        value: 'FIRED',
+      }),
+    });
+
+    await waitFor(() => expect(widget.exposed().setPreviousTab).toBeInstanceOf(Function));
+    store().setSelectedComponents([TABS_ID]);
+
+    await widget.session.store.act(async () => {
+      await widget.exposed().setPreviousTab();
+    });
+    await drain();
+
+    expect(widget.exposed().currentTab).toBe('first');
+    expect(widget.variables().boundaryEvent).toBeUndefined();
+    expect(store().selectedComponents).toEqual([TABS_ID]);
+  });
+
+  test('programmatic navigation remains available when the whole widget is hidden and disabled', async () => {
+    widget.render({
+      properties: {
+        visibility: { value: false },
+        disabledState: { value: true },
+      },
+    });
+
+    await waitFor(() => expect(widget.exposed().isVisible).toBe(false));
+    expect(widget.exposed().isDisabled).toBe(true);
+
+    await widget.session.store.act(async () => {
+      await widget.exposed().setNextTab();
+    });
+
+    expect(widget.exposed().currentTab).toBe('middle');
+    expect(widget.exposed().currentTabTitle).toBe('Middle');
+  });
+
+  test('missing tab data keeps adjacent actions available as safe no-ops', async () => {
+    widget.render({ properties: { tabItems: { value: null } } });
+
+    await waitFor(() => expect(widget.exposed().setNextTab).toBeInstanceOf(Function));
+
+    await widget.session.store.act(async () => {
+      await widget.exposed().setNextTab();
+      await widget.exposed().setPreviousTab();
+    });
+
+    expect(widget.exposed().currentTab).toBe('first');
+  });
+
+  test('malformed tab entries are ignored instead of crashing adjacent actions', async () => {
+    widget.render({ properties: { tabItems: { value: [null] } } });
+
+    await waitFor(() => expect(widget.exposed().setNextTab).toBeInstanceOf(Function));
+
+    await widget.session.store.act(async () => {
+      await widget.exposed().setNextTab();
+    });
+
+    expect(widget.exposed().currentTab).toBe('first');
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/Tabs/__tests__/tabsActions.spec.js
+++ b/frontend/src/AppBuilder/Widgets/Tabs/__tests__/tabsActions.spec.js
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+
+// A component-specific action only works if BOTH halves exist:
+//   1. an `actions[]` entry in the widget manifest, which is what populates the
+//      builder's "Control component -> Action" dropdown (EventManager.jsx), and
+//   2. an exposed value of the same name on the component, which is what
+//      eventsSlice looks up by string key at fire time.
+//
+// Miss either and the failure is silent — an action that never appears in the UI,
+// or a dropdown entry that resolves to undefined and does nothing. The manifest is
+// also duplicated into the server, with no test anywhere enforcing that the two
+// copies agree.
+const repoRoot = path.resolve(__dirname, '../../../../../..');
+const frontendManifest = path.join(repoRoot, 'frontend/src/AppBuilder/WidgetManager/widgets/tabs.js');
+const serverManifest = path.join(repoRoot, 'server/src/modules/apps/services/widget-config/tabs.js');
+const component = path.resolve(__dirname, '../Tabs.jsx');
+
+const read = (file) => fs.readFileSync(file, 'utf8');
+
+// Action handles sit two levels deep (6 spaces); the `handle` keys inside a
+// `params` array sit two deeper still. Anchoring on the indentation keeps param
+// handles like 'tabId' out of the list. Formatting is prettier-enforced here.
+const declaredHandles = (source) => {
+  const actionsBlock = source.slice(source.indexOf('actions: ['));
+  return [...actionsBlock.matchAll(/^ {6}handle: '([^']+)'/gm)].map(([, handle]) => handle);
+};
+
+describe('Tabs component-specific actions', () => {
+  const frontendHandles = declaredHandles(read(frontendManifest));
+  const componentSource = read(component);
+
+  it('declares the new next and previous actions', () => {
+    expect(frontendHandles).toContain('setNextTab');
+    expect(frontendHandles).toContain('setPreviousTab');
+  });
+
+  it('presents adjacent navigation immediately after Set current tab', () => {
+    expect(frontendHandles.slice(0, 3)).toEqual(['setTab', 'setNextTab', 'setPreviousTab']);
+    expect(componentSource).toContain('setNextTab: async function');
+    expect(read(frontendManifest)).toMatch(/handle: 'setNextTab',\s+displayName: 'Go to next tab',\s+params: \[\]/);
+    expect(read(frontendManifest)).toMatch(
+      /handle: 'setPreviousTab',\s+displayName: 'Go to previous tab',\s+params: \[\]/
+    );
+  });
+
+  it('exposes a function for every action the manifest declares', () => {
+    // setVisibility/setDisable/setLoading come from the shared useExposeState
+    // hook rather than from Tabs.jsx itself.
+    const fromSharedHook = ['setVisibility', 'setDisable', 'setLoading'];
+
+    const missing = frontendHandles
+      .filter((handle) => !fromSharedHook.includes(handle))
+      .filter((handle) => !new RegExp(`\\b${handle}\\s*:`).test(componentSource));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('keeps the server copy of the manifest in sync with the frontend', () => {
+    expect(read(serverManifest)).toEqual(read(frontendManifest));
+  });
+});

--- a/frontend/src/AppBuilder/Widgets/Tabs/adjacentTab.js
+++ b/frontend/src/AppBuilder/Widgets/Tabs/adjacentTab.js
@@ -1,0 +1,35 @@
+/**
+ * Id of the tab one step from `currentTabId`, or null when there is none.
+ *
+ * Hidden (`visible === false`) and disabled (`disable` is truthy) tabs are
+ * skipped, and the ends clamp rather than wrap — a null return means "stay put",
+ * which lets the caller avoid firing onTabSwitch for a move that did not happen.
+ *
+ * @param {Array<{id: string|number, visible?: boolean, disable?: boolean}>} tabItems
+ * @param {string|number} currentTabId
+ * @param {'next'|'previous'} direction
+ * @returns {string|number|null}
+ */
+export function resolveAdjacentTab(tabItems, currentTabId, direction) {
+  const items = Array.isArray(tabItems) ? tabItems : [];
+  const step = direction === 'previous' ? -1 : 1;
+  const isNavigable = (tab) => Boolean(tab && tab.visible !== false && !tab.disable);
+
+  // Loose comparison on purpose: a tab list built from code can carry numeric
+  // ids while a configured one carries strings, and the widget compares with ==
+  // almost everywhere else.
+  // eslint-disable-next-line eqeqeq
+  const currentIndex = items.findIndex((tab) => tab?.id == currentTabId);
+
+  // An unknown current id (setTab does not validate) starts the scan from the
+  // near end, so the action still does something sensible. A known one starts
+  // from the neighbouring slot, which also steps off a tab that has since been
+  // hidden.
+  const start = currentIndex === -1 ? (step === 1 ? 0 : items.length - 1) : currentIndex + step;
+
+  for (let index = start; index >= 0 && index < items.length; index += step) {
+    if (isNavigable(items[index])) return items[index].id;
+  }
+
+  return null;
+}

--- a/frontend/src/AppBuilder/Widgets/__tests__/integration/widgetHarness.js
+++ b/frontend/src/AppBuilder/Widgets/__tests__/integration/widgetHarness.js
@@ -68,6 +68,7 @@ export function widgetProps(id, componentType, { darkMode = false, widgetHeight 
  * @param defaultProperties  properties every test gets unless overridden
  * @param capabilities   extra AppBuilderTestSession capabilities beyond the
  *                        observers/media baseline every widget spec needs
+ * @param wrapper        optional React provider wrapper for widget-specific context
  */
 export function createWidgetHarness({
   componentType,
@@ -81,6 +82,7 @@ export function createWidgetHarness({
   capabilities = {},
   widgetHeight = 40,
   widgetWidth = 200,
+  wrapper: Wrapper,
 }) {
   const scenario = defineAppBuilderScenario({
     id: `${componentType.toLowerCase()}-widget`,
@@ -134,7 +136,7 @@ export function createWidgetHarness({
     // mounting alongside what's already there, so every widget sharing a
     // page for this test — the one under test plus any `also` siblings —
     // must go up in ONE render() call as a fragment.
-    return session.render(
+    const tree = (
       <>
         <RenderWidget {...widgetProps(componentId, componentType, { darkMode, widgetHeight, widgetWidth })} />
         {also.map(({ id: siblingId, componentType: siblingType, ...rest }) => (
@@ -142,6 +144,8 @@ export function createWidgetHarness({
         ))}
       </>
     );
+
+    return session.render(Wrapper ? <Wrapper>{tree}</Wrapper> : tree);
   }
 
   return {

--- a/server/src/modules/apps/services/widget-config/tabs.js
+++ b/server/src/modules/apps/services/widget-config/tabs.js
@@ -318,6 +318,16 @@ export const tabsConfig = {
       ],
     },
     {
+      handle: 'setNextTab',
+      displayName: 'Go to next tab',
+      params: [],
+    },
+    {
+      handle: 'setPreviousTab',
+      displayName: 'Go to previous tab',
+      params: [],
+    },
+    {
       handle: 'setVisibility',
       displayName: 'Set visibility',
       params: [{ handle: 'setVisibility', displayName: 'Value', defaultValue: '{{false}}', type: 'toggle' }],


### PR DESCRIPTION
- Introduced new functions to navigate between tabs in the Tabs component.
- Updated tabs configuration to include 'Go to next tab' and 'Go to previous tab' actions.
- Enhanced tab management logic to handle tab switching more effectively.

Closes https://github.com/ToolJet/tj-ee/issues/5422