### PR TITLE
[TEST] dep gate — vulnerable lodash@4.17.4 (expect FAIL)

### DIFF
--- a/dep-gate-test/package-lock.json
+++ b/dep-gate-test/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "dep-gate-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dep-gate-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "4.17.4"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/dep-gate-test/package.json
+++ b/dep-gate-test/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dep-gate-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Isolated fixture to exercise the dependency vulnerability gate. Not shipped.",
+  "dependencies": {
+    "lodash": "4.17.4"
+  }
+}


### PR DESCRIPTION
Manual verification of the dependency vulnerability gate. **Do not merge — will be closed.**

Adds an isolated `dep-gate-test/` tree with `lodash@4.17.4` (CVE-2019-10744 prototype pollution, Critical + several High). Expected: gate scans and **fails** with a new Critical/High in the delta.