### PR TITLE
feat(plugins): add Firecrawl marketplace datasource plugin

### DIFF
--- a/plugins/packages/firecrawl/README.md
+++ b/plugins/packages/firecrawl/README.md
@@ -1,0 +1,13 @@
+# Firecrawl DataSource Plugin for ToolJet
+
+Firecrawl is an API service that turns websites into LLM-ready markdown or structured data.
+
+## Features
+- **Scrape**: Scrape clean markdown, HTML, and metadata from any URL.
+- **Search**: Web search queries returning clean markdown summaries and URLs.
+- **Crawl**: Asynchronously crawl entire websites.
+- **Crawl Status**: Monitor asynchronous crawl jobs and fetch extracted pages.
+- **Map**: Fast discovery and extraction of all URLs for a given domain.
+
+## Setup
+Provide your Firecrawl API key (from https://firecrawl.dev) or configure a custom base URL for self-hosted instances.

--- a/plugins/packages/firecrawl/__tests__/index.test.ts
+++ b/plugins/packages/firecrawl/__tests__/index.test.ts
@@ -1,0 +1,36 @@
+import FirecrawlQueryService from '../lib/index';
+import { QueryError } from '@tooljet-plugins/common';
+
+describe('FirecrawlQueryService', () => {
+  let service: FirecrawlQueryService;
+
+  beforeEach(() => {
+    service = new FirecrawlQueryService();
+  });
+
+  describe('Validation', () => {
+    it('throws error when scrape operation is missing URL', async () => {
+      await expect(
+        service.run({ api_key: 'test_key' }, { operation: 'scrape' } as any)
+      ).rejects.toThrow(QueryError);
+    });
+
+    it('throws error when search operation is missing query', async () => {
+      await expect(
+        service.run({ api_key: 'test_key' }, { operation: 'search' } as any)
+      ).rejects.toThrow(QueryError);
+    });
+
+    it('throws error when crawl_status operation is missing job_id', async () => {
+      await expect(
+        service.run({ api_key: 'test_key' }, { operation: 'crawl_status' } as any)
+      ).rejects.toThrow(QueryError);
+    });
+
+    it('throws error on unsupported operation', async () => {
+      await expect(
+        service.run({ api_key: 'test_key' }, { operation: 'unknown_op' as any })
+      ).rejects.toThrow(QueryError);
+    });
+  });
+});

--- a/plugins/packages/firecrawl/icon.svg
+++ b/plugins/packages/firecrawl/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#FF5C00" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 3z" fill="#FF5C00" fill-opacity="0.2"/>
+</svg>

--- a/plugins/packages/firecrawl/lib/index.ts
+++ b/plugins/packages/firecrawl/lib/index.ts
@@ -1,0 +1,229 @@
+import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-plugins/common';
+import { SourceOptions, QueryOptions } from './types';
+import got, { Headers } from 'got';
+
+export default class FirecrawlQueryService implements QueryService {
+  private getBaseUrl(sourceOptions: SourceOptions): string {
+    const raw = sourceOptions.api_url?.trim() || 'https://api.firecrawl.dev';
+    return raw.replace(/\/+$/, '');
+  }
+
+  private getHeaders(sourceOptions: SourceOptions): Headers {
+    const headers: Headers = {
+      'Content-Type': 'application/json',
+    };
+    if (sourceOptions.api_key?.trim()) {
+      headers['Authorization'] = `Bearer ${sourceOptions.api_key.trim()}`;
+    }
+    return headers;
+  }
+
+  async run(sourceOptions: SourceOptions, queryOptions: QueryOptions): Promise<QueryResult> {
+    const baseUrl = this.getBaseUrl(sourceOptions);
+    const headers = this.getHeaders(sourceOptions);
+    const operation = queryOptions.operation;
+
+    let result: any = null;
+
+    try {
+      switch (operation) {
+        case 'scrape': {
+          if (!queryOptions.url?.trim()) {
+            throw new QueryError('Missing URL', 'URL is required for scrape operation', {});
+          }
+
+          const formats = queryOptions.formats
+            ? queryOptions.formats.split(',').map((f) => f.trim()).filter(Boolean)
+            : ['markdown'];
+
+          const bodyPayload: Record<string, any> = {
+            url: queryOptions.url.trim(),
+            formats,
+            onlyMainContent: queryOptions.only_main_content ?? true,
+          };
+
+          if (queryOptions.search_options?.trim()) {
+            try {
+              const extra = JSON.parse(queryOptions.search_options.trim());
+              Object.assign(bodyPayload, extra);
+            } catch (err) {
+              throw new QueryError('Invalid JSON', 'Additional options must be valid JSON', {});
+            }
+          }
+
+          const response = await got.post(`${baseUrl}/v1/scrape`, {
+            headers,
+            json: bodyPayload,
+            responseType: 'json',
+          });
+
+          result = response.body;
+          break;
+        }
+
+        case 'search': {
+          if (!queryOptions.query?.trim()) {
+            throw new QueryError('Missing query', 'Query string is required for search operation', {});
+          }
+
+          const bodyPayload: Record<string, any> = {
+            query: queryOptions.query.trim(),
+          };
+
+          if (queryOptions.limit) {
+            bodyPayload.limit = Number(queryOptions.limit);
+          }
+
+          if (queryOptions.search_options?.trim()) {
+            try {
+              const extra = JSON.parse(queryOptions.search_options.trim());
+              Object.assign(bodyPayload, extra);
+            } catch (err) {
+              throw new QueryError('Invalid JSON', 'Additional options must be valid JSON', {});
+            }
+          }
+
+          const response = await got.post(`${baseUrl}/v1/search`, {
+            headers,
+            json: bodyPayload,
+            responseType: 'json',
+          });
+
+          result = response.body;
+          break;
+        }
+
+        case 'crawl': {
+          if (!queryOptions.url?.trim()) {
+            throw new QueryError('Missing URL', 'URL is required for crawl operation', {});
+          }
+
+          const bodyPayload: Record<string, any> = {
+            url: queryOptions.url.trim(),
+          };
+
+          if (queryOptions.limit) {
+            bodyPayload.limit = Number(queryOptions.limit);
+          }
+
+          if (queryOptions.search_options?.trim()) {
+            try {
+              const extra = JSON.parse(queryOptions.search_options.trim());
+              Object.assign(bodyPayload, extra);
+            } catch (err) {
+              throw new QueryError('Invalid JSON', 'Additional options must be valid JSON', {});
+            }
+          }
+
+          const response = await got.post(`${baseUrl}/v1/crawl`, {
+            headers,
+            json: bodyPayload,
+            responseType: 'json',
+          });
+
+          result = response.body;
+          break;
+        }
+
+        case 'crawl_status': {
+          if (!queryOptions.job_id?.trim()) {
+            throw new QueryError('Missing Job ID', 'Job ID is required for crawl status operation', {});
+          }
+
+          const jobId = encodeURIComponent(queryOptions.job_id.trim());
+          const response = await got.get(`${baseUrl}/v1/crawl/${jobId}`, {
+            headers,
+            responseType: 'json',
+          });
+
+          result = response.body;
+          break;
+        }
+
+        case 'map': {
+          if (!queryOptions.url?.trim()) {
+            throw new QueryError('Missing URL', 'URL is required for map operation', {});
+          }
+
+          const bodyPayload: Record<string, any> = {
+            url: queryOptions.url.trim(),
+          };
+
+          if (queryOptions.limit) {
+            bodyPayload.limit = Number(queryOptions.limit);
+          }
+
+          if (queryOptions.search_options?.trim()) {
+            try {
+              const extra = JSON.parse(queryOptions.search_options.trim());
+              Object.assign(bodyPayload, extra);
+            } catch (err) {
+              throw new QueryError('Invalid JSON', 'Additional options must be valid JSON', {});
+            }
+          }
+
+          const response = await got.post(`${baseUrl}/v1/map`, {
+            headers,
+            json: bodyPayload,
+            responseType: 'json',
+          });
+
+          result = response.body;
+          break;
+        }
+
+        default:
+          throw new QueryError('Unsupported operation', `Operation ${operation} is not supported`, {});
+      }
+    } catch (error: any) {
+      if (error instanceof QueryError) {
+        throw error;
+      }
+
+      let errorMessage = 'Failed to execute Firecrawl request';
+      let errorDetails: any = {};
+
+      if (error.response?.body) {
+        try {
+          const parsed = typeof error.response.body === 'string' ? JSON.parse(error.response.body) : error.response.body;
+          errorMessage = parsed.error || parsed.message || errorMessage;
+          errorDetails = parsed;
+        } catch {
+          errorDetails = { raw: error.response.body };
+        }
+      }
+
+      throw new QueryError(errorMessage, error.message, errorDetails);
+    }
+
+    return {
+      status: 'ok',
+      data: result,
+    };
+  }
+
+  async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
+    const baseUrl = this.getBaseUrl(sourceOptions);
+    const headers = this.getHeaders(sourceOptions);
+
+    try {
+      const response = await got.get(`${baseUrl}/v1/scrape`, {
+        headers,
+        searchParams: { url: 'https://example.com' },
+        throwHttpErrors: false,
+        responseType: 'json',
+      });
+
+      if (response.statusCode === 401 || response.statusCode === 403) {
+        throw new Error('Authentication failed: Invalid Firecrawl API key');
+      }
+
+      return { status: 'ok' };
+    } catch (error: any) {
+      return {
+        status: 'failed',
+        message: error.message || 'Could not connect to Firecrawl service',
+      };
+    }
+  }
+}

