### PR TITLE
Fix: Query editor is blank for existing queries on a marketplace plugin data source

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -53,7 +53,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = null
     */
   const [selectedQueryId, setSelectedQueryId] = useState(selectedQuery?.id);
   const queryName = selectedQuery?.name ?? '';
-  const sourcecomponentName = selectedQuery?.kind?.charAt(0).toUpperCase() + selectedQuery?.kind?.slice(1);
+  const sourcecomponentName = selectedDataSource?.kind?.charAt(0).toUpperCase() + selectedDataSource?.kind?.slice(1);
 
   // Dummy DS = stub options + maybe no plugin relation. Mounting editor crashes:
   // built-ins read undefined options.X.value, unbundled kinds → allSources[Kind] = undefined.
@@ -61,7 +61,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = null
   const isDummyDataSource = selectedDataSource?.is_dummy === true;
   const ElementToRender = isDummyDataSource
     ? null
-    : selectedQuery?.plugin_id
+    : selectedDataSource?.plugin_id
       ? source
       : allSources[sourcecomponentName];
   const defaultOptions = useRef({});

--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -5,6 +5,7 @@ import { isEmpty } from 'lodash';
 // eslint-disable-next-line import/no-unresolved
 import { diff } from 'deep-object-diff';
 import { allSources, source } from '../QueryEditors';
+import { resolveQueryEditor } from '../utils';
 import DataSourcePicker from './DataSourcePicker';
 import { Transformation } from './Transformation';
 import Preview from './Preview';
@@ -53,17 +54,11 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = null
     */
   const [selectedQueryId, setSelectedQueryId] = useState(selectedQuery?.id);
   const queryName = selectedQuery?.name ?? '';
-  const sourcecomponentName = selectedDataSource?.kind?.charAt(0).toUpperCase() + selectedDataSource?.kind?.slice(1);
 
-  // Dummy DS = stub options + maybe no plugin relation. Mounting editor crashes:
-  // built-ins read undefined options.X.value, unbundled kinds → allSources[Kind] = undefined.
-  // is_dummy warning below already tells user to pull.
-  const isDummyDataSource = selectedDataSource?.is_dummy === true;
-  const ElementToRender = isDummyDataSource
-    ? null
-    : selectedDataSource?.plugin_id
-      ? source
-      : allSources[sourcecomponentName];
+  const editor = resolveQueryEditor({ selectedDataSource, selectedQuery });
+  const ElementToRender =
+    editor.type === 'none' ? null : editor.type === 'plugin' ? source : allSources[editor.componentName];
+
   const defaultOptions = useRef({});
 
   const isFreezed = useStore((state) => state.getShouldFreeze(false, isModuleEditor));

