### PR TITLE
feat(plugins): add Adanos market sentiment datasource plugin

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -19,6 +19,7 @@
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {
+    "@tooljet-plugins/adanos": "file:packages/adanos",
     "@tooljet-plugins/airtable": "file:packages/airtable",
     "@tooljet-plugins/amazonses": "file:packages/amazonses",
     "@tooljet-plugins/appwrite": "file:packages/appwrite",

--- a/plugins/packages/adanos/README.md
+++ b/plugins/packages/adanos/README.md
@@ -1,0 +1,9 @@
+# @tooljet-plugins/adanos
+
+Adanos Market Sentiment datasource plugin for ToolJet.
+
+## Operations
+- **Get Asset Sentiment**: Retrieve sentiment scores, volume, and momentum for specific tickers.
+- **Get Trending Assets**: Retrieve top trending assets across social networks and financial news.
+- **Compare Assets**: Compare sentiment and mention metrics across multiple tickers.
+- **Get Market Sentiment**: Retrieve overall market mood, fear & greed index, and category breakdowns.

--- a/plugins/packages/adanos/__tests__/index.spec.ts
+++ b/plugins/packages/adanos/__tests__/index.spec.ts
@@ -1,0 +1,194 @@
+import AdanosQueryService from '../lib/index';
+import got from 'got';
+
+jest.mock('got');
+
+describe('AdanosQueryService', () => {
+  let service: AdanosQueryService;
+  const mockSourceOptions = {
+    api_key: 'test_adanos_secret_key_123',
+    base_url: 'https://api.adanos.org/v1',
+  };
+
+  beforeEach(() => {
+    service = new AdanosQueryService();
+    jest.clearAllMocks();
+  });
+
+  describe('testConnection', () => {
+    it('should return success when connection verify succeeds', async () => {
+      (got.get as jest.Mock).mockResolvedValueOnce({
+        statusCode: 200,
+        body: { status: 'ok', authenticated: true },
+      });
+
+      const result = await service.testConnection(mockSourceOptions);
+      expect(result.status).toBe('success');
+      expect(got.get).toHaveBeenCalledWith(
+        'https://api.adanos.org/v1/auth/verify',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-API-Key': 'test_adanos_secret_key_123',
+          }),
+        })
+      );
+    });
+
+    it('should return failed when API key is missing', async () => {
+      const result = await service.testConnection({ api_key: '' });
+      expect(result.status).toBe('failed');
+      expect(result.message).toContain('API key is required');
+    });
+
+    it('should return failed when network request fails', async () => {
+      (got.get as jest.Mock).mockRejectedValueOnce({
+        message: 'Unauthorized API key',
+        response: { body: { message: 'Invalid API key provided' } },
+      });
+
+      const result = await service.testConnection(mockSourceOptions);
+      expect(result.status).toBe('failed');
+      expect(result.message).toBe('Invalid API key provided');
+    });
+  });
+
+  describe('run - get_asset_sentiment', () => {
+    it('should fetch sentiment for a single asset', async () => {
+      const mockResponse = {
+        symbol: 'AAPL',
+        sentiment_score: 0.78,
+        mention_volume: 1420,
+        bullish_percentage: 82.5,
+        bearish_percentage: 17.5,
+      };
+
+      (got.get as jest.Mock).mockResolvedValueOnce({
+        body: mockResponse,
+      });
+
+      const result = await service.run(mockSourceOptions, {
+        operation: 'get_asset_sentiment',
+        symbol: 'aapl',
+        source: 'reddit_stocks',
+        time_range: '24h',
+      });
+
+      expect(result.status).toBe('success');
+      expect(result.data).toEqual(mockResponse);
+      expect(got.get).toHaveBeenCalledWith(
+        'https://api.adanos.org/v1/sentiment/asset/AAPL',
+        expect.objectContaining({
+          searchParams: {
+            source: 'reddit_stocks',
+            time_range: '24h',
+          },
+        })
+      );
+    });
+
+    it('should throw error when symbol is omitted', async () => {
+      await expect(
+        service.run(mockSourceOptions, {
+          operation: 'get_asset_sentiment',
+          symbol: '',
+        })
+      ).rejects.toThrow('Symbol / Ticker is required');
+    });
+  });
+
+  describe('run - get_trending_assets', () => {
+    it('should fetch trending assets with category and limit', async () => {
+      const mockTrending = {
+        trending: [
+          { symbol: 'NVDA', score: 0.92, volume: 5400 },
+          { symbol: 'TSLA', score: 0.65, volume: 3200 },
+        ],
+      };
+
+      (got.get as jest.Mock).mockResolvedValueOnce({
+        body: mockTrending,
+      });
+
+      const result = await service.run(mockSourceOptions, {
+        operation: 'get_trending_assets',
+        category: 'stocks',
+        limit: 10,
+      });
+
+      expect(result.status).toBe('success');
+      expect(result.data).toEqual(mockTrending);
+      expect(got.get).toHaveBeenCalledWith(
+        'https://api.adanos.org/v1/sentiment/trending',
+        expect.objectContaining({
+          searchParams: {
+            category: 'stocks',
+            limit: '10',
+          },
+        })
+      );
+    });
+  });
+
+  describe('run - compare_assets', () => {
+    it('should format comma-separated symbols and fetch comparison', async () => {
+      const mockComparison = {
+        comparison: [
+          { symbol: 'AAPL', score: 0.8 },
+          { symbol: 'MSFT', score: 0.85 },
+        ],
+      };
+
+      (got.get as jest.Mock).mockResolvedValueOnce({
+        body: mockComparison,
+      });
+
+      const result = await service.run(mockSourceOptions, {
+        operation: 'compare_assets',
+        symbols: 'AAPL, MSFT',
+        time_range: '7d',
+      });
+
+      expect(result.status).toBe('success');
+      expect(result.data).toEqual(mockComparison);
+      expect(got.get).toHaveBeenCalledWith(
+        'https://api.adanos.org/v1/sentiment/compare',
+        expect.objectContaining({
+          searchParams: {
+            symbols: 'AAPL,MSFT',
+            time_range: '7d',
+          },
+        })
+      );
+    });
+  });
+
+  describe('run - get_market_sentiment', () => {
+    it('should fetch overall market sentiment', async () => {
+      const mockMarket = {
+        market_index: 68.4,
+        sentiment: 'Greed',
+        segment: 'us_equities',
+      };
+
+      (got.get as jest.Mock).mockResolvedValueOnce({
+        body: mockMarket,
+      });
+
+      const result = await service.run(mockSourceOptions, {
+        operation: 'get_market_sentiment',
+        segment: 'us_equities',
+      });
+
+      expect(result.status).toBe('success');
+      expect(result.data).toEqual(mockMarket);
+      expect(got.get).toHaveBeenCalledWith(
+        'https://api.adanos.org/v1/sentiment/market',
+        expect.objectContaining({
+          searchParams: {
+            segment: 'us_equities',
+          },
+        })
+      );
+    });
+  });
+});

