### PR TITLE
fix(migrations): target data_source_version_options in mysql connection-type backfill

### DIFF
--- a/server/data-migrations/1785283260000-BackfillMysqlDatasourceConnectionType.ts
+++ b/server/data-migrations/1785283260000-BackfillMysqlDatasourceConnectionType.ts
@@ -9,12 +9,18 @@ const BATCH_SIZE = 500;
 // "manual" vs "string" (connection string) and a separate protocol field for "hostname"/"socket"
 // ("socket_path" was renamed to "socket"). Datasources already on the new format
 // ("manual" or "string") must be left untouched.
+//
+// data_source_options was dropped in DropDataSourceOptionsTable1773300000000 (runs before this
+// migration by timestamp) once its data was copied to data_source_version_options by
+// ConsolidatedBranchModelSetup1773500000000. Every environment reaching this migration has
+// already gone through that consolidation, so this targets the new table directly.
 const LEGACY_FORMAT_WHERE_CLAUSE = `
-  INNER JOIN data_sources ds ON ds.id = dso.data_source_id
+  INNER JOIN data_source_versions dsv ON dsv.id = dsvo.data_source_version_id
+  INNER JOIN data_sources ds ON ds.id = dsv.data_source_id
   WHERE ds.kind = 'mysql'
     AND (
-      NOT (dso.options::jsonb ? 'connection_type')
-      OR (dso.options::jsonb -> 'connection_type' ->> 'value') IN ('hostname', 'socket_path')
+      NOT (dsvo.options::jsonb ? 'connection_type')
+      OR (dsvo.options::jsonb -> 'connection_type' ->> 'value') IN ('hostname', 'socket_path')
     )
 `;
 
@@ -23,12 +29,12 @@ export class BackfillMysqlDatasourceConnectionType1785283260000 implements Migra
     const entityManager = queryRunner.manager;
 
     const [{ count }] = await entityManager.query(
-      `SELECT COUNT(*) AS count FROM data_source_options dso ${LEGACY_FORMAT_WHERE_CLAUSE}`
+      `SELECT COUNT(*) AS count FROM data_source_version_options dsvo ${LEGACY_FORMAT_WHERE_CLAUSE}`
     );
     const totalCount = parseInt(count, 10);
 
     if (totalCount === 0) {
-      console.log(`${MIGRATION_NAME}: no matching mysql datasource options found.`);
+      console.log(`${MIGRATION_NAME}: no matching mysql datasource version options found.`);
       return;
     }
 
@@ -42,7 +48,7 @@ export class BackfillMysqlDatasourceConnectionType1785283260000 implements Migra
           // Processed rows leave the WHERE clause after update, so always fetch from offset 0.
           async (transactionManager: EntityManager, _skip: number, take: number) => {
             return await transactionManager.query(
-              `SELECT dso.id FROM data_source_options dso ${LEGACY_FORMAT_WHERE_CLAUSE} ORDER BY dso.id LIMIT $1`,
+              `SELECT dsvo.id FROM data_source_version_options dsvo ${LEGACY_FORMAT_WHERE_CLAUSE} ORDER BY dsvo.id LIMIT $1`,
               [take]
             );
           },
@@ -50,7 +56,7 @@ export class BackfillMysqlDatasourceConnectionType1785283260000 implements Migra
             const ids = rows.map((row) => row.id);
 
             await transactionManager.query(
-              `UPDATE data_source_options
+              `UPDATE data_source_version_options
                SET "options" = (
                  ("options"::jsonb - 'connection_type')
                  || jsonb_build_object(
@@ -79,7 +85,7 @@ export class BackfillMysqlDatasourceConnectionType1785283260000 implements Migra
       throw error;
     }
 
-    console.log(`${MIGRATION_NAME}: completed. Updated ${totalUpdated} mysql datasource options.`);
+    console.log(`${MIGRATION_NAME}: completed. Updated ${totalUpdated} mysql datasource version options.`);
   }
 
   public async down(_queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## Summary

`BackfillMysqlDatasourceConnectionType1785283260000` queries `data_source_options` directly, but that table is dropped earlier in the same data-migration batch by `DropDataSourceOptionsTable1773300000000` (main's git-sync/branch-versioning refactor consolidated data-source options into `data_source_version_options`). Running `npm run db:reset` on `chore/merge-3.20.218-lts-main` fails with:

```
error: relation "data_source_options" does not exist
Migration "BackfillMysqlDatasourceConnectionType1785283260000" failed
```

## Why this only shows up here, not on `main` or `lts-3.16`

- `BackfillMysqlDatasourceConnectionType` exists **only on `lts-3.16`** — never on `main`. It was written against lts-3.16's still-current `data_source_options` table (lts never got the branch-versioning schema refactor), so it's correct there.
- `main` has the schema refactor (`DropDataSourceOptionsTable`) but never had this mysql migration at all, so nothing on main ever queries the dropped table.
- Its mssql sibling, `BackfillMssqlDatasourceConnectionType1785283200000`, exists on **both** — main's copy was already fixed for this exact issue in `73314e2325` ("fix: update migration to target data_source_version_options for MSSQL connection type").
- This branch is the first place both lines' migration folders run in the same sequence, so it's the first place the mysql migration ever actually executes against the post-refactor schema. Two independent new files, no git conflict — the collision is in execution order, not text, so it only surfaces by running migrations against a real DB.

## Fix

Mirror the mssql migration's already-correct join through `data_source_versions`, keeping the mysql-specific `connection_type`/`protocol` backfill logic unchanged.

## Verification

- `tsc --noEmit`: clean
- `eslint`: clean
- `npm run db:reset`: exits 0; migration now logs `no matching mysql datasource version options found` (fresh DB, same as its mssql sibling) instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)