### PR TITLE
Fix: cypress-live-reporter silently reported nothing

### DIFF
--- a/cypress-tests/.gitignore
+++ b/cypress-tests/.gitignore
@@ -8,3 +8,4 @@
 /.nyc_output
 /cypress/.webpack_cache
 /.claude
+.env

--- a/cypress-tests/cypress-appbuilder.config.js
+++ b/cypress-tests/cypress-appbuilder.config.js
@@ -68,7 +68,8 @@ module.exports = defineConfig({
         },
       });
 
-      return require("./cypress/plugins/index.js")(on, config);
+      config = require("./cypress/plugins/index.js")(on, config);
+      return require("./tools/cypress-live-reporter/plugin").livePlugin(on, config);
     },
     downloadsFolder: "cypress/downloads",
     experimentalRunAllSpecs: true,

--- a/cypress-tests/tools/cypress-live-reporter/plugin.js
+++ b/cypress-tests/tools/cypress-live-reporter/plugin.js
@@ -23,11 +23,31 @@ const { createSink, createLogger } = require('./sinks');
 
 const TAG = '[cypress-live-reporter]';
 
-// .env support is optional — never a hard dependency
+// .env support is optional — never a hard dependency.
+// Parsed here when dotenv is absent: it is BSD-2-Clause, and only MIT / Apache-2.0 are
+// permitted in this repo.
 try {
-  require('dotenv').config();
+  require('dotenv').config({ quiet: true });
 } catch (err) {
-  /* dotenv not installed — fine */
+  try {
+    const envPath = path.resolve(__dirname, '..', '..', '.env');
+    if (fs.existsSync(envPath)) {
+      for (const rawLine of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+        const eq = line.indexOf('=');
+        if (eq < 1) continue;
+        const key = line.slice(0, eq).trim();
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+        if (process.env[key] !== undefined) continue;
+        const raw = line.slice(eq + 1).trim();
+        const quoted = /^(['"])([\s\S]*)\1$/.exec(raw);
+        process.env[key] = quoted ? quoted[2] : raw.replace(/\s+#.*$/, '');
+      }
+    }
+  } catch (fallbackErr) {
+    /* never let config loading break a run */
+  }
 }
 
 const DEFAULTS = {
@@ -147,6 +167,7 @@ function setup(on, config, opts) {
 
   // env override lets parallel CI machines report into one shared run
   const runId = process.env.CLR_RUN_ID || randomUUID();
+  const projectId = process.env.CLR_PROJECT || null;
   let seq = 0;
   // the test currently executing, learned from the browser's test:start
   // stream — Cypress runs one test at a time per process, so this reliably
@@ -218,6 +239,7 @@ function setup(on, config, opts) {
         emit('run:start', {
           specs,
           totalSpecs: specs.length,
+          ...(projectId ? { project: projectId } : {}),
           browser:
             details && details.browser
               ? { name: details.browser.name, version: details.browser.version }

--- a/cypress-tests/tools/cypress-live-reporter/sinks.js
+++ b/cypress-tests/tools/cypress-live-reporter/sinks.js
@@ -130,6 +130,7 @@ function createSink(opts) {
 
   let inFlight = 0;
   const queue = [];
+  let warnedSendFailure = false;
 
   function pump() {
     while (inFlight < maxParallel && queue.length > 0) {
@@ -137,7 +138,13 @@ function createSink(opts) {
       inFlight++;
       Promise.resolve()
         .then(job)
-        .catch((err) => log('send failed:', err && err.message))
+        .catch((err) => {
+          if (!warnedSendFailure) {
+            warnedSendFailure = true;
+            console.warn(`${TAG} send failed — events are being dropped: ${err && err.message}`);
+          }
+          log('send failed:', err && err.message);
+        })
         .then(() => {
           inFlight--;
           pump();


### PR DESCRIPTION
## Problem

The live reporter produced **no output and no error** in three separate situations. A run looked completely healthy — tests passed, exit code 0 — while the dashboard stayed empty. Each failure was individually swallowed by a `try/catch` or a debug-gated log, so there was nothing to notice.

1. **It was never wired into the app-builder config.** `cypress-appbuilder.config.js` returned `require("./cypress/plugins/index.js")(on, config)` directly, so `livePlugin` was never called for app-builder runs.

2. **`.env` was never read.** `plugin.js` calls `require('dotenv').config()` inside a `try/catch` whose comment read *"dotenv not installed — fine"*. dotenv is not installed here, so the require always threw, the catch swallowed it, and every `CLR_*` variable stayed undefined. The workaround was to prefix each run with `set -a && . ./.env && set +a`; forget it and you got a normal-looking run that reported nothing.

3. **Send failures were invisible.** `sinks.js` sent every delivery error to `log()`, which only prints when `CLR_DEBUG=1`. A wrong credential, an unreachable database, or a missing table dropped every insert in silence — the exact case the package README already warns about under *"Postgres only — create the schema"*.

## Changes

| file | change |
|---|---|
| `cypress-appbuilder.config.js` | register `livePlugin` so the reporter loads for app-builder runs |
| `plugin.js` | parse `.env` in the catch that already guarded the optional `require('dotenv')` |
| `plugin.js` | tag events with `CLR_PROJECT` so runs group by project in the dashboard |
| `sinks.js` | warn once on the first send failure, then fall back to the debug channel |
| `cypress-tests/.gitignore` | ignore `.env` so credentials are never committed |

**No dependencies are added** — `package.json` and `package-lock.json` are untouched. dotenv would have been the obvious fix, but it is BSD-2-Clause and this repo permits only MIT / Apache-2.0, so the file is parsed in the plugin instead. If dotenv is ever present the existing `require` still wins, so nothing regresses for anyone who has it installed.

Real environment variables take precedence over the file, so CI overrides keep working. A trailing comment is stripped only from *unquoted* values, because a connection string can legitimately contain `#`.

The send warning fires **once** per run rather than per event, because this reporter captures and uploads stdout — warning per event would pollute the artifact it stores.

`CLR_PROJECT` is spread in conditionally (`...(projectId ? { project: projectId } : {})`), so the event shape is unchanged when it is unset.

## Reporting stays opt-in

This does not switch reporting on for anyone. The gate is sink presence — `plugin.js` self-disables when neither URL is configured, which is the documented and tested behaviour (`README.md`: *"If neither env var is set, the plugin prints one warning and self-disables — it never throws and never breaks the run."*). `.env` is untracked and absent from this branch, so a fresh clone or a CI runner behaves exactly as before: one warning, then a normal run.

To opt out with a `.env` present: `CLR_PG_URL= npx cypress run …`, or `clr.config.json` with `{"enabled": false}`.

## Verification

- Plain `npx cypress run` with **no prefix** and dotenv **not installed** → `active — mode: postgres`, full event sequence `run:start` → `spec:end`, tests passing.
- Broken sink (`CLR_PG_URL` pointing at a dead port) → exit **0**, tests passing, and exactly one `send failed — events are being dropped: connect ECONNREFUSED` warning. Confirms a reporting failure never breaks the run.
- Unit check: two failed sends produce exactly one warning.
- A pre-set empty `CLR_PG_URL` survives the `.env` load, so the documented opt-out still works.

## Note for reviewers

`project` is written into the `run:start` payload but the `clr_runs` view does not surface it, so consumers currently read `payload->>'project'` themselves. Adding `s.payload->>'project' AS project` to that view would be backward compatible — happy to include it here or leave it for a follow-up.