--- a/plugins/packages/adanos/lib/icon.svg
+++ b/plugins/packages/adanos/lib/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="22 7 13.5 15.5 8.5 10.5 2 17"></polyline>
+  <polyline points="16 7 22 7 22 13"></polyline>
+</svg>

--- a/plugins/packages/adanos/lib/index.ts
+++ b/plugins/packages/adanos/lib/index.ts
@@ -1,0 +1,154 @@
+import { QueryError, QueryResult, QueryService, ConnectionTestResult } from '@tooljet-plugins/common';
+import { SourceOptions, QueryOptions } from './types';
+import got, { Headers } from 'got';
+
+export default class AdanosQueryService implements QueryService {
+  private getBaseUrl(sourceOptions: SourceOptions): string {
+    const raw = sourceOptions.base_url?.trim() || 'https://api.adanos.org/v1';
+    return raw.replace(/\/+$/, '');
+  }
+
+  private authHeaders(apiKey: string): Headers {
+    return {
+      'X-API-Key': apiKey.trim(),
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'ToolJet-Adanos-Plugin/1.0.0',
+    };
+  }
+
+  async run(sourceOptions: SourceOptions, queryOptions: QueryOptions): Promise<QueryResult> {
+    const apiKey = sourceOptions.api_key;
+    if (!apiKey) {
+      throw new QueryError('API Key is required in datasource configuration', '', {});
+    }
+
+    const baseUrl = this.getBaseUrl(sourceOptions);
+    const headers = this.authHeaders(apiKey);
+    const operation = queryOptions.operation;
+
+    try {
+      let endpoint = '';
+      const searchParams: Record<string, string> = {};
+
+      switch (operation) {
+        case 'get_asset_sentiment': {
+          const symbol = queryOptions.symbol?.trim();
+          if (!symbol) {
+            throw new QueryError('Symbol / Ticker is required for asset sentiment query', '', {});
+          }
+          endpoint = `${baseUrl}/sentiment/asset/${encodeURIComponent(symbol.toUpperCase())}`;
+          if (queryOptions.source && queryOptions.source !== 'all') {
+            searchParams.source = queryOptions.source;
+          }
+          if (queryOptions.time_range) {
+            searchParams.time_range = queryOptions.time_range;
+          }
+          break;
+        }
+
+        case 'get_trending_assets': {
+          endpoint = `${baseUrl}/sentiment/trending`;
+          if (queryOptions.category && queryOptions.category !== 'all') {
+            searchParams.category = queryOptions.category;
+          }
+          if (queryOptions.limit) {
+            searchParams.limit = String(queryOptions.limit);
+          }
+          break;
+        }
+
+        case 'compare_assets': {
+          endpoint = `${baseUrl}/sentiment/compare`;
+          let rawSymbols = queryOptions.symbols || '';
+          if (Array.isArray(rawSymbols)) {
+            searchParams.symbols = (rawSymbols as string[]).join(',');
+          } else {
+            try {
+              const parsed = JSON.parse(rawSymbols);
+              if (Array.isArray(parsed)) {
+                searchParams.symbols = parsed.join(',');
+              } else {
+                searchParams.symbols = rawSymbols.trim();
+              }
+            } catch {
+              searchParams.symbols = rawSymbols
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean)
+                .join(',');
+            }
+          }
+          if (!searchParams.symbols) {
+            throw new QueryError('At least one symbol is required for compare_assets', '', {});
+          }
+          if (queryOptions.time_range) {
+            searchParams.time_range = queryOptions.time_range;
+          }
+          break;
+        }
+
+        case 'get_market_sentiment': {
+          endpoint = `${baseUrl}/sentiment/market`;
+          if (queryOptions.segment) {
+            searchParams.segment = queryOptions.segment;
+          }
+          break;
+        }
+
+        default:
+          throw new QueryError(`Unsupported operation: ${operation}`, '', {});
+      }
+
+      const response = await got.get(endpoint, {
+        headers,
+        searchParams,
+        responseType: 'json',
+        timeout: 30000,
+      });
+
+      return {
+        status: 'success',
+        data: response.body,
+      };
+    } catch (error: any) {
+      if (error instanceof QueryError) {
+        throw error;
+      }
+      const responseBody = error?.response?.body;
+      const message = responseBody?.error || responseBody?.message || error?.message || 'Failed to execute Adanos query';
+      throw new QueryError(message, JSON.stringify(responseBody || {}), {});
+    }
+  }
+
+  async testConnection(sourceOptions: SourceOptions): Promise<ConnectionTestResult> {
+    const apiKey = sourceOptions.api_key;
+    if (!apiKey) {
+      return {
+        status: 'failed',
+        message: 'API key is required',
+      };
+    }
+
+    try {
+      const baseUrl = this.getBaseUrl(sourceOptions);
+      const headers = this.authHeaders(apiKey);
+
+      await got.get(`${baseUrl}/auth/verify`, {
+        headers,
+        timeout: 10000,
+      });
+
+      return {
+        status: 'success',
+        message: 'Connection verified successfully',
+      };
+    } catch (error: any) {
+      const msg = error?.response?.body?.message || error?.message || 'Connection test failed';
+      return {
+        status: 'failed',
+        message: msg,
+      };
+    }
+  }
+}