--- a/plugins/packages/firecrawl/lib/manifest.json
+++ b/plugins/packages/firecrawl/lib/manifest.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/manifest.schema.json",
+  "title": "Firecrawl datasource",
+  "description": "Web scraping, crawling, and search API for ToolJet applications",
+  "type": "object",
+  "tj:version": "1.0.0",
+  "tj:source": {
+    "name": "Firecrawl",
+    "kind": "firecrawl",
+    "type": "api"
+  },
+  "properties": {
+    "api_key": {
+      "type": "string",
+      "title": "API Key",
+      "description": "API Key from Firecrawl (optional for unauthenticated self-hosted instances)"
+    },
+    "api_url": {
+      "type": "string",
+      "title": "API Base URL",
+      "description": "Custom base URL for self-hosted instances (default: https://api.firecrawl.dev)"
+    }
+  },
+  "tj:encrypted": [
+    "api_key"
+  ],
+  "required": [],
+  "tj:ui:properties": {
+    "api_key": {
+      "$ref": "#/properties/api_key",
+      "key": "api_key",
+      "label": "API Key",
+      "description": "Firecrawl API key",
+      "widget": "password-v3-textarea",
+      "required": false
+    },
+    "api_url": {
+      "$ref": "#/properties/api_url",
+      "key": "api_url",
+      "label": "API Base URL",
+      "description": "Custom base URL (default: https://api.firecrawl.dev)",
+      "widget": "input-v3-text",
+      "placeholder": "https://api.firecrawl.dev",
+      "required": false
+    }
+  }
+}

