### PR TITLE
Fix: apply eslint prettier formatting across frontend

### DIFF
--- a/frontend/src/AppBuilder/AppCanvas/AutoComputeMobileLayoutAlert.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/AutoComputeMobileLayoutAlert.jsx
@@ -46,7 +46,7 @@ export default function AutoComputeMobileLayoutAlert({ currentLayout, darkMode, 
             top: mobLayout.top,
             width: mobLayout.width,
           }
-        : currentPageComponents[id]?.layouts?.desktop ?? {};
+        : (currentPageComponents[id]?.layouts?.desktop ?? {});
     });
     return updatedBoxes;
   };

--- a/frontend/src/AppBuilder/AppCanvas/ConfigHandle/ConfigHandle.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/ConfigHandle/ConfigHandle.jsx
@@ -205,8 +205,8 @@ export const ConfigHandle = ({
           componentType === 'Modal' && isModalOpen
             ? '0px'
             : position === 'top'
-            ? '-26px'
-            : `${height - (CONFIG_HANDLE_HEIGHT + BUFFER_HEIGHT)}px`,
+              ? '-26px'
+              : `${height - (CONFIG_HANDLE_HEIGHT + BUFFER_HEIGHT)}px`,
         visibility: _showHandle || visibility === false ? 'visible' : 'hidden',
         left: '-1px',
         display: 'flex',

--- a/frontend/src/AppBuilder/AppCanvas/Container.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/Container.jsx
@@ -77,10 +77,10 @@ const Container = React.memo(
     const setCurrentDragCanvasId = useGridStore((state) => state.actions.setCurrentDragCanvasId);
     const setFlexContainerDropTarget = useStore((state) => state.setFlexContainerDropTarget, shallow);
     const flexDirection = useStore(
-      (state) => (isFlexContainer ? state.getResolvedComponent?.(id)?.properties?.direction ?? 'column' : 'column'),
+      (state) => (isFlexContainer ? (state.getResolvedComponent?.(id)?.properties?.direction ?? 'column') : 'column'),
       shallow
     );
-    const flexDirectionForFlex = isFlexContainer ? flexEffectiveDirection ?? flexDirection : flexDirection;
+    const flexDirectionForFlex = isFlexContainer ? (flexEffectiveDirection ?? flexDirection) : flexDirection;
 
     // Initialize ghost moveable hook
     const { activateMoveableGhost, deactivateMoveableGhost, updateGhostSize } = useDropVirtualMoveableGhost();
@@ -281,8 +281,8 @@ const Container = React.memo(
             currentMode === 'view'
               ? computeViewerBackgroundColor(darkMode, canvasBgColor)
               : id === 'canvas'
-              ? canvasBgColor
-              : '#f0f0f0',
+                ? canvasBgColor
+                : '#f0f0f0',
           width: '100%',
           maxWidth: (() => {
             // For Main Canvas

--- a/frontend/src/AppBuilder/AppCanvas/Hooks/useCanvasDropHandler.js
+++ b/frontend/src/AppBuilder/AppCanvas/Hooks/useCanvasDropHandler.js
@@ -142,8 +142,8 @@ export const useCanvasDropHandler = () => {
             isStub: false,
             versionId: shouldUnpin
               ? ''
-              : hydratedVersion.module_reference_id ?? hydratedVersion.moduleReferenceId ?? '',
-            versionName: shouldUnpin ? '' : hydratedVersion.name ?? '',
+              : (hydratedVersion.module_reference_id ?? hydratedVersion.moduleReferenceId ?? ''),
+            versionName: shouldUnpin ? '' : (hydratedVersion.name ?? ''),
             environmentId: hydratedVersion.current_environment_id,
             moduleContainer: hydrated.module_container,
             defaultSize: {

--- a/frontend/src/AppBuilder/AppCanvas/PageMenu/MobileNavigationMenu.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/PageMenu/MobileNavigationMenu.jsx
@@ -190,8 +190,8 @@ const MobileNavigationMenu = ({
           isMobilePreviewMode && !isPreviewInEditor
             ? 'tw-h-[calc(100%_-_44px)]' // To account for the preview settings header height
             : currentMode === 'view' && !isMobilePreviewMode
-            ? 'tw-h-dvh' // In released app, the height should equal to mobile browsers viewport height
-            : 'tw-h-full'
+              ? 'tw-h-dvh' // In released app, the height should equal to mobile browsers viewport height
+              : 'tw-h-full'
         }`,
         style: bgStyles,
       }}

--- a/frontend/src/AppBuilder/AppCanvas/PageMenu/PageGroup.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/PageMenu/PageGroup.jsx
@@ -28,7 +28,7 @@ const RenderPage = ({
 }) => {
   const isPageHidden = useStore((state) => state.getPagesVisibility('canvas', page?.id)); // TODO: rename the getPagesVisibility to getIsPageHidden in state since purpose of the function is to check if the page is hidden
   const isHomePage = page.id === homePageId;
-  const iconName = isHomePage && !page.icon ? 'IconHome2' : page.icon ?? 'IconFile';
+  const iconName = isHomePage && !page.icon ? 'IconHome2' : (page.icon ?? 'IconFile');
   const isActive = page?.id === currentPageId;
 
   if (isPageHidden || page.disabled || (page?.restricted && currentMode !== 'edit')) return null;

--- a/frontend/src/AppBuilder/AppCanvas/WidgetWrapper.jsx
+++ b/frontend/src/AppBuilder/AppCanvas/WidgetWrapper.jsx
@@ -191,7 +191,7 @@ const WidgetWrapper = memo(
       temporaryLayouts?.height != null && gridHeight > layoutData?.height
         ? Math.max(temporaryLayouts.height, gridHeight)
         : temporaryLayouts?.height;
-    const gridFinalHeight = visibility ? flooredTemporaryHeight ?? gridHeight : HIDDEN_COMPONENT_HEIGHT;
+    const gridFinalHeight = visibility ? (flooredTemporaryHeight ?? gridHeight) : HIDDEN_COMPONENT_HEIGHT;
     const layoutContext = indices ?? subContainerIndex;
     const serializedLayoutContext = serializeLayoutContext(layoutContext);
 
@@ -219,12 +219,12 @@ const WidgetWrapper = memo(
     const renderWidgetHeight = isFlexLayout
       ? flexLayout.widgetHeight
       : !visibility && mode === 'edit'
-      ? HIDDEN_COMPONENT_HEIGHT
-      : newLayoutData.height;
-    const configWidgetTop = isFlexLayout ? flexLayout.configWidgetTop : temporaryLayouts?.top ?? layoutData.top;
+        ? HIDDEN_COMPONENT_HEIGHT
+        : newLayoutData.height;
+    const configWidgetTop = isFlexLayout ? flexLayout.configWidgetTop : (temporaryLayouts?.top ?? layoutData.top);
     const configWidgetHeight = isFlexLayout
       ? flexLayout.configWidgetHeight
-      : temporaryLayouts?.height ?? layoutData.height;
+      : (temporaryLayouts?.height ?? layoutData.height);
 
     const isModuleContainer = componentType === 'ModuleContainer';
     const configHandleClassName = cx({

--- a/frontend/src/AppBuilder/CodeBuilder/Elements/Slider.jsx
+++ b/frontend/src/AppBuilder/CodeBuilder/Elements/Slider.jsx
@@ -20,8 +20,8 @@ function Slider1(props) {
     skipAutoConditionCheck || styleDefinition?.auto?.value === '{{false}}'
       ? false
       : styleDefinition?.auto?.value === '{{true}}'
-      ? true
-      : false;
+        ? true
+        : false;
   useEffect(() => {
     setSliderValue(value);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/AppBuilder/CodeBuilder/Elements/Switch.jsx
+++ b/frontend/src/AppBuilder/CodeBuilder/Elements/Switch.jsx
@@ -18,7 +18,7 @@ const Switch = ({ value, onChange, cyLabel, meta, paramName, isIcon, component }
             lucideIconName={option?.lucideIconName}
             style={{ width: meta?.fullWidth ? '100%' : '67px' }}
           >
-            {meta.isIcon ? (option?.lucideIconName ? '' : option?.iconName ?? '') : option?.displayName}
+            {meta.isIcon ? (option?.lucideIconName ? '' : (option?.iconName ?? '')) : option?.displayName}
           </ToggleGroupItem>
         ))}
       </ToggleGroup>

--- a/frontend/src/AppBuilder/CodeEditor/PreviewBox.jsx
+++ b/frontend/src/AppBuilder/CodeEditor/PreviewBox.jsx
@@ -226,12 +226,12 @@ export const PreviewBox = ({
       const jsErrorType = isSecretError
         ? 'Error'
         : _error?.includes('ReferenceError')
-        ? 'ReferenceError'
-        : _error?.includes('TypeError')
-        ? 'TypeError'
-        : _error?.includes('SyntaxError')
-        ? 'SyntaxError'
-        : 'Invalid';
+          ? 'ReferenceError'
+          : _error?.includes('TypeError')
+            ? 'TypeError'
+            : _error?.includes('SyntaxError')
+              ? 'SyntaxError'
+              : 'Invalid';
 
       const errValue = ifCoersionErrorHasCircularDependency(_resolveValue);
 
@@ -239,13 +239,13 @@ export const PreviewBox = ({
         message: isServerConstant
           ? 'Server variables cannot be used in apps'
           : isSecretError
-          ? 'secrets cannot be used in apps'
-          : _error,
+            ? 'secrets cannot be used in apps'
+            : _error,
         value: isSecretError
           ? 'Undefined'
           : jsErrorType === 'Invalid'
-          ? JSON.stringify(errValue, reservedKeywordReplacer)
-          : resolvedValue,
+            ? JSON.stringify(errValue, reservedKeywordReplacer)
+            : resolvedValue,
         type: isSecretError ? 'Error' : jsErrorType,
         completeErrorMessage: completeErrMessage,
       });
@@ -310,20 +310,20 @@ const RenderResolvedValue = ({
   const previewValueType = isWorkspaceVariable
     ? previewType
     : withValidation || (coersionData && coersionData?.typeBeforeCoercion)
-    ? `${coersionData?.typeBeforeCoercion} ${
-        coersionData?.coercionPreview ? ` → ${coersionData?.typeAfterCoercion}` : ''
-      }`
-    : previewType;
+      ? `${coersionData?.typeBeforeCoercion} ${
+          coersionData?.coercionPreview ? ` → ${coersionData?.typeAfterCoercion}` : ''
+        }`
+      : previewType;
 
   const previewContent = isServerConstant
     ? isServerSideGlobalResolveEnabled
       ? 'Server variables would be resolved at runtime'
       : 'Server variables are only available in paid plans'
     : isSecretConstant
-    ? 'Values of secret constants are hidden'
-    : !withValidation
-    ? resolvedValue
-    : computeCoersionPreview(resolvedValue, coersionData);
+      ? 'Values of secret constants are hidden'
+      : !withValidation
+        ? resolvedValue
+        : computeCoersionPreview(resolvedValue, coersionData);
 
   const cls = error ? 'codehinter-error-banner' : 'codehinter-success-banner';
 
@@ -414,8 +414,8 @@ const PreviewContainer = ({
     const defaultValue = validationSchema?.defaultValue
       ? validationSchema?.defaultValue
       : validationSchema
-      ? findDefault(validationSchema?.schema ?? {}, errorMessage?.value)
-      : undefined;
+        ? findDefault(validationSchema?.schema ?? {}, errorMessage?.value)
+        : undefined;
 
     const errorData = {
       key: componentKey,

--- a/frontend/src/AppBuilder/Header/CreateDraftVersionModal.jsx
+++ b/frontend/src/AppBuilder/Header/CreateDraftVersionModal.jsx
@@ -110,8 +110,8 @@ const CreateDraftVersionModal = ({ showCreateAppVersion, setShowCreateAppVersion
     savedVersions.length > 0
       ? savedVersions.map((version) => ({ label: version.name, value: version.id }))
       : selectedVersion && selectedVersion.status !== 'DRAFT'
-      ? [{ label: selectedVersion.name, value: selectedVersion.id }]
-      : [];
+        ? [{ label: selectedVersion.name, value: selectedVersion.id }]
+        : [];
 
   const [versionName, setVersionName] = useState('');
 

--- a/frontend/src/AppBuilder/Header/LockedBranchBanner.jsx
+++ b/frontend/src/AppBuilder/Header/LockedBranchBanner.jsx
@@ -31,10 +31,10 @@ const LockedBranchBanner = ({
     reason === 'released'
       ? 'This branch has been released and is now read-only'
       : isLicenseLock
-      ? licenseLockMessage || 'Your plan has expired. Renew your plan or disable git sync to continue.'
-      : reason === 'main_config_branch'
-      ? `Master is locked. Create a branch to add or ${pageContextText}.`
-      : 'This branch has been merged and is now read-only';
+        ? licenseLockMessage || 'Your plan has expired. Renew your plan or disable git sync to continue.'
+        : reason === 'main_config_branch'
+          ? `Master is locked. Create a branch to add or ${pageContextText}.`
+          : 'This branch has been merged and is now read-only';
 
   return (
     <div className={cx({ 'dark-theme': darkMode })}>

--- a/frontend/src/AppBuilder/Header/SwitchBranchModal.jsx
+++ b/frontend/src/AppBuilder/Header/SwitchBranchModal.jsx
@@ -66,8 +66,8 @@ export function SwitchBranchModal({ show, onClose, appId, organizationId }) {
   const currentBranchName = workspaceActiveBranch?.name
     ? workspaceActiveBranch.name
     : selectedVersion?.versionType === 'branch' || selectedVersion?.version_type === 'branch'
-    ? selectedVersion?.name
-    : currentBranch?.name || defaultBranchName;
+      ? selectedVersion?.name
+      : currentBranch?.name || defaultBranchName;
 
   useEffect(() => {
     if (show && appId && organizationId) {

--- a/frontend/src/AppBuilder/Header/VersionManager/VersionDropdownItem.jsx
+++ b/frontend/src/AppBuilder/Header/VersionManager/VersionDropdownItem.jsx
@@ -77,7 +77,7 @@ const VersionDropdownItem = ({
   const workspaceBranches = useWorkspaceBranchesStore((state) => state.branches);
   const sourceBranchId = parentVersion?.branchId || parentVersion?.branch_id;
   const sourceBranchName = parentIsBranchVersion
-    ? workspaceBranches.find((b) => b.id === sourceBranchId)?.name ?? 'feature-branch'
+    ? (workspaceBranches.find((b) => b.id === sourceBranchId)?.name ?? 'feature-branch')
     : null;
 
   const metadataRef = useRef(null);

--- a/frontend/src/AppBuilder/Header/VersionManager/VersionManagerDropdown.jsx
+++ b/frontend/src/AppBuilder/Header/VersionManager/VersionManagerDropdown.jsx
@@ -590,8 +590,8 @@ const VersionManagerDropdown = ({ darkMode = false, ...props }) => {
               {searchQuery
                 ? 'No versions found'
                 : gitVersionStatus.size === 0 && isGitSyncEnabled
-                ? 'No versions available — click Refresh to check git'
-                : 'No versions available'}
+                  ? 'No versions available — click Refresh to check git'
+                  : 'No versions available'}
             </div>
           ) : (
             mergedVersions.map((version) => {

--- a/frontend/src/AppBuilder/LeftSidebar/Debugger/SidebarDebugger/Logs.jsx
+++ b/frontend/src/AppBuilder/LeftSidebar/Debugger/SidebarDebugger/Logs.jsx
@@ -18,17 +18,17 @@ function Logs({ logProps, idx }) {
     logProps?.type === 'navToDisablePage'
       ? logProps?.message
       : logProps?.isQuerySuccessLog
-      ? 'Completed'
-      : logProps?.type === 'component'
-      ? `Invalid property detected: ${logProps?.message}.`
-      : logProps?.type === 'Custom Log'
-      ? logProps?.description
-      : `${startCase(logProps?.type)} failed: ${
-          logProps?.description ||
-          (isString(logProps?.message) && logProps?.message) ||
-          (isString(logProps?.error?.description) && logProps?.error?.description) || //added string check since description can be an object. eg: runpy
-          logProps?.error?.message
-        }`;
+        ? 'Completed'
+        : logProps?.type === 'component'
+          ? `Invalid property detected: ${logProps?.message}.`
+          : logProps?.type === 'Custom Log'
+            ? logProps?.description
+            : `${startCase(logProps?.type)} failed: ${
+                logProps?.description ||
+                (isString(logProps?.message) && logProps?.message) ||
+                (isString(logProps?.error?.description) && logProps?.error?.description) || //added string check since description can be an object. eg: runpy
+                logProps?.error?.message
+              }`;
 
   const defaultStyles = {
     transform: open ? 'rotate(-90deg)' : 'rotate(0deg)',

--- a/frontend/src/AppBuilder/LeftSidebar/Dependencies/DetailTab.tsx
+++ b/frontend/src/AppBuilder/LeftSidebar/Dependencies/DetailTab.tsx
@@ -126,8 +126,8 @@ export const DetailTab = ({ subject, groups, moduleId, onSelect, darkMode }: Det
       entry.kind === 'component'
         ? getComponentDisplayName(componentType)
         : entry.kind === 'action'
-        ? 'Action'
-        : KIND_SUBTITLES[entry.kind];
+          ? 'Action'
+          : KIND_SUBTITLES[entry.kind];
 
     // Only event-driven relationships carry a tag line; bindings explain themselves
     // through the hover tooltip instead.

--- a/frontend/src/AppBuilder/QueryManager/Components/DataSourceSelect.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/DataSourceSelect.jsx
@@ -451,8 +451,8 @@ function DataSourceSelect({
           item.type === 'group-item' || item.type === 'sample-item'
             ? item.source.id
             : item.type === 'group-end'
-            ? item.key
-            : `${item.type}-${item.kind ?? 'defaults'}`
+              ? item.key
+              : `${item.type}-${item.kind ?? 'defaults'}`
         }
         itemContent={(_, item) => renderItem(item)}
       />

--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -62,8 +62,8 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = null
   const ElementToRender = isDummyDataSource
     ? null
     : selectedQuery?.plugin_id
-    ? source
-    : allSources[sourcecomponentName];
+      ? source
+      : allSources[sourcecomponentName];
   const defaultOptions = useRef({});
 
   const isFreezed = useStore((state) => state.getShouldFreeze(false, isModuleEditor));
@@ -479,8 +479,8 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = null
     const docLink = isSampleDb
       ? 'https://docs.tooljet.com/docs/data-sources/sample-data-sources'
       : selectedDataSource?.plugin_id && selectedDataSource.plugin_id.trim() !== ''
-      ? `https://docs.tooljet.com/docs/marketplace/plugins/marketplace-plugin-${selectedDataSource?.kind}/`
-      : `https://docs.tooljet.com/docs/data-sources/${selectedDataSource?.kind}`;
+        ? `https://docs.tooljet.com/docs/marketplace/plugins/marketplace-plugin-${selectedDataSource?.kind}/`
+        : `https://docs.tooljet.com/docs/data-sources/${selectedDataSource?.kind}`;
     return (
       <>
         <div className={cx({ 'disabled ': isFreezed })} ref={paramListContainerRef}>

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/GRPCv2.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/GRPCv2.jsx
@@ -553,10 +553,10 @@ const GRPCv2Component = ({ darkMode, selectedDataSource, ...restProps }) => {
                   options?.service && options?.method
                     ? `${options.service} → ${options.method}`
                     : isLoadingServices
-                    ? 'Loading services...'
-                    : hierarchicalOptions.length === 0
-                    ? 'No services found'
-                    : 'Select service'
+                      ? 'Loading services...'
+                      : hierarchicalOptions.length === 0
+                        ? 'No services found'
+                        : 'Select service'
                 }
                 disabled={
                   (!options?.service || !options?.method) && (isLoadingServices || hierarchicalOptions.length === 0)

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/DropDownSelect.jsx
@@ -202,21 +202,21 @@ const DropDownSelect = ({
             width: isForeignKeyInEditCell
               ? '300px'
               : foreignKeyAccess
-              ? '403px'
-              : foreignKeyAccessInRowForm === true
-              ? '494px'
-              : isCellEdit
-              ? '266px'
-              : '244px',
+                ? '403px'
+                : foreignKeyAccessInRowForm === true
+                  ? '494px'
+                  : isCellEdit
+                    ? '266px'
+                    : '244px',
             maxWidth: isForeignKeyInEditCell
               ? '300px'
               : foreignKeyAccess
-              ? '403px'
-              : foreignKeyAccessInRowForm === true
-              ? '494px'
-              : isCellEdit
-              ? '266px'
-              : '246px',
+                ? '403px'
+                : foreignKeyAccessInRowForm === true
+                  ? '494px'
+                  : isCellEdit
+                    ? '266px'
+                    : '246px',
             overflow: 'hidden',
             boxShadow: '0px 2px 4px -2px rgba(16, 24, 40, 0.06), 0px 4px 8px -2px rgba(16, 24, 40, 0.10)',
           }}
@@ -369,8 +369,8 @@ const DropDownSelect = ({
                       {foreignKeyAccessInRowForm || showPlaceHolderInForeignKeyDrawer
                         ? topPlaceHolder
                         : placeholder
-                        ? placeholder
-                        : 'Select...'}
+                          ? placeholder
+                          : 'Select...'}
                     </span>
                   ) : (
                     ''

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/JoinConstraint.jsx
@@ -408,14 +408,14 @@ const JoinOn = ({
   const rightFieldTableDetails = (rightFieldTable && findTableDetails(rightFieldTable)) || {};
 
   const leftFieldOptions = leftFieldTableDetails?.table_name
-    ? tableInfo[leftFieldTableDetails.table_name]?.map((col) => ({
+    ? (tableInfo[leftFieldTableDetails.table_name]?.map((col) => ({
         label: col.Header,
         value: col.Header,
         icon: col.dataType,
-      })) ?? []
+      })) ?? [])
     : [];
   const selectedLeftField = leftFieldTableDetails?.table_name
-    ? tableInfo[leftFieldTableDetails.table_name]?.find((col) => col.Header === leftFieldColumn) ?? []
+    ? (tableInfo[leftFieldTableDetails.table_name]?.find((col) => col.Header === leftFieldColumn) ?? [])
     : {};
 
   const rightFieldOptions = rightFieldTableDetails?.table_name
@@ -434,7 +434,7 @@ const JoinOn = ({
     : [];
 
   const selectedRightField = rightFieldTableDetails?.table_name
-    ? tableInfo[rightFieldTableDetails.table_name]?.find((col) => col.Header === rightFieldColumn) ?? []
+    ? (tableInfo[rightFieldTableDetails.table_name]?.find((col) => col.Header === rightFieldColumn) ?? [])
     : {};
 
   const _operators = [{ label: '=', value: '=' }];

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/SelectBox.jsx
@@ -400,12 +400,12 @@ function DataSourceSelect({
             isForeignKeyInEditCell
               ? 'tj-scrollbar tjdb-mainCellEdit-scrollbar'
               : foreignKeyAccess
-              ? 'tj-scrollbar tjdb-dashboard-scrollbar'
-              : foreignKeyAccessInRowForm
-              ? 'tj-scrollbar tjdb-rowForm-scrollbar'
-              : isCellEdit
-              ? 'tj-scrollbar tjdb-cellEdit-scrollbar'
-              : 'tj-scrollbar',
+                ? 'tj-scrollbar tjdb-dashboard-scrollbar'
+                : foreignKeyAccessInRowForm
+                  ? 'tj-scrollbar tjdb-rowForm-scrollbar'
+                  : isCellEdit
+                    ? 'tj-scrollbar tjdb-cellEdit-scrollbar'
+                    : 'tj-scrollbar',
         }}
         ref={selectRef}
         controlShouldRenderValue={false}
@@ -632,12 +632,12 @@ function DataSourceSelect({
               isSelected && highlightSelected
                 ? 'var(--indigo3, #F0F4FF)'
                 : isFocused && !isNested
-                ? 'var(--slate4)'
-                : isDisabled
-                ? 'transparent'
-                : isDisabled && isFocused
-                ? 'var(--slate3, #f1f3f5)'
-                : 'transparent',
+                  ? 'var(--slate4)'
+                  : isDisabled
+                    ? 'transparent'
+                    : isDisabled && isFocused
+                      ? 'var(--slate3, #f1f3f5)'
+                      : 'transparent',
             ...(isNested
               ? { padding: '0 8px', marginLeft: '19px', borderLeft: '1px solid var(--slate5)', width: 'auto' }
               : {}),

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/TooljetDatabase/ToolJetDbOperations.jsx
@@ -571,14 +571,14 @@ const ToolJetDbOperations = ({
                   activeTab === 'GUI mode' && !darkMode
                     ? 'white'
                     : activeTab === 'GUI mode' && darkMode
-                    ? '#242f3c'
-                    : 'transparent',
+                      ? '#242f3c'
+                      : 'transparent',
                 color:
                   activeTab === 'GUI mode' && !darkMode
                     ? '#3E63DD'
                     : activeTab === 'GUI mode' && darkMode
-                    ? 'white'
-                    : '#687076',
+                      ? 'white'
+                      : '#687076',
               }}
               className="row-tab-content"
               data-cy="tooljetdb-gui-mode-tab"
@@ -593,14 +593,14 @@ const ToolJetDbOperations = ({
                   activeTab === 'SQL mode' && !darkMode
                     ? 'white'
                     : activeTab === 'SQL mode' && darkMode
-                    ? '#242f3c'
-                    : 'transparent',
+                      ? '#242f3c'
+                      : 'transparent',
                 color:
                   activeTab === 'SQL mode' && !darkMode
                     ? '#3E63DD'
                     : activeTab === 'SQL mode' && darkMode
-                    ? 'white'
-                    : '#687076',
+                      ? 'white'
+                      : '#687076',
               }}
               className="row-tab-content"
               data-cy="tooljetdb-sql-mode-tab"

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/FlexContainer/FlexChildLayoutPanel.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/FlexContainer/FlexChildLayoutPanel.jsx
@@ -42,7 +42,7 @@ export const FlexChildLayoutPanel = ({ selectedComponentId, allComponents }) => 
   const parentType = parentId ? allComponents?.[parentId]?.component?.component : null;
   const isFlexChild = parentType === 'FlexContainer';
 
-  const layoutData = isFlexChild ? allComponents?.[selectedComponentId]?.layouts?.[currentLayout] ?? {} : {};
+  const layoutData = isFlexChild ? (allComponents?.[selectedComponentId]?.layouts?.[currentLayout] ?? {}) : {};
 
   const containerWidthPx = (parentId && subContainerWidths?.[parentId]) || subContainerWidths?.canvas;
   const gridCellWidthPx = containerWidthPx / NO_OF_GRIDS;

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/KeyValuePair/KeyValuePair.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/KeyValuePair/KeyValuePair.jsx
@@ -62,7 +62,7 @@ export const KeyValuePair = (props) => {
   // Derived state
   const useDynamicField = useMemo(() => {
     const value = component.component.definition.properties.useDynamicField?.value;
-    return value ? resolveReferences(value) ?? false : false;
+    return value ? (resolveReferences(value) ?? false) : false;
   }, [component.component.definition.properties.useDynamicField?.value]);
 
   // Event handlers

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Tags.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Components/Tags.jsx
@@ -201,8 +201,8 @@ export const Tags = ({
       item?.iconVisibility?.value !== undefined
         ? getResolvedValue(item?.iconVisibility?.value)
         : item?.iconVisibility !== undefined
-        ? item?.iconVisibility
-        : false;
+          ? item?.iconVisibility
+          : false;
 
     return (
       <Popover className={`${darkMode && 'dark-theme theme-dark'}`} style={{ minWidth: '248px' }}>

--- a/frontend/src/AppBuilder/RightSideBar/Inspector/Elements/Code.jsx
+++ b/frontend/src/AppBuilder/RightSideBar/Inspector/Elements/Code.jsx
@@ -38,8 +38,8 @@ export const Code = ({
 
   let initialValue = getInitialValue();
   const rawParamMeta = accordian
-    ? customMeta ?? componentMeta[paramType]?.[param.name]
-    : customMeta ?? componentMeta[paramType][param.name];
+    ? (customMeta ?? componentMeta[paramType]?.[param.name])
+    : (customMeta ?? componentMeta[paramType][param.name]);
   const isFlexContainer = component?.component?.component === 'FlexContainer';
   const paramMeta = isFlexContainer ? getFlexAxisAwareMeta(rawParamMeta, component, param.name) : rawParamMeta;
   const displayName = paramMeta.displayName || param.name;

--- a/frontend/src/AppBuilder/Shared/DataTypes/renderers/SelectRenderer.jsx
+++ b/frontend/src/AppBuilder/Shared/DataTypes/renderers/SelectRenderer.jsx
@@ -348,8 +348,8 @@ export const SelectRenderer = ({
           ? defaultOptionsList
           : defaultOptionsList.slice(-1)[0]
         : isMulti
-        ? []
-        : {},
+          ? []
+          : {},
     [isMulti, defaultOptionsList]
   );
 

--- a/frontend/src/AppBuilder/Shared/DataTypes/renderers/TagsRenderer.jsx
+++ b/frontend/src/AppBuilder/Shared/DataTypes/renderers/TagsRenderer.jsx
@@ -346,8 +346,8 @@ export const TagsRenderer = ({
           ? defaultOptionsList
           : defaultOptionsList.slice(-1)[0]
         : isMulti
-        ? []
-        : {},
+          ? []
+          : {},
     [isMulti, defaultOptionsList]
   );
 

--- a/frontend/src/AppBuilder/Shared/EntityDelete/EntityDeleteDialog.tsx
+++ b/frontend/src/AppBuilder/Shared/EntityDelete/EntityDeleteDialog.tsx
@@ -36,7 +36,7 @@ const KIND_SUBTITLES: Record<string, string | undefined> = {
 const subtitleOf = (entry: UsageEntry, componentsById?: ComponentsById): string =>
   entry.kind === 'component'
     ? getComponentDisplayName(componentsById?.[entry.id as string]?.component?.component)
-    : KIND_SUBTITLES[entry.kind] ?? '';
+    : (KIND_SUBTITLES[entry.kind] ?? '');
 
 type SubjectIconProps = {
   subject: DeleteSubject;

--- a/frontend/src/AppBuilder/Shared/EntityDelete/deleteDialogCopy.ts
+++ b/frontend/src/AppBuilder/Shared/EntityDelete/deleteDialogCopy.ts
@@ -37,7 +37,7 @@ export type DeleteDialogCopyInput = {
 const PLURALS: Record<string, string> = { component: 'components', query: 'queries' };
 
 export const pluralizeEntity = (entityLabel: string, count: number): string =>
-  count === 1 ? entityLabel : PLURALS[entityLabel] ?? `${entityLabel}s`;
+  count === 1 ? entityLabel : (PLURALS[entityLabel] ?? `${entityLabel}s`);
 
 /** Card header count, e.g. "Used by 1 entity" / "Used by 4 entities". */
 export const usedByLabel = (count: number): string => `Used by ${count} ${count === 1 ? 'entity' : 'entities'}`;

--- a/frontend/src/AppBuilder/Viewer/Viewer.jsx
+++ b/frontend/src/AppBuilder/Viewer/Viewer.jsx
@@ -198,8 +198,8 @@ export const Viewer = ({
                                 isPagesSidebarHidden || currentLayout === 'mobile'
                                   ? 'auto'
                                   : position === 'top'
-                                  ? '0px'
-                                  : '256px',
+                                    ? '0px'
+                                    : '256px',
                             }}
                           >
                             <div

--- a/frontend/src/AppBuilder/Widgets/Accordion/Accordion.jsx
+++ b/frontend/src/AppBuilder/Widgets/Accordion/Accordion.jsx
@@ -153,8 +153,8 @@ export const Accordion = ({
     height: !exposedVariablesTemporaryState.isExpanded
       ? headerHeight + CONTAINER_FORM_CANVAS_PADDING + 3 + 2 // 3 for bottom padding and 2 for top-bottom border
       : isDynamicHeightEnabled
-      ? '100%'
-      : height,
+        ? '100%'
+        : height,
     display:
       exposedVariablesTemporaryState.isVisible && (showHeader || exposedVariablesTemporaryState.isExpanded)
         ? 'flex'

--- a/frontend/src/AppBuilder/Widgets/BaseComponents/BaseInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/BaseComponents/BaseInput.jsx
@@ -96,15 +96,15 @@ export const BaseInput = ({
   const computedIconColor = shouldUsePlaceholderTextColorForIcon
     ? placeholderTextColor
     : iconColor !== '#CFD3D859'
-    ? iconColor
-    : 'var(--icons-weak-disabled)';
+      ? iconColor
+      : 'var(--icons-weak-disabled)';
 
   const inputStyles = {
     color: !['#1B1F24', '#000', '#000000ff'].includes(textColor)
       ? textColor
       : disable || loading
-      ? 'var(--text-disabled)'
-      : 'var(--text-primary)',
+        ? 'var(--text-disabled)'
+        : 'var(--text-primary)',
     textOverflow: 'ellipsis',
     backgroundColor: 'inherit',
     ...(shouldOverridePlaceholderTextColor && { '--cc-placeholder-text': placeholderTextColor }),
@@ -134,8 +134,8 @@ export const BaseInput = ({
         ? '30px'
         : '10px'
       : defaultAlignment === 'top' && hasLabel
-      ? 'calc(50% + 10px)'
-      : '50%';
+        ? 'calc(50% + 10px)'
+        : '50%';
   const clearButtonTransform = inputType === 'textarea' ? 'none' : 'translateY(-50%)';
   const clearButton = shouldShowClearBtn ? (
     <button
@@ -217,23 +217,23 @@ export const BaseInput = ({
               !isValid && showValidationError
                 ? 'var(--cc-error-systemStatus)'
                 : isFocused
-                ? accentColor != '4368E3'
-                  ? accentColor
-                  : 'var(--primary-accent-strong)'
-                : borderColor != '#CCD1D5'
-                ? borderColor
-                : disable || loading
-                ? '1px solid var(--borders-disabled-on-white)'
-                : 'var(--borders-default)',
+                  ? accentColor != '4368E3'
+                    ? accentColor
+                    : 'var(--primary-accent-strong)'
+                  : borderColor != '#CCD1D5'
+                    ? borderColor
+                    : disable || loading
+                      ? '1px solid var(--borders-disabled-on-white)'
+                      : 'var(--borders-default)',
             '--tblr-input-border-color-darker': getModifiedColor(borderColor, 8),
             backgroundColor:
               backgroundColor != '#fff'
                 ? backgroundColor
                 : disable || loading
-                ? darkMode
-                  ? 'var(--surfaces-app-bg-default)'
-                  : 'var(--surfaces-surface-03)'
-                : 'var(--surfaces-surface-01)',
+                  ? darkMode
+                    ? 'var(--surfaces-app-bg-default)'
+                    : 'var(--surfaces-surface-03)'
+                  : 'var(--surfaces-surface-01)',
             boxShadow,
             ...(isDynamicHeightEnabled && { minHeight: `${height}px` }),
             ...(defaultAlignment === 'top' &&

--- a/frontend/src/AppBuilder/Widgets/Button.jsx
+++ b/frontend/src/AppBuilder/Widgets/Button.jsx
@@ -78,8 +78,8 @@ export const Button = function Button(props) {
         ? 'var(--cc-primary-brand)'
         : 'transparent'
       : type === 'primary'
-      ? backgroundColor
-      : 'transparent';
+        ? backgroundColor
+        : 'transparent';
 
   const computedHoverBgColor =
     type === 'primary'

--- a/frontend/src/AppBuilder/Widgets/Camera/Camera.jsx
+++ b/frontend/src/AppBuilder/Widgets/Camera/Camera.jsx
@@ -350,11 +350,11 @@ export const Camera = ({ properties, styles, fireEvent, setExposedVariable, setE
       // On mobile the camera is chosen by facing direction, so no deviceId is selected.
       if (!isMobile) {
         setSelectedCameraId((prev) =>
-          prev && cameras.some((d) => d.value === prev) ? prev : cameras[0]?.value ?? null
+          prev && cameras.some((d) => d.value === prev) ? prev : (cameras[0]?.value ?? null)
         );
       }
       setSelectedMicrophoneId((prev) =>
-        prev && microphones.some((d) => d.value === prev) ? prev : microphones[0]?.value ?? null
+        prev && microphones.some((d) => d.value === prev) ? prev : (microphones[0]?.value ?? null)
       );
     } catch (error) {
       console.error('Failed to enumerate media devices', error);
@@ -403,8 +403,8 @@ export const Camera = ({ properties, styles, fireEvent, setExposedVariable, setE
         video: isMobile
           ? { facingMode: { ideal: facingMode } }
           : selectedCameraId && !selectedCameraId.startsWith?.('camera-')
-          ? { deviceId: { exact: selectedCameraId } }
-          : true,
+            ? { deviceId: { exact: selectedCameraId } }
+            : true,
         audio:
           selectedMicrophoneId && !selectedMicrophoneId.startsWith?.('microphone-')
             ? { deviceId: { exact: selectedMicrophoneId } }

--- a/frontend/src/AppBuilder/Widgets/Cascader/Cascader.tsx
+++ b/frontend/src/AppBuilder/Widgets/Cascader/Cascader.tsx
@@ -104,8 +104,8 @@ export const Cascader = ({
   const rawSource = !advanced
     ? properties.options
     : isExpectedDataType(properties.data, 'array')
-    ? properties.data
-    : [];
+      ? properties.data
+      : [];
   const tree = normalizeTree(rawSource, getResolvedValue);
   const shouldShowOptionsLoading = Boolean(advanced && optionsLoadingState);
 
@@ -174,15 +174,15 @@ export const Cascader = ({
     selectedTextColor !== '#1B1F24'
       ? selectedTextColor
       : interactionBlocked
-      ? 'var(--text-disabled)'
-      : 'var(--text-primary)';
+        ? 'var(--text-disabled)'
+        : 'var(--text-primary)';
 
   const menuWidthStyle =
     menuWidthMode === 'custom'
       ? `${parseFloat(menuCustomWidth) || 256}px`
       : menuWidthMode === 'matchContent'
-      ? 'auto'
-      : 'var(--radix-popover-trigger-width)';
+        ? 'auto'
+        : 'var(--radix-popover-trigger-width)';
   const shouldOverridePlaceholderTextColor =
     typeof placeholderTextColor === 'string' &&
     placeholderTextColor.length > 0 &&

--- a/frontend/src/AppBuilder/Widgets/Cascader/CascaderMenu.tsx
+++ b/frontend/src/AppBuilder/Widgets/Cascader/CascaderMenu.tsx
@@ -216,8 +216,8 @@ const CascaderMenu = forwardRef<CascaderMenuRef, CascaderMenuProps>(
                     backgroundColor: isHighlighted
                       ? 'var(--interactive-overlays-fill-hover)'
                       : isSelected
-                      ? 'var(--cc-primary-accent-subtle, rgba(67,104,227,0.1))'
-                      : 'transparent',
+                        ? 'var(--cc-primary-accent-subtle, rgba(67,104,227,0.1))'
+                        : 'transparent',
                   }}
                 >
                   {/* Reserve the left gutter for every row (parent + leaf) so all

--- a/frontend/src/AppBuilder/Widgets/Chart.jsx
+++ b/frontend/src/AppBuilder/Widgets/Chart.jsx
@@ -75,7 +75,7 @@ export default function Chart({
 
   const jsonChartData = isDescriptionJson ? JSON.parse(jsonData).data : [];
 
-  const chartLayout = isDescriptionJson ? JSON.parse(jsonData).layout ?? {} : {};
+  const chartLayout = isDescriptionJson ? (JSON.parse(jsonData).layout ?? {}) : {};
 
   const updatedBgColor = ['#fff', '#ffffff'].includes(modifiedBackgroundColor)
     ? darkMode
@@ -85,7 +85,7 @@ export default function Chart({
 
   const fontColor = getColor(updatedBgColor);
 
-  const chartTitle = plotFromJson ? chartLayout?.title ?? title : title;
+  const chartTitle = plotFromJson ? (chartLayout?.title ?? title) : title;
   useEffect(() => {
     if (isInitialRender.current) return;
     const { xaxis, yaxis } = chartLayout;

--- a/frontend/src/AppBuilder/Widgets/CirularProgressbar.jsx
+++ b/frontend/src/AppBuilder/Widgets/CirularProgressbar.jsx
@@ -63,10 +63,10 @@ export const CircularProgressBar = function CircularProgressBar({
           exposedVariablesTemporaryState.value >= 100
             ? completionColor
             : allowNegativeProgress
-            ? exposedVariablesTemporaryState.value >= 0
-              ? color
-              : negativeColor
-            : color,
+              ? exposedVariablesTemporaryState.value >= 0
+                ? color
+                : negativeColor
+              : color,
         text: label,
       };
 

--- a/frontend/src/AppBuilder/Widgets/ColorPicker/ColorPicker.jsx
+++ b/frontend/src/AppBuilder/Widgets/ColorPicker/ColorPicker.jsx
@@ -247,10 +247,10 @@ export const ColorPicker = (props) => {
   const buttonBorderColor = !isValid
     ? errTextColor
     : isFocusedOrOpen
-    ? accentColor
-    : isHovered
-    ? getModifiedColor(borderColor, 24)
-    : borderColor;
+      ? accentColor
+      : isHovered
+        ? getModifiedColor(borderColor, 24)
+        : borderColor;
 
   const buttonStyles = {
     borderRadius: `${borderRadius}px`,

--- a/frontend/src/AppBuilder/Widgets/Date/BaseDateComponent.jsx
+++ b/frontend/src/AppBuilder/Widgets/Date/BaseDateComponent.jsx
@@ -74,26 +74,26 @@ export const BaseDateComponent = ({
         ? accentColor
         : 'var(--primary-accent-strong)'
       : fieldBorderColor != '#CCD1D5'
-      ? fieldBorderColor
-      : disable || loading
-      ? '1px solid var(--borders-disabled-on-white)'
-      : 'var(--borders-default)',
+        ? fieldBorderColor
+        : disable || loading
+          ? '1px solid var(--borders-disabled-on-white)'
+          : 'var(--borders-default)',
     '--tblr-input-border-color-darker': getModifiedColor(fieldBorderColor, 24),
     borderRadius: `${fieldBorderRadius || borderRadius}px`,
     color: !['#1B1F24', '#000', '#000000ff'].includes(selectedTextColor)
       ? selectedTextColor
       : disable || loading
-      ? 'var(--text-disabled)'
-      : 'var(--text-primary)',
+        ? 'var(--text-disabled)'
+        : 'var(--text-primary)',
     boxShadow: boxShadow,
     backgroundColor:
       fieldBackgroundColor != '#fff'
         ? fieldBackgroundColor
         : disable || loading
-        ? darkMode
-          ? 'var(--surfaces-app-bg-default)'
-          : 'var(--surfaces-surface-03)'
-        : 'var(--surfaces-surface-01)',
+          ? darkMode
+            ? 'var(--surfaces-app-bg-default)'
+            : 'var(--surfaces-surface-03)'
+          : 'var(--surfaces-surface-01)',
     paddingLeft: '10px',
     ...(iconVisibility && {
       ...(iconDirection === 'left' ? { paddingLeft: '30px' } : { paddingRight: '30px' }),

--- a/frontend/src/AppBuilder/Widgets/DropDown.jsx
+++ b/frontend/src/AppBuilder/Widgets/DropDown.jsx
@@ -246,11 +246,11 @@ export const DropDown = function DropDown({
               backgroundColor: state.isDisabled
                 ? 'transparent'
                 : state.value === currentValue
-                ? hoverBgColorValue
-                : getModifiedColor(
-                    state.value === currentValue ? 'var(--cc-primary-brand)' : 'var(--cc-surface1-surface)',
-                    'hover'
-                  ),
+                  ? hoverBgColorValue
+                  : getModifiedColor(
+                      state.value === currentValue ? 'var(--cc-primary-brand)' : 'var(--cc-surface1-surface)',
+                      'hover'
+                    ),
             },
             maxWidth: 'auto',
             minWidth: 'max-content',
@@ -262,11 +262,11 @@ export const DropDown = function DropDown({
               backgroundColor: state.isDisabled
                 ? 'transparent'
                 : state.value === currentValue
-                ? hoverBgColorValue
-                : getModifiedColor(
-                    state.value === currentValue ? 'var(--cc-primary-brand)' : 'var(--cc-surface1-surface)',
-                    'hover'
-                  ),
+                  ? hoverBgColorValue
+                  : getModifiedColor(
+                      state.value === currentValue ? 'var(--cc-primary-brand)' : 'var(--cc-surface1-surface)',
+                      'hover'
+                    ),
             },
             maxWidth: 'auto',
             minWidth: 'max-content',

--- a/frontend/src/AppBuilder/Widgets/FileButton/FileButton.jsx
+++ b/frontend/src/AppBuilder/Widgets/FileButton/FileButton.jsx
@@ -141,7 +141,7 @@ export const FileButton = (props) => {
     hoverBackgroundColor !== 'auto' ? hoverBackgroundColor : getModifiedColor(backgroundColor, 'hover');
   const computedPressedBgColor = getModifiedColor(backgroundColor, 'active');
   const resolvedBgColor = backgroundColor?.startsWith('var(')
-    ? getCssVarValue(document.documentElement, backgroundColor) ?? backgroundColor
+    ? (getCssVarValue(document.documentElement, backgroundColor) ?? backgroundColor)
     : backgroundColor;
   const computedDisabledBgColor = tinycolor(resolvedBgColor).setAlpha(DISABLED_BG_ALPHA).toRgbString();
 

--- a/frontend/src/AppBuilder/Widgets/FileInput/FileInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/FileInput/FileInput.jsx
@@ -166,25 +166,25 @@ export const FileInput = (props) => {
       borderColor: hasError
         ? errTextColor
         : borderColor !== '#CCD1D5'
-        ? borderColor
-        : disabledState
-        ? 'var(--borders-disabled-on-white)'
-        : 'var(--borders-default)',
+          ? borderColor
+          : disabledState
+            ? 'var(--borders-disabled-on-white)'
+            : 'var(--borders-default)',
       '--tblr-input-border-color-darker': getModifiedColor(borderColor, 24),
       boxShadow,
       backgroundColor:
         backgroundColor !== '#fff'
           ? backgroundColor
           : disabledState || isLoading
-          ? darkMode
-            ? 'var(--surfaces-app-bg-default)'
-            : 'var(--surfaces-surface-03)'
-          : 'var(--surfaces-surface-01)',
+            ? darkMode
+              ? 'var(--surfaces-app-bg-default)'
+              : 'var(--surfaces-surface-03)'
+            : 'var(--surfaces-surface-01)',
       color: !['#1B1F24', '#000', '#000000ff'].includes(textColor)
         ? textColor
         : disabledState
-        ? 'var(--text-disabled)'
-        : 'var(--text-primary)',
+          ? 'var(--text-disabled)'
+          : 'var(--text-primary)',
       display: 'flex',
       alignItems: 'center',
       overflow: 'visible',
@@ -230,8 +230,8 @@ export const FileInput = (props) => {
     selectedFiles.length === 0
       ? placeholder
       : selectedFiles.length === 1
-      ? selectedFiles[0].name
-      : `${selectedFiles.length} files selected`;
+        ? selectedFiles[0].name
+        : `${selectedFiles.length} files selected`;
 
   if (!isVisible) return null;
 

--- a/frontend/src/AppBuilder/Widgets/FilePicker/Components/ValidationBar.jsx
+++ b/frontend/src/AppBuilder/Widgets/FilePicker/Components/ValidationBar.jsx
@@ -49,8 +49,8 @@ const ValidationBar = ({
           {minSize > 0 && maxSize < Infinity
             ? `${formatFileSize(minSize)} to ${formatFileSize(maxSize)}` // Min and Max
             : maxSize < Infinity && maxSize > 0
-            ? `Up to ${formatFileSize(maxSize)}` // Only Max
-            : `Min ${formatFileSize(minSize)}`}
+              ? `Up to ${formatFileSize(maxSize)}` // Only Max
+              : `Min ${formatFileSize(minSize)}`}
         </span>
       )}
 

--- a/frontend/src/AppBuilder/Widgets/FlexContainer/FlexContainer.jsx
+++ b/frontend/src/AppBuilder/Widgets/FlexContainer/FlexContainer.jsx
@@ -89,12 +89,12 @@ export const FlexContainer = ({
         overflowY: 'visible',
       }
     : shouldStack
-    ? { overflowY: 'auto' }
-    : flexWrap
-    ? {}
-    : isRow
-    ? { overflowX: 'auto' }
-    : { overflowY: 'auto' };
+      ? { overflowY: 'auto' }
+      : flexWrap
+        ? {}
+        : isRow
+          ? { overflowX: 'auto' }
+          : { overflowY: 'auto' };
 
   const outerStyles = {
     height: isDynamicHeightEnabled ? 'auto' : '100%',

--- a/frontend/src/AppBuilder/Widgets/FlexContainer/useFlexWidgetLayout.js
+++ b/frontend/src/AppBuilder/Widgets/FlexContainer/useFlexWidgetLayout.js
@@ -41,8 +41,8 @@ export const useFlexWidgetLayout = ({
   // it remains in place. In viewer mode, prefer the temporary height so flex
   // layout and dynamic-height reflow agree on the child's actual size.
   const visibleHeightPx = dynamicHeight
-    ? temporaryHeight ?? height ?? flexLayoutData.height ?? 100
-    : height ?? flexLayoutData.height ?? 100;
+    ? (temporaryHeight ?? height ?? flexLayoutData.height ?? 100)
+    : (height ?? flexLayoutData.height ?? 100);
   const effectiveHeightPx = visibility ? visibleHeightPx : mode === 'edit' ? HIDDEN_COMPONENT_HEIGHT : 0;
   const availableWidth = containerWidth ?? effectiveWidthPx;
   let widgetWidth = fillWidth ? availableWidth : effectiveWidthPx;
@@ -59,8 +59,8 @@ export const useFlexWidgetLayout = ({
       ? authoredHeightPx
       : visibleHeightPx
     : mode === 'edit'
-    ? HIDDEN_COMPONENT_HEIGHT
-    : 0;
+      ? HIDDEN_COMPONENT_HEIGHT
+      : 0;
   const flexMainFill = isFlexRow ? fillWidth : false;
   const flexMainPx = isFlexRow ? effectiveWidthPx : effectiveHeightPx;
 

--- a/frontend/src/AppBuilder/Widgets/Image/Image.jsx
+++ b/frontend/src/AppBuilder/Widgets/Image/Image.jsx
@@ -210,8 +210,8 @@ export default function Image({
           borderType === 'rounded-circle'
             ? '50%'
             : borderType === 'rounded' || borderType === 'img-thumbnail'
-            ? '4px'
-            : `${borderRadius}px`,
+              ? '4px'
+              : `${borderRadius}px`,
         borderColor: borderColor || (borderType === 'img-thumbnail' ? '#e7eaef' : 'transparent'),
         objectPosition: alignment,
       }}

--- a/frontend/src/AppBuilder/Widgets/Listview/ListviewSubcontainer.jsx
+++ b/frontend/src/AppBuilder/Widgets/Listview/ListviewSubcontainer.jsx
@@ -40,7 +40,7 @@ export const ListviewSubcontainer = ({
     (state) => state.temporaryLayouts?.[getDynamicLayoutKey(id, contextIndices, '', moduleId)],
     shallow
   );
-  const transformedRowHeight = isDynamicHeightEnabled ? temporaryLayout?.height ?? rowHeight : rowHeight;
+  const transformedRowHeight = isDynamicHeightEnabled ? (temporaryLayout?.height ?? rowHeight) : rowHeight;
 
   useDynamicHeight({
     isDynamicHeightEnabled,

--- a/frontend/src/AppBuilder/Widgets/ModalV2/ModalV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/ModalV2/ModalV2.jsx
@@ -80,8 +80,8 @@ export const ModalV2 = function Modal({
   const computedTriggerButtonFontWeight = normalizedTriggerButtonFontWeight
     ? normalizedTriggerButtonFontWeight
     : normalizedTriggerButtonFontWeight === '0'
-    ? 0
-    : 'normal';
+      ? 0
+      : 'normal';
   const isInitialRender = useRef(true);
   const title = properties.title ?? '';
   const titleAlignment = properties.titleAlignment ?? 'left';

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/adapters/ButtonColumnAdapter.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/DataTypes/adapters/ButtonColumnAdapter.jsx
@@ -54,8 +54,8 @@ export const ButtonColumn = ({
       ? 'transparent'
       : 'var(--cc-primary-brand)'
     : isOutline
-    ? 'transparent'
-    : backgroundColor;
+      ? 'transparent'
+      : backgroundColor;
 
   const computedLabelColor = isDefaultLabel
     ? isOutline

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/Footer/_components/Pagination/Pagination.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/Footer/_components/Pagination/Pagination.jsx
@@ -31,8 +31,8 @@ export const Pagination = function Pagination({
   const effectivePageCount = knowTotalPages
     ? Math.ceil(parsedTotalRecords / parsedServerSideRowsPerPage)
     : serverSidePagination
-    ? 0
-    : pageCount;
+      ? 0
+      : pageCount;
 
   const canGoToNextPage = serverSidePagination ? enableNextButton : table.getCanNextPage();
   const canGoToPreviousPage = serverSidePagination ? enablePrevButton : table.getCanPreviousPage();

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/_components/TableRow.jsx
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/_components/TableRow.jsx
@@ -76,7 +76,7 @@ export const TableRow = ({
         const cellBackgroundColor =
           pinnedPosition && [undefined, null, '', 'inherit', 'transparent'].includes(resolvedCellBackgroundColor)
             ? 'var(--cc-table-pinned-column-bg, var(--cc-surface1-surface))'
-            : resolvedCellBackgroundColor ?? 'inherit';
+            : (resolvedCellBackgroundColor ?? 'inherit');
         const cellStyles = {
           backgroundColor: cellBackgroundColor,
           justifyContent: isButtonColumn

--- a/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/pinColumnsUtils.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_components/TableData/pinColumnsUtils.js
@@ -14,7 +14,7 @@ export const getPinnedPosition = (column) => {
 
 const getPinnedLeafColumns = (table, position) => {
   if (!table) return [];
-  return position === 'left' ? table.getLeftLeafColumns?.() ?? [] : table.getRightLeafColumns?.() ?? [];
+  return position === 'left' ? (table.getLeftLeafColumns?.() ?? []) : (table.getRightLeafColumns?.() ?? []);
 };
 
 const getPinnedOffsetFallback = (column, table, position) => {

--- a/frontend/src/AppBuilder/Widgets/NewTable/_hooks/useTable.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_hooks/useTable.js
@@ -55,7 +55,7 @@ export function useTable({
 
   useEffect(() => {
     setPagination((prev) => ({
-      pageIndex: serverSidePagination ? prev.pageIndex ?? 0 : 0,
+      pageIndex: serverSidePagination ? (prev.pageIndex ?? 0) : 0,
       pageSize: enablePagination ? rowsPerPage : data.length,
     }));
   }, [enablePagination, rowsPerPage, data.length, serverSidePagination]);

--- a/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/initSlice.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_stores/slices/initSlice.js
@@ -66,7 +66,7 @@ export const createInitSlice = (set, get) => ({
         state.components[id].properties.enabledSort = properties?.enabledSort ?? true;
         state.components[id].properties.columnSizes = properties?.columnSizes ?? {};
         state.components[id].properties.allowSelection =
-          properties?.allowSelection ?? (properties?.showBulkSelector || properties?.highlightSelectedRow)
+          (properties?.allowSelection ?? (properties?.showBulkSelector || properties?.highlightSelectedRow))
             ? true
             : false;
         state.components[id].properties.defaultSelectedRow = properties?.defaultSelectedRow ?? { id: 1 };

--- a/frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.js
@@ -125,7 +125,7 @@ export default function generateColumnsData({
 
       const columnSize = useDynamicColumn
         ? column.columnSize || columnSizes[column?.id] || columnSizes[column?.name]
-        : columnSizes[column?.id] ?? columnSizes[column?.name] ?? column.columnSize;
+        : (columnSizes[column?.id] ?? columnSizes[column?.name] ?? column.columnSize);
       const columnType = column?.columnType;
 
       // Process column options for select types

--- a/frontend/src/AppBuilder/Widgets/PhoneCurrency/CurrencyInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/PhoneCurrency/CurrencyInput.jsx
@@ -112,26 +112,26 @@ export const CurrencyInput = (props) => {
     color: !['#1B1F24', '#000', '#000000ff'].includes(textColor)
       ? textColor
       : disabledState
-      ? 'var(--text-disabled)'
-      : 'var(--text-primary)',
+        ? 'var(--text-disabled)'
+        : 'var(--text-primary)',
     borderColor: isFocused
       ? accentColor != '4368E3'
         ? accentColor
         : 'var(--primary-accent-strong)'
       : borderColor != '#CCD1D5'
-      ? borderColor
-      : disabledState
-      ? '1px solid var(--borders-disabled-on-white)'
-      : 'var(--borders-default)',
+        ? borderColor
+        : disabledState
+          ? '1px solid var(--borders-disabled-on-white)'
+          : 'var(--borders-default)',
     '--tblr-input-border-color-darker': getModifiedColor(borderColor, 24),
     backgroundColor:
       backgroundColor != '#fff'
         ? backgroundColor
         : disabledState
-        ? darkMode
-          ? 'var(--surfaces-app-bg-default)'
-          : 'var(--surfaces-surface-03)'
-        : 'var(--surfaces-surface-01)',
+          ? darkMode
+            ? 'var(--surfaces-app-bg-default)'
+            : 'var(--surfaces-surface-03)'
+          : 'var(--surfaces-surface-01)',
     padding: '8px 10px',
     paddingRight: shouldShowClearBtn ? '32px' : undefined,
     overflow: 'hidden',

--- a/frontend/src/AppBuilder/Widgets/PhoneCurrency/PhoneInput.jsx
+++ b/frontend/src/AppBuilder/Widgets/PhoneCurrency/PhoneInput.jsx
@@ -195,26 +195,26 @@ export const PhoneInput = (props) => {
     color: !['#1B1F24', '#000', '#000000ff'].includes(textColor)
       ? textColor
       : disabledState
-      ? 'var(--text-disabled)'
-      : 'var(--text-primary)',
+        ? 'var(--text-disabled)'
+        : 'var(--text-primary)',
     borderColor: isFocused
       ? accentColor != '4368E3'
         ? accentColor
         : 'var(--primary-accent-strong)'
       : borderColor != '#CCD1D5'
-      ? borderColor
-      : disabledState
-      ? '1px solid var(--borders-disabled-on-white)'
-      : 'var(--borders-default)',
+        ? borderColor
+        : disabledState
+          ? '1px solid var(--borders-disabled-on-white)'
+          : 'var(--borders-default)',
     '--tblr-input-border-color-darker': getModifiedColor(borderColor, 24),
     backgroundColor:
       backgroundColor != '#fff'
         ? backgroundColor
         : disabledState
-        ? darkMode
-          ? 'var(--surfaces-app-bg-default)'
-          : 'var(--surfaces-surface-03)'
-        : 'var(--surfaces-surface-01)',
+          ? darkMode
+            ? 'var(--surfaces-app-bg-default)'
+            : 'var(--surfaces-surface-03)'
+          : 'var(--surfaces-surface-01)',
     padding: '8px 10px',
     paddingRight: shouldShowClearBtn ? '32px' : undefined,
     overflow: 'hidden',

--- a/frontend/src/AppBuilder/Widgets/PopoverMenu/components/CustomButton.jsx
+++ b/frontend/src/AppBuilder/Widgets/PopoverMenu/components/CustomButton.jsx
@@ -65,8 +65,8 @@ export const CustomButton = forwardRef((props, forwardedRef) => {
         ? 'var(--cc-primary-brand)'
         : 'transparent'
       : buttonType === 'primary'
-      ? backgroundColor
-      : 'transparent';
+        ? backgroundColor
+        : 'transparent';
 
   const computedHoverBgColor =
     buttonType === 'primary'

--- a/frontend/src/AppBuilder/Widgets/RadioButtonV2/RadioButtonV2.jsx
+++ b/frontend/src/AppBuilder/Widgets/RadioButtonV2/RadioButtonV2.jsx
@@ -307,8 +307,8 @@ export const RadioButtonV2 = ({
                         optionsTextColor !== '#1B1F24'
                           ? optionsTextColor
                           : isDisabled || isLoading
-                          ? 'var(--text-disabled)'
-                          : 'var(--text-primary)',
+                            ? 'var(--text-disabled)'
+                            : 'var(--text-primary)',
                     }}
                   >
                     {String(option.label)}

--- a/frontend/src/AppBuilder/Widgets/Tags/Tags.jsx
+++ b/frontend/src/AppBuilder/Widgets/Tags/Tags.jsx
@@ -188,8 +188,8 @@ export const Tags = function Tags({
       tag?.iconVisibility?.value !== undefined
         ? tag.iconVisibility.value
         : tag?.iconVisibility !== undefined
-        ? tag.iconVisibility
-        : false;
+          ? tag.iconVisibility
+          : false;
 
     if (!iconName || !iconVisible) return null;
 

--- a/frontend/src/AppBuilder/Widgets/TagsInput/TagsInputMenuList.jsx
+++ b/frontend/src/AppBuilder/Widgets/TagsInput/TagsInputMenuList.jsx
@@ -24,8 +24,8 @@ const TagsInputMenuList = ({
   const selectedValues = Array.isArray(selectProps?.value)
     ? selectProps.value
     : selectProps?.value
-    ? [selectProps.value]
-    : [];
+      ? [selectProps.value]
+      : [];
 
   // Check if inputValue already exists in selected tags or all options (case-insensitive)
   const trimmedInput = inputValue?.trim()?.toLowerCase();

--- a/frontend/src/AppBuilder/Widgets/Timer.jsx
+++ b/frontend/src/AppBuilder/Widgets/Timer.jsx
@@ -103,7 +103,7 @@ export const Timer = function Timer({ height, properties = {}, styles, setExpose
                   HH--;
 
                   if (HH < 0) {
-                    (MS = 0), (SS = 0), (MM = 0), (HH = 0);
+                    ((MS = 0), (SS = 0), (MM = 0), (HH = 0));
                   }
                 }
               }

--- a/frontend/src/AppBuilder/Widgets/TreeSelect/TreeSelect.jsx
+++ b/frontend/src/AppBuilder/Widgets/TreeSelect/TreeSelect.jsx
@@ -139,8 +139,8 @@ const TreeSelect = ({
   const rawData = !advanced
     ? filterNodes(options)
     : isExpectedDataType(properties.data, 'array')
-    ? filterNodes(properties.data)
-    : [];
+      ? filterNodes(properties.data)
+      : [];
 
   const evaluatedCheckedData = !advanced ? derivedChecked : checkedData;
   const evaluatedExpandedData = !advanced ? derivedExpanded : expandedData;

--- a/frontend/src/AppBuilder/Widgets/utils.js
+++ b/frontend/src/AppBuilder/Widgets/utils.js
@@ -40,7 +40,7 @@ export function getModifiedColor(color, stateOrModificationAmount, options = { e
   const modificationAmount =
     typeof stateOrModificationAmount === 'number'
       ? stateOrModificationAmount
-      : defaultModificationAmountMappingByState[stateOrModificationAmount] ?? 0;
+      : (defaultModificationAmountMappingByState[stateOrModificationAmount] ?? 0);
 
   const colorValue = color?.startsWith('var(') ? getCssVarValue(options?.element, color) : color;
 

--- a/frontend/src/AppBuilder/_helpers/editorHelpers.js
+++ b/frontend/src/AppBuilder/_helpers/editorHelpers.js
@@ -231,16 +231,14 @@ function convertToBracketNotation(base, accessors) {
 }
 
 function verifyDotAndBracketNotations(jsString) {
-  if (
-    !(
-      jsString.includes('components.') ||
-      jsString.includes('globals.') ||
-      jsString.includes('queries.') ||
-      jsString.includes('page.') ||
-      jsString.includes('variables.') ||
-      jsString.includes('constants.')
-    )
-  ) {
+  if (!(
+    jsString.includes('components.') ||
+    jsString.includes('globals.') ||
+    jsString.includes('queries.') ||
+    jsString.includes('page.') ||
+    jsString.includes('variables.') ||
+    jsString.includes('constants.')
+  )) {
     return false;
   }
 

--- a/frontend/src/AppBuilder/_helpers/queryDataShape.js
+++ b/frontend/src/AppBuilder/_helpers/queryDataShape.js
@@ -126,7 +126,7 @@ const mergeKeyNode = (a, b) => {
   }
   if (a.type === 'array') {
     merged.length = Math.max(a.length ?? 0, b.length ?? 0);
-    merged.items = a.items && b.items ? mergeKeyNode(a.items, b.items) : a.items ?? b.items;
+    merged.items = a.items && b.items ? mergeKeyNode(a.items, b.items) : (a.items ?? b.items);
   }
   if (a.format !== b.format) merged.format = null;
   return merged;

--- a/frontend/src/AppBuilder/_stores/slices/appSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/appSlice.js
@@ -166,7 +166,7 @@ export const createAppSlice = (set, get) => ({
       }
       const temporaryLayout = temporaryLayouts?.[getDynamicLayoutKey(component.id, null, '', moduleId)];
       const top = temporaryLayout?.top ?? layout.top;
-      const height = visibility ? temporaryLayout?.height ?? layout.height : 10;
+      const height = visibility ? (temporaryLayout?.height ?? layout.height) : 10;
       return Math.max(max, top + height);
     }, 0);
 

--- a/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/componentsSlice.js
@@ -2516,11 +2516,11 @@ export const createComponentsSlice = (set, get) => ({
     );
   },
   setFocusedParentId: (parentId) => {
-    set((state) => {
+    (set((state) => {
       state.focusedParentId = parentId;
     }),
       false,
-      { type: 'setFocusedParentId', payload: { parentId } };
+      { type: 'setFocusedParentId', payload: { parentId } });
   },
   saveComponentChanges: (diff, type, operation, moduleId = 'canvas', { onCycleReject } = {}) => {
     set(
@@ -3217,13 +3217,13 @@ export const createComponentsSlice = (set, get) => ({
     const resolvedAuto = resolveDynamicValues(auto?.value + '', getAllExposedValues(moduleId)) ?? false;
     const labelType = componentDefinition?.component?.definition?.properties?.labelType;
     const resolvedLabelType = labelType
-      ? resolveDynamicValues(labelType.value + '', getAllExposedValues(moduleId)) ?? 'auto'
+      ? (resolveDynamicValues(labelType.value + '', getAllExposedValues(moduleId)) ?? 'auto')
       : undefined;
     const legacyInputSizeProperty = componentDefinition?.component?.definition?.properties?.legacyInputSize;
     const resolvedLegacyInputSize =
       resolvedStyleLegacyInputSize ??
       (legacyInputSizeProperty
-        ? resolveDynamicValues(legacyInputSizeProperty.value + '', getAllExposedValues(moduleId)) ?? false
+        ? (resolveDynamicValues(legacyInputSizeProperty.value + '', getAllExposedValues(moduleId)) ?? false)
         : false);
 
     const { alignment: resolvedAlignment, isDynamicAlignment } = resolveInputCanvasAlignment({

--- a/frontend/src/AppBuilder/_stores/slices/debuggerSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/debuggerSlice.js
@@ -188,8 +188,8 @@ export const createDebuggerSlice = (set, get) => ({
       const defaultValue = validationSchema?.defaultValue
         ? validationSchema?.defaultValue
         : validationSchema
-        ? findDefault(validationSchema, value)
-        : undefined;
+          ? findDefault(validationSchema, value)
+          : undefined;
 
       const schema = _.isUndefined(validationSchema) ? any() : generateSchemaFromValidationDefinition(validationSchema);
 

--- a/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/environmentsAndVersionsSlice.js
@@ -512,8 +512,8 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
               'is_maintenance_on' in data
                 ? data.is_maintenance_on
                 : 'isMaintenanceOn' in data
-                ? data.isMaintenanceOn
-                : false,
+                  ? data.isMaintenanceOn
+                  : false,
             homePageId: data.editing_version?.homePageId || data.editing_version?.home_page_id,
           },
           moduleId
@@ -574,8 +574,8 @@ export const createEnvironmentsAndVersionsSlice = (set, get) => ({
           get().globalSettings?.appMode && get().globalSettings.appMode !== 'auto'
             ? get().globalSettings.appMode
             : localStorage.getItem('darkMode') === 'true'
-            ? 'dark'
-            : 'light';
+              ? 'dark'
+              : 'light';
         get().setResolvedGlobals('theme', { name: exposedTheme }, moduleId);
         get().setResolvedGlobals(
           'urlparams',

--- a/frontend/src/AppBuilder/_stores/slices/leftSideBarSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/leftSideBarSlice.js
@@ -3,9 +3,9 @@ const storedIsSidebarPinned = localStorage.getItem('isLeftSideBarPinned') === 't
 const storedSelectedSidebarItem = !storedIsSidebarPinned
   ? null
   : localStorage.getItem('selectedSidebarItem') &&
-    validSidebarItems.includes(localStorage.getItem('selectedSidebarItem'))
-  ? localStorage.getItem('selectedSidebarItem')
-  : 'page';
+      validSidebarItems.includes(localStorage.getItem('selectedSidebarItem'))
+    ? localStorage.getItem('selectedSidebarItem')
+    : 'page';
 
 const initialState = {
   isLeftSideBarPinned: storedIsSidebarPinned,

--- a/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
+++ b/frontend/src/AppBuilder/_stores/slices/queryPanelSlice.js
@@ -24,7 +24,7 @@ const initialState = {
   isQueryPaneExpanded: queryManagerPreferences?.isExpanded ?? true,
   isDraggingQueryPane: false,
   // eslint-disable-next-line no-constant-binary-expression
-  queryPanelHeight: queryManagerPreferences?.isExpanded ? queryManagerPreferences?.queryPanelHeight : 95 ?? 70,
+  queryPanelHeight: queryManagerPreferences?.isExpanded ? queryManagerPreferences?.queryPanelHeight : (95 ?? 70),
   selectedQuery: null,
   previewPanelHeight: 0,
   selectedDataSource: null,
@@ -626,15 +626,15 @@ export const createQueryPanelSlice = (set, get) => ({
                   response: errorData?.data?.responseObject,
                 }
               : query.kind === 'restapi'
-              ? {
-                  metadata: errorData?.metadata,
-                  request: errorData?.data?.requestObject,
-                  response: errorData?.data?.responseObject,
-                  responseHeaders: errorData?.data?.responseHeaders,
-                }
-              : query.kind === 'workflows'
-              ? { metadata: errorData?.metadata, response: errorData?.metadata?.response }
-              : {}),
+                ? {
+                    metadata: errorData?.metadata,
+                    request: errorData?.data?.requestObject,
+                    response: errorData?.data?.responseObject,
+                    responseHeaders: errorData?.data?.responseHeaders,
+                  }
+                : query.kind === 'workflows'
+                  ? { metadata: errorData?.metadata, response: errorData?.metadata?.response }
+                  : {}),
           },
           moduleId
         );
@@ -805,7 +805,7 @@ export const createQueryPanelSlice = (set, get) => ({
             // Handle synchronous queries (original code)
 
             let queryStatusCode = data?.status ?? null;
-            const promiseStatus = query.kind === 'runpy' ? data?.data?.status ?? 'ok' : data.status;
+            const promiseStatus = query.kind === 'runpy' ? (data?.data?.status ?? 'ok') : data.status;
             // Note: Need to move away from statusText -> statusCode
             if (
               promiseStatus === 'failed' ||
@@ -1127,7 +1127,7 @@ export const createQueryPanelSlice = (set, get) => ({
 
             let finalData = data.data;
             let queryStatusCode = data?.status ?? null;
-            const queryStatus = query.kind === 'runpy' ? data?.data?.status ?? 'ok' : data.status;
+            const queryStatus = query.kind === 'runpy' ? (data?.data?.status ?? 'ok') : data.status;
             switch (true) {
               case queryStatus === 'Bad Request' ||
                 queryStatus === 'Not Found' ||

--- a/frontend/src/AppBuilder/_stores/utils/appDataCaseConversion.ts
+++ b/frontend/src/AppBuilder/_stores/utils/appDataCaseConversion.ts
@@ -37,9 +37,8 @@ const OPAQUE_VALUE_KEYS: readonly string[] = ['pages', 'events', 'dataQueries', 
 
 export function convertAllKeysToSnakeCase(o: JsonValue): JsonValue {
   if (Array.isArray(o)) {
-    return o.map(
-      (value: JsonValue): JsonValue =>
-        typeof value === 'object' && value !== null ? convertAllKeysToSnakeCase(value) : value
+    return o.map((value: JsonValue): JsonValue =>
+      typeof value === 'object' && value !== null ? convertAllKeysToSnakeCase(value) : value
     );
   } else if (typeof o === 'object' && o !== null) {
     const source = o as JsonObject;

--- a/frontend/src/AppBuilder/_stores/utils/dynamicHeightReflow.js
+++ b/frontend/src/AppBuilder/_stores/utils/dynamicHeightReflow.js
@@ -649,7 +649,7 @@ export const resolveContainerHeight = ({
     const activeTabFromExposedState = getExposedPropertyForAdditionalActions(componentId, context, 'currentTab');
     const configuredTabs = component?.properties?.tabItems || component?.properties?.tabs;
     const firstVisibleTabId = Array.isArray(configuredTabs)
-      ? configuredTabs.find((tabItem) => tabItem?.visible !== false)?.id ?? configuredTabs[0]?.id
+      ? (configuredTabs.find((tabItem) => tabItem?.visible !== false)?.id ?? configuredTabs[0]?.id)
       : null;
     const activeTab =
       activeTabFromElement ?? activeTabFromExposedState ?? component?.properties?.defaultTab ?? firstVisibleTabId;
@@ -1356,7 +1356,7 @@ export const buildReflowPatch = ({
     let nextHeight =
       componentId === changedComponentId
         ? changedNewHeight
-        : resolvedHeights[componentId] ?? currentEffectiveLayout?.height ?? 0;
+        : (resolvedHeights[componentId] ?? currentEffectiveLayout?.height ?? 0);
 
     // Floor a non-changed sibling at its calc-bumped canonical so a stale/raw temp can't pin a top-label input below its rendered label row.
     if (componentId !== changedComponentId) {

--- a/frontend/src/AppBuilder/_utils/component-properties-validation.js
+++ b/frontend/src/AppBuilder/_utils/component-properties-validation.js
@@ -124,8 +124,8 @@ export const validateProperties = (resolvedProperties, propertyDefinitions, type
       const defaultValue = validationDefinition?.defaultValue
         ? validationDefinition?.defaultValue
         : validationDefinition
-        ? findDefault(validationDefinition, value)
-        : undefined;
+          ? findDefault(validationDefinition, value)
+          : undefined;
 
       const schema = _.isUndefined(validationDefinition)
         ? any()

--- a/frontend/src/AppBuilder/_utils/entityUsage/types.ts
+++ b/frontend/src/AppBuilder/_utils/entityUsage/types.ts
@@ -1,13 +1,5 @@
 export type UsageEntryKind =
-  | 'component'
-  | 'query'
-  | 'variable'
-  | 'pageVariable'
-  | 'global'
-  | 'constant'
-  | 'page'
-  | 'action'
-  | 'unknown';
+  'component' | 'query' | 'variable' | 'pageVariable' | 'global' | 'constant' | 'page' | 'action' | 'unknown';
 
 /**
  * One reason an entry is related to the subject.

--- a/frontend/src/HomePage/AppCard.jsx
+++ b/frontend/src/HomePage/AppCard.jsx
@@ -237,8 +237,8 @@ export default function AppCard({
             app?.current_version_id === null
               ? t('homePage.appCard.noDeployedVersion', 'App does not have a deployed version')
               : !canAccessReleased
-              ? t('homePage.appCard.noReleasedAccess', 'You do not have permission to access released apps')
-              : t('homePage.appCard.openInAppViewer', 'Open in app viewer')
+                ? t('homePage.appCard.noReleasedAccess', 'You do not have permission to access released apps')
+                : t('homePage.appCard.openInAppViewer', 'Open in app viewer')
           }
         >
           <button
@@ -267,8 +267,8 @@ export default function AppCard({
                 app?.current_version_id === null || app?.is_maintenance_on || !canAccessReleased
                   ? '#4C5155'
                   : darkMode
-                  ? '#FDFDFE'
-                  : '#11181C'
+                    ? '#FDFDFE'
+                    : '#11181C'
               }
             />
 

--- a/frontend/src/HomePage/AppMenu.jsx
+++ b/frontend/src/HomePage/AppMenu.jsx
@@ -53,9 +53,9 @@ export const AppMenu = function AppMenu({
       ? currentSession?.workflow_group_permissions?.is_all_editable ||
         currentSession?.workflow_group_permissions?.editable_workflows_id?.includes(appId)
       : appType === 'module'
-      ? canEditModule(currentSession, appId, appUserId)
-      : currentSession?.app_group_permissions?.is_all_editable ||
-        currentSession?.app_group_permissions?.editable_apps_id?.includes(appId);
+        ? canEditModule(currentSession, appId, appUserId)
+        : currentSession?.app_group_permissions?.is_all_editable ||
+          currentSession?.app_group_permissions?.editable_apps_id?.includes(appId);
 
   const canModifyApp = canEditApp || isAppOwner;
 
@@ -166,8 +166,8 @@ export const AppMenu = function AppMenu({
                       appType === 'workflow'
                         ? t('homePage.appCard.deleteWorkflow', 'Delete workflow')
                         : appType === 'front-end'
-                        ? t('homePage.appCard.deleteApp', 'Delete app')
-                        : 'Delete module'
+                          ? t('homePage.appCard.deleteApp', 'Delete app')
+                          : 'Delete module'
                     }
                     customClass="field__danger"
                     onClick={deleteApp}

--- a/frontend/src/HomePage/HomePage.jsx
+++ b/frontend/src/HomePage/HomePage.jsx
@@ -2111,8 +2111,8 @@ class HomePageComponent extends React.Component {
                   this.props.appType === 'workflow'
                     ? 'homePage.deleteWorkflowAndData'
                     : this.props.appType === 'front-end'
-                    ? 'homePage.deleteAppAndData'
-                    : deleteModuleText,
+                      ? 'homePage.deleteAppAndData'
+                      : deleteModuleText,
                   { appName: appToBeDeleted?.name }
                 )
               )
@@ -2444,8 +2444,8 @@ class HomePageComponent extends React.Component {
                       this.props.appType === 'workflow'
                         ? 'workflows'
                         : this.props.appType === 'module'
-                        ? 'modules'
-                        : 'apps'
+                          ? 'modules'
+                          : 'apps'
                     }
                     isAvailable={true}
                     noTooltipIfValid={true}
@@ -2466,8 +2466,8 @@ class HomePageComponent extends React.Component {
                             this.props.appType === 'workflow'
                               ? 'workflows'
                               : this.props.appType === 'module'
-                              ? 'modules'
-                              : 'apps'
+                                ? 'modules'
+                                : 'apps'
                           }-button`}
                         >
                           <>
@@ -2716,8 +2716,8 @@ class HomePageComponent extends React.Component {
                             !moduleEnabled
                               ? 'Modules are not available on your current plan.'
                               : this.isGitSyncLicenseLocked()
-                              ? 'Git sync is not enabled as per your current plan. Disable git sync to continue.'
-                              : "You don't have permission to create a module."
+                                ? 'Git sync is not enabled as per your current plan. Disable git sync to continue.'
+                                : "You don't have permission to create a module."
                           }
                           placement="bottom"
                         >
@@ -2734,8 +2734,8 @@ class HomePageComponent extends React.Component {
                       {this.props.appType === 'workflow'
                         ? this.props.t('homePage.noWorkflowFound', 'No Workflows found')
                         : this.props.appType === 'module'
-                        ? this.props.t('homePage.noModuleFound', 'No Modules found')
-                        : this.props.t('homePage.noApplicationFound', 'No Applications found')}
+                          ? this.props.t('homePage.noModuleFound', 'No Modules found')
+                          : this.props.t('homePage.noApplicationFound', 'No Applications found')}
                     </span>
                   </div>
                 )}

--- a/frontend/src/ResetPassword/ResetPasswordPage.jsx
+++ b/frontend/src/ResetPassword/ResetPasswordPage.jsx
@@ -170,8 +170,8 @@ class ResetPasswordComponent extends React.Component {
                                     ? '#D1D5DB'
                                     : '#656565'
                                   : this.state?.password?.length
-                                  ? '#384151'
-                                  : '#D1D5DB'
+                                    ? '#384151'
+                                    : '#D1D5DB'
                               }
                             />
                           ) : (
@@ -182,8 +182,8 @@ class ResetPasswordComponent extends React.Component {
                                     ? '#D1D5DB'
                                     : '#656565'
                                   : this.state?.password?.length
-                                  ? '#384151'
-                                  : '#D1D5DB'
+                                    ? '#384151'
+                                    : '#D1D5DB'
                               }
                             />
                           )}
@@ -226,8 +226,8 @@ class ResetPasswordComponent extends React.Component {
                                     ? '#D1D5DB'
                                     : '#656565'
                                   : this.state?.password_confirmation?.length
-                                  ? '#384151'
-                                  : '#D1D5DB'
+                                    ? '#384151'
+                                    : '#D1D5DB'
                               }
                             />
                           ) : (
@@ -238,8 +238,8 @@ class ResetPasswordComponent extends React.Component {
                                     ? '#D1D5DB'
                                     : '#656565'
                                   : this.state?.password_confirmation?.length
-                                  ? '#384151'
-                                  : '#D1D5DB'
+                                    ? '#384151'
+                                    : '#D1D5DB'
                               }
                             />
                           )}

--- a/frontend/src/SuccessInfoScreen/VerificationSuccessInfoScreen.jsx
+++ b/frontend/src/SuccessInfoScreen/VerificationSuccessInfoScreen.jsx
@@ -163,9 +163,9 @@ export const VerificationSuccessInfoScreen = function VerificationSuccessInfoScr
     userDetails?.onboarding_details?.questions && !userDetails?.onboarding_details?.password
       ? setShowOnboarding(true)
       : (userDetails?.onboarding_details?.password && !userDetails?.onboarding_details?.questions) ||
-        (userDetails?.onboarding_details?.password && userDetails?.onboarding_details?.questions)
-      ? setShowJoinWorkspace(true)
-      : setUpAccount(e);
+          (userDetails?.onboarding_details?.password && userDetails?.onboarding_details?.questions)
+        ? setShowJoinWorkspace(true)
+        : setUpAccount(e);
   };
 
   return (
@@ -247,8 +247,8 @@ export const VerificationSuccessInfoScreen = function VerificationSuccessInfoScr
                                       ? '#D1D5DB'
                                       : '#656565'
                                     : password?.length
-                                    ? '#384151'
-                                    : '#D1D5DB'
+                                      ? '#384151'
+                                      : '#D1D5DB'
                                 }
                               />
                             ) : (
@@ -259,8 +259,8 @@ export const VerificationSuccessInfoScreen = function VerificationSuccessInfoScr
                                       ? '#D1D5DB'
                                       : '#656565'
                                     : password?.length
-                                    ? '#384151'
-                                    : '#D1D5DB'
+                                      ? '#384151'
+                                      : '#D1D5DB'
                                 }
                               />
                             )}

--- a/frontend/src/TooljetDatabase/Filter/index.jsx
+++ b/frontend/src/TooljetDatabase/Filter/index.jsx
@@ -256,10 +256,10 @@ const Filter = ({
                 areFiltersApplied
                   ? '#3E63DD'
                   : show && filterCount === 0
-                  ? '#ACB2B9'
-                  : show && filterCount > 0
-                  ? '#4368E3'
-                  : '#889096'
+                    ? '#ACB2B9'
+                    : show && filterCount > 0
+                      ? '#4368E3'
+                      : '#889096'
               }
             />
             <div className="tw-flex items-center tw-ml-[3px]">

--- a/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ColumnForm.jsx
@@ -448,8 +448,8 @@ const ColumnForm = ({
                       dataType === 'serial'
                         ? 'Auto-generated'
                         : foreignKeyDefaultValue?.value === null
-                        ? 'Null'
-                        : 'Enter a value'
+                          ? 'Null'
+                          : 'Enter a value'
                     }
                     onChange={(value) => {
                       setForeignKeyDefaultValue(value);
@@ -481,12 +481,12 @@ const ColumnForm = ({
               dataType?.value === 'serial'
                 ? 'Foreign key relation cannot be created for serial type column'
                 : dataType?.value === 'boolean'
-                ? 'Foreign key relation cannot be created for boolean type column'
-                : dataType?.value === 'timestamp with time zone'
-                ? 'Foreign key relation cannot be created with this data type'
-                : isJsonbColumnType
-                ? 'Foreign key relation cannot be created for jsonb type column'
-                : 'Fill in column details to create a foreign key relation'
+                  ? 'Foreign key relation cannot be created for boolean type column'
+                  : dataType?.value === 'timestamp with time zone'
+                    ? 'Foreign key relation cannot be created with this data type'
+                    : isJsonbColumnType
+                      ? 'Foreign key relation cannot be created for jsonb type column'
+                      : 'Fill in column details to create a foreign key relation'
             }
             placement="top"
             tooltipClassName="tootip-table"
@@ -618,10 +618,10 @@ const ColumnForm = ({
               dataType?.value === 'boolean'
                 ? 'Unique constraint cannot be added for boolean type column'
                 : dataType?.value === 'timestamp with time zone'
-                ? 'Unique constraint cannot be added for this type column'
-                : isJsonbColumnType
-                ? 'Unique constraint cannot be added for JSON type column'
-                : ''
+                  ? 'Unique constraint cannot be added for this type column'
+                  : isJsonbColumnType
+                    ? 'Unique constraint cannot be added for JSON type column'
+                    : ''
             }
             placement="top"
             tooltipClassName="tootip-table"

--- a/frontend/src/TooljetDatabase/Forms/ColumnsForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ColumnsForm.jsx
@@ -129,11 +129,11 @@ const ColumnsForm = ({
             size="sm"
             style={{ fontSize: '14px' }}
             onClick={() => {
-              setColumns((prevColumns) => ({
+              (setColumns((prevColumns) => ({
                 ...prevColumns,
                 [+Object.keys(prevColumns).pop() + 1 || 0]: { configurations: {} },
               })),
-                setColumnSelection({ index: 0, value: '', configurations: {} });
+                setColumnSelection({ index: 0, value: '', configurations: {} }));
             }}
             data-cy="add-more-columns-button"
           >

--- a/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditColumnForm.jsx
@@ -804,8 +804,8 @@ const ColumnForm = ({
                         selectedColumn?.dataType === 'serial'
                           ? 'Auto-generated'
                           : foreignKeyDefaultValue?.value === null || defaultValue === null
-                          ? 'Null'
-                          : 'Enter a value'
+                            ? 'Null'
+                            : 'Enter a value'
                       }
                       onChange={(value) => {
                         setForeignKeyDefaultValue(value);
@@ -847,12 +847,12 @@ const ColumnForm = ({
                 dataType === 'serial'
                   ? 'Foreign key relation cannot be created for serial type column'
                   : dataType === 'boolean'
-                  ? 'Foreign key relation cannot be created for boolean type column'
-                  : dataType === 'timestamp with time zone'
-                  ? 'Foreign key relation cannot be created for this data type'
-                  : dataType === 'jsonb'
-                  ? 'Foreign key relation cannot be created for JSON data type'
-                  : 'Fill in column details to create a foreign key relation'
+                    ? 'Foreign key relation cannot be created for boolean type column'
+                    : dataType === 'timestamp with time zone'
+                      ? 'Foreign key relation cannot be created for this data type'
+                      : dataType === 'jsonb'
+                        ? 'Foreign key relation cannot be created for JSON data type'
+                        : 'Fill in column details to create a foreign key relation'
               }
               placement="top"
               tooltipClassName="tootip-table"
@@ -966,10 +966,10 @@ const ColumnForm = ({
               selectedColumn.constraints_type.is_primary_key === true
                 ? 'Primary key values cannot be null'
                 : selectedColumn.dataType === 'serial' &&
-                  (selectedColumn.constraints_type.is_primary_key !== true ||
-                    selectedColumn.constraints_type.is_primary_key === true)
-                ? 'Serial data type cannot have null value'
-                : null
+                    (selectedColumn.constraints_type.is_primary_key !== true ||
+                      selectedColumn.constraints_type.is_primary_key === true)
+                  ? 'Serial data type cannot have null value'
+                  : null
             }
             placement="top"
             tooltipClassName="tooltip-table-edit-column"
@@ -1013,16 +1013,16 @@ const ColumnForm = ({
               selectedColumn.constraints_type.is_primary_key === true
                 ? 'Primary key values must be unique'
                 : selectedColumn.dataType === 'serial' &&
-                  (selectedColumn.constraints_type.is_primary_key !== true ||
-                    selectedColumn.constraints_type.is_primary_key === true)
-                ? 'Serial data type value must be unique'
-                : selectedColumn.dataType === 'boolean'
-                ? 'Unique constraint cannot be added for boolean type column'
-                : selectedColumn.dataType === 'timestamp with time zone'
-                ? 'Unique constraint cannot be added for this type column'
-                : selectedColumn.dataType === 'jsonb'
-                ? 'Unique constraint cannot be added for JSON type column'
-                : null
+                    (selectedColumn.constraints_type.is_primary_key !== true ||
+                      selectedColumn.constraints_type.is_primary_key === true)
+                  ? 'Serial data type value must be unique'
+                  : selectedColumn.dataType === 'boolean'
+                    ? 'Unique constraint cannot be added for boolean type column'
+                    : selectedColumn.dataType === 'timestamp with time zone'
+                      ? 'Unique constraint cannot be added for this type column'
+                      : selectedColumn.dataType === 'jsonb'
+                        ? 'Unique constraint cannot be added for JSON type column'
+                        : null
             }
             placement="top"
             tooltipClassName="tooltip-table-edit-column"

--- a/frontend/src/TooljetDatabase/Forms/EditRowForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/EditRowForm.jsx
@@ -221,14 +221,14 @@ const EditRowForm = ({
           newInputValues[index].value === null
             ? null
             : newInputValues[index].value === actualDefaultVal
-            ? defaultValue === 'true'
-              ? true
-              : false
-            : newInputValues[index].value === currentValue
-            ? currentValue
-            : currentValue === null && customBooleanVal === false
-            ? null
-            : null,
+              ? defaultValue === 'true'
+                ? true
+                : false
+              : newInputValues[index].value === currentValue
+                ? currentValue
+                : currentValue === null && customBooleanVal === false
+                  ? null
+                  : null,
       });
     } else if (dataType === 'jsonb') {
       setRowData({
@@ -237,12 +237,12 @@ const EditRowForm = ({
           newInputValues[index].value === null
             ? null
             : compareValueInObject(newInputValues[index].value, defaultValue)
-            ? defaultValue
-            : _.isEqual(newInputValues[index].value, currentValue)
-            ? currentValue
-            : currentValue === null && customVal === ''
-            ? ''
-            : null,
+              ? defaultValue
+              : _.isEqual(newInputValues[index].value, currentValue)
+                ? currentValue
+                : currentValue === null && customVal === ''
+                  ? ''
+                  : null,
       });
     } else {
       setRowData({
@@ -251,12 +251,12 @@ const EditRowForm = ({
           newInputValues[index].value === null
             ? null
             : newInputValues[index].value === defaultValue
-            ? defaultValue
-            : newInputValues[index].value === currentValue
-            ? currentValue
-            : currentValue === null && customVal === ''
-            ? ''
-            : null,
+              ? defaultValue
+              : newInputValues[index].value === currentValue
+                ? currentValue
+                : currentValue === null && customVal === ''
+                  ? ''
+                  : null,
       });
     }
   };
@@ -801,14 +801,14 @@ const EditRowForm = ({
                               activeTab[index] === 'Null' && !darkMode
                                 ? 'white'
                                 : activeTab[index] === 'Null' && darkMode
-                                ? '#242f3c'
-                                : 'transparent',
+                                  ? '#242f3c'
+                                  : 'transparent',
                             color:
                               activeTab[index] === 'Null' && !darkMode
                                 ? '#3E63DD'
                                 : activeTab[index] === 'Null' && darkMode
-                                ? 'white'
-                                : '#687076',
+                                  ? 'white'
+                                  : '#687076',
                           }}
                           className="row-tab-content"
                         >
@@ -833,14 +833,14 @@ const EditRowForm = ({
                               activeTab[index] === 'Default' && !darkMode
                                 ? 'white'
                                 : activeTab[index] === 'Default' && darkMode
-                                ? '#242f3c'
-                                : 'transparent',
+                                  ? '#242f3c'
+                                  : 'transparent',
                             color:
                               activeTab[index] === 'Default' && !darkMode
                                 ? '#3E63DD'
                                 : activeTab[index] === 'Default' && darkMode
-                                ? 'white'
-                                : '#687076',
+                                  ? 'white'
+                                  : '#687076',
                           }}
                           className="row-tab-content"
                         >
@@ -865,14 +865,14 @@ const EditRowForm = ({
                               activeTab[index] === 'Custom' && !darkMode
                                 ? 'white'
                                 : activeTab[index] === 'Custom' && darkMode
-                                ? '#242f3c'
-                                : 'transparent',
+                                  ? '#242f3c'
+                                  : 'transparent',
                             color:
                               activeTab[index] === 'Custom' && !darkMode
                                 ? '#3E63DD'
                                 : activeTab[index] === 'Custom' && darkMode
-                                ? 'white'
-                                : '#687076',
+                                  ? 'white'
+                                  : '#687076',
                           }}
                           className="row-tab-content"
                         >
@@ -886,8 +886,8 @@ const EditRowForm = ({
                       isSerialDataTypeColumn
                         ? 'Serial data type values cannot be modified'
                         : constraints_type?.is_primary_key
-                        ? 'Cannot edit primary key values'
-                        : null
+                          ? 'Cannot edit primary key values'
+                          : null
                     }
                     placement="top"
                     tooltipClassName="tootip-table"

--- a/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
+++ b/frontend/src/TooljetDatabase/Forms/ForeignKeyRelation.jsx
@@ -418,8 +418,8 @@ function ForeignKeyRelation({
                 ? setOnChangeInForeignKey(true)
                 : handleEditForeignKeyInCreate()
               : newChangesInForeignKey?.length > 0
-              ? setOnChangeInForeignKey(true)
-              : handleEditForeignKey()
+                ? setOnChangeInForeignKey(true)
+                : handleEditForeignKey()
           }
           createForeignKeyInEdit={createForeignKeyInEdit}
           selectedTable={selectedTable}

--- a/frontend/src/TooljetDatabase/Forms/RowForm.jsx
+++ b/frontend/src/TooljetDatabase/Forms/RowForm.jsx
@@ -227,8 +227,8 @@ const RowForm = ({
           inputValuesArr[index].value === null
             ? null
             : compareValueInObject(inputValuesArr[index].value, defaultVal)
-            ? defaultVal
-            : inputValuesArr[index].value,
+              ? defaultVal
+              : inputValuesArr[index].value,
       });
     } else {
       setData({
@@ -237,8 +237,8 @@ const RowForm = ({
           inputValuesArr[index].value === null
             ? null
             : inputValuesArr[index].value === 'Default'
-            ? defaultVal
-            : inputValuesArr[index].value,
+              ? defaultVal
+              : inputValuesArr[index].value,
       });
     }
   };
@@ -443,8 +443,8 @@ const RowForm = ({
                   isSerialDataTypeColumn
                     ? 'Auto-generated'
                     : inputValues[index]?.value === null
-                    ? ''
-                    : inputValues[index]?.value
+                      ? ''
+                      : inputValues[index]?.value
                 }
                 onFocus={handleInputFocus}
                 onChange={(e) => handleInputChange(index, e.target.value, columnName)}
@@ -456,10 +456,10 @@ const RowForm = ({
                   isSerialDataTypeColumn && !darkMode
                     ? 'primary-idKey-light'
                     : isSerialDataTypeColumn && darkMode
-                    ? 'primary-idKey-dark'
-                    : !darkMode
-                    ? 'form-control'
-                    : 'form-control dark-form-row',
+                      ? 'primary-idKey-dark'
+                      : !darkMode
+                        ? 'form-control'
+                        : 'form-control dark-form-row',
                   errorMap[columnName] ? 'input-error-border' : ''
                 )}
                 data-cy={`${String(columnName).toLocaleLowerCase().replace(/\s+/g, '-')}-input-field`}
@@ -758,14 +758,14 @@ const RowForm = ({
                             activeTab[index] === 'Null' && !darkMode
                               ? 'white'
                               : activeTab[index] === 'Null' && darkMode
-                              ? '#242f3c'
-                              : 'transparent',
+                                ? '#242f3c'
+                                : 'transparent',
                           color:
                             activeTab[index] === 'Null' && !darkMode
                               ? '#3E63DD'
                               : activeTab[index] === 'Null' && darkMode
-                              ? 'white'
-                              : '#687076',
+                                ? 'white'
+                                : '#687076',
                         }}
                         className="row-tab-content"
                       >
@@ -780,14 +780,14 @@ const RowForm = ({
                             activeTab[index] === 'Default' && !darkMode
                               ? 'white'
                               : activeTab[index] === 'Default' && darkMode
-                              ? '#242f3c'
-                              : 'transparent',
+                                ? '#242f3c'
+                                : 'transparent',
                           color:
                             activeTab[index] === 'Default' && !darkMode
                               ? '#3E63DD'
                               : activeTab[index] === 'Default' && darkMode
-                              ? 'white'
-                              : '#687076',
+                                ? 'white'
+                                : '#687076',
                         }}
                         className="row-tab-content"
                       >
@@ -802,14 +802,14 @@ const RowForm = ({
                             activeTab[index] === 'Custom' && !darkMode
                               ? 'white'
                               : activeTab[index] === 'Custom' && darkMode
-                              ? '#242f3c'
-                              : 'transparent',
+                                ? '#242f3c'
+                                : 'transparent',
                           color:
                             activeTab[index] === 'Custom' && !darkMode
                               ? '#3E63DD'
                               : activeTab[index] === 'Custom' && darkMode
-                              ? 'white'
-                              : '#687076',
+                                ? 'white'
+                                : '#687076',
                         }}
                         className="row-tab-content"
                       >

--- a/frontend/src/TooljetDatabase/Forms/TableDetailsDropdown.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableDetailsDropdown.jsx
@@ -106,20 +106,20 @@ function TableDetailsDropdown({
                   {isEmpty(targetTable)
                     ? 'Please select the table'
                     : isSourceColumnAvailable
-                    ? 'Please select source column'
-                    : tableColumns.length === 0
-                    ? 'There are no columns of the same datatype'
-                    : 'There are no columns of the same datatype'}
+                      ? 'Please select source column'
+                      : tableColumns.length === 0
+                        ? 'There are no columns of the same datatype'
+                        : 'There are no columns of the same datatype'}
                 </div>
               }
               value={
                 source && (!isEditColumn || !isCreateColumn)
                   ? sourceColumn
                   : source && (isEditColumn || isCreateColumn)
-                  ? defaultValue
-                  : actions
-                  ? onDelete
-                  : targetColumn
+                    ? defaultValue
+                    : actions
+                      ? onDelete
+                      : targetColumn
               }
               foreignKeyAccess={true}
               topPlaceHolder={!actions && 'Select column..'}

--- a/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableKeyRelations.jsx
@@ -198,8 +198,8 @@ function SourceKeyRelation({
           }
         })
       : (isEditColumn || isCreateColumn) && targetColumnList.length > 0
-      ? targetColumnList?.filter((item) => sourceColumns[0]?.dataType === item?.dataType)
-      : [];
+        ? targetColumnList?.filter((item) => sourceColumns[0]?.dataType === item?.dataType)
+        : [];
 
   useEffect(() => {
     if ((isEditMode && !createForeignKeyInEdit) || !createForeignKeyInEdit) {
@@ -226,11 +226,11 @@ function SourceKeyRelation({
     (targetColumn?.dataType === 'integer' || targetColumn?.dataType === 'serial')
       ? true
       : sourceColumn?.dataType === 'bigint' &&
-        (targetColumn?.dataType === 'integer' || targetColumn?.dataType === 'bigint')
-      ? true
-      : sourceColumn?.dataType === targetColumn?.dataType
-      ? true
-      : false;
+          (targetColumn?.dataType === 'integer' || targetColumn?.dataType === 'bigint')
+        ? true
+        : sourceColumn?.dataType === targetColumn?.dataType
+          ? true
+          : false;
 
   useEffect(() => {
     if (!isSameDataTypeColumns) {

--- a/frontend/src/TooljetDatabase/Forms/TableSchema.jsx
+++ b/frontend/src/TooljetDatabase/Forms/TableSchema.jsx
@@ -283,8 +283,8 @@ function TableSchema({
                   columnDetails[index]?.constraints_type?.is_primary_key === true
                     ? 'Primary key data type cannot be modified'
                     : columnDetails[index]?.data_type === 'timestamp with time zone'
-                    ? 'Date with time'
-                    : null
+                      ? 'Date with time'
+                      : null
                 }
                 placement="top"
                 tooltipClassName="tootip-table"
@@ -324,8 +324,8 @@ function TableSchema({
                       columnConstraints.is_unique = prevColumns[index].constraints_type?.is_primary_key
                         ? true
                         : value?.value === 'boolean'
-                        ? false
-                        : false;
+                          ? false
+                          : false;
 
                       columnConstraints.is_primary_key = value.value === 'boolean' && false;
                       // columnConstraints.is_primary_key = value.value === 'serial' && true;
@@ -442,12 +442,12 @@ function TableSchema({
                     columnDetails[index]?.data_type === 'serial'
                       ? 'Serial data type values cannot be modified'
                       : columnDetails[index]?.data_type === 'timestamp with time zone' &&
-                        columnDetails[index]?.column_default
-                      ? convertDateToTimeZoneFormatted(
-                          columnDetails[index].column_default,
-                          columnDetails[index]?.configurations?.timezone || getLocalTimeZone()
-                        )
-                      : null
+                          columnDetails[index]?.column_default
+                        ? convertDateToTimeZoneFormatted(
+                            columnDetails[index].column_default,
+                            columnDetails[index]?.configurations?.timezone || getLocalTimeZone()
+                          )
+                        : null
                   }
                   placement="top"
                   tooltipClassName="tootip-table"
@@ -505,12 +505,12 @@ function TableSchema({
                           columnDetails[index].data_type === 'serial'
                             ? 'Auto-generated'
                             : // : checkDefaultValue(columnDetails[index].column_default)
-                            // ? null
-                            columnDetails[index].data_type === 'jsonb'
-                            ? columnDetails[index].constraints_type?.is_not_null
-                              ? JSON.stringify({})
-                              : null
-                            : columnDetails[index].column_default
+                              // ? null
+                              columnDetails[index].data_type === 'jsonb'
+                              ? columnDetails[index].constraints_type?.is_not_null
+                                ? JSON.stringify({})
+                                : null
+                              : columnDetails[index].column_default
                         }
                         type="text"
                         className="form-control defaultValue"
@@ -538,10 +538,10 @@ function TableSchema({
                   columnDetails[index]?.data_type === 'boolean'
                     ? 'Boolean type column cannot be a primary key'
                     : columnDetails[index]?.data_type === 'timestamp with time zone'
-                    ? ' Primary key cannot be created with this column type'
-                    : columnDetails[index]?.data_type === 'jsonb'
-                    ? 'JSON type column cannot be a primary key'
-                    : 'There must be atleast one Primary key'
+                      ? ' Primary key cannot be created with this column type'
+                      : columnDetails[index]?.data_type === 'jsonb'
+                        ? 'JSON type column cannot be a primary key'
+                        : 'There must be atleast one Primary key'
                 }
                 placement="top"
                 tooltipClassName="tootip-table"
@@ -557,8 +557,8 @@ function TableSchema({
                       ['boolean', 'timestamp with time zone', 'jsonb'].includes(columnDetails[index]?.data_type)
                         ? false
                         : columnDetails[index]?.constraints_type?.is_primary_key
-                        ? true
-                        : false
+                          ? true
+                          : false
                     }
                     onChange={(e) => {
                       const prevColumns = { ...columnDetails };
@@ -597,9 +597,9 @@ function TableSchema({
                   columnDetails[index]?.constraints_type?.is_primary_key === true
                     ? 'Primary key values cannot be null'
                     : columnDetails[index]?.data_type === 'serial' &&
-                      columnDetails[index]?.constraints_type?.is_primary_key !== true
-                    ? 'Serial data type cannot have NULL value'
-                    : null
+                        columnDetails[index]?.constraints_type?.is_primary_key !== true
+                      ? 'Serial data type cannot have NULL value'
+                      : null
                 }
                 placement="top"
                 tooltipClassName="tootip-table"
@@ -615,7 +615,7 @@ function TableSchema({
                     <input
                       className="form-check-input"
                       data-cy={`${String(
-                        columnDetails[index]?.constraints_type?.is_not_null ?? false ? 'NOT NULL' : 'NULL'
+                        (columnDetails[index]?.constraints_type?.is_not_null ?? false) ? 'NOT NULL' : 'NULL'
                       )
                         .toLowerCase()
                         .replace(/\s+/g, '-')}-checkbox`}
@@ -636,7 +636,7 @@ function TableSchema({
                   </label>
                   <p
                     data-cy={`${String(
-                      columnDetails[index]?.constraints_type?.is_not_null ?? false ? 'NOT NULL' : 'NULL'
+                      (columnDetails[index]?.constraints_type?.is_not_null ?? false) ? 'NOT NULL' : 'NULL'
                     )
                       .toLowerCase()
                       .replace(/\s+/g, '-')}-text`}

--- a/frontend/src/TooljetDatabase/Table/ActionsPopover/UniqueConstraintPopOver.jsx
+++ b/frontend/src/TooljetDatabase/Table/ActionsPopover/UniqueConstraintPopOver.jsx
@@ -123,12 +123,12 @@ export const UniqueConstraintPopOver = ({
                 columns[index]?.constraints_type?.is_primary_key === true
                   ? 'Primary key values must be unique'
                   : columns[index]?.data_type === 'boolean'
-                  ? 'Boolean data type cannot be unique'
-                  : columns[index]?.data_type === 'timestamp with time zone'
-                  ? 'Unique constraint cannot be added to this column type'
-                  : columns[index]?.data_type === 'jsonb'
-                  ? 'JSON cannot cannot have unique constraint'
-                  : null
+                    ? 'Boolean data type cannot be unique'
+                    : columns[index]?.data_type === 'timestamp with time zone'
+                      ? 'Unique constraint cannot be added to this column type'
+                      : columns[index]?.data_type === 'jsonb'
+                        ? 'JSON cannot cannot have unique constraint'
+                        : null
               }
               placement="top"
               tooltipClassName="tootip-table"
@@ -149,12 +149,12 @@ export const UniqueConstraintPopOver = ({
                       columns[index]?.constraints_type?.is_primary_key
                         ? true
                         : columns[index]?.data_type === 'boolean'
-                        ? false
-                        : columns[index]?.data_type === 'serial'
-                        ? true
-                        : columns[index]?.constraints_type?.is_unique
-                        ? true
-                        : false
+                          ? false
+                          : columns[index]?.data_type === 'serial'
+                            ? true
+                            : columns[index]?.constraints_type?.is_unique
+                              ? true
+                              : false
                     }
                     onChange={(e) => {
                       const prevColumns = { ...columns };

--- a/frontend/src/TooljetDatabase/Table/index.jsx
+++ b/frontend/src/TooljetDatabase/Table/index.jsx
@@ -1233,15 +1233,15 @@ const Table = ({ collapseSidebar }) => {
                       key={column.Header}
                       width={230}
                       style={{ height: index === 0 ? '32px' : '' }}
-                      title={column?.constraints_type?.is_primary_key ?? false ? '' : column?.Header}
+                      title={(column?.constraints_type?.is_primary_key ?? false) ? '' : column?.Header}
                       className={
                         darkMode
                           ? 'table-header-dark tj-database-column-header tj-text-xsm'
                           : !darkMode
-                          ? 'table-header tj-database-column-header tj-text-xsm'
-                          : editColumnHeader?.clickedColumn === index && editColumnHeader?.columnEditPopover === true
-                          ? 'table-header-click tj-database-column-header tj-text-xsm'
-                          : 'table-header tj-database-column-header tj-text-xsm'
+                            ? 'table-header tj-database-column-header tj-text-xsm'
+                            : editColumnHeader?.clickedColumn === index && editColumnHeader?.columnEditPopover === true
+                              ? 'table-header-click tj-database-column-header tj-text-xsm'
+                              : 'table-header tj-database-column-header tj-text-xsm'
                       }
                       data-cy={`${String(column.Header).toLocaleLowerCase().replace(/\s+/g, '-')}-column-header`}
                       {...column.getHeaderProps()}
@@ -1321,7 +1321,7 @@ const Table = ({ collapseSidebar }) => {
                           }}
                         >
                           <IndeterminateCheckbox
-                            checked={!isDirectRowExpand ? selectedRowIds[row.id] ?? false : false}
+                            checked={!isDirectRowExpand ? (selectedRowIds[row.id] ?? false) : false}
                             onChange={() => toggleRowSelection(row.id)}
                           />
 
@@ -1358,20 +1358,20 @@ const Table = ({ collapseSidebar }) => {
                                 !darkMode
                                   ? `table-columnHeader-click`
                                   : editColumnHeader?.clickedColumn === index &&
-                                    editColumnHeader?.columnEditPopover === true &&
-                                    darkMode
-                                  ? `table-columnHeader-click-dark`
-                                  : editColumnHeader?.hoveredColumn === index && !darkMode
-                                  ? 'table-cell-hover-background'
-                                  : editColumnHeader?.hoveredColumn === index && darkMode
-                                  ? 'table-cell-hover-background-dark'
-                                  : cellClick.rowIndex === rIndex &&
-                                    cellClick.cellIndex === index &&
-                                    cellClick.editable === true
-                                  ? 'table-editable-parent-cell'
-                                  : darkMode
-                                  ? `table-cell table-cell-dark`
-                                  : `table-cell`
+                                      editColumnHeader?.columnEditPopover === true &&
+                                      darkMode
+                                    ? `table-columnHeader-click-dark`
+                                    : editColumnHeader?.hoveredColumn === index && !darkMode
+                                      ? 'table-cell-hover-background'
+                                      : editColumnHeader?.hoveredColumn === index && darkMode
+                                        ? 'table-cell-hover-background-dark'
+                                        : cellClick.rowIndex === rIndex &&
+                                            cellClick.cellIndex === index &&
+                                            cellClick.editable === true
+                                          ? 'table-editable-parent-cell'
+                                          : darkMode
+                                            ? `table-cell table-cell-dark`
+                                            : `table-cell`
                               }`,
                               {
                                 'table-cell-selected': selectedRowIds[row.id] ?? false,
@@ -1390,10 +1390,10 @@ const Table = ({ collapseSidebar }) => {
                                       getConfigurationProperty(cell.column.Header, 'timezone', getLocalTimeZone())
                                     )
                                   : cell.column.dataType === 'jsonb' &&
-                                    typeof cell?.value !== 'string' &&
-                                    cell?.value !== null
-                                  ? JSON.stringify(cell?.value)
-                                  : cell?.value,
+                                      typeof cell?.value !== 'string' &&
+                                      cell?.value !== null
+                                    ? JSON.stringify(cell?.value)
+                                    : cell?.value,
                                 index
                               )}
                               placement="bottom"
@@ -1417,11 +1417,11 @@ const Table = ({ collapseSidebar }) => {
                                   cellClick.errorState === true
                                     ? 'tjdb-cell-error'
                                     : cellClick.rowIndex === rIndex &&
-                                      cellClick.cellIndex === index &&
-                                      cellClick.editable === true &&
-                                      !isCellUpdateInProgress
-                                    ? 'tjdb-selected-cell'
-                                    : 'tjdb-column-select-border'
+                                        cellClick.cellIndex === index &&
+                                        cellClick.editable === true &&
+                                        !isCellUpdateInProgress
+                                      ? 'tjdb-selected-cell'
+                                      : 'tjdb-column-select-border'
                                 }`}
                                 id={`tjdb-cell-row${rIndex}-column${index}`}
                               >
@@ -1628,15 +1628,15 @@ const Table = ({ collapseSidebar }) => {
                                             {isBoolean(cell?.value)
                                               ? cell?.value?.toString()
                                               : cell.column?.dataType === 'timestamp with time zone'
-                                              ? convertDateToTimeZoneFormatted(
-                                                  cell?.value,
-                                                  getConfigurationProperty(
-                                                    cell.column.Header,
-                                                    'timezone',
-                                                    getLocalTimeZone()
+                                                ? convertDateToTimeZoneFormatted(
+                                                    cell?.value,
+                                                    getConfigurationProperty(
+                                                      cell.column.Header,
+                                                      'timezone',
+                                                      getLocalTimeZone()
+                                                    )
                                                   )
-                                                )
-                                              : cell.render('Cell')}
+                                                : cell.render('Cell')}
                                           </div>
                                           {/* <ToolTip
                                             message={'Open referenced table'}

--- a/frontend/src/TooljetDatabase/constants.js
+++ b/frontend/src/TooljetDatabase/constants.js
@@ -284,26 +284,26 @@ export default function tjdbDropdownStyles(
         state.isDisabled && darkMode
           ? darkDisabledBackground
           : state.isDisabled && !darkMode
-          ? lightDisabledBackground
-          : state.isFocused && !darkMode
-          ? lightFocussedBackground
-          : state.isFocused && darkMode
-          ? darkFocussedBackground
-          : !darkMode
-          ? lightBackground
-          : darkBackground,
+            ? lightDisabledBackground
+            : state.isFocused && !darkMode
+              ? lightFocussedBackground
+              : state.isFocused && darkMode
+                ? darkFocussedBackground
+                : !darkMode
+                  ? lightBackground
+                  : darkBackground,
       borderColor:
         state.isFocused && !darkMode
           ? lightFocussedBorder
           : state.isFocused && darkMode
-          ? darkFocussedBorder
-          : darkMode && state.isDisabled
-          ? !darkMode && state.isDisabled
-            ? lightDisabledBorder
-            : darkDisabledBorder
-          : darkMode
-          ? darkBorder
-          : lightBorder,
+            ? darkFocussedBorder
+            : darkMode && state.isDisabled
+              ? !darkMode && state.isDisabled
+                ? lightDisabledBorder
+                : darkDisabledBorder
+              : darkMode
+                ? darkBorder
+                : lightBorder,
       '&:hover': {
         borderColor: darkMode ? darkBorderHover : lightBorderHover,
       },

--- a/frontend/src/_components/ColumnSelect/index.jsx
+++ b/frontend/src/_components/ColumnSelect/index.jsx
@@ -103,8 +103,8 @@ const ColumnSelect = React.memo(function ColumnSelect({
   const selectedOption = isMulti
     ? (Array.isArray(value) ? value : []).map((v) => columns.find((c) => c.value === v) ?? { value: v, label: v })
     : value
-    ? columns.find((c) => c.value === value) ?? { value, label: value }
-    : null;
+      ? (columns.find((c) => c.value === value) ?? { value, label: value })
+      : null;
 
   const handleChange = (opt) => {
     if (isMulti) {

--- a/frontend/src/_components/ConfirmDialog.jsx
+++ b/frontend/src/_components/ConfirmDialog.jsx
@@ -59,7 +59,7 @@ export function ConfirmDialog({
   return (
     <Modal
       show={showModal}
-      onHide={staticBackdrop ? () => {} : onCloseIconClick ?? handleClose}
+      onHide={staticBackdrop ? () => {} : (onCloseIconClick ?? handleClose)}
       size="sm"
       animation={false}
       centered={true}

--- a/frontend/src/_components/DynamicForm.jsx
+++ b/frontend/src/_components/DynamicForm.jsx
@@ -447,8 +447,8 @@ const DynamicForm = ({
         return {
           getter: key,
           options: isRenderedAsQueryEditor
-            ? options?.[key] ?? schema?.defaults?.[key]
-            : options?.[key]?.value ?? schema?.defaults?.[key]?.value,
+            ? (options?.[key] ?? schema?.defaults?.[key])
+            : (options?.[key]?.value ?? schema?.defaults?.[key]?.value),
           optionchanged,
           isRenderedAsQueryEditor,
           workspaceConstants: currentOrgEnvironmentConstants,
@@ -485,8 +485,8 @@ const DynamicForm = ({
         return {
           getter: key,
           options: isRenderedAsQueryEditor
-            ? options?.[key] ?? schema?.defaults?.[key]
-            : options?.[key]?.value ?? schema?.defaults?.[key]?.value,
+            ? (options?.[key] ?? schema?.defaults?.[key])
+            : (options?.[key]?.value ?? schema?.defaults?.[key]?.value),
           optionchanged,
           isRenderedAsQueryEditor,
           workspaceConstants: currentOrgEnvironmentConstants,
@@ -591,8 +591,8 @@ const DynamicForm = ({
           cyLabel: label
             ? generateCypressDataCy(label)
             : key
-            ? `${String(key).toLocaleLowerCase().replace(/\s+/g, '-')}`
-            : '',
+              ? `${String(key).toLocaleLowerCase().replace(/\s+/g, '-')}`
+              : '',
           disabled,
           delayOnChange: false,
           renderCopilot,
@@ -816,7 +816,7 @@ const DynamicForm = ({
           ].includes(type);
           // shouldRenderTheProperty - key is used for Dynamic connection parameters
           const enabled = shouldRenderTheProperty
-            ? selectedDataSource?.options?.[shouldRenderTheProperty]?.value ?? false
+            ? (selectedDataSource?.options?.[shouldRenderTheProperty]?.value ?? false)
             : true;
 
           // const elementProps = getElementProps({

--- a/frontend/src/_components/DynamicFormV2.jsx
+++ b/frontend/src/_components/DynamicFormV2.jsx
@@ -526,12 +526,12 @@ const DynamicFormV2 = ({
           autoFillStrategy && key === autoFillStrategy.connectionStringKey && customValidation.valid !== null
             ? customValidation
             : skipValidation
-            ? { valid: null, message: '' }
-            : validationMessages[key]
-            ? { valid: false, message: validationMessages[key] }
-            : isRequired
-            ? { valid: true, message: '' }
-            : { valid: null, message: '' };
+              ? { valid: null, message: '' }
+              : validationMessages[key]
+                ? { valid: false, message: validationMessages[key] }
+                : isRequired
+                  ? { valid: true, message: '' }
+                  : { valid: null, message: '' };
 
         return {
           propertyKey: key,
@@ -585,8 +585,8 @@ const DynamicFormV2 = ({
         return {
           getter: key,
           options: isRenderedAsQueryEditor
-            ? options?.[key] ?? schema?.defaults?.[key]
-            : options?.[key]?.value ?? schema?.defaults?.[key]?.value,
+            ? (options?.[key] ?? schema?.defaults?.[key])
+            : (options?.[key]?.value ?? schema?.defaults?.[key]?.value),
           handleOptionChange,
           isRenderedAsQueryEditor,
           workspaceConstants: currentOrgEnvironmentConstants,

--- a/frontend/src/_components/MultiSelectUser.jsx
+++ b/frontend/src/_components/MultiSelectUser.jsx
@@ -93,10 +93,10 @@ function MultiSelectUser({
           filteredOptions?.length > 0
             ? 'Not Found'
             : searchText
-            ? 'Not found'
-            : searchLabel
-            ? searchLabel
-            : 'Please enter some text'
+              ? 'Not found'
+              : searchLabel
+                ? searchLabel
+                : 'Please enter some text'
         }
         disabled={isLoading}
         fuzzySearch

--- a/frontend/src/_components/ResetPasswordModal.jsx
+++ b/frontend/src/_components/ResetPasswordModal.jsx
@@ -171,8 +171,8 @@ export function ResetPasswordModal({ darkMode = false, closeModal, show, user })
                                     ? '#D1D5DB'
                                     : '#656565'
                                   : password?.length
-                                  ? '#384151'
-                                  : '#D1D5DB'
+                                    ? '#384151'
+                                    : '#D1D5DB'
                               }
                             />
                           ) : (
@@ -183,8 +183,8 @@ export function ResetPasswordModal({ darkMode = false, closeModal, show, user })
                                     ? '#D1D5DB'
                                     : '#656565'
                                   : password?.length
-                                  ? '#384151'
-                                  : '#D1D5DB'
+                                    ? '#384151'
+                                    : '#D1D5DB'
                               }
                             />
                           )}

--- a/frontend/src/_components/SqlGroupBy/index.jsx
+++ b/frontend/src/_components/SqlGroupBy/index.jsx
@@ -25,8 +25,8 @@ const SqlGroupBy = React.memo(function SqlGroupBy({
   queryName,
 }) {
   const depKeys = Array.isArray(columnSelectorDependsOn) ? columnSelectorDependsOn : [];
-  const schema = depKeys.includes('schema') ? options?.schema ?? '' : '';
-  const table = depKeys.includes('table') ? options?.table ?? '' : '';
+  const schema = depKeys.includes('schema') ? (options?.schema ?? '') : '';
+  const table = depKeys.includes('table') ? (options?.table ?? '') : '';
 
   // group_by is stored as { [uuid]: string[] }
   const groupByMap = readValueMapFromOptions(options, getter, parseKey);
@@ -35,7 +35,7 @@ const SqlGroupBy = React.memo(function SqlGroupBy({
   const existingEntries = Object.entries(groupByMap);
   const groupByEntryKey = existingEntries.length > 0 ? existingEntries[0][0] : null;
   const selectedColumns = useMemo(
-    () => (existingEntries.length > 0 ? existingEntries[0][1] ?? [] : []),
+    () => (existingEntries.length > 0 ? (existingEntries[0][1] ?? []) : []),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [groupByMap]
   );

--- a/frontend/src/_helpers/editorHelpers.js
+++ b/frontend/src/_helpers/editorHelpers.js
@@ -42,16 +42,14 @@ function convertToBracketNotation(base, accessors) {
 }
 
 function verifyDotAndBracketNotations(jsString) {
-  if (
-    !(
-      jsString.includes('components.') ||
-      jsString.includes('globals.') ||
-      jsString.includes('queries.') ||
-      jsString.includes('page.') ||
-      jsString.includes('variables.') ||
-      jsString.includes('constants.')
-    )
-  ) {
+  if (!(
+    jsString.includes('components.') ||
+    jsString.includes('globals.') ||
+    jsString.includes('queries.') ||
+    jsString.includes('page.') ||
+    jsString.includes('variables.') ||
+    jsString.includes('constants.')
+  )) {
     return false;
   }
 

--- a/frontend/src/_stores/queryPanelStore.js
+++ b/frontend/src/_stores/queryPanelStore.js
@@ -6,7 +6,7 @@ import { useDataSourcesStore } from '@/_stores/dataSourcesStore';
 const queryManagerPreferences = JSON.parse(localStorage.getItem('queryManagerPreferences')) ?? {};
 const initialState = {
   // eslint-disable-next-line no-constant-binary-expression
-  queryPanelHeight: queryManagerPreferences?.isExpanded ? queryManagerPreferences?.queryPanelHeight : 95 ?? 70,
+  queryPanelHeight: queryManagerPreferences?.isExpanded ? queryManagerPreferences?.queryPanelHeight : (95 ?? 70),
   previewPanelHeight: 0,
   selectedQuery: null,
   selectedDataSource: null,

--- a/frontend/src/_ui/DynamicSelector/index.jsx
+++ b/frontend/src/_ui/DynamicSelector/index.jsx
@@ -668,10 +668,10 @@ const DynamicSelector = ({
             ? '#1f2936'
             : '#f4f6fa'
           : darkMode
-          ? '#2b3547'
-          : state.menuIsOpen
-          ? '#F1F3F5'
-          : '#fff',
+            ? '#2b3547'
+            : state.menuIsOpen
+              ? '#F1F3F5'
+              : '#fff',
         cursor: 'pointer',
         '&:hover': {
           backgroundColor: darkMode ? '' : '#F8F9FA',
@@ -770,10 +770,10 @@ const DynamicSelector = ({
                       ? 'Discovering...'
                       : `Search or Select ${label ?? ''}`
                     : isMulti
-                    ? isLoading
-                      ? 'Discovering...'
+                      ? isLoading
+                        ? 'Discovering...'
+                        : `Select ${label ?? ''}`
                       : `Select ${label ?? ''}`
-                    : `Select ${label ?? ''}`
                 }
                 isDisabled={disabled || (isDependentField && !depsReady)}
                 isLoading={isMulti ? isLoading && getCurrentValue().length === 0 : isLoading}

--- a/frontend/src/_ui/Label.jsx
+++ b/frontend/src/_ui/Label.jsx
@@ -59,8 +59,8 @@ function Label({
                 direction == 'right'
                   ? '6px'
                   : (label?.length > 0 && defaultAlignment === 'side') || defaultAlignment === 'top'
-                  ? '12px'
-                  : '',
+                    ? '12px'
+                    : '',
               paddingLeft: label?.length > 0 && defaultAlignment === 'side' && direction != 'left' ? '12px' : '',
               ...(top && { top }),
             }}

--- a/frontend/src/_ui/Select/styles.js
+++ b/frontend/src/_ui/Select/styles.js
@@ -8,7 +8,7 @@ export default function styles(darkMode, width = 224, height = 32, styles = {}, 
     }),
     control: (provided, state) => ({
       ...provided,
-      border: state.isDisabled && darkMode ? 'none' : styles.border ?? '1px solid var(--slate7)',
+      border: state.isDisabled && darkMode ? 'none' : (styles.border ?? '1px solid var(--slate7)'),
       boxShadow: 'none',
       '&:hover': {
         backgroundColor: darkMode ? '' : '#F8F9FA',
@@ -19,10 +19,10 @@ export default function styles(darkMode, width = 224, height = 32, styles = {}, 
           ? '#1f2936'
           : '#f4f6fa'
         : darkMode
-        ? '#2b3547'
-        : state.menuIsOpen
-        ? '#F1F3F5'
-        : '#fff',
+          ? '#2b3547'
+          : state.menuIsOpen
+            ? '#F1F3F5'
+            : '#fff',
       height: height,
       minHeight: height,
       cursor: styles.cursor ?? 'pointer',

--- a/frontend/src/_ui/WorkspaceBranchDropdown/WorkspacePullConflictModal.jsx
+++ b/frontend/src/_ui/WorkspaceBranchDropdown/WorkspacePullConflictModal.jsx
@@ -169,8 +169,8 @@ function ConflictRow({
                       {group.conflictField === 'slug' || group.conflictField === 'invalid_name'
                         ? item.name
                         : item.coRelationId
-                        ? `#${item.coRelationId.slice(0, 8)}`
-                        : item.name}
+                          ? `#${item.coRelationId.slice(0, 8)}`
+                          : item.name}
                     </span>
 
                     {/* invalid_name is one-sided — no counterpart for the badge to contrast against. */}

--- a/frontend/src/components/ui/Dropdown/Index.jsx
+++ b/frontend/src/components/ui/Dropdown/Index.jsx
@@ -116,7 +116,7 @@ const DropdownComponent = ({
                     {options[key].label ?? key}
                   </OverflowTooltip>
                 ) : (
-                  options[key].label ?? key
+                  (options[key].label ?? key)
                 )}
               </SelectItem>
             ))}

--- a/frontend/src/components/ui/FileUploader/FileUpload/FileUpload.jsx
+++ b/frontend/src/components/ui/FileUploader/FileUpload/FileUpload.jsx
@@ -60,8 +60,8 @@ const FileUpload = ({
             disabled
               ? 'tw-bg-background-surface-layer-02 tw-border-border-disabled'
               : isHovering
-              ? 'tw-bg-background-accent-weak tw-border-interactive-focus-outline'
-              : 'tw-bg-background-surface-layer-01 tw-border-border-default hover:tw-bg-[#CCD1D5]/30 hover:tw-border-border-strong'
+                ? 'tw-bg-background-accent-weak tw-border-interactive-focus-outline'
+                : 'tw-bg-background-surface-layer-01 tw-border-border-default hover:tw-bg-[#CCD1D5]/30 hover:tw-border-border-strong'
           }`}
           onDragOver={handleDragEnter}
           onDragLeave={handleDragLeave}

--- a/frontend/src/components/ui/Input/CommonInput/NumberInput.jsx
+++ b/frontend/src/components/ui/Input/CommonInput/NumberInput.jsx
@@ -27,8 +27,8 @@ const NumberInput = ({ size, leadingIcon, response, disabled, ...restProps }) =>
     response === true
       ? 'tw-border-border-success-strong focus-visible:!tw-ring-0 focus-visible:!tw-ring-offset-0 focus-visible:!tw-border-border-success-strong'
       : response === false
-      ? 'tw-border-border-danger-strong focus-visible:!tw-ring-0 focus-visible:!tw-ring-offset-0 focus-visible:!tw-border-border-success-strong'
-      : ''
+        ? 'tw-border-border-danger-strong focus-visible:!tw-ring-0 focus-visible:!tw-ring-offset-0 focus-visible:!tw-border-border-success-strong'
+        : ''
   }`;
 
   const handleIncrement = () => {

--- a/frontend/src/components/ui/Input/CommonInput/TextInput.jsx
+++ b/frontend/src/components/ui/Input/CommonInput/TextInput.jsx
@@ -20,8 +20,8 @@ const TextInput = ({
     response === true
       ? '!tw-border-border-success-strong focus-visible:!tw-ring-0 focus-visible:!tw-ring-offset-0 focus-visible:!tw-border-border-success-strong'
       : response === false
-      ? '!tw-border-border-danger-strong focus-visible:!tw-ring-0 focus-visible:!tw-ring-offset-0 focus-visible:!tw-border-border-danger-strong'
-      : 'tw-border-border-default'
+        ? '!tw-border-border-danger-strong focus-visible:!tw-ring-0 focus-visible:!tw-ring-offset-0 focus-visible:!tw-border-border-danger-strong'
+        : 'tw-border-border-default'
   }`;
 
   return (

--- a/frontend/src/components/ui/ListItems/ListItems.jsx
+++ b/frontend/src/components/ui/ListItems/ListItems.jsx
@@ -24,8 +24,8 @@ const ListItems = (props) => {
           props.disabled
             ? 'tw-bg-interactive-disabled'
             : props.background
-            ? 'tw-bg-[#CCD1D5]/30 active:tw-bg-[#ACB2B9]/45'
-            : 'active:tw-bg-[#CCD1D5]/30'
+              ? 'tw-bg-[#CCD1D5]/30 active:tw-bg-[#ACB2B9]/45'
+              : 'active:tw-bg-[#CCD1D5]/30'
         } hover:tw-bg-[#ACB2B9]/35 tw-py-[7px] tw-px-[8px] tw-items-center tw-rounded-[6px]`,
         props.className
       )}

--- a/frontend/src/modules/WorkspaceSettings/components/ManageOrgConstantsSettings/ConstantForm.jsx
+++ b/frontend/src/modules/WorkspaceSettings/components/ManageOrgConstantsSettings/ConstantForm.jsx
@@ -346,8 +346,8 @@ const ConstantForm = ({
                               ? '#D1D5DB'
                               : '#656565'
                             : String(fields['value'])?.length
-                            ? '#384151'
-                            : '#D1D5DB'
+                              ? '#384151'
+                              : '#D1D5DB'
                         }
                       />
                     ) : (
@@ -358,8 +358,8 @@ const ConstantForm = ({
                               ? '#D1D5DB'
                               : '#656565'
                             : String(fields['value'])?.length
-                            ? '#384151'
-                            : '#D1D5DB'
+                              ? '#384151'
+                              : '#D1D5DB'
                         }
                         data-cy="test"
                       />

--- a/frontend/src/modules/WorkspaceSettings/components/ManageOrgConstantsSettings/ConstantTable.jsx
+++ b/frontend/src/modules/WorkspaceSettings/components/ManageOrgConstantsSettings/ConstantTable.jsx
@@ -159,8 +159,8 @@ const ConstantTable = ({
                                           ? '#D1D5DB'
                                           : '#656565'
                                         : String(constant.value)?.length
-                                        ? '#384151'
-                                        : '#D1D5DB'
+                                          ? '#384151'
+                                          : '#D1D5DB'
                                     }
                                   />
                                 ) : (
@@ -171,8 +171,8 @@ const ConstantTable = ({
                                           ? '#D1D5DB'
                                           : '#656565'
                                         : String(constant.value)?.length
-                                        ? '#384151'
-                                        : '#D1D5DB'
+                                          ? '#384151'
+                                          : '#D1D5DB'
                                     }
                                   />
                                 )}

--- a/frontend/src/modules/WorkspaceSettings/components/ManageOrgConstantsSettings/EmptyState.jsx
+++ b/frontend/src/modules/WorkspaceSettings/components/ManageOrgConstantsSettings/EmptyState.jsx
@@ -17,8 +17,8 @@ const EmptyState = ({ activeTab, canCreateVariable, setIsManageVarDrawerOpen, is
                     ? 'No global constants yet'
                     : 'No workspace secrets yet'
                   : activeTab === 'Global'
-                  ? 'No global constants found'
-                  : 'No workspace secrets found'}
+                    ? 'No global constants found'
+                    : 'No workspace secrets found'}
               </h3>
               <p className="info mt-2" data-cy="empty-state-text">
                 {activeTab === 'Global'

--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGranularAccess/BaseManageGranularAccess.jsx
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGranularAccess/BaseManageGranularAccess.jsx
@@ -1061,10 +1061,10 @@ class BaseManageGranularAccess extends React.Component {
     const addPermissionTooltipMessage = !newPermissionName
       ? 'Please input permissions name'
       : isCustom && this.getSelectedResources().length === 0
-      ? 'Please select apps or select all apps option'
-      : isEmptyDsPermission
-      ? 'Select an access level or restrict query run'
-      : '';
+        ? 'Please select apps or select all apps option'
+        : isEmptyDsPermission
+          ? 'Select an access level or restrict query run'
+          : '';
     const isBasicPlan = this.props.isBasicPlan;
     const disableEditUpdate = currentGroupPermission.name == 'end-user' || isBasicPlan;
 
@@ -1115,10 +1115,10 @@ class BaseManageGranularAccess extends React.Component {
                       resourceType === RESOURCE_TYPE.APPS
                         ? 'apps'
                         : resourceType === RESOURCE_TYPE.MODULES
-                        ? 'modules'
-                        : resourceType === RESOURCE_TYPE.WORKFLOWS
-                        ? 'workflows'
-                        : 'datasource'
+                          ? 'modules'
+                          : resourceType === RESOURCE_TYPE.WORKFLOWS
+                            ? 'workflows'
+                            : 'datasource'
                     }
                     fill="var(--slate8)"
                   />

--- a/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
+++ b/frontend/src/modules/WorkspaceSettings/pages/Groups/components/BaseManageGroupPermissionResources/BaseManageGroupPermissionResources.jsx
@@ -1695,8 +1695,8 @@ class BaseManageGroupPermissionResources extends React.Component {
                                     selectedAdminUsers.length !== 0
                                       ? '#ffffff'
                                       : this.props.darkMode
-                                      ? '#131620'
-                                      : '#C1C8CD'
+                                        ? '#131620'
+                                        : '#C1C8CD'
                                   }
                                   iconWidth="16"
                                   className="add-users-button"

--- a/frontend/src/modules/auth/pages/ForgotPasswordPage/components/ForgotPasswordInfoScreen/ForgotPasswordInfoScreen.jsx
+++ b/frontend/src/modules/auth/pages/ForgotPasswordPage/components/ForgotPasswordInfoScreen/ForgotPasswordInfoScreen.jsx
@@ -13,10 +13,10 @@ const ForgotPasswordInfoScreen = ({ email, appSlug, redirectTo, organizationSlug
   const loginPath = appSlug
     ? `/applications/${appSlug}/login?redirectTo=${encodeURIComponent(redirectTo || `/applications/${appSlug}`)}`
     : organizationSlug
-    ? `/login/${organizationSlug}${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
-    : redirectTo
-    ? `/login?redirectTo=${encodeURIComponent(redirectTo)}`
-    : '/login';
+      ? `/login/${organizationSlug}${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
+      : redirectTo
+        ? `/login?redirectTo=${encodeURIComponent(redirectTo)}`
+        : '/login';
 
   const message = t(
     'forgotPasswordInfo.message',

--- a/frontend/src/modules/auth/pages/LoginPage/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/modules/auth/pages/LoginPage/components/LoginForm/LoginForm.jsx
@@ -201,8 +201,8 @@ const LoginForm = ({
                             redirectTo || `/applications/${appSlug}`
                           )}`
                         : paramOrganizationSlug
-                        ? `/forgot-password?oid=${paramOrganizationSlug}`
-                        : '/forgot-password'
+                          ? `/forgot-password?oid=${paramOrganizationSlug}`
+                          : '/forgot-password'
                     }
                     hint={''}
                   />

--- a/frontend/src/modules/auth/pages/ResetPasswordPage/components/ResetPasswordInfoScreen/ResetPasswordInfoScreen.jsx
+++ b/frontend/src/modules/auth/pages/ResetPasswordPage/components/ResetPasswordInfoScreen/ResetPasswordInfoScreen.jsx
@@ -15,8 +15,8 @@ const ResetPasswordInfoScreen = ({ organizationSlug, redirectTo }) => {
   const loginPath = organizationSlug
     ? `/login/${organizationSlug}${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
     : redirectTo
-    ? `/login?redirectTo=${encodeURIComponent(redirectTo)}`
-    : '/login';
+      ? `/login?redirectTo=${encodeURIComponent(redirectTo)}`
+      : '/login';
 
   return (
     <div className="forgot-password-info-wrapper info-screen">

--- a/frontend/src/modules/common/components/LeftNavSideBar/components/BaseLeftNavSideBar/BaseLeftNavSideBar.jsx
+++ b/frontend/src/modules/common/components/LeftNavSideBar/components/BaseLeftNavSideBar/BaseLeftNavSideBar.jsx
@@ -87,8 +87,8 @@ const BaseLeftNavSideBar = ({
                     router.pathname === getPrivateRoute('workflows') && `current-seleted-route`
                       ? '#3E63DD'
                       : darkMode
-                      ? '#4C5155'
-                      : '#C1C8CD'
+                        ? '#4C5155'
+                        : '#C1C8CD'
                   }
                 />
               </Link>

--- a/frontend/src/modules/common/components/LinkExpiredCard/LinkExpiredCard.jsx
+++ b/frontend/src/modules/common/components/LinkExpiredCard/LinkExpiredCard.jsx
@@ -64,10 +64,10 @@ const LinkExpiredCard = ({ variant = 'reset', organizationSlug, appSlug, redirec
   const resolvedLoginPath = appSlug
     ? `/applications/${appSlug}/login${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
     : organizationSlug
-    ? `/login/${organizationSlug}${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
-    : redirectTo
-    ? `/login?redirectTo=${encodeURIComponent(redirectTo)}`
-    : '/login';
+      ? `/login/${organizationSlug}${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
+      : redirectTo
+        ? `/login?redirectTo=${encodeURIComponent(redirectTo)}`
+        : '/login';
 
   const resolvedCtaPath = config.ctaPath === '/login' ? resolvedLoginPath : config.ctaPath;
   const resolvedSignInPath = config.signInPath ? resolvedLoginPath : undefined;

--- a/frontend/src/modules/dataSources/components/DataSourceManager/DataSourceManager.jsx
+++ b/frontend/src/modules/dataSources/components/DataSourceManager/DataSourceManager.jsx
@@ -1076,8 +1076,8 @@ class DataSourceManagerComponent extends React.Component {
       const activeKey = Object.prototype.hasOwnProperty.call(normalizedCurrentOptions, key)
         ? key
         : Object.prototype.hasOwnProperty.call(normalizedCurrentOptions, camelize(key))
-        ? camelize(key)
-        : key;
+          ? camelize(key)
+          : key;
       if (normalizedSavedOptions[activeKey] === undefined) normalizedSavedOptions[activeKey] = { value: '' };
       if (normalizedCurrentOptions[activeKey] === undefined) normalizedCurrentOptions[activeKey] = { value: '' };
     });
@@ -1094,8 +1094,8 @@ class DataSourceManagerComponent extends React.Component {
     const docLink = isSampleDb
       ? 'https://docs.tooljet.com/docs/data-sources/sample-data-sources'
       : selectedDataSource?.pluginId && selectedDataSource.pluginId.trim() !== ''
-      ? `https://docs.tooljet.com/docs/marketplace/plugins/marketplace-plugin-${selectedDataSource?.kind}/`
-      : `https://docs.tooljet.com/docs/data-sources/${selectedDataSource?.kind}`;
+        ? `https://docs.tooljet.com/docs/marketplace/plugins/marketplace-plugin-${selectedDataSource?.kind}/`
+        : `https://docs.tooljet.com/docs/data-sources/${selectedDataSource?.kind}`;
     const OAuthDs = [
       'slack',
       'zendesk',

--- a/frontend/src/modules/dataSources/components/GlobalDataSources/index.jsx
+++ b/frontend/src/modules/dataSources/components/GlobalDataSources/index.jsx
@@ -186,8 +186,8 @@ export const GlobalDataSources = ({ darkMode = false, updateSelectedDatasource }
         }
       });
       datasourceGroup.list = [...arr];
-      (datasourceGroup.renderDatasources = () => renderCardGroup(datasourceGroup.list, datasourceGroup.type)),
-        (arr = []);
+      ((datasourceGroup.renderDatasources = () => renderCardGroup(datasourceGroup.list, datasourceGroup.type)),
+        (arr = []));
       return datasourceGroup;
     });
     const filteredDsList = filtered.reduce((acc, filteredGroup) => [...acc, ...filteredGroup.list], []);


### PR DESCRIPTION
## 📝 What this does
Runs `npm run lint` in `frontend/` and applies `eslint --fix` to resolve the 683 auto-fixable prettier/prettier errors. Pre-existing no-unused-vars and react-hooks/exhaustive-deps warnings (1886) are intentionally left untouched to keep this change formatting-only and low risk.
- [ee-server](no changes)
- [ee-frontend](https://github.com/ToolJet/ee-frontend/pull/620)

## 🔀 Changes
- Reformatted 128 files under `frontend/src` to match prettier rules
- Reformatted 2 files under `frontend/ee` (page-load-audit reference script, LDAP SSO modal) via the submodule PR
- Updated the `frontend/ee` submodule pointer

## 🧪 How to test
- [ ] Run `cd frontend && npm run lint` and confirm 0 errors (1886 pre-existing warnings remain)
- [ ] Spot-check a few changed files to confirm no behavioral change, only formatting