--- a/plugins/packages/adanos/lib/manifest.json
+++ b/plugins/packages/adanos/lib/manifest.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/manifest.schema.json",
+  "title": "Adanos Sentiment datasource",
+  "description": "A schema defining Adanos Market Sentiment datasource",
+  "type": "object",
+  "tj:version": "1.0.0",
+  "tj:source": {
+    "name": "Adanos",
+    "kind": "adanos",
+    "type": "api"
+  },
+  "properties": {
+    "api_key": {
+      "type": "string",
+      "title": "API Key",
+      "description": "Adanos API Key (X-API-Key)"
+    },
+    "base_url": {
+      "type": "string",
+      "title": "Base URL",
+      "description": "Optional custom Adanos API endpoint",
+      "default": "https://api.adanos.org/v1"
+    }
+  },
+  "tj:encrypted": [
+    "api_key"
+  ],
+  "required": [
+    "api_key"
+  ],
+  "tj:ui:properties": {
+    "api_key": {
+      "$ref": "#/properties/api_key",
+      "key": "api_key",
+      "label": "API Key",
+      "description": "Adanos API Key (X-API-Key)",
+      "widget": "password-v3-textarea",
+      "required": true
+    },
+    "base_url": {
+      "$ref": "#/properties/base_url",
+      "key": "base_url",
+      "label": "Base URL",
+      "description": "Custom API endpoint (defaults to https://api.adanos.org/v1)",
+      "widget": "text",
+      "required": false
+    }
+  }
+}

