### PR TITLE
Chore: bundle tooljet-mcp into the EE production image

### DIFF
--- a/docker/LTS/ee/ee-production.Dockerfile
+++ b/docker/LTS/ee/ee-production.Dockerfile
@@ -25,6 +25,16 @@ RUN /opt/python-runtime/bin/pip install --no-cache-dir --upgrade pip setuptools 
     typing-extensions==4.12.2
 
 
+# tooljet-mcp, for the self-hosted MCP-over-socket relay (ee-server#827).
+FROM node:22.15.1 AS mcp-builder
+WORKDIR /mcp
+ARG CUSTOM_GITHUB_TOKEN
+ARG TOOLJET_MCP_REF=main
+RUN git config --global url."https://x-access-token:${CUSTOM_GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+RUN git clone https://github.com/ToolJet/tooljet-mcp.git . && git checkout ${TOOLJET_MCP_REF}
+RUN npm ci && npm run build:plugin
+
+
 FROM node:22.15.1 AS builder
 
 # Fix for JS heap limit allocation issue
@@ -236,6 +246,12 @@ COPY --from=builder --chown=appuser:0 /app/server/scripts ./app/server/scripts
 COPY --from=builder --chown=appuser:0 /app/server/dist ./app/server/dist
 COPY --from=builder --chown=appuser:0 /app/server/ee/ai/assets ./app/server/ee/ai/assets
 COPY ./docker/LTS/ee/ee-entrypoint.sh ./app/server/ee-entrypoint.sh
+
+# tooljet-mcp bundle for the socket relay (ee-server#827). data/ must sit next to mcp/,
+# not inside it — bundle resolves it as ../data. package.json ships for its "type":"module".
+COPY --from=mcp-builder --chown=appuser:0 /mcp/bundle/index.js ./app/mcp/index.js
+COPY --from=mcp-builder --chown=appuser:0 /mcp/package.json ./app/mcp/package.json
+COPY --from=mcp-builder --chown=appuser:0 /mcp/data ./app/data
 
 # Set group write permissions for frontend build files to support RedHat arbitrary user assignment
 RUN chmod -R g+w /app/frontend/build

--- a/docker/pre-release/ee/ee-production.Dockerfile
+++ b/docker/pre-release/ee/ee-production.Dockerfile
@@ -1,3 +1,13 @@
+# tooljet-mcp, for the self-hosted MCP-over-socket relay (ee-server#827).
+FROM node:22.15.1 AS mcp-builder
+WORKDIR /mcp
+ARG CUSTOM_GITHUB_TOKEN
+ARG TOOLJET_MCP_REF=main
+RUN git config --global url."https://x-access-token:${CUSTOM_GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+RUN git clone https://github.com/ToolJet/tooljet-mcp.git . && git checkout ${TOOLJET_MCP_REF}
+RUN npm ci && npm run build:plugin
+
+
 FROM node:22.15.1 AS builder
 
 # Fix for JS heap limit allocation issue
@@ -160,6 +170,12 @@ COPY --from=builder --chown=appuser:0 /app/server/scripts ./app/server/scripts
 COPY --from=builder --chown=appuser:0 /app/server/dist ./app/server/dist
 COPY --from=builder --chown=appuser:0 /app/server/ee/ai/assets ./app/server/ee/ai/assets
 COPY ./docker/pre-release/ee/ee-entrypoint.sh ./app/server/ee-entrypoint.sh
+
+# tooljet-mcp bundle for the socket relay (ee-server#827). data/ must sit next to mcp/,
+# not inside it — bundle resolves it as ../data. package.json ships for its "type":"module".
+COPY --from=mcp-builder --chown=appuser:0 /mcp/bundle/index.js ./app/mcp/index.js
+COPY --from=mcp-builder --chown=appuser:0 /mcp/package.json ./app/mcp/package.json
+COPY --from=mcp-builder --chown=appuser:0 /mcp/data ./app/data
 
 
 # Create directory /home/appuser and set ownership to appuser


### PR DESCRIPTION
## What this does
Bakes `tooljet-mcp` into both EE production images, stacked on `feat/multi-model-builds`. This is the packaging step  https://github.com/ToolJet/ee-server/pull/827 names as the one thing left before the self-hosted MCP-over-socket relay actually works — until this lands, the relay stays inert everywhere.

## 🏗️ Architecture
```mermaid
flowchart LR
    subgraph builder[build stage]
        MB[mcp-builder: clone tooljet-mcp, build:plugin]
    end
    subgraph final[final image]
        MI[/app/mcp/index.js/]
        MP[/app/mcp/package.json/]
        MD[/app/data/]
    end
    MB -->|bundle/index.js| MI
    MB -->|package.json| MP
    MB -->|data/| MD
```

## Design considerations
- **Why a separate build stage, not part of the existing `builder` stage?** `tooljet-mcp` ships as a child process ToolJet spawns at runtime — unrelated to the server/frontend build, and pinned to its own ref (`TOOLJET_MCP_REF`, defaults `main`) independent of ToolJet's own `BRANCH_NAME`.
- **Why does `data/` land at `/app/data`, not `/app/mcp/data`?** The bundle resolves its own catalog data as `../data` relative to itself (`tooljet-mcp/src/catalog.ts`) — get this path wrong and it fails silently at runtime, not at build time.
- **Why copy `package.json` at all, just for one file?** It declares `"type": "module"`, which `server/package.json` doesn't. Without it scoped inside `/app/mcp/`, Node walks up, finds the server's CommonJS `package.json`, and the bundle's ESM `import`s fail before the relay ever spawns it.
- **Why not touch the cloud Dockerfiles?** Cloud's own MCP server calls back into `app.tooljet.ai`, our own infrastructure — never the customer's network, so it was never the broken case this relay exists for. `docker/LTS/cloud/*` is already a separate build tree and stays untouched.

## 🔀 Changes
- Added an `mcp-builder` stage to `docker/LTS/ee/ee-production.Dockerfile` and `docker/pre-release/ee/ee-production.Dockerfile`
- Copies `bundle/index.js`, `package.json`, and `data/` into the final image at the exact paths `ee-server#827`'s relay expects

## 🧪 How to test
- [x] Build either image, confirm `/app/mcp/index.js`, `/app/mcp/package.json`, and `/app/data/component-schemas.json` all exist
- [x] `node /app/mcp/index.js` inside the built image starts clean, no ESM/module errors
- [x] With `ENABLE_MCP_SOCKET_RELAY` set, confirm `ee-server#827`'s relay actually finds the bundle and spawns it
- [x] Cloud images build unaffected — not touched by this change

Stacked on `feat/multi-model-builds`. Pairs with `ToolJet/tooljet-agent#182` and `ToolJet/ee-server#827`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)