### PR TITLE
ci: dependency vulnerability gate for pull requests

### DIFF
--- a/.github/scripts/dependency-vulnerability-delta.mjs
+++ b/.github/scripts/dependency-vulnerability-delta.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const severityRank = {
+  info: 0,
+  low: 1,
+  moderate: 2,
+  high: 3,
+  critical: 4,
+};
+
+function readAudit(path) {
+  const report = JSON.parse(readFileSync(path, 'utf8'));
+
+  if (!report || typeof report !== 'object' || !report.metadata) {
+    throw new Error(`${path} is not a valid npm audit report`);
+  }
+
+  return report;
+}
+
+function advisoryId(via) {
+  if (typeof via === 'string') return `dependency:${via}`;
+  if (via.source !== undefined) return `source:${via.source}`;
+  if (via.url) return `url:${via.url}`;
+  return `title:${via.title ?? 'unknown'}`;
+}
+
+function findings(report) {
+  const result = new Map();
+
+  for (const [packageName, vulnerability] of Object.entries(report.vulnerabilities ?? {})) {
+    const entries = Array.isArray(vulnerability.via) && vulnerability.via.length > 0
+      ? vulnerability.via
+      : ['unknown'];
+
+    for (const via of entries) {
+      const severity = String(
+        typeof via === 'object' && via !== null ? via.severity : vulnerability.severity
+      ).toLowerCase();
+
+      if (!(severity in severityRank)) continue;
+
+      const id = advisoryId(via);
+      const key = `${packageName}|${id}`;
+      const existing = result.get(key);
+
+      if (!existing || severityRank[severity] > severityRank[existing.severity]) {
+        result.set(key, {
+          packageName,
+          id,
+          severity,
+          title: typeof via === 'object' && via !== null ? via.title : String(via),
+          range: typeof via === 'object' && via !== null
+            ? (via.range ?? vulnerability.range ?? 'unknown')
+            : (vulnerability.range ?? 'unknown'),
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+if (process.argv.length !== 4) {
+  console.error('Usage: dependency-vulnerability-delta.mjs <base-audit.json> <head-audit.json>');
+  process.exit(2);
+}
+
+try {
+  const base = findings(readAudit(process.argv[2]));
+  const head = findings(readAudit(process.argv[3]));
+  const blocking = [];
+
+  for (const [key, finding] of head) {
+    if (severityRank[finding.severity] < severityRank.high) continue;
+
+    const previous = base.get(key);
+    if (!previous || severityRank[finding.severity] > severityRank[previous.severity]) {
+      blocking.push(finding);
+    }
+  }
+
+  blocking.sort((a, b) =>
+    severityRank[b.severity] - severityRank[a.severity]
+      || a.packageName.localeCompare(b.packageName)
+  );
+
+  if (blocking.length === 0) {
+    console.log('No new Critical or High runtime dependency vulnerabilities were introduced.');
+    process.exit(0);
+  }
+
+  console.error(`Found ${blocking.length} new or severity-increased runtime vulnerability finding(s):`);
+  for (const finding of blocking) {
+    console.error(
+      `- ${finding.severity.toUpperCase()} ${finding.packageName}: ${finding.title} `
+      + `(${finding.id}, vulnerable range: ${finding.range})`
+    );
+  }
+  process.exit(1);
+} catch (error) {
+  console.error(`Unable to compare npm audit reports: ${error.message}`);
+  process.exit(2);
+}

--- a/.github/scripts/dependency-vulnerability-delta.test.mjs
+++ b/.github/scripts/dependency-vulnerability-delta.test.mjs
@@ -1,0 +1,250 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const script = new URL('./dependency-vulnerability-delta.mjs', import.meta.url).pathname;
+
+function advisory({ severity, source = 101, title, range = '<1.0.0' }) {
+  return {
+    source,
+    severity,
+    range,
+    title: title ?? `Advisory ${source}`,
+    url: `https://github.example/advisories/${source}`,
+  };
+}
+
+function vulnerable(packageName, severity, { via, range = '<1.0.0' } = {}) {
+  return {
+    [packageName]: {
+      name: packageName,
+      severity,
+      range,
+      via: via ?? [advisory({ severity })],
+    },
+  };
+}
+
+function report(vulnerabilities = {}) {
+  return { metadata: { vulnerabilities: {} }, vulnerabilities };
+}
+
+function compare(base, head) {
+  const directory = mkdtempSync(join(tmpdir(), 'dependency-vulnerability-delta-'));
+  const basePath = join(directory, 'base.json');
+  const headPath = join(directory, 'head.json');
+  writeFileSync(basePath, typeof base === 'string' ? base : JSON.stringify(base));
+  writeFileSync(headPath, typeof head === 'string' ? head : JSON.stringify(head));
+
+  return spawnSync(process.execPath, [script, basePath, headPath], { encoding: 'utf8' });
+}
+
+test('passes when neither report contains a vulnerability', () => {
+  const result = compare(report(), report());
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No new Critical or High runtime dependency vulnerabilities/);
+});
+
+test('passes when a report omits the vulnerabilities key entirely', () => {
+  const result = compare({ metadata: {} }, { metadata: {} });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('treats a vulnerability present in the base as baseline and does not block', () => {
+  const result = compare(
+    report(vulnerable('lodash', 'critical')),
+    report(vulnerable('lodash', 'critical'))
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('blocks a newly introduced Critical', () => {
+  const result = compare(report(), report(vulnerable('lodash', 'critical')));
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /1 new or severity-increased runtime vulnerability finding/);
+  assert.match(result.stderr, /CRITICAL lodash/);
+  assert.match(result.stderr, /vulnerable range: <1\.0\.0/);
+});
+
+test('blocks a newly introduced High', () => {
+  const result = compare(report(), report(vulnerable('axios', 'high')));
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /HIGH axios/);
+});
+
+test('does not block a newly introduced Moderate or Low', () => {
+  const result = compare(
+    report(),
+    report({
+      ...vulnerable('braces', 'moderate'),
+      ...vulnerable('semver', 'low'),
+    })
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('blocks when an existing finding increases from Moderate to High', () => {
+  const result = compare(
+    report(vulnerable('braces', 'moderate')),
+    report(vulnerable('braces', 'high'))
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /HIGH braces/);
+});
+
+test('blocks when an existing finding increases from High to Critical', () => {
+  const result = compare(
+    report(vulnerable('axios', 'high')),
+    report(vulnerable('axios', 'critical'))
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /CRITICAL axios/);
+});
+
+test('does not block when an existing finding decreases from Critical to High', () => {
+  const result = compare(
+    report(vulnerable('axios', 'critical')),
+    report(vulnerable('axios', 'high'))
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('keys findings per advisory so a second advisory on the same package blocks', () => {
+  const result = compare(
+    report(vulnerable('lodash', 'high', { via: [advisory({ severity: 'high', source: 101 })] })),
+    report(
+      vulnerable('lodash', 'high', {
+        via: [
+          advisory({ severity: 'high', source: 101 }),
+          advisory({ severity: 'critical', source: 202, title: 'Prototype pollution' }),
+        ],
+      })
+    )
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /CRITICAL lodash: Prototype pollution \(source:202/);
+  assert.doesNotMatch(result.stderr, /source:101/);
+});
+
+test('uses the package severity when via lists a transitive dependency name', () => {
+  const result = compare(
+    report(),
+    report(vulnerable('body-parser', 'high', { via: ['qs'] }))
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /HIGH body-parser: qs \(dependency:qs/);
+});
+
+test('falls back to the package severity when via is empty', () => {
+  const result = compare(report(), report(vulnerable('tar', 'critical', { via: [] })));
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /CRITICAL tar: unknown \(dependency:unknown/);
+});
+
+test('identifies an advisory by url when it carries no source', () => {
+  const result = compare(
+    report(),
+    report(
+      vulnerable('ws', 'high', {
+        via: [{ severity: 'high', title: 'DoS', url: 'https://github.example/advisories/ws' }],
+      })
+    )
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /url:https:\/\/github\.example\/advisories\/ws/);
+});
+
+test('identifies an advisory by title when it carries neither source nor url', () => {
+  const result = compare(
+    report(),
+    report(vulnerable('ws', 'high', { via: [{ severity: 'high', title: 'DoS' }] }))
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /title:DoS/);
+});
+
+test('keeps the highest severity when one advisory appears more than once', () => {
+  const result = compare(
+    report(),
+    report(
+      vulnerable('minimist', 'moderate', {
+        via: [
+          { severity: 'moderate', title: 'First report', url: 'https://github.example/a' },
+          { severity: 'critical', title: 'Second report', url: 'https://github.example/a' },
+        ],
+      })
+    )
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /CRITICAL minimist/);
+  assert.doesNotMatch(result.stderr, /MODERATE/);
+});
+
+test('ignores a finding whose severity is not a known npm severity', () => {
+  const result = compare(
+    report(),
+    report(vulnerable('mystery', 'unspecified', { via: [advisory({ severity: 'unspecified' })] }))
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('reports Critical findings before High findings', () => {
+  const result = compare(
+    report(),
+    report({
+      ...vulnerable('axios', 'high'),
+      ...vulnerable('lodash', 'critical'),
+    })
+  );
+  assert.equal(result.status, 1);
+  assert.ok(
+    result.stderr.indexOf('CRITICAL lodash') < result.stderr.indexOf('HIGH axios'),
+    `expected Critical before High, got:\n${result.stderr}`
+  );
+});
+
+test('orders findings of equal severity by package name', () => {
+  const result = compare(
+    report(),
+    report({
+      ...vulnerable('zod', 'high'),
+      ...vulnerable('axios', 'high'),
+    })
+  );
+  assert.equal(result.status, 1);
+  assert.ok(
+    result.stderr.indexOf('HIGH axios') < result.stderr.indexOf('HIGH zod'),
+    `expected axios before zod, got:\n${result.stderr}`
+  );
+});
+
+test('exits with a usage error when the argument count is wrong', () => {
+  const result = spawnSync(process.execPath, [script, 'only-one-report.json'], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Usage: dependency-vulnerability-delta\.mjs/);
+});
+
+test('exits with a scan error rather than a pass when a report is not valid JSON', () => {
+  const result = compare(report(), 'this is not json');
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Unable to compare npm audit reports/);
+});
+
+test('exits with a scan error when a report is not an npm audit report', () => {
+  const result = compare(report(), { vulnerabilities: {} });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /is not a valid npm audit report/);
+});
+
+test('exits with a scan error when a report file is missing', () => {
+  const result = spawnSync(process.execPath, [script, 'missing-base.json', 'missing-head.json'], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Unable to compare npm audit reports/);
+});

--- a/.github/workflows/dependency-vulnerability-gate.yml
+++ b/.github/workflows/dependency-vulnerability-gate.yml
@@ -1,0 +1,158 @@
+name: Dependency Vulnerability Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-vulnerability-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-gate:
+    name: security/dependency-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up repository Node.js version
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Find affected dependency trees
+        id: dependency-trees
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          git diff --name-only --diff-filter=ACDMRT "$BASE_SHA" "$HEAD_SHA" \
+            | awk '/(^|\/)(package.json|package-lock.json)$/' > "$RUNNER_TEMP/changed-dependency-files.txt"
+
+          while IFS= read -r deleted_lockfile; do
+            manifest="$(dirname "$deleted_lockfile")/package.json"
+            if [ "$(dirname "$deleted_lockfile")" = "." ]; then
+              manifest="package.json"
+            fi
+            if git cat-file -e "$HEAD_SHA:$manifest" 2>/dev/null; then
+              echo "A package-lock.json cannot be deleted while $manifest still exists." >&2
+              exit 1
+            fi
+          done < <(git diff --name-only --diff-filter=D "$BASE_SHA" "$HEAD_SHA" \
+            | awk '/(^|\/)package-lock.json$/')
+
+          : > "$RUNNER_TEMP/dependency-tree-directories.txt"
+          while IFS= read -r dependency_file; do
+            directory=$(dirname "$dependency_file")
+            while true; do
+              lockfile="$directory/package-lock.json"
+              if [ "$directory" = "." ]; then
+                lockfile="package-lock.json"
+              fi
+
+              if [ -f "$lockfile" ] || git cat-file -e "$BASE_SHA:$lockfile" 2>/dev/null; then
+                echo "$directory" >> "$RUNNER_TEMP/dependency-tree-directories.txt"
+                break
+              fi
+
+              if [ "$directory" = "." ]; then
+                break
+              fi
+              directory=$(dirname "$directory")
+            done
+          done < "$RUNNER_TEMP/changed-dependency-files.txt"
+
+          sort -u -o "$RUNNER_TEMP/dependency-tree-directories.txt" \
+            "$RUNNER_TEMP/dependency-tree-directories.txt"
+
+          if [ -s "$RUNNER_TEMP/dependency-tree-directories.txt" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Dependency trees to scan:"
+            sed 's/^/- /' "$RUNNER_TEMP/dependency-tree-directories.txt"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No dependency tree changed; the security gate passes without scanning."
+          fi
+
+      - name: Check for newly introduced runtime vulnerabilities
+        if: steps.dependency-trees.outputs.changed == 'true'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          base_checkout="$RUNNER_TEMP/dependency-gate-base"
+          reports="$RUNNER_TEMP/dependency-gate-reports"
+          mkdir -p "$reports"
+          git worktree add --detach "$base_checkout" "$BASE_SHA"
+
+          audit_tree() {
+            local checkout=$1
+            local directory=$2
+            local output=$3
+            local audit_directory="$checkout/$directory"
+
+            if [ ! -f "$audit_directory/package-lock.json" ]; then
+              echo '{"metadata":{},"vulnerabilities":{}}' > "$output"
+              return
+            fi
+
+            if ! (cd "$audit_directory" && npm audit --omit=dev --json > "$output"); then
+              # npm audit exits non-zero when it finds vulnerabilities. A valid JSON
+              # report means the scan itself succeeded and is safe to compare.
+              if ! jq -e '.metadata and (.vulnerabilities | type == "object")' "$output" >/dev/null; then
+                echo "npm audit failed to produce a valid report for $directory" >&2
+                return 2
+              fi
+            fi
+          }
+
+          failed=0
+          index=0
+          echo "## Dependency vulnerability gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r directory; do
+            index=$((index + 1))
+            base_report="$reports/base-$index.json"
+            head_report="$reports/head-$index.json"
+            comparison_report="$reports/comparison-$index.txt"
+
+            echo "Scanning dependency tree: $directory"
+            audit_tree "$base_checkout" "$directory" "$base_report"
+            audit_tree "$GITHUB_WORKSPACE" "$directory" "$head_report"
+
+            set +e
+            node .github/scripts/dependency-vulnerability-delta.mjs \
+              "$base_report" "$head_report" 2>&1 | tee "$comparison_report"
+            comparison_exit=${PIPESTATUS[0]}
+            set -e
+
+            echo "### \`$directory\`" >> "$GITHUB_STEP_SUMMARY"
+            echo '```text' >> "$GITHUB_STEP_SUMMARY"
+            cat "$comparison_report" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+            if [ "$comparison_exit" -ne 0 ]; then
+              failed=1
+            fi
+          done < "$RUNNER_TEMP/dependency-tree-directories.txt"
+
+          if [ "$failed" -ne 0 ]; then
+            echo "The PR introduces a new Critical or High runtime dependency vulnerability." >&2
+            exit 1
+          fi
+
+          echo "All affected dependency trees passed the vulnerability delta check."


### PR DESCRIPTION
## What this adds

A **pull-request merge gate** that blocks a PR only when it **introduces a new Critical or High severity runtime dependency vulnerability**.

- **`.github/workflows/dependency-vulnerability-gate.yml`** — runs on `pull_request` (opened/synchronize/reopened). Job context: **`security/dependency-gate`**. It diffs `package.json`/`package-lock.json` between base and head, finds each affected lockfile tree, and `npm audit --omit=dev`s that tree on both base and head. `permissions: contents: read`, **no secrets** — so it works on fork PRs.
- **`.github/scripts/dependency-vulnerability-delta.mjs`** — compares the base vs head audit reports and fails **only** on findings that are newly introduced or increased in severity to High/Critical. Pre-existing (baseline) vulnerabilities do not block.

### Behavior
- Documentation-only / no-dependency PRs pass instantly with no npm audit.
- A dependency change is scanned; it passes when no new High/Critical runtime vuln appears, and fails when one is introduced or an existing finding rises into High/Critical.

## Verification

Exercised end-to-end against three throwaway PRs (since closed); each behaved as designed, confirmed from the Actions logs:

| Scenario | Result | Evidence |
|---|---|---|
| Docs-only change | ✅ pass | "No dependency tree changed; the security gate passes without scanning" — no audit ran |
| Clean runtime dep (`ms@2.1.3`) | ✅ pass | Scanned the tree → "No new Critical or High… passed" |
| Vulnerable runtime dep (`lodash@4.17.4`) | ✅ fail | Scanned → `CRITICAL lodash: Prototype Pollution` + 4 High → gate blocked |

---

## Rollout runbook

Follow this after the gate is merged into the default branch.

### Prerequisites
- The workflow exists at `.github/workflows/dependency-vulnerability-gate.yml` (this PR).
- The workflow has completed at least once on a pull request.
- You have repository administration permission.
- Confirm the completed check is named exactly **`security/dependency-gate`**.

### Enable the required check
1. Open **ToolJet/ToolJet → Settings → Rules → Rulesets**.
2. Open the active ruleset protecting `main`, or create a branch ruleset for `main`.
3. Enable **Require status checks to pass before merging**.
4. Add **`security/dependency-gate`** to the required status checks.
5. Enable **Require branches to be up to date before merging** if that matches the repository's existing merge policy.
6. Save the ruleset without removing or weakening any existing required checks.

Repeat for each maintained release branch that should receive the same protection.

### Verify
Test with two pull requests:
1. A documentation-only change — the gate should pass quickly without running an npm audit.
2. A dependency change — the gate should scan the affected lockfile tree and:
   - pass when no new Critical/High runtime vulnerability is introduced;
   - fail when such a vulnerability is introduced or increases in severity.

Confirm that merging is unavailable while the required check is pending or failed.

### Operational response
If the check fails:
1. Read the **Dependency vulnerability gate** workflow summary.
2. Upgrade, replace, or remove the dependency responsible for the new finding.
3. Push the updated manifest and lockfile; the check reruns automatically.

Do not bypass the check for an existing vulnerability: unchanged vulnerabilities are already treated as baseline and do not block the pull request.

### Emergency rollback
If the gate is failing because the scanner or npm registry is unavailable:
1. Confirm the failure is a tooling outage rather than a vulnerability finding.
2. Temporarily remove only `security/dependency-gate` from the required checks.
3. Record an owner and deadline to restore it.
4. Restore the required check after a successful verification run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
