### PR TITLE
fix(security): sanitize user entity queries to exclude password hashes and sensitive tokens

### DIFF
--- a/server/src/modules/group-permissions/repository.ts
+++ b/server/src/modules/group-permissions/repository.ts
@@ -22,6 +22,7 @@ import { GroupUsers } from '@entities/group_users.entity';
 import { USER_STATUS, WORKSPACE_USER_STATUS } from '@modules/users/constants/lifecycle';
 import { User } from '@entities/user.entity';
 import { DATA_BASE_CONSTRAINTS } from './constants/error';
+import { SAFE_USER_SELECT_FIELDS, SAFE_USER_QB_COLUMNS } from '@modules/users/constants';
 @Injectable()
 export class GroupPermissionsRepository extends Repository<GroupPermissions> {
   constructor(private dataSource: DataSource) {
@@ -253,6 +254,26 @@ export class GroupPermissionsRepository extends Repository<GroupPermissions> {
               organizationUsers: true,
             },
           },
+          select: {
+            id: true,
+            groupId: true,
+            userId: true,
+            createdAt: true,
+            updatedAt: true,
+            group: {
+              id: true,
+              name: true,
+              type: true,
+            },
+            user: {
+              ...SAFE_USER_SELECT_FIELDS,
+              organizationUsers: {
+                id: true,
+                organizationId: true,
+                status: true,
+              },
+            },
+          },
         });
       }
 
@@ -263,6 +284,26 @@ export class GroupPermissionsRepository extends Repository<GroupPermissions> {
           group: true,
           user: {
             organizationUsers: true,
+          },
+        },
+        select: {
+          id: true,
+          groupId: true,
+          userId: true,
+          createdAt: true,
+          updatedAt: true,
+          group: {
+            id: true,
+            name: true,
+            type: true,
+          },
+          user: {
+            ...SAFE_USER_SELECT_FIELDS,
+            organizationUsers: {
+              id: true,
+              organizationId: true,
+              status: true,
+            },
           },
         },
       });
@@ -277,6 +318,20 @@ export class GroupPermissionsRepository extends Repository<GroupPermissions> {
         },
         relations: {
           group: true,
+          user: true,
+        },
+        select: {
+          id: true,
+          groupId: true,
+          userId: true,
+          createdAt: true,
+          updatedAt: true,
+          group: {
+            id: true,
+            name: true,
+            type: true,
+          },
+          user: SAFE_USER_SELECT_FIELDS,
         },
       });
     }, manager || this.manager);
@@ -405,6 +460,7 @@ export class GroupPermissionsRepository extends Repository<GroupPermissions> {
         .createQueryBuilder(User, 'user')
         .innerJoin('user.userGroups', 'groupUser')
         .innerJoin('groupUser.group', 'group')
+        .select(SAFE_USER_QB_COLUMNS)
         .where('group.name = :name', { name: 'admin' })
         .andWhere('group.organizationId = :organizationId', { organizationId })
         .andWhere('user.status != :archived', { archived: USER_STATUS.ARCHIVED })

--- a/server/src/modules/organization-users/repository.ts
+++ b/server/src/modules/organization-users/repository.ts
@@ -6,6 +6,7 @@ import {
   WORKSPACE_USER_SOURCE,
   WORKSPACE_USER_STATUS,
 } from '@modules/users/constants/lifecycle';
+import { SAFE_USER_SELECT_FIELDS } from '@modules/users/constants';
 import { Injectable } from '@nestjs/common';
 import { UserFilterOptions } from './types';
 import { Organization } from '@entities/organization.entity';
@@ -119,6 +120,24 @@ export class OrganizationUsersRepository extends Repository<OrganizationUser> {
         invitationToken,
       },
       relations: ['organization', 'user'],
+      select: {
+        id: true,
+        userId: true,
+        organizationId: true,
+        role: true,
+        status: true,
+        source: true,
+        invitationToken: true,
+        createdAt: true,
+        updatedAt: true,
+        organization: {
+          id: true,
+          name: true,
+          status: true,
+          slug: true,
+        },
+        user: SAFE_USER_SELECT_FIELDS,
+      },
     });
   }
 

--- a/server/src/modules/organization-users/util.service.ts
+++ b/server/src/modules/organization-users/util.service.ts
@@ -10,6 +10,7 @@ import {
   WORKSPACE_USER_SOURCE,
   WORKSPACE_USER_STATUS,
 } from '@modules/users/constants/lifecycle';
+import { SAFE_USER_SELECT_FIELDS } from '@modules/users/constants';
 import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
 import { Organization } from '@entities/organization.entity';
 import { InviteNewUserDto } from '@modules/organization-users/dto/invite-new-user.dto';
@@ -188,6 +189,14 @@ export class OrganizationUsersUtilService implements IOrganizationUsersUtilServi
         where: { email },
         relations: {
           organization: true,
+        },
+        select: {
+          ...SAFE_USER_SELECT_FIELDS,
+          organization: {
+            id: true,
+            name: true,
+            status: true,
+          },
         },
       });
     }, manager);

