### PR TITLE
Fix: expose selected map marker in widget catalogs

### DIFF
--- a/frontend/src/AppBuilder/WidgetManager/widgets/map.js
+++ b/frontend/src/AppBuilder/WidgetManager/widgets/map.js
@@ -127,6 +127,7 @@ export const mapConfig = {
   },
   exposedVariables: {
     center: {},
+    selectedMarker: {},
   },
   definition: {
     others: {

--- a/server/src/modules/apps/services/widget-config/map.js
+++ b/server/src/modules/apps/services/widget-config/map.js
@@ -127,6 +127,7 @@ export const mapConfig = {
   },
   exposedVariables: {
     center: {},
+    selectedMarker: {},
   },
   definition: {
     others: {


### PR DESCRIPTION
## 📝 What this does
Makes the map's existing selected-marker value discoverable through both widget catalogs, so builders and generated applications can bind marker selections to record details.

## 🔀 Changes
- Added `selectedMarker` to the frontend and server map exposed-variable catalogs.
- Preserved the existing marker-click runtime behavior and all saved configuration keys.

This is a two-line change based directly on `lts-3.16`; no EE submodule changes are included.

## 🧪 How to test
- [x] Parse both catalogs and confirm they remain identical.
- [x] Confirm the map renderer already publishes `selectedMarker` on marker click.
- [x] Check the exact PR diff for whitespace errors and secrets with Gitleaks.
- [x] Run targeted frontend/server ESLint on the original change before transplanting it to LTS.
- [ ] Bind a detail component to `components.<map>.selectedMarker` and click two different markers.

Full server lint in the original checkout reported existing failures across unrelated files. A full LTS runtime/CI pass remains outstanding; no lint or push hooks were bypassed.