--- a/plugins/packages/adanos/lib/operations.json
+++ b/plugins/packages/adanos/lib/operations.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ToolJet/ToolJet/develop/plugins/schemas/operations.schema.json",
+  "title": "Adanos datasource",
+  "description": "A schema defining Adanos datasource operations",
+  "type": "api",
+  "properties": {
+    "operation": {
+      "label": "Operation",
+      "key": "operation",
+      "type": "dropdown-component-flip",
+      "description": "Select Adanos sentiment operation",
+      "list": [
+        {
+          "value": "get_asset_sentiment",
+          "name": "Get Asset Sentiment"
+        },
+        {
+          "value": "get_trending_assets",
+          "name": "Get Trending Assets"
+        },
+        {
+          "value": "compare_assets",
+          "name": "Compare Assets"
+        },
+        {
+          "value": "get_market_sentiment",
+          "name": "Get Market Sentiment"
+        }
+      ]
+    },
+    "get_asset_sentiment": {
+      "symbol": {
+        "label": "Asset Symbol / Ticker",
+        "key": "symbol",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "description": "Ticker symbol (e.g., AAPL, TSLA, BTC)",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins",
+        "placeholder": "AAPL"
+      },
+      "source": {
+        "label": "Data Source",
+        "key": "source",
+        "type": "dropdown",
+        "description": "Sentiment data source channel",
+        "list": [
+          {
+            "value": "all",
+            "name": "All Sources"
+          },
+          {
+            "value": "reddit_stocks",
+            "name": "Reddit Stocks"
+          },
+          {
+            "value": "twitter_fintwit",
+            "name": "X / FinTwit"
+          },
+          {
+            "value": "news",
+            "name": "Financial News"
+          },
+          {
+            "value": "polymarket",
+            "name": "Polymarket"
+          },
+          {
+            "value": "reddit_crypto",
+            "name": "Reddit Crypto"
+          }
+        ]
+      },
+      "time_range": {
+        "label": "Time Window",
+        "key": "time_range",
+        "type": "dropdown",
+        "description": "Aggregation window",
+        "list": [
+          {
+            "value": "1h",
+            "name": "Last 1 Hour"
+          },
+          {
+            "value": "24h",
+            "name": "Last 24 Hours"
+          },
+          {
+            "value": "7d",
+            "name": "Last 7 Days"
+          },
+          {
+            "value": "30d",
+            "name": "Last 30 Days"
+          }
+        ]
+      }
+    },
+    "get_trending_assets": {
+      "category": {
+        "label": "Category",
+        "key": "category",
+        "type": "dropdown",
+        "description": "Asset category",
+        "list": [
+          {
+            "value": "stocks",
+            "name": "Stocks"
+          },
+          {
+            "value": "crypto",
+            "name": "Crypto"
+          },
+          {
+            "value": "all",
+            "name": "All Assets"
+          }
+        ]
+      },
+      "limit": {
+        "label": "Limit",
+        "key": "limit",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "description": "Number of trending assets to return (1-100)",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins",
+        "placeholder": "20"
+      }
+    },
+    "compare_assets": {
+      "symbols": {
+        "label": "Symbols (comma-separated or JSON array)",
+        "key": "symbols",
+        "type": "codehinter",
+        "lineNumbers": false,
+        "description": "Symbols to compare (e.g. AAPL,MSFT,NVDA)",
+        "width": "320px",
+        "height": "36px",
+        "className": "codehinter-plugins",
+        "placeholder": "AAPL, MSFT, NVDA"
+      },
+      "time_range": {
+        "label": "Time Window",
+        "key": "time_range",
+        "type": "dropdown",
+        "description": "Aggregation window",
+        "list": [
+          {
+            "value": "24h",
+            "name": "Last 24 Hours"
+          },
+          {
+            "value": "7d",
+            "name": "Last 7 Days"
+          },
+          {
+            "value": "30d",
+            "name": "Last 30 Days"
+          }
+        ]
+      }
+    },
+    "get_market_sentiment": {
+      "segment": {
+        "label": "Market Segment",
+        "key": "segment",
+        "type": "dropdown",
+        "description": "Market segment",
+        "list": [
+          {
+            "value": "us_equities",
+            "name": "US Equities"
+          },
+          {
+            "value": "crypto",
+            "name": "Cryptocurrency"
+          },
+          {
+            "value": "global",
+            "name": "Global Macro"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/plugins/packages/adanos/lib/types.ts
+++ b/plugins/packages/adanos/lib/types.ts
@@ -1,0 +1,15 @@
+export type SourceOptions = {
+  api_key: string;
+  base_url?: string;
+};
+
+export type QueryOptions = {
+  operation: 'get_asset_sentiment' | 'get_trending_assets' | 'compare_assets' | 'get_market_sentiment';
+  symbol?: string;
+  symbols?: string;
+  source?: string;
+  time_range?: string;
+  category?: string;
+  limit?: string | number;
+  segment?: string;
+};

--- a/plugins/packages/adanos/package.json
+++ b/plugins/packages/adanos/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tooljet-plugins/adanos",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "build": "tsc -b",
+    "clean": "rimraf ./dist && rimraf tsconfig.tsbuildinfo"
+  },
+  "homepage": "https://github.com/tooljet/tooljet#readme",
+  "dependencies": {
+    "@tooljet-plugins/common": "file:../common",
+    "got": "^11.8.3"
+  }
+}

--- a/plugins/packages/adanos/tsconfig.json
+++ b/plugins/packages/adanos/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./lib",
+    "composite": true
+  },
+  "include": [
+    "./lib"
+  ]
+}


### PR DESCRIPTION
### Summary
Adds an optional Adanos marketplace datasource plugin (\@tooljet-plugins/adanos\) authenticated with an encrypted \X-API-Key\, addressing #17644.

### Operations Supported
- **Get Asset Sentiment**: Query sentiment score, mention volume, and breakdown across Reddit, X / FinTwit, news, Polymarket, and crypto.
- **Get Trending Assets**: Query top trending assets by category and limit.
- **Compare Assets**: Compare sentiment and volume metrics across multiple tickers.
- **Get Market Sentiment**: Query aggregate market mood and fear/greed indices.

### Changes
- \plugins/package.json\: Register \@tooljet-plugins/adanos\ plugin dependency.
- \plugins/packages/adanos/package.json\: Plugin package metadata.
- \plugins/packages/adanos/tsconfig.json\: TypeScript project configuration.
- \plugins/packages/adanos/lib/manifest.json\: Manifest schema declaring datasource credentials and encrypted API key.
- \plugins/packages/adanos/lib/operations.json\: UI operations schema defining operation dropdowns, codehinters, and parameter controls.
- \plugins/packages/adanos/lib/types.ts\: Source and query option types.
- \plugins/packages/adanos/lib/index.ts\: Query service implementation with error handling and connection test verification.
- \plugins/packages/adanos/lib/icon.svg\: Datasource icon.
- \plugins/packages/adanos/__tests__/index.spec.ts\: Unit tests covering connection testing, all four operations, parameter formatting, and error propagation.