### PR TITLE
Fix: Prevent query editor crashes for empty OpenAPI specs

### DIFF
--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/AGENTS.md
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/AGENTS.md
@@ -1,0 +1,10 @@
+# Query editors
+
+Connector-specific editors map saved query options and data source configuration to Query Manager controls.
+
+## OpenAPI
+
+- `Openapi.jsx` reads the parsed spec from `selectedDataSource.options.spec.value`.
+- Saved/imported data sources can contain an empty spec (`{}`), or no `paths`. Show the existing localized invalid-spec message before resolving hosts or operations; the editor must not crash while opening these queries.
+- Keep valid operation selection and saved parameters intact when handling invalid specs.
+- Regression coverage: `__tests__/Openapi.spec.jsx`.

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/Openapi.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/Openapi.jsx
@@ -31,7 +31,7 @@ class OpenapiComponent extends React.Component {
         path: options?.path,
       },
       spec: selectedDataSource.options?.spec?.value,
-      selectedOperation: selectedDataSource.options?.spec?.value?.paths[options?.path]?.[options?.operation] || null,
+      selectedOperation: selectedDataSource.options?.spec?.value?.paths?.[options?.path]?.[options?.operation] || null,
       operationParams: {},
     };
   }
@@ -246,7 +246,12 @@ class OpenapiComponent extends React.Component {
 
   render() {
     const { options, spec, selectedOperation } = this.state;
-    let baseUrls = spec ? this.resolveHosts() : [];
+    if (!spec?.paths) {
+      return (
+        <div className="p-3">{this.props.t('openApi.noValidOpenApi', 'Valid OpenAPI Spec is not available!.')}</div>
+      );
+    }
+    let baseUrls = this.resolveHosts();
     let pathParams = [];
     let headerParams = [];
     let queryParams = [];
@@ -265,10 +270,6 @@ class OpenapiComponent extends React.Component {
 
     return (
       <div>
-        {!spec && (
-          <div className="p-3">{this.props.t('openApi.noValidOpenApi', 'Valid OpenAPI Spec is not available!.')}</div>
-        )}
-
         {options && spec && (
           <div>
             {baseUrls.length > 0 && (

--- a/frontend/src/AppBuilder/QueryManager/QueryEditors/__tests__/Openapi.spec.jsx
+++ b/frontend/src/AppBuilder/QueryManager/QueryEditors/__tests__/Openapi.spec.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Openapi } from '../Openapi';
+
+const invalidSpecMessage = 'Valid OpenAPI Spec is not available!.';
+
+function renderEditor(spec, options = {}) {
+  return render(
+    <Openapi selectedDataSource={{ options: { spec: { value: spec } } }} options={options} optionsChanged={jest.fn()} />
+  );
+}
+
+describe('OpenAPI query editor', () => {
+  test.each([undefined, null, {}, { paths: null }])('shows the invalid-spec message for %p', (spec) => {
+    renderEditor(spec);
+    expect(screen.getByText(invalidSpecMessage)).toBeInTheDocument();
+    expect(screen.queryByText('Operation')).not.toBeInTheDocument();
+  });
+
+  test('handles an empty spec in a saved query with an operation', () => {
+    renderEditor({}, { path: '/items', operation: 'get' });
+    expect(screen.getByText(invalidSpecMessage)).toBeInTheDocument();
+  });
+
+  test('renders operations for a valid spec', () => {
+    renderEditor({ paths: { '/items': { get: { summary: 'List items' } } } }, { path: '/items', operation: 'get' });
+    expect(screen.getByText('Operation')).toBeInTheDocument();
+    expect(screen.getByText('List items')).toBeInTheDocument();
+    expect(screen.queryByText(invalidSpecMessage)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 📝 What this does
Opening an OpenAPI query whose saved spec is `{}` currently crashes the query editor before its invalid-spec message can render. Show that existing localized message when the spec has no paths, so the editor remains usable.

Relates to: #14272

The attached app in the issue contains an empty parsed spec. This crash is still reproducible on current `lts-3.16`; this PR addresses the query-editor portion of the report.

## 🔀 Changes
- Made the initial saved-operation lookup tolerate missing paths.
- Checked for missing paths before resolving hosts or rendering operation controls.
- Added regression coverage for empty/missing specs and valid saved operations.

## 🧪 How to test
- [x] Run `cd frontend && npm test -- --runInBand --runTestsByPath src/AppBuilder/QueryManager/QueryEditors/__tests__/Openapi.spec.jsx` — all 6 tests pass; 3 failed on the unchanged base.
- [x] Run ESLint on the changed JavaScript files and `git diff --check`.
- [x] Open a query with an empty saved OpenAPI spec and confirm the existing invalid-spec message appears.
- [ ] Open a valid OpenAPI query and confirm its operation and description still render.

Reviewed with the help of AI.
