### PR TITLE
Fix: ESLint crash from typescript-eslint v8 rule removals

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -184,12 +184,25 @@ export default [
       '@typescript-eslint': tsPlugin,
       react: pluginReact,
       'react-hooks': pluginReactHooks,
+      // Register import-x under the 'import' namespace so existing
+      // `eslint-disable import/...` directives continue to work
+      import: pluginImportX,
       prettier: pluginPrettier,
     },
 
     settings: {
       react: {
         version: 'detect',
+      },
+      // Without this the node resolver only knows .js/.jsx and reports every
+      // extensionless relative import of a .ts/.tsx module as unresolved.
+      'import-x/resolver': {
+        node: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        },
+        webpack: {
+          config: new URL('./webpack.config.js', import.meta.url).pathname,
+        },
       },
     },
 
@@ -207,19 +220,23 @@ export default [
       // @typescript-eslint recommended
       '@typescript-eslint/adjacent-overload-signatures': 'error',
       '@typescript-eslint/ban-ts-comment': 'error',
-      '@typescript-eslint/ban-types': 'error',
       '@typescript-eslint/no-array-constructor': 'error',
-      '@typescript-eslint/no-empty-interface': 'error',
+      // `ban-types` was removed in typescript-eslint v8 and split into these three rules
+      '@typescript-eslint/no-empty-object-type': 'error',
+      '@typescript-eslint/no-unsafe-function-type': 'error',
+      '@typescript-eslint/no-wrapper-object-types': 'error',
       '@typescript-eslint/no-extra-non-null-assertion': 'error',
       '@typescript-eslint/no-inferrable-types': 'error',
-      '@typescript-eslint/no-loss-of-precision': 'error',
+      // `no-loss-of-precision` was deprecated in v8 in favour of the base ESLint rule,
+      // which is already enabled via eslint:recommended above.
       '@typescript-eslint/no-misused-new': 'error',
       '@typescript-eslint/no-namespace': 'error',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
       '@typescript-eslint/no-non-null-assertion': 'warn',
       '@typescript-eslint/no-this-alias': 'error',
       '@typescript-eslint/no-unnecessary-type-constraint': 'error',
-      '@typescript-eslint/no-var-requires': 'error',
+      // replaces the deprecated `no-var-requires`
+      '@typescript-eslint/no-require-imports': 'error',
       '@typescript-eslint/prefer-as-const': 'error',
       '@typescript-eslint/triple-slash-reference': 'error',
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -304,6 +304,8 @@
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
     "lint-quiet": "eslint --quiet 'src/**/*.{js,jsx,ts,tsx}'",
     "format": "eslint --fix 'src/**/*.{js,jsx,ts,tsx}'",
+    "lint:changed": "bash -c 'FILES=$(git diff --relative --name-only --diff-filter=ACMR; git diff --relative --name-only --cached --diff-filter=ACMR; git ls-files --others --exclude-standard); FILES=$(echo \"$FILES\" | sort -u | grep -E \"^src/.*\\.(js|jsx|ts|tsx)$\"); if [ -z \"$FILES\" ]; then echo \"No changed files to lint.\"; else echo \"$FILES\" | tr \"\\n\" \"\\0\" | xargs -0 ./node_modules/.bin/eslint; fi'",
+    "format:changed": "bash -c 'FILES=$(git diff --relative --name-only --diff-filter=ACMR; git diff --relative --name-only --cached --diff-filter=ACMR; git ls-files --others --exclude-standard); FILES=$(echo \"$FILES\" | sort -u | grep -E \"^src/.*\\.(js|jsx|ts|tsx)$\"); if [ -z \"$FILES\" ]; then echo \"No changed files to format.\"; else echo \"$FILES\" | tr \"\\n\" \"\\0\" | xargs -0 ./node_modules/.bin/eslint --fix; fi'",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/frontend/src/AppBuilder/Widgets/Cascader/CascaderMenu.tsx
+++ b/frontend/src/AppBuilder/Widgets/Cascader/CascaderMenu.tsx
@@ -197,7 +197,8 @@ const CascaderMenu = forwardRef<CascaderMenuRef, CascaderMenuProps>(
           ) : (
             currentNodes.map((node, index) => {
               const isParent = !!node.children;
-              const isSelected = !isParent && selectedValue != null && areCascaderValuesEqual(node.value, selectedValue);
+              const isSelected =
+                !isParent && selectedValue != null && areCascaderValuesEqual(node.value, selectedValue);
               const isHighlighted = index === highlightedIndex && !node.disabled;
               return (
                 <div

--- a/frontend/src/AppBuilder/Widgets/Cascader/useCascader.ts
+++ b/frontend/src/AppBuilder/Widgets/Cascader/useCascader.ts
@@ -16,11 +16,7 @@ import type {
   CascaderValidationStatus,
   CascaderValue,
 } from './types';
-import {
-  buildPathMaps,
-  computeSelection,
-  getCascaderValueKey,
-} from './utils';
+import { buildPathMaps, computeSelection, getCascaderValueKey } from './utils';
 
 interface UseCascaderParams {
   tree: CascaderNode[];
@@ -119,7 +115,9 @@ export function useCascader({
 
   const [selectedValue, setSelectedValue] = useState<CascaderValue | null>(() => {
     const initialMaps = buildPathMaps(tree);
-    return defaultValue !== null && defaultValue !== undefined && initialMaps.leafSet.has(getCascaderValueKey(defaultValue))
+    return defaultValue !== null &&
+      defaultValue !== undefined &&
+      initialMaps.leafSet.has(getCascaderValueKey(defaultValue))
       ? defaultValue
       : null;
   });

--- a/frontend/src/AppBuilder/Widgets/Cascader/utils.ts
+++ b/frontend/src/AppBuilder/Widgets/Cascader/utils.ts
@@ -48,10 +48,7 @@ export const areCascaderValuesEqual = (a: CascaderValue, b: CascaderValue): bool
  *
  * Returns nodes shaped `{ label, value, disabled, children }`.
  */
-export const normalizeTree = (
-  items: unknown,
-  getResolvedValue: (value: unknown) => unknown
-): CascaderNode[] => {
+export const normalizeTree = (items: unknown, getResolvedValue: (value: unknown) => unknown): CascaderNode[] => {
   if (!Array.isArray(items)) return [];
   return items
     .filter((item): item is CascaderOption => item !== null && typeof item === 'object')

--- a/frontend/src/AppBuilder/_stores/batchManager.ts
+++ b/frontend/src/AppBuilder/_stores/batchManager.ts
@@ -25,11 +25,7 @@ interface StoreWithDependencies {
   updateDependencyValues: (path: string, moduleId: string) => void;
 }
 
-type ImmerSet<S> = (
-  updater: (state: S) => S | Partial<S> | void,
-  replace?: boolean,
-  actionName?: string
-) => void;
+type ImmerSet<S> = (updater: (state: S) => S | Partial<S> | void, replace?: boolean, actionName?: string) => void;
 
 type StoreGet<S> = () => S;
 

--- a/frontend/src/AppBuilder/_stores/utils/appDataCaseConversion.ts
+++ b/frontend/src/AppBuilder/_stores/utils/appDataCaseConversion.ts
@@ -37,8 +37,9 @@ const OPAQUE_VALUE_KEYS: readonly string[] = ['pages', 'events', 'dataQueries', 
 
 export function convertAllKeysToSnakeCase(o: JsonValue): JsonValue {
   if (Array.isArray(o)) {
-    return o.map((value: JsonValue): JsonValue =>
-      typeof value === 'object' && value !== null ? convertAllKeysToSnakeCase(value) : value
+    return o.map(
+      (value: JsonValue): JsonValue =>
+        typeof value === 'object' && value !== null ? convertAllKeysToSnakeCase(value) : value
     );
   } else if (typeof o === 'object' && o !== null) {
     const source = o as JsonObject;
@@ -100,7 +101,7 @@ type QueryLike = { options?: Record<string, unknown> };
  *
  * NO-OP FOR CORRECTLY-STORED DATA (post backend-serialization unification)
  *  - The editor writes these keys camelCase, they are stored verbatim, and all the backend endpoints now return the `options` blob verbatim
- *  - so the whitelisted keys arrive camelCase everywhere and the guard below (`options[snakeKey] !== undefined`) never fires. 
+ *  - so the whitelisted keys arrive camelCase everywhere and the guard below (`options[snakeKey] !== undefined`) never fires.
  *
  * WHY IT'S KEPT (a cheap, idempotent safety net)
  *  - It still HEALS rows that already have these keys stored snake_case

--- a/frontend/src/components/ui/Dialog/index.tsx
+++ b/frontend/src/components/ui/Dialog/index.tsx
@@ -6,14 +6,7 @@ import { Button } from '@/components/ui/Button/Button';
 import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle } from '@/components/ui/Rocket/Dialog/Dialog';
 import { generateCypressDataCy } from '@/modules/common/helpers/cypressHelpers';
 
-type ButtonVariant =
-  | 'primary'
-  | 'secondary'
-  | 'outline'
-  | 'ghost'
-  | 'ghostBrand'
-  | 'dangerPrimary'
-  | 'dangerSecondary';
+type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'ghostBrand' | 'dangerPrimary' | 'dangerSecondary';
 type ButtonSize = 'large' | 'default' | 'medium' | 'small';
 
 interface TjButtonProps extends React.ComponentPropsWithoutRef<'button'> {
@@ -36,9 +29,7 @@ const TypedDialogContent = DialogContent as ComponentType<
 >;
 const TypedDialogHeader = DialogHeader as ComponentType<React.ComponentPropsWithoutRef<'div'>>;
 const TypedDialogFooter = DialogFooter as ComponentType<React.ComponentPropsWithoutRef<'div'>>;
-const TypedDialogTitle = DialogTitle as ComponentType<
-  React.ComponentPropsWithoutRef<'h2'> & { 'data-cy'?: string }
->;
+const TypedDialogTitle = DialogTitle as ComponentType<React.ComponentPropsWithoutRef<'h2'> & { 'data-cy'?: string }>;
 const TypedButton = Button as ComponentType<TjButtonProps>;
 
 interface CancelBtnProps extends Omit<TjButtonProps, 'children'> {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": "10.9.2"
   },
   "lint-staged": {
-    "./frontend/src/**/*.{js,jsx}": [
+    "./frontend/src/**/*.{js,jsx,ts,tsx}": [
       "eslint --fix"
     ]
   },


### PR DESCRIPTION
## 📝 What this does
`npm run lint` in the frontend has been aborting during config load instead of linting anything, because the config still enables `@typescript-eslint/ban-types` — a rule removed in typescript-eslint v8, which is the version installed. This repairs the config so linting runs again, which also makes `.ts`/`.tsx` files lintable for the first time.

## 🔀 Changes
- Replaced `ban-types` with the three rules it was split into, and swapped the remaining v8-deprecated entries
- Registered the import plugin and its resolver on the TypeScript block so extensionless `.ts`/`.tsx` imports resolve
- Fixed the prettier drift this surfaced in six TypeScript files
- Extended the lint-staged glob to `.ts`/`.tsx` so pre-commit auto-fixes them like it always has for JS
- Added `lint:changed` and `format:changed` to lint only touched files instead of the whole tree

## 🧪 How to test
- [ ] Run `npm run lint` in `frontend` — completes with 0 errors (warnings are pre-existing)
- [ ] Run `npx tsc --noEmit` in `frontend` — passes clean
- [ ] Run `npm run lint:changed` in `frontend` — reports only files you have touched
- [ ] Commit a deliberately misformatted `.ts` file — pre-commit reformats it