### PR TITLE
feat: add triage-access-control-advisories skill

### DIFF
--- a/.claude/skills/triage-access-control-advisories
+++ b/.claude/skills/triage-access-control-advisories
@@ -1,0 +1,1 @@
+../../frontend/ee/.agents/skills/triage-access-control-advisories


### PR DESCRIPTION
## What

Adds the `triage-access-control-advisories` agent skill and wires it into `.claude/skills/`.

The skill lives in the `frontend/ee` submodule (**ToolJet/ee-frontend#632**); this PR adds the `.claude/skills/triage-access-control-advisories` symlink and bumps the `frontend/ee` submodule pointer.

## The skill

Turns the ToolJet repository security-advisory backlog into assigned work for the **Access Control / IDOR / auth** category. Each run:

1. Fetches open (`triage`) advisories from `ToolJet/ToolJet`.
2. Filters to Access Control / IDOR / auth (by CWE family **or** summary root cause — CWE is an accelerator, not the gate; ~1 in 10 advisories carry no CWE).
3. Clusters duplicate reports into canonical bugs.
4. Ranks by report frequency (deterministic severity/age tie-breaks).
5. Assigns the top unassigned bugs one-per-developer — filing a tracking issue in the private `ToolJet/tj-ee` tracker and adding the same developer as a collaborator on each underlying advisory.

Dedup is GHSA-anchored against the `tj-ee` tracking issues (GitHub is the ledger, no state file); both GitHub writes are approval-gated on every run.

## Merge order

Merge **ToolJet/ee-frontend#632 first**, then this PR (its submodule pointer references that commit).

## Testing

Read-only dry run against live advisories: 128 open → 49 in-category → 18 canonical bugs → a top-5 assignment plan. No writes performed.