### PR TITLE
Fix: format frontend lint

### DIFF
--- a/frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.js
+++ b/frontend/src/AppBuilder/Widgets/NewTable/_utils/generateColumnsData.js
@@ -107,7 +107,7 @@ export default function generateColumnsData({
 
       const columnSize = useDynamicColumn
         ? column.columnSize || columnSizes[column?.id] || columnSizes[column?.name]
-        : columnSizes[column?.id] ?? columnSizes[column?.name] ?? column.columnSize;
+        : (columnSizes[column?.id] ?? columnSizes[column?.name] ?? column.columnSize);
       const columnType = column?.columnType;
 
       // Process column options for select types

--- a/frontend/src/AppBuilder/_hooks/useAppData.js
+++ b/frontend/src/AppBuilder/_hooks/useAppData.js
@@ -490,8 +490,8 @@ const useAppData = (
               'is_maintenance_on' in result
                 ? result.is_maintenance_on
                 : 'isMaintenanceOn' in result
-                ? result.isMaintenanceOn
-                : false,
+                  ? result.isMaintenanceOn
+                  : false,
             organizationId: appData.organizationId || appData.organization_id,
             homePageId: homePageId,
             isPublic: appData.is_public,
@@ -964,8 +964,8 @@ const useAppData = (
             'is_maintenance_on' in appData
               ? appData.is_maintenance_on
               : 'isMaintenanceOn' in appData
-              ? appData.isMaintenanceOn
-              : false,
+                ? appData.isMaintenanceOn
+                : false,
           organizationId: appData.organizationId || appData.organization_id,
           homePageId: appData.editing_version.homePageId,
           isPublic: appData.isPublic,

--- a/frontend/src/modules/dataSources/components/DataSourceManager/DataSourceManager.jsx
+++ b/frontend/src/modules/dataSources/components/DataSourceManager/DataSourceManager.jsx
@@ -1076,8 +1076,8 @@ class DataSourceManagerComponent extends React.Component {
       const activeKey = Object.prototype.hasOwnProperty.call(normalizedCurrentOptions, key)
         ? key
         : Object.prototype.hasOwnProperty.call(normalizedCurrentOptions, camelize(key))
-        ? camelize(key)
-        : key;
+          ? camelize(key)
+          : key;
       if (normalizedSavedOptions[activeKey] === undefined) normalizedSavedOptions[activeKey] = { value: '' };
       if (normalizedCurrentOptions[activeKey] === undefined) normalizedCurrentOptions[activeKey] = { value: '' };
     });
@@ -1094,8 +1094,8 @@ class DataSourceManagerComponent extends React.Component {
     const docLink = isSampleDb
       ? 'https://docs.tooljet.com/docs/data-sources/sample-data-sources'
       : selectedDataSource?.pluginId && selectedDataSource.pluginId.trim() !== ''
-      ? `https://docs.tooljet.com/docs/marketplace/plugins/marketplace-plugin-${selectedDataSource?.kind}/`
-      : `https://docs.tooljet.com/docs/data-sources/${selectedDataSource?.kind}`;
+        ? `https://docs.tooljet.com/docs/marketplace/plugins/marketplace-plugin-${selectedDataSource?.kind}/`
+        : `https://docs.tooljet.com/docs/data-sources/${selectedDataSource?.kind}`;
     const OAuthDs = [
       'slack',
       'zendesk',


### PR DESCRIPTION
## 📝 What this does

Unblocks the `Lint & Build · frontend` CI job on `main`, which has been failing with 9 `prettier/prettier` errors. CI installs prettier 3.9.6 from `frontend/package-lock.json`, and three files were still carrying prettier 2 formatting.

Formatting only — no behaviour change.

## 🔀 Changes

- Re-indented nested ternaries in `useAppData.js` and `DataSourceManager.jsx` to prettier 3's stepped style
- Parenthesised the `??` chain inside a ternary branch in `generateColumnsData.js`

## 🧪 How to test

- [ ] Run `cd frontend && npm ci` so the local prettier matches the lockfile (3.9.6) — a stale prettier 2 install reports these files as clean
- [ ] Run `npm run --prefix frontend lint` and confirm 0 errors

> Note: if your local `frontend/node_modules` predates the prettier 3 bump, the husky pre-commit hook will silently reformat these files back to prettier 2 style. `npm ci` in `frontend/` fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ic66TksRLGKMCBGuVXLLM