### PR TITLE
fix(ui): revoke Avatar blob URLs and guard against stale fetch responses

### DIFF
--- a/frontend/src/_ui/Avatar/index.jsx
+++ b/frontend/src/_ui/Avatar/index.jsx
@@ -9,14 +9,22 @@ const Avatar = ({ text, image, avatarId, title = '', borderShape, indexId = 0, c
   const [avatar, setAvatar] = React.useState();
 
   React.useEffect(() => {
+    let objectUrl;
+    let cancelled = false;
+
     async function fetchAvatar() {
       const blob = await userService.getAvatar(avatarId);
-      setAvatar(URL.createObjectURL(blob));
+      if (cancelled) return;
+      objectUrl = URL.createObjectURL(blob);
+      setAvatar(objectUrl);
     }
+
     if (avatarId) fetchAvatar();
 
-    () => avatar && URL.revokeObjectURL(avatar);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
   }, [avatarId]);
 
   return (


### PR DESCRIPTION
Fixes #17526

## Summary
Fixes memory leak in Avatar component where blob URLs were never revoked, and adds stale response guard to prevent wrong avatar display in virtualized lists.

## Changes
- frontend/src/_ui/Avatar/index.jsx: Added proper cleanup with  in useEffect, store created objectUrl locally, and use cancelled flag to ignore stale responses

## Testing
- Verified the fix follows same pattern as Camera.jsx, PDF.jsx, Chat/index.js, _lib/generate-file.js, and BulkUploadDrawer which properly revoke blob URLs

Note: jest-environment-jsdom is missing from frontend/package.json (mentioned in issue), but not addressed in this PR as it's a separate concern.