--- a/server/src/modules/roles/repository.ts
+++ b/server/src/modules/roles/repository.ts
@@ -3,6 +3,7 @@ import { User } from '@entities/user.entity';
 import { dbTransactionWrap } from '@helpers/database.helper';
 import { USER_STATUS } from '@modules/users/constants/lifecycle';
 import { USER_ROLE, GROUP_PERMISSIONS_TYPE } from '@modules/group-permissions/constants';
+import { SAFE_USER_SELECT_FIELDS } from '@modules/users/constants';
 import { Injectable } from '@nestjs/common';
 import { DataSource, EntityManager, In, Not, Repository } from 'typeorm';
 
@@ -32,6 +33,7 @@ export class RolesRepository extends Repository<GroupPermissions> {
   ): Promise<User[]> {
     return dbTransactionWrap(async (manager: EntityManager) => {
       return manager.find(User, {
+        select: SAFE_USER_SELECT_FIELDS,
         relations: {
           userGroups: {
             group: true,

--- a/server/src/modules/users/constants/index.ts
+++ b/server/src/modules/users/constants/index.ts
@@ -5,3 +5,44 @@ export enum FEATURE_KEY {
   CHANGE_USER_PASSWORD = 'CHANGE_USER_PASSWORD',
   UPDATE_USER_TYPE_INSTANCE = 'UPDATE_USER_TYPE_INSTANCE',
 }
+
+export const SAFE_USER_SELECT_FIELDS = {
+  id: true,
+  email: true,
+  firstName: true,
+  lastName: true,
+  phoneNumber: true,
+  status: true,
+  source: true,
+  onboardingStatus: true,
+  userType: true,
+  avatarId: true,
+  defaultOrganizationId: true,
+  companyName: true,
+  role: true,
+  companySize: true,
+  autoActivated: true,
+  createdAt: true,
+  updatedAt: true,
+};
+
+export const SAFE_USER_QB_COLUMNS = [
+  'user.id',
+  'user.email',
+  'user.firstName',
+  'user.lastName',
+  'user.phoneNumber',
+  'user.status',
+  'user.source',
+  'user.onboardingStatus',
+  'user.userType',
+  'user.avatarId',
+  'user.defaultOrganizationId',
+  'user.companyName',
+  'user.role',
+  'user.companySize',
+  'user.autoActivated',
+  'user.createdAt',
+  'user.updatedAt',
+];
+

--- a/server/src/modules/users/repositories/repository.ts
+++ b/server/src/modules/users/repositories/repository.ts
@@ -20,6 +20,7 @@ import { isSuperAdmin } from '@helpers/utils.helper';
 import * as uuid from 'uuid';
 import { USER_ROLE } from '@modules/group-permissions/constants';
 import { USER_STATUS } from '@modules/users/constants/lifecycle';
+import { SAFE_USER_SELECT_FIELDS } from '@modules/users/constants';
 
 type UserFilterOptions = { searchText?: string; status?: string; page?: number };
 
@@ -100,10 +101,11 @@ export class UserRepository extends Repository<User> {
 
       if (existingUser) {
         await manager.update(User, { id: existingUser.id }, user);
-        return manager.findOne(User, { where: { id: existingUser.id } });
+        return manager.findOne(User, { where: { id: existingUser.id }, select: SAFE_USER_SELECT_FIELDS });
       } else {
         const newUser = manager.create(User, user);
-        return manager.save(User, newUser);
+        const saved = await manager.save(User, newUser);
+        return manager.findOne(User, { where: { id: saved.id }, select: SAFE_USER_SELECT_FIELDS });
       }
     }, manager || this.manager);
   }

--- a/server/test/modules/users/user_entity_sanitization.spec.ts
+++ b/server/test/modules/users/user_entity_sanitization.spec.ts
@@ -1,0 +1,135 @@
+import { SAFE_USER_SELECT_FIELDS, SAFE_USER_QB_COLUMNS } from '../../../src/modules/users/constants';
+import { RolesRepository } from '../../../src/modules/roles/repository';
+import { GroupPermissionsRepository } from '../../../src/modules/group-permissions/repository';
+import { OrganizationUsersRepository } from '../../../src/modules/organization-users/repository';
+import { OrganizationUsersUtilService } from '../../../src/modules/organization-users/util.service';
+import { USER_ROLE } from '../../../src/modules/group-permissions/constants';
+import { DataSource } from 'typeorm';
+
+describe('User Entity Sanitization and Safe Select', () => {
+  describe('SAFE_USER_SELECT_FIELDS definition', () => {
+    it('should include standard user profile fields', () => {
+      expect(SAFE_USER_SELECT_FIELDS.id).toBe(true);
+      expect(SAFE_USER_SELECT_FIELDS.email).toBe(true);
+      expect(SAFE_USER_SELECT_FIELDS.firstName).toBe(true);
+      expect(SAFE_USER_SELECT_FIELDS.lastName).toBe(true);
+      expect(SAFE_USER_SELECT_FIELDS.status).toBe(true);
+    });
+
+    it('should strictly exclude sensitive security fields', () => {
+      const sensitiveKeys = [
+        'password',
+        'invitationToken',
+        'forgotPasswordToken',
+        'expiredPasswordToken',
+        'passwordRetryCount',
+        'passwordExpiry',
+        'invitationTokenExpiry',
+        'forgotPasswordTokenExpiry',
+      ];
+
+      for (const key of sensitiveKeys) {
+        expect((SAFE_USER_SELECT_FIELDS as any)[key]).toBeUndefined();
+      }
+    });
+
+    it('should define safe query builder columns excluding password and tokens', () => {
+      expect(SAFE_USER_QB_COLUMNS).toContain('user.id');
+      expect(SAFE_USER_QB_COLUMNS).toContain('user.email');
+      expect(SAFE_USER_QB_COLUMNS).toContain('user.firstName');
+      expect(SAFE_USER_QB_COLUMNS).not.toContain('user.password');
+      expect(SAFE_USER_QB_COLUMNS).not.toContain('user.invitationToken');
+      expect(SAFE_USER_QB_COLUMNS).not.toContain('user.forgotPasswordToken');
+    });
+  });
+
+  describe('RolesRepository.getRoleUsersList', () => {
+    let rolesRepo: RolesRepository;
+    let mockManager: any;
+
+    beforeEach(() => {
+      const mockDataSource = {
+        createEntityManager: jest.fn().mockReturnValue({}),
+      } as unknown as DataSource;
+      rolesRepo = new RolesRepository(mockDataSource);
+      mockManager = {
+        find: jest.fn().mockResolvedValue([]),
+      };
+    });
+
+    it('should query users with SAFE_USER_SELECT_FIELDS', async () => {
+      await rolesRepo.getRoleUsersList(USER_ROLE.ADMIN, 'org-123', undefined, mockManager);
+
+      expect(mockManager.find).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          select: SAFE_USER_SELECT_FIELDS,
+        })
+      );
+    });
+  });
+
+  describe('OrganizationUsersRepository.findByInvitationToken', () => {
+    let orgUsersRepo: OrganizationUsersRepository;
+
+    beforeEach(() => {
+      const mockDataSource = {
+        createEntityManager: jest.fn().mockReturnValue({}),
+      } as unknown as DataSource;
+      orgUsersRepo = new OrganizationUsersRepository(mockDataSource);
+      orgUsersRepo.findOne = jest.fn().mockResolvedValue(null);
+    });
+
+    it('should select safe user fields when looking up by invitation token', async () => {
+      await orgUsersRepo.findByInvitationToken('invite-token-abc');
+
+      expect(orgUsersRepo.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { invitationToken: 'invite-token-abc' },
+          select: expect.objectContaining({
+            user: SAFE_USER_SELECT_FIELDS,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('OrganizationUsersUtilService.findInvitingUserByEmail', () => {
+    let utilService: OrganizationUsersUtilService;
+    let mockManager: any;
+
+    beforeEach(() => {
+      utilService = new OrganizationUsersUtilService(
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any
+      );
+      mockManager = {
+        findOne: jest.fn().mockResolvedValue(null),
+      };
+    });
+
+    it('should query user with SAFE_USER_SELECT_FIELDS', async () => {
+      await utilService.findInvitingUserByEmail('test@example.com', mockManager);
+
+      expect(mockManager.findOne).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          where: { email: 'test@example.com' },
+          select: expect.objectContaining({
+            id: true,
+            email: true,
+            firstName: true,
+          }),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #17717

### Description
This PR resolves sensitive field exposure across User, GroupUsers, and OrganizationUser query flows where entity queries previously omitted explicit \select\ projections, preventing password hashes and sensitive authentication/reset tokens from leaking in API responses.

### Changes
- **\server/src/modules/users/constants/index.ts\**: Defined \SAFE_USER_SELECT_FIELDS\ and \SAFE_USER_QB_COLUMNS\ excluding \password\, \invitationToken\, \orgotPasswordToken\, \expiredPasswordToken\, and retry counters.
- **\server/src/modules/roles/repository.ts\**: Applied \select: SAFE_USER_SELECT_FIELDS\ to \getRoleUsersList\.
- **\server/src/modules/group-permissions/repository.ts\**: Added safe user select clauses to \getUsersInGroup\, \getGroupUser\, and \getAdminUserForOrg\.
- **\server/src/modules/users/repositories/repository.ts\**: Ensured sanitized user return in \createOrUpdate\.
- **\server/src/modules/organization-users/repository.ts\**: Added safe select filtering in \indByInvitationToken\.
- **\server/src/modules/organization-users/util.service.ts\**: Added safe select filtering in \indInvitingUserByEmail\.
- **\server/test/modules/users/user_entity_sanitization.spec.ts\**: Added unit test coverage validating sensitive field exclusion.