### PR TITLE
Fix: widget test-contract research could not locate most widget docs

### DIFF
--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -9,9 +9,8 @@ and canonical contract paths live in `widget-testing-manifest.json`; widget-spec
 Research is a hard gate. Existing widgets require the widget's official doc page plus the last 2
 years of Git history. New widgets require an approved GitHub, ClickUp, or Notion PRD instead. Doc
 pages live on the `documentation` branch and are mapped per component type in that skill's
-`widget-docs.json`; Context7 indexes `main` and is missing several widget pages, so a Context7 miss
-is not evidence a widget is undocumented. Record the applicable source in the canonical contract; if
-the doc page cannot be resolved, stop and ask before writing tests.
+`widget-docs.json`. Record the applicable source in the canonical contract; if the doc page cannot
+be resolved, stop and ask before writing tests.
 
 ## Glossary
 

--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -6,10 +6,12 @@ Before adding or changing tests for `src/AppBuilder/**`, read
 `src/test/app-builder/README.md`, then use `ee/.agents/skills/app-builder-widget-tdd/SKILL.md`. Registered widget status
 and canonical contract paths live in `widget-testing-manifest.json`; widget-specific facts under
 `ee/test/app-builder/widgets/<ComponentType>/TESTING.md` must not be generalized to other widgets.
-Research is a hard gate. Existing widgets require Context7 official ToolJet documentation plus the
-last 2 years of Git history. New widgets require an approved GitHub, ClickUp, or Notion PRD instead.
-Record the applicable source in the canonical contract; if Context7 is required but unavailable,
-stop and request installation/configuration before writing tests.
+Research is a hard gate. Existing widgets require the widget's official doc page plus the last 2
+years of Git history. New widgets require an approved GitHub, ClickUp, or Notion PRD instead. Doc
+pages live on the `documentation` branch and are mapped per component type in that skill's
+`widget-docs.json`; Context7 indexes `main` and is missing several widget pages, so a Context7 miss
+is not evidence a widget is undocumented. Record the applicable source in the canonical contract; if
+the doc page cannot be resolved, stop and ask before writing tests.
 
 ## Glossary
 

--- a/frontend/src/test/app-builder/README.md
+++ b/frontend/src/test/app-builder/README.md
@@ -25,11 +25,13 @@ inline; do not guess.
 Research is required before writing or modifying widget tests:
 
 1. Classify the work as `existing-widget` or `new-widget` in the contract.
-2. For `existing-widget`, use Context7 for official ToolJet widget documentation and inspect Git
-   commits from the last 2 years for bugs, regressions, fixes, and behavior changes. If Context7
-   is unavailable, stop and ask the agent or engineer to install/configure it first.
+2. For `existing-widget`, read the widget's official doc page and inspect Git commits from the last
+   2 years for bugs, regressions, fixes, and behavior changes. Doc pages live on the `documentation`
+   branch, mapped per component type in the widget-TDD skill's `widget-docs.json`. If the page
+   cannot be resolved, stop and ask before continuing — a Context7 miss is not evidence a widget is
+   undocumented, because Context7 indexes `main` and lacks several widget pages.
 3. For `new-widget`, use an approved product PRD from GitHub, ClickUp, or Notion. This replaces the
-   Context7 and Git-history prerequisites because no released widget docs or history exists yet.
+   doc-page and Git-history prerequisites because no released widget docs or history exists yet.
 4. Record the applicable source and findings in the widget's canonical `TESTING.md` before proposing
    scenarios.
 

--- a/frontend/src/test/app-builder/README.md
+++ b/frontend/src/test/app-builder/README.md
@@ -28,8 +28,7 @@ Research is required before writing or modifying widget tests:
 2. For `existing-widget`, read the widget's official doc page and inspect Git commits from the last
    2 years for bugs, regressions, fixes, and behavior changes. Doc pages live on the `documentation`
    branch, mapped per component type in the widget-TDD skill's `widget-docs.json`. If the page
-   cannot be resolved, stop and ask before continuing — a Context7 miss is not evidence a widget is
-   undocumented, because Context7 indexes `main` and lacks several widget pages.
+   cannot be resolved, stop and ask before continuing.
 3. For `new-widget`, use an approved product PRD from GitHub, ClickUp, or Notion. This replaces the
    doc-page and Git-history prerequisites because no released widget docs or history exists yet.
 4. Record the applicable source and findings in the widget's canonical `TESTING.md` before proposing

--- a/frontend/src/test/app-builder/__tests__/widgetContractValidator.spec.js
+++ b/frontend/src/test/app-builder/__tests__/widgetContractValidator.spec.js
@@ -144,19 +144,29 @@ describe('widget testing contract validator', () => {
     expect(result.warnings).toEqual([`Cannot map modified widget test ${unmapped} to a registered component type`]);
   });
 
