### PR TITLE
Chore: assign AgentBuildingOverlay to builder-shell coverage subsystem

### DIFF
--- a/frontend/app-builder-coverage-manifest.json
+++ b/frontend/app-builder-coverage-manifest.json
@@ -16,7 +16,7 @@
     { "id": "persistence-import-export", "name": "Persistence, import, and export", "owner": "", "roots": [] },
     { "id": "editor-viewer", "name": "Editor and Viewer", "owner": "", "roots": ["Viewer"] },
     { "id": "collaboration-history", "name": "Collaboration and history", "owner": "", "roots": ["RealTimeEditor"] },
-    { "id": "builder-shell", "name": "Builder shell", "owner": "", "roots": ["Header", "LeftSidebar", "Popups", "Shared"], "files": ["AppBuilder.jsx", "Cursor.jsx", "EmbedApp.jsx", "RealtimeCursors.jsx", "index.js"] }
+    { "id": "builder-shell", "name": "Builder shell", "owner": "", "roots": ["Header", "LeftSidebar", "Popups", "Shared"], "files": ["AgentBuildingOverlay.jsx", "AppBuilder.jsx", "Cursor.jsx", "EmbedApp.jsx", "RealtimeCursors.jsx", "index.js"] }
   ],
   "overrides": {
     "src/AppBuilder/_stores/slices/appSlice.js": "persistence-import-export",


### PR DESCRIPTION
## 📝 What this does
`npm run validate:app-builder-coverage-manifest` has been failing since the AI builder recovery work landed, because the coverage manifest never learned about the new overlay file. This assigns it and gets the check green again.

## 🔀 Changes
- Assigned `AgentBuildingOverlay.jsx` to the `builder-shell` subsystem in the App Builder coverage manifest

## 🧪 How to test
- [ ] Run `npm run validate:app-builder-coverage-manifest` in `frontend/` — exits 0 and prints the per-subsystem counts
- [ ] Confirm `builder-shell` reports 93 files