--- a/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
+++ b/frontend/src/AppBuilder/QueryManager/Components/QueryManagerBody.jsx
@@ -249,9 +249,7 @@ export const BaseQueryManagerBody = ({ darkMode, activeTab, renderCopilot = null
           <ElementToRender
             renderCopilot={(props) => renderCopilot?.({ ...props, selectedDataSource })}
             key={selectedQuery?.id}
-            pluginSchema={
-              selectedDataSource?.plugin?.operations_file?.data ?? selectedQuery?.plugin?.operations_file?.data
-            }
+            pluginSchema={selectedDataSource?.plugin?.operations_file?.data}
             selectedDataSource={selectedDataSource}
             options={selectedQuery?.options}
             optionsChanged={optionsChanged}

--- a/frontend/src/AppBuilder/QueryManager/__tests__/utils.test.js
+++ b/frontend/src/AppBuilder/QueryManager/__tests__/utils.test.js
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment node
+ */
+
+const { resolveQueryEditor } = require('@/AppBuilder/QueryManager/utils');
+
+// A query as the server actually returns it. `data_queries` has no plugin_id column and
+// neither serializer emits one, so the plugin binding is reachable only via the data source.
+const existingMarketplaceQuery = {
+  id: 'a1b2c3d4-0000-0000-0000-000000000001',
+  name: 'getAccounts',
+  kind: 'xero',
+  data_source_id: 'ab9a0fc9-d989-4dd3-ae05-2162aed92409',
+  options: {},
+};
+
+const marketplaceDataSource = {
+  id: 'ab9a0fc9-d989-4dd3-ae05-2162aed92409',
+  kind: 'xero',
+  plugin_id: 'xero',
+  plugin: { operations_file: { data: { properties: {} } } },
+};
+
+describe('resolveQueryEditor', () => {
+  // The defect: after a reload the query carries no plugin_id, so routing on it fell through to
+  // allSources['Xero'] — undefined, because marketplace kinds are not in the client-side built-in
+  // bundle — and the editor body rendered nothing.
+  test('picks the plugin editor for an existing marketplace-plugin query', () => {
+    expect(
+      resolveQueryEditor({
+        selectedDataSource: marketplaceDataSource,
+        selectedQuery: existingMarketplaceQuery,
+      })
+    ).toEqual({ type: 'plugin' });
+  });
+
+  // Guard: routing must not regress to the query's plugin_id. Restoring `selectedQuery?.plugin_id`
+  // would still pass the test above (the store fakes plugin_id on create) but fail this one.
+  test('picks the plugin editor for a marketplace query created in-session', () => {
+    const optimisticQuery = {
+      ...existingMarketplaceQuery,
+      plugin_id: 'xero',
+      plugin: marketplaceDataSource.plugin,
+    };
+    expect(
+      resolveQueryEditor({
+        selectedDataSource: marketplaceDataSource,
+        selectedQuery: optimisticQuery,
+      })
+    ).toEqual({
+      type: 'plugin',
+    });
+  });
+
+  // Guard: built-ins have no plugin_id, so they must keep routing to the bundled editor.
+  // Returning { type: 'plugin' } unconditionally, or capitalising differently, fails this.
+  test('picks the built-in editor, capitalised, for a built-in data source', () => {
+    expect(
+      resolveQueryEditor({
+        selectedDataSource: { id: 'ds-pg', kind: 'postgresql' },
+        selectedQuery: {
+          id: 'q2',
+          kind: 'postgresql',
+          data_source_id: 'ds-pg',
+        },
+      })
+    ).toEqual({ type: 'builtin', componentName: 'Postgresql' });
+  });
+
+  // Guard: defaultSources stubs are { kind, id, name } only — no plugin_id — and must stay built-in.
+  test('picks the built-in editor for a default-source stub', () => {
+    expect(
+      resolveQueryEditor({
+        selectedDataSource: {
+          kind: 'runjs',
+          id: 'runjs',
+          name: 'Run JavaScript code',
+        },
+        selectedQuery: { id: 'q3', kind: 'runjs', data_source_id: 'runjs' },
+      })
+    ).toEqual({ type: 'builtin', componentName: 'Runjs' });
+  });
+
+  // Guard: resolveDataSourceForQuery returns null when the data source is not in the loaded lists
+  // (RBAC-filtered, or the frame before the lists land). Reading kind from the data source instead
+  // of the query yields `undefined + undefined` → NaN → allSources[NaN] → a blank editor.
+  test('falls back to the query kind when the data source has not resolved', () => {
+    expect(
+      resolveQueryEditor({
+        selectedDataSource: null,
+        selectedQuery: {
+          id: 'q4',
+          kind: 'postgresql',
+          data_source_id: 'ds-pg',
+        },
+      })
+    ).toEqual({ type: 'builtin', componentName: 'Postgresql' });
+  });
+
+  // Guard: a dummy data source must render nothing — mounting an editor over stub options crashes.
+  test('renders no editor for a dummy data source', () => {
+    expect(
+      resolveQueryEditor({
+        selectedDataSource: { ...marketplaceDataSource, is_dummy: true },
+        selectedQuery: existingMarketplaceQuery,
+      })
+    ).toEqual({ type: 'none' });
+  });
+});

--- a/frontend/src/AppBuilder/QueryManager/utils.js
+++ b/frontend/src/AppBuilder/QueryManager/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Decides which editor the query panel body should mount for the selected query.
+ *
+ * Returns a decision, not a component, so the choice can be unit-tested without
+ * pulling in the query editor bundle. `QueryManagerBody` maps it:
+ *   'none'    -> render nothing
+ *   'plugin'  -> the generic operations.json-driven DynamicForm
+ *   'builtin' -> allSources[componentName]
+ */
+export const resolveQueryEditor = ({ selectedDataSource, selectedQuery }) => {
+  // Dummy DS = stub options + maybe no plugin relation. Mounting editor crashes:
+  // built-ins read undefined options.X.value, unbundled kinds → allSources[Kind] = undefined.
+  // is_dummy warning in the panel already tells user to pull.
+  if (selectedDataSource?.is_dummy === true) return { type: 'none' };
+
+  if (selectedDataSource?.plugin_id) return { type: 'plugin' };
+
+  const kind = selectedQuery?.kind;
+  return {
+    type: 'builtin',
+    componentName: kind?.charAt(0).toUpperCase() + kind?.slice(1),
+  };
+};


### PR DESCRIPTION
Closes - https://github.com/ToolJet/tj-ee/issues/5433

This pull request improves the logic for choosing which query editor component to render in the query manager, ensuring correct handling of marketplace plugins, built-in sources, and dummy data sources. The main change is the introduction of a new utility function, `resolveQueryEditor`, which centralizes and clarifies this decision logic. Comprehensive unit tests are also added to prevent regressions and handle edge cases.

**Query Editor Selection Logic Improvements:**

* Added a new `resolveQueryEditor` utility in `utils.js` to determine which editor component should be rendered based on the selected data source and query, addressing previous issues with plugin and built-in editor routing.
* Updated `QueryManagerBody.jsx` to use `resolveQueryEditor` for selecting the editor component, improving reliability and maintainability. [[1]](diffhunk://#diff-0255f10990a502f4bccec18c3b8212b4d4b7562dbfa0e4485042d5d0e05562a9R8) [[2]](diffhunk://#diff-0255f10990a502f4bccec18c3b8212b4d4b7562dbfa0e4485042d5d0e05562a9L56-R61)

**Bug Fixes and Edge Case Handling:**

* Fixed a bug where queries associated with marketplace plugins would not render the correct editor after a reload, by ensuring the editor selection does not rely solely on `plugin_id`. [[1]](diffhunk://#diff-0255f10990a502f4bccec18c3b8212b4d4b7562dbfa0e4485042d5d0e05562a9L56-R61) [[2]](diffhunk://#diff-cf9f53a91b1768f1fa361ed5aeb6d5048287ad1be72b3c61838825f60ec255a6R1-R23)
* Ensured that dummy data sources render no editor to avoid crashes, and that built-in sources always use the correct built-in editor component. [[1]](diffhunk://#diff-0255f10990a502f4bccec18c3b8212b4d4b7562dbfa0e4485042d5d0e05562a9L56-R61) [[2]](diffhunk://#diff-cf9f53a91b1768f1fa361ed5aeb6d5048287ad1be72b3c61838825f60ec255a6R1-R23)

**Testing:**

* Added comprehensive unit tests for `resolveQueryEditor` covering marketplace plugins, built-in sources, default stubs, unresolved sources, and dummy data sources, preventing regressions and clarifying expected behavior.

**Other Minor Improvements:**

* Simplified the logic for passing the `pluginSchema` prop to the editor component, now always using the data source's schema.