+  test('accepts either research_docs or the retired research_context7', () => {
+    // The fixture above still uses the retired name, so that path is covered by
+    // every other case here. This pins the canonical one, and pins that supplying
+    // NEITHER is what fails — see REQUIRED_RESEARCH_FIELDS.
+    const renamed = validContract().replace('research_context7:', 'research_docs:');
+    expect(run({ contract: renamed }).errors).toEqual([]);
+    expect(run({ contract: validContract() }).errors).toEqual([]);
+  });
+
   test('rejects mismatched or empty approved frontmatter', () => {
     const bad = validContract()
       .replace('component_type: DropdownV2', 'component_type: Nope')
       .replace('baseline: lts-3.16', 'baseline: main')
       .replace('contract_status: approved', 'contract_status: shipped')
       .replace(/research_context7: .*/, 'research_context7:')
+      .replace(/research_docs: .*/, 'research_docs:')
       .replace(/research_git_history: .*/, 'research_git_history:');
     expect(run({ contract: bad }).errors).toEqual(
       expect.arrayContaining([
         'DropdownV2: contract component_type does not match the manifest',
         'DropdownV2: contract baseline does not match the manifest',
         'DropdownV2: unknown contract_status shipped',
-        'DropdownV2: approved contract requires research_context7',
+        'DropdownV2: approved contract requires research_docs',
         'DropdownV2: approved contract requires research_git_history',
       ])
     );

--- a/frontend/src/test/app-builder/widgetContractValidator.js
+++ b/frontend/src/test/app-builder/widgetContractValidator.js
@@ -18,7 +18,11 @@ const SCENARIO_STATUSES = new Set([
 ]);
 const OWNERS = new Set(['Engineering', 'QA']);
 const DEVELOPMENT_TYPES = new Set(['existing-widget', 'new-widget']);
-const REQUIRED_RESEARCH_FIELDS = ['research_context7', 'research_git_history'];
+// Each entry is a field name, or a list of accepted names whose FIRST is canonical.
+// `research_context7` is the retired name for `research_docs`:
+//  - widget docs are read from the `documentation` branch now, not Context7
+//  - Both are accepted so contracts written under either gate keep validating.
+const REQUIRED_RESEARCH_FIELDS = [['research_docs', 'research_context7'], 'research_git_history'];
 const DISPOSITION_SECTIONS = [
   '## Research findings',
   '## Registered-surface disposition',
@@ -296,8 +300,9 @@ function validateWidgetTestingContracts(frontendRoot, { changedFiles = [] } = {}
         }
       } else {
         for (const field of REQUIRED_RESEARCH_FIELDS) {
-          if (!contract.metadata[field]) {
-            errors.push(`${widget.componentType}: ${widget.status} contract requires ${field}`);
+          const accepted = Array.isArray(field) ? field : [field];
+          if (!accepted.some((name) => contract.metadata[name])) {
+            errors.push(`${widget.componentType}: ${widget.status} contract requires ${accepted[0]}`);
           }
         }
       }


### PR DESCRIPTION
ee-frontend - https://github.com/ToolJet/ee-frontend/pull/647

This pull request updates the widget test research requirements and related validation logic to reflect the migration from Context7-based documentation to official widget doc pages on the `documentation` branch. The changes ensure that both the new `research_docs` and the legacy `research_context7` fields are accepted in widget test contracts, improving clarity and backward compatibility for test authors and validators.

**Research workflow and documentation updates:**

* Updated documentation in `CONTEXT.md` and `README.md` to clarify that official widget doc pages (on the `documentation` branch) are now the primary source for existing widget research, replacing reliance on Context7, and to explain how doc pages are mapped and indexed. [[1]](diffhunk://#diff-5da190d015766c952493c7197fd4881a432ef78cf4bc48a23adac62e5d38e858L9-R14) [[2]](diffhunk://#diff-6eebf7143da3decb17c9f52aeaed858e6a43813bb2fc9d61cd0b943357c19ea6L28-R34)

**Contract validation logic improvements:**

* Modified `widgetContractValidator.js` so that the required research fields for existing widgets now accept either `research_docs` (canonical) or the retired `research_context7` field, ensuring legacy contracts remain valid. Error messages now reference `research_docs` as the canonical field. [[1]](diffhunk://#diff-7f5c18c002f2be2534e4bf9ad25c6557872eb571a6b11e1aa7022bef8747699dL21-R25) [[2]](diffhunk://#diff-7f5c18c002f2be2534e4bf9ad25c6557872eb571a6b11e1aa7022bef8747699dL299-R305)

**Test coverage:**

* Added a test in `widgetContractValidator.spec.js` to verify that contracts with either `research_docs` or `research_context7` are accepted, and that omitting both results in a validation error.

**Dependency update:**

* Updated the `ee` submodule to the latest commit.
