### PR TITLE
[DO NOT MERGE] Probe: Patch Coverage gate fail path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ concurrency:
   # cancel superseded PR runs (last label wins); never kill a push-validation run
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # Minimum % of a PR's changed executable lines the server suites must cover
+  # for the 'Patch Coverage' commit status to pass (see ci-gate). The
+  # 'skip-patch-coverage' PR label exempts a PR.
+  PATCH_COV_THRESHOLD: "80"
+
 jobs:
   # ---------------------------------------------------------------------------
   # 1. Detect which directories changed — gates all downstream jobs
@@ -364,7 +370,8 @@ jobs:
       # Patch coverage (server suite): of the lines this PR changed, how many did the
       # server tests cover. Computed here (not in ci-gate) because it must diff inside
       # the server/ee submodule, which is checked out with the token in this job. PR
-      # events only (needs a base SHA); informational — never gates.
+      # events only (needs a base SHA); enforced by ci-gate's 'Patch Coverage'
+      # commit status against PATCH_COV_THRESHOLD.
       - name: Patch coverage (server)
         if: >-
           ${{ !cancelled() && github.event_name == 'pull_request'
@@ -513,7 +520,8 @@ jobs:
         run: npm run --prefix server test:gitsync:e2e
       # Patch coverage (git-sync suite): diffs inside server/ee (checked out with the
       # token in this job) and intersects with the git-sync unit coverage. PR events
-      # only; informational — never gates.
+      # only; enforced by ci-gate's 'Patch Coverage' commit status against
+      # PATCH_COV_THRESHOLD.
       # v1: unit coverage only — git-sync lines exercised solely by the e2e suite read
       # as uncovered here (wiring e2e coverage in is a documented follow-up).
       - name: Patch coverage (git-sync)
@@ -768,7 +776,9 @@ jobs:
           # Coverage merging is a continue-on-error STEP inside test-server, not a
           # separate job — its own failure can't flip test-server.result, so it's
           # already excluded from the gate without needing an array exclusion here.
-          # coverageThreshold is 0 everywhere anyway; this is informational only.
+          # Global coverageThreshold is 0 everywhere and stays informational;
+          # patch coverage is enforced separately via the 'Patch Coverage'
+          # commit status (steps.patchcov below), not this verdict.
           builds=(
             "build-server:${{ needs.build-server.result }}"
             "build-frontend:${{ needs.build-frontend.result }}"
@@ -889,6 +899,25 @@ jobs:
           name: patch-coverage-gitsync
           path: /tmp/ci-results/patchcov
 
+      # Patch coverage enforcement: union both suites' patch-coverage JSONs and
+      # compare against PATCH_COV_THRESHOLD. Feeds the 'Patch Coverage' commit
+      # status below. The 'skip-patch-coverage' PR label exempts a PR; missing
+      # artifacts (push events, no server changes, failed suite) read as 'na'.
+      - name: Evaluate patch coverage
+        id: patchcov
+        if: >-
+          steps.eval.outputs.mode == 'full'
+          && contains(fromJSON('["pass","fail"]'), steps.eval.outputs.verdict)
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-patch-coverage') }}" == "true" ]]; then
+            echo "verdict=skipped" >> "$GITHUB_OUTPUT"
+            echo "Patch coverage skipped via skip-patch-coverage label"
+          else
+            node scripts/check-patch-coverage.mjs \
+              --inputs /tmp/ci-results/patchcov/server.json,/tmp/ci-results/patchcov/gitsync.json \
+              --threshold "$PATCH_COV_THRESHOLD"
+          fi
+
       - name: Render PR comment
         if: >-
           github.event_name == 'pull_request'
@@ -978,6 +1007,36 @@ jobs:
               state: verdict === 'pass' ? 'success' : 'failure',
               context: 'CI Gate',
               description: verdict === 'pass' ? 'Full CI green' : 'Full CI failed',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Post Patch Coverage commit status
+        # Merge-enforcement companion to 'CI Gate': same `if`, so whenever a run
+        # mints a CI Gate status it also mints 'Patch Coverage' — a ruleset
+        # requiring it can never wedge a PR on an unposted status. success for
+        # na/skipped; failure only when coverage is below PATCH_COV_THRESHOLD.
+        if: >-
+          steps.eval.outputs.mode == 'full'
+          && contains(fromJSON('["pass","fail"]'), steps.eval.outputs.verdict)
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const verdict = '${{ steps.patchcov.outputs.verdict }}' || 'na';
+            const pct = '${{ steps.patchcov.outputs.pct }}';
+            const threshold = process.env.PATCH_COV_THRESHOLD;
+            const desc = {
+              pass: `${pct}% of changed executable lines covered (>= ${threshold}%)`,
+              fail: `${pct}% < ${threshold}% — changed lines need tests (see PR comment)`,
+              na: 'no applicable server changes',
+              skipped: 'skipped via skip-patch-coverage label',
+            }[verdict] || 'no applicable server changes';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request?.head?.sha || context.sha,
+              state: verdict === 'fail' ? 'failure' : 'success',
+              context: 'Patch Coverage',
+              description: desc.slice(0, 140),
               target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
 

--- a/scripts/check-patch-coverage.mjs
+++ b/scripts/check-patch-coverage.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Enforces the patch-coverage threshold for the ci-gate's 'Patch Coverage'
+ * commit status.
+ *
+ * Reads the per-suite JSONs produced by compute-patch-coverage.mjs, unions
+ * their per-file executable/covered line sets (a line covered by ANY suite
+ * counts), and compares covered/executable against the threshold.
+ *
+ * Verdicts (written to $GITHUB_OUTPUT when set, always echoed to stdout):
+ *   pass — coverage >= threshold
+ *   fail — coverage <  threshold
+ *   na   — nothing to enforce: no input files, no changed files, or zero
+ *          changed executable lines (docs/config-only PRs, push events where
+ *          patch coverage was never computed, or coverage merge skipped)
+ *
+ * Always exits 0 — the workflow step reads the verdict and decides; a crash
+ * here must not flip the Gate job's conclusion.
+ *
+ * Usage:
+ *   node scripts/check-patch-coverage.mjs \
+ *     --inputs /tmp/patchcov/server.json,/tmp/patchcov/gitsync.json \
+ *     --threshold 80
+ */
+import fs from 'node:fs';
+
+function parseArgs(argv) {
+  const a = {};
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--inputs') a.inputs = argv[++i];
+    else if (k === '--threshold') a.threshold = Number(argv[++i]);
+  }
+  if (!a.inputs || !Number.isFinite(a.threshold)) {
+    console.error('Usage: check-patch-coverage.mjs --inputs <a.json,b.json> --threshold <pct>');
+    process.exit(2);
+  }
+  return a;
+}
+
+function loadInputs(csv) {
+  const out = [];
+  for (const p of csv.split(',').map((s) => s.trim()).filter(Boolean)) {
+    if (!fs.existsSync(p)) continue;
+    try {
+      out.push(JSON.parse(fs.readFileSync(p, 'utf8')));
+    } catch {
+      /* skip malformed */
+    }
+  }
+  return out;
+}
+
+// Same union as render-patch-coverage.mjs: Map<file, {exec:Set, cov:Set}>.
+function unionByFile(inputs) {
+  const map = new Map();
+  for (const input of inputs) {
+    for (const f of input.files || []) {
+      const entry = map.get(f.file) || { exec: new Set(), cov: new Set() };
+      for (const ln of f.executable || []) entry.exec.add(ln);
+      for (const ln of f.covered || []) entry.cov.add(ln);
+      map.set(f.file, entry);
+    }
+  }
+  return map;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const inputs = loadInputs(args.inputs);
+const byFile = unionByFile(inputs);
+
+let exec = 0;
+let cov = 0;
+for (const e of byFile.values()) {
+  exec += e.exec.size;
+  cov += e.cov.size;
+}
+
+let verdict;
+let pct = '';
+if (inputs.length === 0 || exec === 0) {
+  verdict = 'na';
+} else {
+  pct = ((cov / exec) * 100).toFixed(1);
+  verdict = Number(pct) >= args.threshold ? 'pass' : 'fail';
+}
+
+const lines = [`verdict=${verdict}`, `pct=${pct}`, `covered=${cov}`, `executable=${exec}`];
+for (const l of lines) console.log(l);
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, lines.join('\n') + '\n');
+}

--- a/scripts/render-patch-coverage.mjs
+++ b/scripts/render-patch-coverage.mjs
@@ -130,9 +130,14 @@ const shown = uncovered.slice(0, MAX_FILES);
 const suiteRow = (label, t) =>
   `| ${label} | ${t.cov}/${t.exec} | ${bar(t.cov, t.exec)} ${fmtPct(t.cov, t.exec)} |`;
 
+// Threshold verdict mirrors ci-gate's 'Patch Coverage' commit status.
+const THRESHOLD = Number(process.env.PATCH_COV_THRESHOLD || 80);
+const totalPct = total.exec === 0 ? null : (total.cov / total.exec) * 100;
+const gate = totalPct === null ? '' : totalPct >= THRESHOLD ? ` · ✅ meets ${THRESHOLD}% gate` : ` · ❌ below ${THRESHOLD}% gate`;
+
 const lines = [
   '<details>',
-  `<summary><b>🎯 Patch coverage — ${fmtPct(total.cov, total.exec)}</b> · ${total.cov}/${total.exec} changed lines covered</summary>`,
+  `<summary><b>🎯 Patch coverage — ${fmtPct(total.cov, total.exec)}</b> · ${total.cov}/${total.exec} changed lines covered${gate}</summary>`,
   '',
   '| Suite | Lines | Covered |',
   '|---|---:|---:|',
@@ -157,7 +162,8 @@ if (shown.length) {
 lines.push(
   '<sub>Patch coverage = covered ÷ changed executable lines (added/modified vs the merge-base). ' +
     'Combined counts a line as covered if either suite hit it; server/git-sync split is by file path. ' +
-    'Informational only — never gates the merge.</sub>',
+    `Enforced by the required 'Patch Coverage' commit status (≥${THRESHOLD}%); ` +
+    'the `skip-patch-coverage` PR label exempts a PR.</sub>',
   '</details>'
 );
 

--- a/server/src/helpers/patch-coverage-probe.helper.ts
+++ b/server/src/helpers/patch-coverage-probe.helper.ts
@@ -1,0 +1,18 @@
+// Throwaway probe for the Patch Coverage CI gate — delete before merge.
+export function classifyScore(score: number): 'low' | 'mid' | 'high' {
+  if (score < 30) {
+    return 'low';
+  }
+  if (score < 70) {
+    return 'mid';
+  }
+  return 'high';
+}
+
+export function summarizeScores(scores: number[]): Record<'low' | 'mid' | 'high', number> {
+  const summary = { low: 0, mid: 0, high: 0 };
+  for (const score of scores) {
+    summary[classifyScore(score)] += 1;
+  }
+  return summary;
+}


### PR DESCRIPTION
Throwaway PR to exercise the `Patch Coverage` commit status from #17777 — branched off `ci/patch-coverage-gate` so the new gate wiring runs.

Adds an untested helper (`server/src/helpers/patch-coverage-probe.helper.ts`). Expected: `Patch Coverage` status = **failure**, PR comment lists the uncovered lines. Follow-ups on this PR: add a spec → success; `skip-patch-coverage` label → success.

Will be closed without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJvJdiwfmL47dJWsrQ3vr3