--- a/plugins/packages/firecrawl/lib/operations.json
+++ b/plugins/packages/firecrawl/lib/operations.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/operations.schema.json",
+  "title": "Firecrawl Operations",
+  "description": "Query operations supported by Firecrawl datasource",
+  "type": "object",
+  "properties": {
+    "operation": {
+      "type": "string",
+      "enum": [
+        "scrape",
+        "search",
+        "crawl",
+        "crawl_status",
+        "map"
+      ]
+    }
+  },
+  "required": [
+    "operation"
+  ],
+  "tj:ui:properties": {
+    "operation": {
+      "$ref": "#/properties/operation",
+      "label": "Operation",
+      "widget": "dropdown-v3",
+      "options": [
+        {
+          "label": "Scrape URL",
+          "value": "scrape"
+        },
+        {
+          "label": "Search Web",
+          "value": "search"
+        },
+        {
+          "label": "Start Crawl Job",
+          "value": "crawl"
+        },
+        {
+          "label": "Get Crawl Status",
+          "value": "crawl_status"
+        },
+        {
+          "label": "Map Website URLs",
+          "value": "map"
+        }
+      ]
+    },
+    "url": {
+      "key": "url",
+      "label": "URL",
+      "description": "Target URL to scrape, crawl, or map",
+      "widget": "input-v3-text",
+      "placeholder": "https://example.com"
+    },
+    "query": {
+      "key": "query",
+      "label": "Search Query",
+      "description": "Query text to search across the web",
+      "widget": "input-v3-text",
+      "placeholder": "What is ToolJet?"
+    },
+    "job_id": {
+      "key": "job_id",
+      "label": "Crawl Job ID",
+      "description": "ID of the asynchronous crawl job",
+      "widget": "input-v3-text",
+      "placeholder": "e.g. 550e8400-e29b-41d4-a716-446655440000"
+    },
+    "limit": {
+      "key": "limit",
+      "label": "Page / Result Limit",
+      "description": "Maximum number of pages or search results to return",
+      "widget": "input-v3-text",
+      "placeholder": "10"
+    },
+    "formats": {
+      "key": "formats",
+      "label": "Output Formats",
+      "description": "Comma-separated list of formats (markdown, html, rawHtml, links, screenshot)",
+      "widget": "input-v3-text",
+      "placeholder": "markdown, html"
+    },
+    "only_main_content": {
+      "key": "only_main_content",
+      "label": "Only Main Content",
+      "description": "Exclude navigation, footers, headers, and boilerplate",
+      "widget": "toggle-v3"
+    },
+    "search_options": {
+      "key": "search_options",
+      "label": "Additional Search / Scrape Options (JSON)",
+      "description": "Optional JSON object containing advanced parameters",
+      "widget": "code-editor-v3-json"
+    }
+  },
+  "definitions": {
+    "scrape": {
+      "properties": {
+        "url": {
+          "$ref": "#/tj:ui:properties/url"
+        },
+        "formats": {
+          "$ref": "#/tj:ui:properties/formats"
+        },
+        "only_main_content": {
+          "$ref": "#/tj:ui:properties/only_main_content"
+        },
+        "search_options": {
+          "$ref": "#/tj:ui:properties/search_options"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "search": {
+      "properties": {
+        "query": {
+          "$ref": "#/tj:ui:properties/query"
+        },
+        "limit": {
+          "$ref": "#/tj:ui:properties/limit"
+        },
+        "search_options": {
+          "$ref": "#/tj:ui:properties/search_options"
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "crawl": {
+      "properties": {
+        "url": {
+          "$ref": "#/tj:ui:properties/url"
+        },
+        "limit": {
+          "$ref": "#/tj:ui:properties/limit"
+        },
+        "search_options": {
+          "$ref": "#/tj:ui:properties/search_options"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "crawl_status": {
+      "properties": {
+        "job_id": {
+          "$ref": "#/tj:ui:properties/job_id"
+        }
+      },
+      "required": [
+        "job_id"
+      ]
+    },
+    "map": {
+      "properties": {
+        "url": {
+          "$ref": "#/tj:ui:properties/url"
+        },
+        "limit": {
+          "$ref": "#/tj:ui:properties/limit"
+        },
+        "search_options": {
+          "$ref": "#/tj:ui:properties/search_options"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    }
+  }
+}

--- a/plugins/packages/firecrawl/lib/types.ts
+++ b/plugins/packages/firecrawl/lib/types.ts
@@ -1,0 +1,19 @@
+export type SourceOptions = {
+  api_key?: string;
+  api_url?: string;
+};
+
+export type QueryOptions = {
+  operation: 'scrape' | 'search' | 'crawl' | 'crawl_status' | 'map';
+  url?: string;
+  query?: string;
+  job_id?: string;
+  limit?: number | string;
+  formats?: string;
+  only_main_content?: boolean;
+  wait_for?: number | string;
+  include_tags?: string;
+  exclude_tags?: string;
+  search_options?: string;
+  crawl_options?: string;
+};

--- a/plugins/packages/firecrawl/package.json
+++ b/plugins/packages/firecrawl/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tooljet-plugins/firecrawl",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "build": "tsc -b",
+    "clean": "rimraf ./dist && rimraf tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@tooljet-plugins/common": "file:../common",
+    "got": "^11.8.6",
+    "rimraf": "^3.0.2"
+  }
+}

--- a/plugins/packages/firecrawl/tsconfig.json
+++ b/plugins/packages/firecrawl/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "lib"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Description
Fixes #17529

Adds the **Firecrawl** marketplace datasource plugin to ToolJet. Firecrawl is an API service that turns websites into LLM-ready markdown or structured data.

### Operations Added:
- **Scrape URL**: Extract markdown, HTML, rawHtml, links, and metadata from a web page.
- **Search Web**: Perform web searches returning clean markdown summaries and ranked URLs.
- **Start Crawl Job**: Asynchronously crawl entire websites.
- **Get Crawl Status**: Monitor crawl jobs and retrieve extracted pages by job ID.
- **Map Website URLs**: Fast discovery and extraction of all URLs for a given domain.

### Supported Configurations:
- API key authentication with encrypted storage.
- Custom base URL option for self-hosted instances (default: \https://api.firecrawl.dev\).

### Files Created:
- \plugins/packages/firecrawl/package.json\
- \plugins/packages/firecrawl/tsconfig.json\
- \plugins/packages/firecrawl/icon.svg\
- \plugins/packages/firecrawl/README.md\
- \plugins/packages/firecrawl/lib/types.ts\
- \plugins/packages/firecrawl/lib/manifest.json\
- \plugins/packages/firecrawl/lib/operations.json\
- \plugins/packages/firecrawl/lib/index.ts\
- \plugins/packages/firecrawl/__tests__/index.test.ts\

### Validation:
- Unit tests written for query validation and error handling.
- Manifest and operations schemas adhere to ToolJet datasource specifications.