### PR TITLE
[TEST] dep gate — clean dep ms@2.1.3 (expect PASS)

### DIFF
--- a/dep-gate-test/package-lock.json
+++ b/dep-gate-test/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "dep-gate-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dep-gate-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "ms": "2.1.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    }
+  }
+}

--- a/dep-gate-test/package.json
+++ b/dep-gate-test/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dep-gate-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Isolated fixture to exercise the dependency vulnerability gate. Not shipped.",
+  "dependencies": {
+    "ms": "2.1.3"
+  }
+}


### PR DESCRIPTION
Manual verification of the dependency vulnerability gate. **Do not merge — will be closed.**

Adds an isolated `dep-gate-test/` tree with `ms@2.1.3` (no advisories). Expected: gate scans the tree and passes — no new Critical/High.