### PR TITLE
fix(frontend): handle empty arrays and load jspdf-autotable in generateFile PDF export

### DIFF
--- a/frontend/src/_lib/generate-file.js
+++ b/frontend/src/_lib/generate-file.js
@@ -19,10 +19,15 @@ export default async function generateFile(filename, data, fileType) {
     window.URL.revokeObjectURL(elem.href);
   }
 }
+
 async function generatePDF(filename, data) {
   // eslint-disable-next-line import/no-unresolved
-  const jsPDFNamespace = await import('jspdf');
+  const [jsPDFNamespace, jsPDFAutoTableNamespace] = await Promise.all([
+    import('jspdf'),
+    import('jspdf-autotable'),
+  ]);
   const jsPDF = jsPDFNamespace.jsPDF || jsPDFNamespace.default;
+  const autoTable = jsPDFAutoTableNamespace.autoTable || jsPDFAutoTableNamespace.default;
   const doc = new jsPDF();
   const pageWidth = doc.internal.pageSize.getWidth();
   const margin = 10;
@@ -39,27 +44,42 @@ async function generatePDF(filename, data) {
       });
       y += 10;
     } else if (Array.isArray(value)) {
-      const columnNames = Object.keys(value[0]);
+      if (value.length === 0) {
+        return;
+      }
+      const columnNames = Object.keys(value[0] || {});
 
       // Print table headers
-      doc.autoTable({
+      const tableOptions = {
         startY: y,
         head: [columnNames],
         body: value.map((item) => Object.values(item)),
-      });
+      };
 
-      y = doc.lastAutoTable.finalY + 10;
+      if (typeof doc.autoTable === 'function') {
+        doc.autoTable(tableOptions);
+      } else if (typeof autoTable === 'function') {
+        autoTable(doc, tableOptions);
+      }
+
+      y = (doc.lastAutoTable?.finalY ?? y) + 10;
     } else if (valueType === 'object' && value !== null) {
       const columnNames = Object.keys(value);
 
       // Print table headers
-      doc.autoTable({
+      const tableOptions = {
         startY: y,
         head: [columnNames],
         body: [Object.values(value)],
-      });
+      };
 
-      y = doc.lastAutoTable.finalY + 10;
+      if (typeof doc.autoTable === 'function') {
+        doc.autoTable(tableOptions);
+      } else if (typeof autoTable === 'function') {
+        autoTable(doc, tableOptions);
+      }
+
+      y = (doc.lastAutoTable?.finalY ?? y) + 10;
     } else {
       throw new Error('Invalid data type. Expected string, object, or array.');
     }


### PR DESCRIPTION
## Description
Fixes #17903.

When exporting to PDF via \generateFile(filename, data, 'pdf')\:
1. **Empty Array Handling**: Passing an empty array (\[]\, e.g. from an empty query or table result) previously attempted \Object.keys(value[0])\, throwing \TypeError: Cannot convert undefined or null to object\. Empty arrays are now handled cleanly by returning early and proceeding to \doc.save(filename)\, successfully downloading the blank/empty PDF.
2. **AutoTable Integration**: In \generatePDF\, \jspdf-autotable\ was never loaded, causing \doc.autoTable is not a function\ when exporting an array of objects or single objects. Now both \jspdf\ and \jspdf-autotable\ are dynamically imported in parallel (matching \rontend/src/AppBuilder/Widgets/NewTable/_utils/exportData.js\), and table generation supports both \doc.autoTable\ and standalone \utoTable(doc, ...)\.

## Testing
- Verified dynamic import of \jspdf\ and \jspdf-autotable\.
- Verified empty arrays (\[]\) do not throw \TypeError\ and save an empty document without crashing.
- Verified non-empty arrays of objects and single objects pass through \utoTable\ with headers and row values.
- Preserved existing CSV and plain text export behavior.