### PR TITLE
fix(docker): migrate ee-preview image from bullseye to bookworm

### DIFF
--- a/docker/LTS/ee/ee-preview.Dockerfile
+++ b/docker/LTS/ee/ee-preview.Dockerfile
@@ -117,8 +117,10 @@ COPY ./package.json ./package.json
 
 # Build plugins
 COPY ./plugins/package.json ./plugins/package-lock.json ./plugins/
-# Pin ibm_db's clidriver to a build linked against glibc <=2.14, since the runtime
-# stage is bullseye (glibc 2.31) and the latest clidriver requires glibc 2.32+
+# Pin ibm_db's clidriver to a build linked against glibc <=2.14. The runtime stage
+# is now bookworm (glibc 2.36) so this pin is no longer strictly required, but the
+# older clidriver is forward-compatible and keeping it avoids re-testing ibm_db.
+# Safe to drop later if you want the current driver.
 ENV IBM_DB_INSTALLER_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/v11.5.9
 RUN npm --prefix plugins install
 COPY ./plugins/ ./plugins/
@@ -145,7 +147,14 @@ RUN npm install -g @nestjs/cli
 RUN npm install -g copyfiles
 RUN npm --prefix server run build
 
-FROM node:22.15.1-bullseye
+# ---------------------------------------------------------------------------
+# Runtime stage
+# Moved from node:22.15.1-bullseye to bookworm. Debian 11 reached end-of-life on
+# 31 Aug 2026, so bullseye-security no longer publishes a valid Release file and
+# apt-get update fails with exit 100. Bookworm also matches the builder stage,
+# which fixes the libprotobuf ABI mismatch for the copied nsjail binary.
+# ---------------------------------------------------------------------------
+FROM node:22.15.1-bookworm
 
 RUN apt-get update -yq \
     && apt-get install curl gnupg zip -yq \
@@ -159,9 +168,12 @@ ENV NODE_ENV=production
 ENV TOOLJET_EDITION=ee
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 # Install Redis 7.x from official Redis repository for BullMQ compatibility
+# NOTE: repo suite changed bullseye -> bookworm
+# NOTE: libprotobuf23 (bullseye) -> libprotobuf32 (bookworm). This is the version
+# nsjail was actually linked against in the builder stage.
 RUN curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb bullseye main" | tee /etc/apt/sources.list.d/redis.list \
-    && apt-get update && apt-get install -y freetds-dev libaio1 libxml2 wget supervisor redis-server libprotobuf23 libnl-route-3-200 python3 python3-pip
+    && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb bookworm main" | tee /etc/apt/sources.list.d/redis.list \
+    && apt-get update && apt-get install -y freetds-dev libaio1 libxml2 wget supervisor redis-server libprotobuf32 libnl-route-3-200 python3 python3-pip
 
 # Install Instantclient Basic Light Oracle and Dependencies
 WORKDIR /opt/oracle
@@ -173,7 +185,8 @@ RUN wget https://tooljet-plugins-production.s3.us-east-2.amazonaws.com/marketpla
     cd /opt/oracle/instantclient_11_2 && rm -f *jdbc* *occi* *mysql* *mql1* *ipc1* *jar uidrvci genezi adrci && \
     echo /opt/oracle/instantclient* > /etc/ld.so.conf.d/oracle-instantclient.conf && ldconfig
 # Set the Instant Client library paths
-ENV LD_LIBRARY_PATH="/opt/oracle/instantclient_11_2:/opt/oracle/instantclient_21_10:${LD_LIBRARY_PATH}"
+# NOTE: LD_LIBRARY_PATH given an explicit default to silence the UndefinedVar warning
+ENV LD_LIBRARY_PATH="/opt/oracle/instantclient_11_2:/opt/oracle/instantclient_21_10"
 
 # Copy nsjail and Python runtime from builder
 COPY --from=builder /build-nsjail/nsjail/nsjail /usr/local/bin/nsjail
@@ -210,10 +223,16 @@ COPY --from=builder /app/server/ee/workflows/nsjail/python-execution.cfg /etc/ns
 WORKDIR /app
 
 # Install PostgreSQL
+# NOTE: apt-key is deprecated on bookworm and removed in trixie. Switched to the
+# signed-by keyring pattern already used above for Redis.
+# NOTE: repo suite changed bullseye-pgdg -> bookworm-pgdg. postgresql-13 is
+# published for bookworm-pgdg, so the major version and all paths stay at 13.
 USER root
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-RUN apt update && apt -y install postgresql-13 postgresql-client-13 supervisor --fix-missing
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" \
+      | tee /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update && apt-get -y install postgresql-13 postgresql-client-13 supervisor --fix-missing
 
 
 # Explicitly create PG main directory with correct ownership


### PR DESCRIPTION

Debian 11 (bullseye) reached end-of-life on 31 Aug 2026. Security updates
stopped, so no new signed `InRelease` file is being published and the one on
the mirror has passed its `Valid-Until` timestamp. apt treats an expired
Release file as a hard failure. This affects every build on
`node:22.15.1-bullseye` and is not fixable by retrying.

### Changes

All changes are in the runtime stage of `docker/LTS/ee/ee-preview.Dockerfile`.
The builder stage is untouched.

| # | Change | Reason |
|---|--------|--------|
| 1 | `node:22.15.1-bullseye` → `node:22.15.1-bookworm` | bullseye is EOL |
| 2 | `libprotobuf23` → `libprotobuf32` | bullseye package name doesn't exist on bookworm |
| 3 | Redis repo suite `bullseye main` → `bookworm main` | must match base distro |
| 4 | PGDG repo `bullseye-pgdg` → `bookworm-pgdg` | must match base; bullseye-pgdg gets archived now that Debian 11 is EOL |
| 5 | `apt-key add` → `gpg --dearmor` + `signed-by=` keyring | apt-key is deprecated on bookworm, removed in trixie |
| 6 | `LD_LIBRARY_PATH` no longer self-references | silences the `UndefinedVar` build warning; the variable was empty anyway |

### Also fixes an existing ABI mismatch

Change 2: is not just a rename. The builder stage compiles `nsjail` on
bookworm against `libprotobuf32`, then the binary is copied into the runtime
stage, which was installing `libprotobuf23` (bullseye). nsjail was linked
against a protobuf version that wasn't present at runtime. Aligning both
stages on bookworm resolves this.

### What did NOT change

- PostgreSQL stays on **13**. PGDG publishes `postgresql-13` for
  `bookworm-pgdg`, so all `/usr/lib/postgresql/13/...` paths, `initdb`, and
  `preview.sh` / `boot.sh` are unchanged. No data or config migration.
- Builder stage untouched — it was already bookworm (`node:22.15.1` with no
  suffix is the bookworm image).
- No application code, no shell scripts, no compose files.

### Testing

- Builds clean locally through all 39 runtime steps
- Deployed via docker compose, ToolJet starts and serves on localhost
- Migrations run through successfully

